### PR TITLE
Color pytest 0207

### DIFF
--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -100,6 +100,18 @@ tasks:
 
 #####
 
+  build_nodejs:
+    deps:
+      - task: build_nodejs:{{OS}}
+
+  build_nodejs:darwin:
+    platforms: [darwin]
+    cmds:
+      - task: build_libcuemol2
+      - bash build_nodejs_posix/run.sh "{{.WORKDIR}}" "{{.CONFIG}}"
+
+#####
+
   build_cli:
     deps:
       - task: build_cli:{{OS}}

--- a/nodejs/src/tests/matrix.test.js
+++ b/nodejs/src/tests/matrix.test.js
@@ -1,0 +1,366 @@
+import { cm } from './setup.js';
+
+/** Create a Vector with 3 or 4 components */
+const vec = (x, y, z, w) => {
+  const v = cm.createObj('Vector');
+  w !== undefined ? v.set4(x, y, z, w) : v.set3(x, y, z);
+  return v;
+};
+
+/** Create a diagonal matrix with given values */
+const diagMatrix = (a = 10.2, b = 100.1, c = 1111.3, d = 1234.5) => {
+  const m = cm.createObj('Matrix');
+  m.setAt(1, 1, a);
+  m.setAt(2, 2, b);
+  m.setAt(3, 3, c);
+  m.setAt(4, 4, d);
+  return m;
+};
+
+/** Assert all off-diagonal elements are zero */
+const expectOffDiagonalZero = (m) => {
+  for (let i = 1; i <= 4; i++)
+    for (let j = 1; j <= 4; j++)
+      if (i !== j) expect(m.getAt(i, j)).toBe(0);
+};
+
+/** Assert matrix is identity */
+const expectIdentity = (m) => {
+  for (let i = 1; i <= 4; i++)
+    for (let j = 1; j <= 4; j++)
+      expect(m.getAt(i, j)).toBe(i === j ? 1 : 0);
+};
+
+/** Assert matrix is all zeros */
+const expectAllZero = (m) => {
+  for (let i = 1; i <= 4; i++)
+    for (let j = 1; j <= 4; j++)
+      expect(m.getAt(i, j)).toBe(0);
+};
+
+describe('Matrix', () => {
+  let mat;
+
+  beforeEach(() => {
+    mat = cm.createObj('Matrix');
+  });
+
+  describe('element access', () => {
+    it('sets and gets diagonal elements', () => {
+      mat.setAt(1, 1, 10.2);
+      mat.setAt(2, 2, 100.1);
+      mat.setAt(3, 3, 1111.3);
+      mat.setAt(4, 4, 1234.5);
+
+      expect(mat.getAt(1, 1)).toBe(10.2);
+      expect(mat.getAt(2, 2)).toBe(100.1);
+      expect(mat.getAt(3, 3)).toBe(1111.3);
+      expect(mat.getAt(4, 4)).toBe(1234.5);
+    });
+
+    it('sets and gets off-diagonal elements', () => {
+      mat.setAt(1, 3, 42.0);
+      mat.setAt(3, 1, 99.9);
+
+      expect(mat.getAt(1, 3)).toBe(42.0);
+      expect(mat.getAt(3, 1)).toBe(99.9);
+    });
+
+    it.each([
+      ['setAt', (m) => m.setAt(100, 1, 0)],
+      ['setAt', (m) => m.setAt(1, 100, 0)],
+      ['getAt', (m) => m.getAt(100, 1)],
+      ['getAt', (m) => m.getAt(1, 100)],
+      ['addAt', (m) => m.addAt(100, 1, 0)],
+      ['addAt', (m) => m.addAt(1, 100, 0)],
+    ])('%s throws on out-of-range index', (_name, fn) => {
+      expect(() => fn(mat)).toThrow();
+    });
+
+    it('addAt accumulates onto existing value', () => {
+      mat.addAt(1, 1, 10.2);
+      mat.addAt(2, 2, 100.1);
+
+      // Default identity has 1 on diagonal
+      expect(mat.getAt(1, 1)).toBe(1 + 10.2);
+      expect(mat.getAt(2, 2)).toBe(1 + 100.1);
+    });
+  });
+
+  describe('initialization and state', () => {
+    it('starts as identity matrix', () => {
+      expect(mat.isIdent()).toBe(true);
+      expectIdentity(mat);
+    });
+
+    it('setIdent resets to identity', () => {
+      const m = diagMatrix();
+      m.setIdent();
+      expectIdentity(m);
+    });
+
+    it('setZero clears all elements', () => {
+      const m = diagMatrix();
+      m.setZero();
+      expectAllZero(m);
+    });
+
+    it('isZero returns true only for zero matrix', () => {
+      expect(mat.isZero()).toBe(false);
+      mat.setZero();
+      expect(mat.isZero()).toBe(true);
+    });
+
+    it('isIdent returns false after modification', () => {
+      mat.setAt(1, 2, 5.0);
+      expect(mat.isIdent()).toBe(false);
+    });
+  });
+
+  describe('toString and equals', () => {
+    it('serializes to formatted string', () => {
+      const m = diagMatrix();
+      expect(m.toString()).toBe(
+        '(10.2000000,0.0000000,0.0000000,0.0000000,' +
+        '0.0000000,100.1000000,0.0000000,0.0000000,' +
+        '0.0000000,0.0000000,1111.3000000,0.0000000,' +
+        '0.0000000,0.0000000,0.0000000,1234.5000000)'
+      );
+    });
+
+    it('equals returns true for identical matrices', () => {
+      const m1 = diagMatrix();
+      const m2 = diagMatrix();
+      expect(m1.equals(m2)).toBe(true);
+    });
+
+    it('equals returns false for different matrices', () => {
+      const m1 = diagMatrix();
+      const m2 = diagMatrix(1, 2, 3, 4);
+      expect(m1.equals(m2)).toBe(false);
+    });
+  });
+
+  describe('scalar arithmetic', () => {
+    it('scale multiplies all elements', () => {
+      const m = diagMatrix();
+      const r = m.scale(2.0);
+
+      expect(r.getAt(1, 1)).toBe(10.2 * 2);
+      expect(r.getAt(2, 2)).toBe(100.1 * 2);
+      expect(r.getAt(3, 3)).toBe(1111.3 * 2);
+      expect(r.getAt(4, 4)).toBe(1234.5 * 2);
+      expectOffDiagonalZero(r);
+    });
+
+    it('divide divides all elements', () => {
+      const m = diagMatrix();
+      const r = m.divide(2.0);
+
+      expect(r.getAt(1, 1)).toBe(10.2 / 2);
+      expect(r.getAt(2, 2)).toBe(100.1 / 2);
+      expect(r.getAt(3, 3)).toBe(1111.3 / 2);
+      expect(r.getAt(4, 4)).toBe(1234.5 / 2);
+      expectOffDiagonalZero(r);
+    });
+
+    it('scale(1) preserves the matrix', () => {
+      const m = diagMatrix();
+      const r = m.scale(1.0);
+      expect(r.equals(m)).toBe(true);
+    });
+
+    it('scale(0) produces zero matrix', () => {
+      const m = diagMatrix();
+      const r = m.scale(0.0);
+      expect(r.isZero()).toBe(true);
+    });
+
+    it('scale(-1) negates all elements', () => {
+      const m = diagMatrix();
+      const r = m.scale(-1.0);
+
+      expect(r.getAt(1, 1)).toBe(-10.2);
+      expect(r.getAt(2, 2)).toBe(-100.1);
+      expect(r.getAt(3, 3)).toBe(-1111.3);
+      expect(r.getAt(4, 4)).toBe(-1234.5);
+    });
+  });
+
+  describe('matrix arithmetic', () => {
+    it('add sums element-wise', () => {
+      const m2 = diagMatrix();
+      const r = mat.add(m2); // identity + diag
+
+      expect(r.getAt(1, 1)).toBe(1 + 10.2);
+      expect(r.getAt(2, 2)).toBe(1 + 100.1);
+      expect(r.getAt(3, 3)).toBe(1 + 1111.3);
+      expect(r.getAt(4, 4)).toBe(1 + 1234.5);
+      expectOffDiagonalZero(r);
+    });
+
+    it('sub subtracts element-wise', () => {
+      const m2 = diagMatrix();
+      const r = m2.sub(mat); // diag - identity
+
+      expect(r.getAt(1, 1)).toBe(10.2 - 1);
+      expect(r.getAt(2, 2)).toBe(100.1 - 1);
+      expect(r.getAt(3, 3)).toBe(1111.3 - 1);
+      expect(r.getAt(4, 4)).toBe(1234.5 - 1);
+      expectOffDiagonalZero(r);
+    });
+
+    it('sub self produces zero matrix', () => {
+      const m = diagMatrix();
+      const r = m.sub(m);
+      expect(r.isZero()).toBe(true);
+    });
+
+    it('mul with identity preserves the matrix', () => {
+      const m2 = diagMatrix();
+      const r = mat.mul(m2); // identity * diag
+
+      expect(r.getAt(1, 1)).toBe(10.2);
+      expect(r.getAt(2, 2)).toBe(100.1);
+      expect(r.getAt(3, 3)).toBe(1111.3);
+      expect(r.getAt(4, 4)).toBe(1234.5);
+      expectOffDiagonalZero(r);
+    });
+
+    it('mul is not commutative in general', () => {
+      const a = cm.createObj('Matrix');
+      a.setAt(1, 2, 1.0);
+      const b = cm.createObj('Matrix');
+      b.setAt(2, 1, 1.0);
+
+      const ab = a.mul(b);
+      const ba = b.mul(a);
+      expect(ab.equals(ba)).toBe(false);
+    });
+
+    it('mulvec transforms vector by matrix', () => {
+      const m = diagMatrix();
+      const v = m.mulvec(vec(1, 2, 3, 4));
+
+      expect(v.x).toBeCloseTo(10.2);
+      expect(v.y).toBeCloseTo(200.2);
+      expect(v.z).toBeCloseTo(3333.9);
+      expect(v.w).toBeCloseTo(4938.0);
+    });
+
+    it('identity mulvec preserves vector', () => {
+      const v = mat.mulvec(vec(1, 2, 3, 4));
+
+      expect(v.x).toBe(1);
+      expect(v.y).toBe(2);
+      expect(v.z).toBe(3);
+      expect(v.w).toBe(4);
+    });
+  });
+
+  describe('transforms', () => {
+    it('setRotate produces correct rotation matrix', () => {
+      const cen = vec(1, 1, 1);
+      const ax = vec(1, 1, 1).normalize();
+      mat.setRotate(cen, ax, 60.0);
+
+      // Expected: 60-degree rotation around (1,1,1) axis
+      const expected = [
+        [0.6666667, 0.6666667, -0.3333333, 0],
+        [-0.3333333, 0.6666667, 0.6666667, 0],
+        [0.6666667, -0.3333333, 0.6666667, 0],
+        [0, 0, 0, 1],
+      ];
+
+      for (let i = 0; i < 4; i++)
+        for (let j = 0; j < 4; j++)
+          expect(mat.getAt(i + 1, j + 1)).toBeCloseTo(expected[i][j]);
+    });
+
+    it('setTranslate produces correct translation matrix', () => {
+      mat.setTranslate(vec(1, 1, 1));
+
+      for (let i = 1; i <= 4; i++) {
+        for (let j = 1; j <= 4; j++) {
+          if (i === j) expect(mat.getAt(i, j)).toBe(1);
+          else if (j === 4) expect(mat.getAt(i, j)).toBe(1);
+          else expect(mat.getAt(i, j)).toBe(0);
+        }
+      }
+    });
+
+    it('setTranslate with zero vector produces identity', () => {
+      mat.setTranslate(vec(0, 0, 0));
+      expectIdentity(mat);
+    });
+  });
+
+  describe('diag3', () => {
+    it('returns 3x3 inverse with translation component', () => {
+      const m = diagMatrix();
+      const r = m.diag3();
+
+      // Upper-left 3x3 block
+      expect(r.getAt(1, 1)).toBeCloseTo(1);
+      expect(r.getAt(2, 2)).toBeCloseTo(1);
+      expect(r.getAt(3, 3)).toBeCloseTo(1);
+
+      // Translation column
+      expect(r.getAt(4, 1)).toBeCloseTo(10.2);
+      expect(r.getAt(4, 2)).toBeCloseTo(100.1);
+      expect(r.getAt(4, 3)).toBeCloseTo(1111.3);
+    });
+  });
+
+  describe('row and column access', () => {
+    it('setRow fills rows correctly', () => {
+      const v = vec(1, 2, 3, 4);
+      for (let i = 1; i <= 4; i++) mat.setRow(i, v);
+
+      for (let i = 1; i <= 4; i++)
+        for (let j = 1; j <= 4; j++)
+          expect(mat.getAt(i, j)).toBe(j);
+    });
+
+    it('setCol fills columns correctly', () => {
+      const v = vec(1, 2, 3, 4);
+      for (let j = 1; j <= 4; j++) mat.setCol(j, v);
+
+      for (let i = 1; i <= 4; i++)
+        for (let j = 1; j <= 4; j++)
+          expect(mat.getAt(i, j)).toBe(i);
+    });
+
+    it('row() returns correct row vector', () => {
+      for (let i = 1; i <= 4; i++)
+        for (let j = 1; j <= 4; j++)
+          mat.setAt(i, j, j);
+
+      const expected = vec(1, 2, 3, 4);
+      for (let i = 1; i <= 4; i++)
+        expect(expected.equals(mat.row(i))).toBe(true);
+    });
+
+    it('col() returns correct column vector', () => {
+      for (let i = 1; i <= 4; i++)
+        for (let j = 1; j <= 4; j++)
+          mat.setAt(i, j, i);
+
+      const expected = vec(1, 2, 3, 4);
+      for (let j = 1; j <= 4; j++)
+        expect(expected.equals(mat.col(j))).toBe(true);
+    });
+
+    it('setRow and row() round-trip correctly', () => {
+      const v = vec(5, 10, 15, 20);
+      mat.setRow(2, v);
+      expect(v.equals(mat.row(2))).toBe(true);
+    });
+
+    it('setCol and col() round-trip correctly', () => {
+      const v = vec(5, 10, 15, 20);
+      mat.setCol(3, v);
+      expect(v.equals(mat.col(3))).toBe(true);
+    });
+  });
+});

