### PR TITLE
Use "is_absolute" for boost >= 1.85

### DIFF
--- a/src/jsbr/Interp.cpp
+++ b/src/jsbr/Interp.cpp
@@ -53,7 +53,7 @@ errorReporterFunc(JSContext *cx, const char *message, JSErrorReport *report)
   }
 
   LString prefix;
-  if (report->lineno) { 
+  if (report->lineno) {
     prefix = LString::format("%s %u:",
 			     (report->filename)?(report->filename):"(unknown)",
 			     report->lineno);
@@ -62,12 +62,12 @@ errorReporterFunc(JSContext *cx, const char *message, JSErrorReport *report)
     prefix = LString::format("%s:",
 			     report->filename);
   }
-  
+
   if (JSREPORT_IS_WARNING(report->flags)) {
     prefix += LString::format("%swarning: ",
 			      JSREPORT_IS_STRICT(report->flags) ? "strict " : "");
   }
-  
+
   LOG_DPRINTLN("%s %s", prefix.c_str(), message);
   return;
 }
@@ -102,7 +102,7 @@ bool Interp::init(qlib::LScriptable *pMainObj)
 #endif
   if (!pJsGlob)
     return false;
-  
+
   JSBool res = JS_InitStandardClasses(pcx, pJsGlob);
   if (!res)
     return false;
@@ -225,7 +225,7 @@ void Interp::eval(const qlib::LString &scr)
 {
   JSContext *pcx = (JSContext *)m_pdata;
   JSObject *pJsGlob = (JSObject *)m_pGlob;
-  
+
   const char *script = scr.c_str();
   const char *filename = "(none)";
   int lineno = 0;
@@ -264,10 +264,10 @@ LString Interp::resolvePath(const LString &fname) const
   fs::path inpath(fname.c_str());
 
 #if (BOOST_FILESYSTEM_VERSION==2)
-  if (inpath.is_complete())
+  if (inpath.is_absolute())
     return inpath.file_string();
 #else
-  if (inpath.is_complete())
+  if (inpath.is_absolute())
     return inpath.string();
 #endif
 

--- a/src/modules/rendering/PovSceneExporter.cpp
+++ b/src/modules/rendering/PovSceneExporter.cpp
@@ -56,7 +56,7 @@ void PovSceneExporter::write()
     if (!str_povpath.isEmpty() && !str_incpath.isEmpty()) {
       // Check and modify the main pov file path
       fs::path povpath(str_povpath.c_str());
-      if (!povpath.is_complete()) {
+      if (!povpath.is_absolute()) {
 #if (BOOST_FILESYSTEM_VERSION==2)
         povpath = fs::complete(povpath);
         setPath(povpath.file_string());
@@ -68,7 +68,7 @@ void PovSceneExporter::write()
       fs::path base_path = povpath.parent_path();
       // Check and modify the inc file path
       fs::path incpath(str_incpath.c_str());
-      if (!incpath.is_complete()) {
+      if (!incpath.is_absolute()) {
         ppovdc->setIncFileName(str_incpath);
 #if (BOOST_FILESYSTEM_VERSION==2)
         incpath = fs::complete(incpath, base_path);
@@ -92,7 +92,7 @@ void PovSceneExporter::write()
   else {
     ppovdc->setIncFileName(str_incpath);
   }
-  
+
   // Main stream
   qlib::OutStream *pOutPov = createOutStream();
   // Sub stream (inc file)
@@ -106,7 +106,7 @@ void PovSceneExporter::write()
   // ppovdc->setTargetView(pView);
   ppovdc->init(pOutPov, pOutInc);
   //ppovdc->startPovRender();
-  
+
   ppovdc->setClipZ(m_bUseClipZ);
   ppovdc->setPostBlend(m_bPostBlend);
   ppovdc->setPerspective(m_bPerspective);
@@ -125,7 +125,7 @@ void PovSceneExporter::write()
   ppovdc->loadIdent();
   ppovdc->rotate(pCam->m_rotQuat);
   ppovdc->translate(-(pCam->m_center));
-  
+
   // calc line width factor
   int height = getHeight();
   if (height<=0 && pScene->getViewCount()>0) {


### PR DESCRIPTION
In boost::filesystem v3, is_complete() is deprecated.

- `./src/modules/rendering/PovSceneExporter.cpp`
- `./src/jsbr/Interp.cpp`