--- a/nodejs/src/tests/setup.js
+++ b/nodejs/src/tests/setup.js
@@ -1,0 +1,7 @@
+/**
+ * Shared CueMol instance for test suites.
+ * Import `cm` to create CueMol objects in tests.
+ */
+import * as core from '../index.js';
+
+export const cm = core.createCueMol();

--- a/nodejs/src/tests/timevalue.test.js
+++ b/nodejs/src/tests/timevalue.test.js
@@ -1,0 +1,78 @@
+import { cm } from './setup.js';
+
+describe('test timevalue', () => {
+  let sut;
+
+  beforeEach(() => {
+    sut = cm.createObj("TimeValue");
+  });
+
+  it('default value', () => {
+    expect(sut).toBeTruthy();
+    expect(sut.strval).toBe("0");
+  });
+
+  it('toString from millisec and second', () => {
+    sut.millisec = 123;
+    expect(sut.millisec).toBeCloseTo(123);
+    expect(sut.toString()).toBe("0.123");
+    expect(sut.strval).toBe("0.123");
+
+    sut.millisec = 123.456;
+    expect(sut.millisec).toBeCloseTo(123.456);
+    expect(sut.toString()).toBe("0.123");
+
+    sut.second = 123;
+    expect(sut.second).toBeCloseTo(123.0);
+    expect(sut.toString()).toBe("2:3");
+
+    sut.second = 123.456;
+    expect(sut.second).toBeCloseTo(123.456);
+    expect(sut.toString()).toBe("2:3.456");
+
+    sut.second = 123456.789;
+    expect(sut.second).toBeCloseTo(123456.789);
+    expect(sut.toString()).toBe("34:17:36.789");
+  });
+
+  it('fromString via strval', () => {
+    sut.strval = "0.123";
+    expect(sut.millisec).toBeCloseTo(123);
+
+    sut.strval = "2:3";
+    expect(sut.second).toBeCloseTo(123.0);
+
+    sut.strval = "2:3.456";
+    expect(sut.second).toBeCloseTo(123.456);
+
+    sut.strval = "34:17:36.789";
+    expect(sut.second).toBeCloseTo(123456.789);
+  });
+
+  it('getXX with and without remainder flag', () => {
+    sut.second = 123456.789;
+
+    // With remainder (true)
+    expect(sut.getHour()).toBe(34);
+    expect(sut.getMinute(true)).toBe(17);
+    expect(sut.getSecond(true)).toBe(36);
+    expect(sut.getMilliSec(true)).toBe(789);
+
+    // Without remainder (false) - total values
+    expect(sut.getMinute(false)).toBe(2057);
+    expect(sut.getSecond(false)).toBe(123456);
+    expect(sut.getMilliSec(false)).toBe(123456789);
+  });
+
+  it('equals', () => {
+    const tv1 = cm.createObj("TimeValue");
+    tv1.strval = "12:34:56.78";
+    const tv2 = cm.createObj("TimeValue");
+    tv2.strval = "12:34:56.78";
+    expect(tv1.equals(tv2)).toBe(true);
+
+    const tv3 = cm.createObj("TimeValue");
+    tv3.strval = "34:56.78";
+    expect(tv1.equals(tv3)).toBe(false);
+  });
+});

--- a/nodejs/src/tests/vector.test.js
+++ b/nodejs/src/tests/vector.test.js
@@ -1,6 +1,4 @@
-import * as core from '../index.js';
-
-const cm = core.createCueMol();
+import { cm } from './setup.js';
 
 describe('test vector', () => {
   let sut;
@@ -9,42 +7,39 @@ describe('test vector', () => {
     sut = cm.createObj("Vector");
   });
 
-  it('vector props', () => {
-    let v = sut;
-    v.x = 10.2
-    v.y = 100.1
-    v.z = 1111.3
-    v.w = 1234.5
-    expect(v.x).toBe(10.2)
-    expect(v.y).toBe(100.1)
-    expect(v.z).toBe(1111.3)
-    expect(v.w).toBe(1234.5)
-  })
+  it('props', () => {
+    sut.x = 10.2;
+    sut.y = 100.1;
+    sut.z = 1111.3;
+    sut.w = 1234.5;
+    expect(sut.x).toBe(10.2);
+    expect(sut.y).toBe(100.1);
+    expect(sut.z).toBe(1111.3);
+    expect(sut.w).toBe(1234.5);
+  });
 
-  it('vector strvalue', () => {
-    let vec_obj = sut;
-    expect(vec_obj.strvalue).toBe('(0,0,0)')
-    vec_obj.strvalue = '(1, 2, 3.14)'
-    expect(vec_obj.strvalue).toBe('(1,2,3.14)')
-  })
+  it('strvalue', () => {
+    expect(sut.strvalue).toBe('(0,0,0)');
+    sut.strvalue = '(1, 2, 3.14)';
+    expect(sut.strvalue).toBe('(1,2,3.14)');
+  });
 
-  it('vector_init', () => {
-    let v = sut;
-    expect(v.x).toBe(0.0)
-    expect(v.y).toBe(0.0)
-    expect(v.z).toBe(0.0)
-    expect(v.w).toBe(0.0)
+  it('init and set3/set4', () => {
+    expect(sut.x).toBe(0.0);
+    expect(sut.y).toBe(0.0);
+    expect(sut.z).toBe(0.0);
+    expect(sut.w).toBe(0.0);
 
-    v.set3(1.0, 2.3, 4.5)
-    expect(v.x).toBe(1.0)
-    expect(v.y).toBe(2.3)
-    expect(v.z).toBe(4.5)
-    expect(v.w).toBe(0.0)
-    
-    v.set4(11.0, 12.3, 14.5, 34.5)
-    expect(v.x).toBe(11.0)
-    expect(v.y).toBe(12.3)
-    expect(v.z).toBe(14.5)
-    expect(v.w).toBe(34.5)
-  })
+    sut.set3(1.0, 2.3, 4.5);
+    expect(sut.x).toBe(1.0);
+    expect(sut.y).toBe(2.3);
+    expect(sut.z).toBe(4.5);
+    expect(sut.w).toBe(0.0);
+
+    sut.set4(11.0, 12.3, 14.5, 34.5);
+    expect(sut.x).toBe(11.0);
+    expect(sut.y).toBe(12.3);
+    expect(sut.z).toBe(14.5);
+    expect(sut.w).toBe(34.5);
+  });
 });

--- a/src/perl/Jsclass.pm
+++ b/src/perl/Jsclass.pm
@@ -368,7 +368,7 @@ sub genEs6InvokeCode($$)
     # }
     else {
       # basic types
-      print OUT "  return rval;\n";
+      print OUT "  return result;\n";
     }
 
     print OUT "};\n";

--- a/tests/gfx_tests/test_color_syntax.py
+++ b/tests/gfx_tests/test_color_syntax.py
@@ -1,0 +1,134 @@
+"""
+Tests for color definition syntax in CueMol.
+Reference: src/gfx/color_parser.yxx, src/gfx/color_scanner.lxx
+"""
+
+import cuemol
+import pytest
+
+
+# Module-level fixtures
+stylem = None
+scene = None
+
+
+def setup_module():
+    """Initialize services once for all tests."""
+    global stylem, scene
+    stylem = cuemol.getService("StyleManager")
+    scene = cuemol.createScene()
+
+
+def compile_color(color_str):
+    """Compile color and return (color, error)."""
+    try:
+        color = stylem.compileColor(color_str, scene.uid)
+        return color, None if color else "error: compilation failed"
+    except Exception as e:
+        return None, str(e).lower()
+
+
+# =============================================================================
+# Test Cases: (color_string, should_succeed, error_substring_if_fail)
+# =============================================================================
+
+NAMED_COLORS = [
+    ("red", True, None),
+    ("color_1", True, None),  # Underscore and number
+    (" red", True, None),  # Whitespace
+    ("color space", False, "error"),  # Invalid space
+    ("red blue", False, "error"),  # Multiple tokens
+]
+
+HTML_COLORS = [
+    ("#fff", True, None),
+    ("#ffffff", True, None),
+    ("#AbC", True, None),  # Case variation
+    ("#ggg", False, "error"),  # Invalid hex
+]
+
+RGB_COLORS = [
+    ("rgb(255, 0, 0)", True, None),
+    ("rgb(1.0, 0.5, 0.0)", True, None),  # Float
+    ("RGB(128, 128, 128)", True, None),  # Uppercase
+    ("rgba(255, 0, 0, 0.5)", True, None),
+    ("rgb(255, 0)", False, "error"),  # Wrong arg count
+    ("rgb(255; 0; 0)", False, "error"),  # Wrong separator
+]
+
+HSB_COLORS = [
+    ("hsb(0.0, 1.0, 1.0)", True, None),
+    ("HSB(120.0, 0.5, 0.5)", True, None),  # Uppercase
+    ("hsba(240.0, 1.0, 1.0, 0.5)", True, None),
+    ("hsb(0.0, 1.0)", False, "error"),  # Wrong arg count
+]
+
+MOLCOL_COLORS = [
+    ("$molcol", True, None),
+    ("$mol col", False, "error"),  # Space
+]
+
+MODIFIERS = [
+    ("red{alpha: 0.5}", True, None),
+    ("rgb(255, 0, 0){alpha: 0.5; brightness: 1.2}", True, None),
+    ("red{alpha: 0.5", False, "error"),  # Missing brace
+]
+
+EDGE_CASES = [
+    ("", False, "compilation failed"),
+    ("   ", False, "compilation failed"),
+    ("Rgb(255, 0, 0)", False, None),  # Mixed case keyword
+]
+
+
+# Combine all test cases
+ALL_CASES = (
+    NAMED_COLORS
+    + HTML_COLORS
+    + RGB_COLORS
+    + HSB_COLORS
+    + MOLCOL_COLORS
+    + MODIFIERS
+    + EDGE_CASES
+)
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+@pytest.mark.parametrize("color_str,should_succeed,error_substr", ALL_CASES)
+def test_color_syntax(color_str, should_succeed, error_substr):
+    """Test color syntax - both valid and invalid cases."""
+    color, error = compile_color(color_str)
+
+    if should_succeed:
+        # Should compile without syntax error
+        if error:
+            assert "syntax" not in error, (
+                f"Syntax error for valid color: {color_str!r}, error: {error}"
+            )
+    else:
+        # Should fail
+        assert error is not None or color is None, f"Should have failed: {color_str!r}"
+        if error_substr and error:
+            assert error_substr in error, (
+                f"Expected '{error_substr}' in error for {color_str!r}, got: {error}"
+            )
+
+
+def test_case_sensitivity():
+    """Verify case sensitivity rules for keywords."""
+    # All lowercase or all uppercase works
+    for color_str in [
+        "rgb(255, 0, 0)",
+        "RGB(255, 0, 0)",
+        "hsb(0, 1, 1)",
+        "HSB(0, 1, 1)",
+    ]:
+        color, error = compile_color(color_str)
+        assert error is None and color is not None, f"Failed: {color_str}"
+
+    # Mixed case fails
+    assert compile_color("Rgb(255, 0, 0)")[0] is None

--- a/tests/gfx_tests/test_color_syntax.py
+++ b/tests/gfx_tests/test_color_syntax.py
@@ -23,61 +23,61 @@ def compile_color(color_str):
     """Compile color and return (color, error)."""
     try:
         color = stylem.compileColor(color_str, scene.uid)
-        return color, None if color else "error: compilation failed"
+        return color, "failed" if color is None else None
     except Exception as e:
-        return None, str(e).lower()
+        return None, str(e)
 
 
 # =============================================================================
-# Test Cases: (color_string, should_succeed, error_substring_if_fail)
+# Test Cases: (color_string, should_succeed)
 # =============================================================================
 
 NAMED_COLORS = [
-    ("red", True, None),
-    ("color_1", True, None),  # Underscore and number
-    (" red", True, None),  # Whitespace
-    ("color space", False, "error"),  # Invalid space
-    ("red blue", False, "error"),  # Multiple tokens
+    ("red", True),
+    ("color_1", True),  # Underscore and number
+    (" red", True),  # Whitespace
+    ("color space", False),  # Invalid space
+    ("red blue", False),  # Multiple tokens
 ]
 
 HTML_COLORS = [
-    ("#fff", True, None),
-    ("#ffffff", True, None),
-    ("#AbC", True, None),  # Case variation
-    ("#ggg", False, "error"),  # Invalid hex
+    ("#fff", True),
+    ("#ffffff", True),
+    ("#AbC", True),  # Case variation
+    ("#ggg", False),  # Invalid hex
 ]
 
 RGB_COLORS = [
-    ("rgb(255, 0, 0)", True, None),
-    ("rgb(1.0, 0.5, 0.0)", True, None),  # Float
-    ("RGB(128, 128, 128)", True, None),  # Uppercase
-    ("rgba(255, 0, 0, 0.5)", True, None),
-    ("rgb(255, 0)", False, "error"),  # Wrong arg count
-    ("rgb(255; 0; 0)", False, "error"),  # Wrong separator
+    ("rgb(255, 0, 0)", True),
+    ("rgb(1.0, 0.5, 0.0)", True),  # Float
+    ("RGB(128, 128, 128)", True),  # Uppercase
+    ("rgba(255, 0, 0, 0.5)", True),
+    ("rgb(255, 0)", False),  # Wrong arg count
+    ("rgb(255; 0; 0)", False),  # Wrong separator
 ]
 
 HSB_COLORS = [
-    ("hsb(0.0, 1.0, 1.0)", True, None),
-    ("HSB(120.0, 0.5, 0.5)", True, None),  # Uppercase
-    ("hsba(240.0, 1.0, 1.0, 0.5)", True, None),
-    ("hsb(0.0, 1.0)", False, "error"),  # Wrong arg count
+    ("hsb(0.0, 1.0, 1.0)", True),
+    ("HSB(120.0, 0.5, 0.5)", True),  # Uppercase
+    ("hsba(240.0, 1.0, 1.0, 0.5)", True),
+    ("hsb(0.0, 1.0)", False),  # Wrong arg count
 ]
 
 MOLCOL_COLORS = [
-    ("$molcol", True, None),
-    ("$mol col", False, "error"),  # Space
+    ("$molcol", True),
+    ("$mol col", False),  # Space
 ]
 
 MODIFIERS = [
-    ("red{alpha: 0.5}", True, None),
-    ("rgb(255, 0, 0){alpha: 0.5; brightness: 1.2}", True, None),
-    ("red{alpha: 0.5", False, "error"),  # Missing brace
+    ("red{alpha: 0.5}", True),
+    ("rgb(255, 0, 0){alpha: 0.5; brightness: 1.2}", True),
+    ("red{alpha: 0.5", False),  # Missing brace
 ]
 
 EDGE_CASES = [
-    ("", False, "compilation failed"),
-    ("   ", False, "compilation failed"),
-    ("Rgb(255, 0, 0)", False, None),  # Mixed case keyword
+    ("", False),
+    ("   ", False),
+    ("Rgb(255, 0, 0)", False),  # Mixed case keyword
 ]
 
 
@@ -98,24 +98,23 @@ ALL_CASES = (
 # =============================================================================
 
 
-@pytest.mark.parametrize("color_str,should_succeed,error_substr", ALL_CASES)
-def test_color_syntax(color_str, should_succeed, error_substr):
+@pytest.mark.parametrize("color_str,should_succeed", ALL_CASES)
+def test_color_syntax(color_str, should_succeed):
     """Test color syntax - both valid and invalid cases."""
     color, error = compile_color(color_str)
 
     if should_succeed:
-        # Should compile without syntax error
-        if error:
-            assert "syntax" not in error, (
-                f"Syntax error for valid color: {color_str!r}, error: {error}"
-            )
+        # Must compile successfully: no error and color exists
+        assert error is None, (
+            f"Expected successful compilation for {color_str!r}, got error: {error}"
+        )
+        assert color is not None, f"Expected color object for {color_str!r}, got None"
     else:
-        # Should fail
-        assert error is not None or color is None, f"Should have failed: {color_str!r}"
-        if error_substr and error:
-            assert error_substr in error, (
-                f"Expected '{error_substr}' in error for {color_str!r}, got: {error}"
-            )
+        # Should fail: either error or no color
+        # Don't check error message content - it may change in implementation
+        assert error is not None or color is None, (
+            f"Expected failure for {color_str!r}, but compilation succeeded"
+        )
 
 
 def test_case_sensitivity():


### PR DESCRIPTION
Adds/updates automated tests around CueMol color parsing (Python/pytest) and Node.js wrapper objects (Jest), plus a small ES6 wrapper codegen fix and a Taskfile entry to build/test the Node.js addon.

Changes:

Add pytest coverage for color syntax parsing/validation.
Add/expand Jest coverage for Vector/Matrix/TimeValue Node.js wrapper objects and introduce shared test setup.
Update ES6 wrapper generator to return the correct variable and add a Taskfile target for Node.js builds on macOS.