### PR TITLE
Refactor cross-process boundaries with typed contract maps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,15 +94,29 @@ core (@cuemol/core): C++ addon + auto-generated TypeScript wrappers
 - 状態同期は「どの値を source of truth にするか」を先に決める。UI 操作後の menu checked などは、必要がなければ不安定な読み返し値ではなく成功した command の要求値で更新する
 - Electron native menu と React menu は同じ template から作っても挙動が同一とは限らない。radio/checkbox など platform 側が状態を持つ item は、main 側の更新方式と衝突しないか確認する
 - 契約が確認できたら、その契約に従って実装し、不要な正規化や互換コードを足さない。防御コードが必要な場合は、実際に観測された入力差分に限定する
+- 境界 (main↔preload↔renderer / renderer↔worker / コマンド) をまたぐ追加は **型契約マップ** に行追加が起点 — `shared/ipcContract.ts` (`InvokeChannels`/`PushChannels`)、`worker/shared/WorkerCalls.ts` (`ServiceMap`/`MethodMap`/`RpcMap`)、`commands/CommandMap.ts`。マップ行を足すと callsite 側が compile error で誘導される。詳細は `tritium/CLAUDE.md`
+- LSP の警告 (`Cannot find module '@cuemol/core/...'`、`electronAPI does not exist on Window` など) は project-references 解決の noise が多い。検証は `npx tsc -p tsconfig.<project>.json --noEmit` と production build (`task build_tritium`) を真とする
 
-**新規ダイアログの追加パターン**
-1. `worker/services/xxx.service.ts` — C++ データ取得
-2. `AsyncCueMol.ts` — `invokeWorker('xxx', args)` のラッパーメソッド
-3. `components/XxxDialog.tsx` — Blueprint `Dialog` コンポーネント
-4. `contexts/DialogContext.tsx` — `showXxxDialog()` を追加
-5. `commands/ids.ts` — `CmdId.UiXxxDialog` を追加
-6. `hooks/useMenuDispatch.ts` — `'menu:xxx'` チャネルのハンドリング
-7. `commands/useSceneCommands.ts` — コマンド登録
+**End-to-end 検証チェーン**
+
+`npm test` は worker や main を mock するので、実 IPC 経路や bundle 整合性は捕捉できない。リファクタや境界変更の最終確認は次の順で:
+
+1. `cd tritium/react-gui && npm test` (Vitest, ~200+ tests)
+2. `cd tritium/react-gui && npx tsc -p tsconfig.web.json --noEmit` (renderer 型) と `tsconfig.node.json` (main + preload 型)
+3. `cd build_scripts && task build_tritium` (electron-vite production bundle — bundler レベルの依存解決を catch)
+4. `cd build_scripts && task run_tritium` で起動し、`launch worker OK` → `CueMol2 nodejs add-on : INITIALIZED` → `bindCanvas` → `shader program created OK` まで進むか確認
+
+**Refactoring 前の degrade 検出テスト**
+
+大きな構造変更 (ファイル分割・型システム入れ替え・状態同期パターン変更) の前に、**touch する境界の観測契約** を pin するテストを `__test__/` に先に書く。例: 「`invoke(IPC.X, payload)` は `ipcRenderer.invoke(channel, payload)` に流れる」「`useActiveViewState` は activeMolViewId 変化時に 3 getter を呼んで `MENU_UPDATE_STATE` を発火する」など。実装の中身ではなく **wire 形式 / IPC channel 名 / payload shape / 観測される call 順序** を pin することで、内部を入れ替えても同じテストが pass し続ける形にする
+
+**新規ダイアログの追加パターン (post-F factory)**
+- `components/.../XxxDialog.tsx` — Blueprint `Dialog` 本体 (props: `visible`, `onConfirm`/`onCancel` 等の既存パターン)
+- `components/.../XxxDialogProvider.tsx` — `createDialogHook` (`hooks/useDialogFactory.tsx`) で `Provider` / `useShowXxxDialog` を生やす (約 15 行)
+- `contexts/DialogContext.tsx` の composite に `<XxxDialogProvider>` を 1 行追加
+- `commands/ids.ts` に `CmdId.UiXxxDialog`、`commands/CommandMap.ts` に対応する `{ args; result }` 行
+- 対応 `commands/useXxxCommands.ts` で `useShowXxxDialog()` を呼んで `useRegisterCommand`
+- C++ データ取得が要れば `worker/server/services/xxx.service.ts` + `worker/shared/WorkerCalls.ts` の `ServiceMap` 行追加
 
 ---
 

--- a/tritium/CLAUDE.md
+++ b/tritium/CLAUDE.md
@@ -19,7 +19,7 @@ renderer/worker/
 └── shared/   # imported from both threads (ObjTuple, gestureAxes)
 ```
 
-**Rule of thumb**: file location determines execution thread. `client/` code talks to the worker via `transport.invokeWorker(...)`. `server/services/*.service.ts` runs synchronously inside the Web Worker.
+**Rule of thumb**: file location determines execution thread. `client/` code talks to the worker via the typed helpers `transport.invokeService<K>` / `invokeMethod<K>` / `invokeRpc<K>` (or the low-level `invokeWorker` escape hatch). `server/services/*.service.ts` runs synchronously inside the Web Worker.
 
 The Worker entry URL in `client/WorkerTransport.ts` resolves to `../server/worker_launcher.ts` and is auto-detected by Vite — no `electron.vite.config.ts` change is needed when files move within these subdirs.
 
@@ -94,14 +94,15 @@ A single-action file simply exports `services = { actionOne }`. `services/index.
 
 ### `_methods` vs `_registered`
 
-`WorkerService` has two dispatch tables, intentionally kept separate:
+`WorkerService` has two dispatch tables, intentionally kept separate, plus an RPC handler table:
 
-| Table | Purpose | Examples | Dispatch |
+| Table | Purpose | Map (in `worker/shared/WorkerCalls.ts`) | Dispatch |
 |---|---|---|---|
-| `_methods` (`ServiceMethod`) | Infrastructure, hot-path events, RPC handlers | `bindCanvas`, `mouseMove`, `_rpcCreateObj`, `_rpcInvokeMethod` | `fn.apply(this, args)` (sync) |
-| `_registered` (`ServiceFn`) | Business-logic services | `undo`, `loadObject`, `sceneBgColor`, `naviClickAtom` | `Promise.resolve().then(() => fn(ctx, args[0]))` |
+| `_methods` (variadic) | Infrastructure / hot-path events | `MethodMap` (`bindCanvas`, `mouseMove`, …) | `fn.apply(this, args)` (sync) |
+| `_methods` (RPC) | ObjProxy bridge (proxy property access) | `RpcMap` (`createObj`, `getProp`, `invokeMethod`, …) | same as above; conceptually distinct |
+| `_registered` (single-arg) | Business-logic services | `ServiceMap` (`undo`, `loadObject`, `naviClickAtom`, …) | `Promise.resolve().then(() => fn(ctx, args[0]))` |
 
-Don't migrate `_methods` entries into `_registered` without a concrete benefit — the two tables have different invocation semantics on purpose. New business-logic actions go into a `*.service.ts` file under `server/services/`.
+Don't migrate `_methods` entries into `_registered` without a concrete benefit — the two tables have different invocation semantics on purpose. New business-logic actions go into a `*.service.ts` file under `server/services/` **and** a row in `ServiceMap`. Adding the row drives type-checking through `register<K>` and the renderer-side `invokeService<K>` helper.
 
 ---
 
@@ -154,37 +155,50 @@ return withUndoTxn(scene, 'Label', () => { /* mutations */ return result; });
 
 ## IPC patterns
 
-All channel name constants live in `shared/ipcChannels.ts` (`IPC` object). Types live in `shared/ipcTypes.ts`. The preload script (`preload/index.ts`) exposes them via `contextBridge` as `window.electronAPI`.
+All channel name constants live in `shared/ipcChannels.ts` (`IPC` object). The contract — request/response shapes for invoke channels and payload types for push channels — lives in `shared/ipcContract.ts` as the `InvokeChannels` / `PushChannels` maps. The preload script (`preload/index.ts`) exposes a single typed pair via `contextBridge`:
 
-### Invoke channel that returns a value (renderer → main → renderer)
-
-For UI operations that need a result from the main process (e.g., a native menu selection), use `ipcMain.handle` returning a Promise:
-
-```typescript
-// main/ipcHandlers.ts
-ipcMain.handle(IPC.MY_ACTION, (_event, payload: MyPayload) =>
-  doSomethingInMain(mainWindow, payload),
-)
-
-// main/myFeature.ts — wrap non-blocking APIs in a Promise
-export function doSomethingInMain(win: BrowserWindow, payload: MyPayload): Promise<Result | null> {
-  return new Promise((resolve) => {
-    let chosen: Result | null = null
-    // e.g. Menu.popup — click handler runs before callback (close)
-    menu.popup({ window: win, callback: () => resolve(chosen) })
-  })
-}
-
-// preload/index.ts
-myAction: (payload: MyPayload) => ipcRenderer.invoke(IPC.MY_ACTION, payload),
-
-// renderer
-const result = await window.electronAPI.myAction(payload)
+```ts
+window.electronAPI.invoke<C>(channel: C, ...args): Promise<InvokeRes<C>>
+window.electronAPI.onPush<C>(channel: C, callback): () => void   // returns unsubscribe
 ```
+
+`invoke` is for renderer→main request/reply; `onPush` is for main→renderer notifications.
+
+### Adding a new invoke channel
+
+1. Add the channel constant to `shared/ipcChannels.ts`.
+2. Add a row to `InvokeChannels` in `shared/ipcContract.ts`: `[IPC.MY_ACTION]: { req: MyPayload; res: MyResult }`.
+3. Register the handler in `main/ipcHandlers.ts` via the typed `handleInvoke` wrapper:
+   ```ts
+   handleInvoke(IPC.MY_ACTION, (_event, payload) => doSomethingInMain(mainWindow, payload))
+   ```
+4. Call from renderer: `await window.electronAPI.invoke(IPC.MY_ACTION, payload)` — `payload` and the resolved value are typed by the map.
+
+For `req: void` channels, `invoke(IPC.X)` works with no second arg (variadic-tuple `InvokeArgs<C>`).
+
+### Adding a new push channel
+
+1. Add the channel constant + a row to `PushChannels`.
+2. Send from main: `mainWindow.webContents.send(IPC.X, payload)`.
+3. Subscribe from renderer: `window.electronAPI.onPush(IPC.X, (payload) => ...)`. The callback is typed; `void`-payload channels take a `() => void` callback.
 
 ### Native context menus
 
-Use `Menu.buildFromTemplate()` + `menu.popup({ window, x, y, callback })` in the main process. See `main/naviContextMenu.ts` for a complete example. The `click` handler on each item runs **before** `callback`, enabling a `Promise<action | null>` pattern.
+Use `Menu.buildFromTemplate()` + `menu.popup({ window, x, y, callback })` in the main process. See `main/naviContextMenu.ts` for a complete example. The `click` handler on each item runs **before** `callback`, enabling a `Promise<action | null>` pattern returned through `IPC.NAVI_CTX_SHOW`.
+
+### Generic-dispatch design pattern (cross-process)
+
+The same shape recurs in every renderer↔(other-thread) boundary:
+
+| Boundary | Map file | Generic dispatcher |
+|---|---|---|
+| renderer ↔ main | `shared/ipcContract.ts` (`InvokeChannels` / `PushChannels`) | `electronAPI.invoke<C>` / `onPush<C>` |
+| renderer ↔ Web Worker | `worker/shared/WorkerCalls.ts` (`ServiceMap` / `MethodMap` / `RpcMap`) | `cm.invokeService<K>` / `invokeMethodTyped<K>` / `invokeRpc<K>` |
+| renderer-internal command bus | `commands/CommandMap.ts` | `useCommands().dispatch<K>` / `useRegisterCommand<K>` |
+
+Workflow when adding a feature: (1) add a row to the relevant map; (2) implement the producer side (`handleInvoke`, `*.service.ts`, `useRegisterCommand`); (3) call from the consumer side. The compiler walks both sides for you.
+
+Variadic-tuple trick for `void` args (used in all three): `type Args<K> = X extends void ? [] : [X]` so `dispatch(id)` works for void-args entries while non-void requires the payload.
 
 ---
 
@@ -216,7 +230,7 @@ Note: the C++ `View` / `Scene` objects are not destroyed by `removeView`; that i
 cd tritium/react-gui && npm test    # vitest run
 ```
 
-Tests use **Vitest + jsdom**. Files go in `src/renderer/__test__/*.test.{ts,tsx}`. No `@testing-library/react` — use `createRoot` + `act()` directly, following the pattern in `useActiveTool.test.ts`.
+Tests use **Vitest + jsdom**. Files go in `src/renderer/__test__/*.test.{ts,tsx}`. No `@testing-library/react` — use `createRoot` + `act()` directly, following the pattern in `useActiveTool.test.ts`. Common helpers (`makeRenderHook`, `mountTree`, `setupElectronAPI`, `flushPromises`) live in `__test__/helpers/testHarness.tsx`.
 
 ### Required mocks
 
@@ -231,13 +245,36 @@ vi.mock('../hooks/useCueMol', () => ({
 }));
 ```
 
-To mock `window.electronAPI` (jsdom: `window === globalThis`):
+To mock `window.electronAPI`, use the helper (matches the post-B `invoke` / `onPush` shape):
 
 ```ts
-beforeEach(() => {
-    (window as any).electronAPI = { showNaviContextMenu: vi.fn() };
-});
+import { setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
+
+beforeEach(() => { api = setupElectronAPI() })
+afterEach(() => { teardownElectronAPI() })
+// To route a specific channel, override:
+//   setupElectronAPI({ invoke: vi.fn((c, p) => c === IPC.X ? mockX(p) : Promise.resolve()) })
 ```
+
+`setupElectronAPI` returns the mock object so you can assert on `api.invoke.mock.calls` directly.
+
+### `import React` is required at vitest runtime
+
+Vitest's JSX transform uses the **classic** runtime even when production (electron-vite) uses automatic JSX. Files containing JSX MUST `import React from 'react'`; if React isn't otherwise referenced, add `void React` after the import to silence `noUnusedLocals` without removing the runtime-required identifier.
+
+### Stabilizing callbacks in effect deps
+
+A callback prop recreated on every render (e.g. `getActiveSceneInfo: () => ({ ... })`) will retrigger a `useEffect` whose dep list includes it, which in a tab-switch fetch can race with state set by user-action callbacks (the fetch resolves *after* the user click and overwrites the new value). When an effect needs to *read* a callback but should not *re-run* on its identity change, capture it via a ref:
+
+```ts
+const cbRef = useRef(callback)
+cbRef.current = callback
+useEffect(() => {
+  // ... use cbRef.current() instead of callback ...
+}, [/* identity-stable deps only */])
+```
+
+`hooks/useActiveViewState.ts` uses this pattern for `getActiveSceneInfo`.
 
 ### React 18 + fake timers
 
@@ -256,11 +293,16 @@ act(() => { timerCb!(); });
 
 ### AsyncCueMol dispatch summary
 
-| Method | Response awaited | Counted as pending |
-|--------|------------------|--------------------|
-| `invokeWorker` | Yes (Promise) | Yes — `isBusy()` / `subscribeBusy()` |
-| `invokeWorkerWithTransfer` | Yes (Promise) | No — used only by `bindCanvas` |
-| `resized`, `onMouseEvent`, `onWheelEvent`, `onGestureEvent` | No (fire-and-forget) | No |
+Prefer the typed helpers (`invokeService`, `invokeMethodTyped`, `invokeRpc`) — they pin the args/result shape against `WorkerCalls.ts`. The untyped `invokeWorker` is a low-level escape hatch that returns the raw response array tail.
+
+| Method | Maps to | Awaits | Pending count |
+|--------|---------|--------|---------------|
+| `invokeService<K>(name, args)` | `ServiceMap[K]` | Yes | Yes |
+| `invokeMethodTyped<K>(name, ...args)` | `MethodMap[K]` | Yes | Yes |
+| `invokeRpc<K>(name, ...args)` | `RpcMap[K]` (used by `ObjProxy`) | Yes | Yes |
+| `invokeWorker(method, ...args)` | none — raw transport | Yes | Yes — `isBusy()` / `subscribeBusy()` |
+| `invokeWorkerWithTransfer` | raw transport with transferable | Yes | No — used only by `bindCanvas` |
+| `resized`, `onMouseEvent`, `onWheelEvent`, `onGestureEvent` | direct `postMessage` | No (fire-and-forget) | No |
 
 ### getService from renderer
 
@@ -276,3 +318,34 @@ expect(sut.stereoMode as unknown as string).toBe('none');
 ```
 
 Do not edit generated wrapper files — they are overwritten at build time.
+
+---
+
+## Per-dialog factory pattern
+
+`hooks/useDialogFactory.tsx` exports `createDialogHook<TArgs, TResult>({ render, name })` which returns a `Provider` and `useShow` pair. Each dialog gets its own provider file under `components/dialogs/XxxDialogProvider.tsx` (or `components/.../XxxDialogProvider.tsx` for nested groups), and `contexts/DialogContext.tsx` mounts them as a composite.
+
+```tsx
+// components/dialogs/AboutDialogProvider.tsx
+import React from 'react'
+import { AboutDialog } from './AboutDialog'
+import { createDialogHook } from '../../hooks/useDialogFactory'
+void React  // required by classic JSX runtime in vitest
+
+export const { Provider: AboutDialogProvider, useShow: useShowAboutDialog } =
+  createDialogHook<void, void>({
+    name: 'AboutDialog',
+    render: ({ visible, resolve }) => (
+      <AboutDialog visible={visible} onClose={() => resolve()} />
+    ),
+  })
+```
+
+Caller side:
+
+```ts
+const showAbout = useShowAboutDialog()  // (args) => Promise<result>
+await showAbout()
+```
+
+The render-prop maps the dialog's existing `onConfirm`/`onCancel`/`onClose` props to a single `resolve(result)` call. Existing `Xxx.tsx` dialog components do **not** need to change — only the provider wrapper.

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -2,8 +2,8 @@
  * IPC handler registration for the Electron main process.
  *
  * Call `registerIpcHandlers(mainWindow)` once after the BrowserWindow is
- * created. All channel names are imported from `shared/ipcChannels` so there
- * are no magic strings here.
+ * created. All channel names come from `shared/ipcChannels` and request /
+ * response shapes from `shared/ipcContract`.
  */
 
 import { ipcMain, app, dialog } from 'electron'
@@ -11,10 +11,34 @@ import type { BrowserWindow } from 'electron'
 import path from 'path'
 import fs from 'fs'
 import { IPC } from '../shared/ipcChannels'
-import type { LayoutState, FileDialogOptions, NaviCtxMenuPayload, MenuState } from '../shared/ipcTypes'
+import type {
+  InvokeChannel,
+  InvokeReq,
+  InvokeRes,
+} from '../shared/ipcContract'
+import type { FileDialogOptions } from '../shared/ipcTypes'
 import { loadLayout, saveLayout, loadUi, saveUi } from './stateStore'
 import { showNaviContextMenu } from './naviContextMenu'
 import { updateMenuState } from './menu'
+
+// ─────────────────────────────────────────────
+// Typed handle wrapper
+// ─────────────────────────────────────────────
+
+/**
+ * Type-safe wrapper for `ipcMain.handle`. Picks request / response types from
+ * `InvokeChannels` so adding a channel only requires adding a map entry plus a
+ * handler call.
+ */
+function handleInvoke<C extends InvokeChannel>(
+  channel: C,
+  handler: (
+    event: Electron.IpcMainInvokeEvent,
+    req: InvokeReq<C>,
+  ) => InvokeRes<C> | Promise<InvokeRes<C>>,
+): void {
+  ipcMain.handle(channel, handler as Parameters<typeof ipcMain.handle>[1])
+}
 
 // ─────────────────────────────────────────────
 // Helpers
@@ -69,7 +93,7 @@ export async function handleOpenFile(mainWindow: BrowserWindow, options: FileDia
 // ─────────────────────────────────────────────
 
 export function registerIpcHandlers(mainWindow: BrowserWindow): void {
-  ipcMain.handle(IPC.APP_PATH, async () => {
+  handleInvoke(IPC.APP_PATH, async () => {
     const userStylePath = getUserStylePath()
     let userStyleExists = false
     try {
@@ -88,27 +112,25 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
     }
   })
 
-  ipcMain.handle(IPC.DIALOG_OPEN, async (_event, options: FileDialogOptions) => {
+  handleInvoke(IPC.DIALOG_OPEN, async (_event, options) => {
     await handleOpenFile(mainWindow, options)
   })
 
-  ipcMain.handle(IPC.LAYOUT_LOAD, async (): Promise<LayoutState | null> => {
-    return loadLayout() ?? null
-  })
+  handleInvoke(IPC.LAYOUT_LOAD, async () => loadLayout() ?? null)
 
-  ipcMain.handle(IPC.LAYOUT_SAVE, async (_event, layout: LayoutState): Promise<void> => {
+  handleInvoke(IPC.LAYOUT_SAVE, async (_event, layout) => {
     saveLayout(layout)
   })
 
-  ipcMain.handle(IPC.UI_LOAD, () => loadUi())
-  ipcMain.handle(IPC.UI_SAVE, (_e, state) => saveUi(state))
-  ipcMain.handle(IPC.MENU_UPDATE_STATE, (_e, state: MenuState) => updateMenuState(state))
+  handleInvoke(IPC.UI_LOAD, () => loadUi())
+  handleInvoke(IPC.UI_SAVE, (_e, state) => saveUi(state))
+  handleInvoke(IPC.MENU_UPDATE_STATE, (_e, state) => updateMenuState(state))
 
-  ipcMain.handle(IPC.NAVI_CTX_SHOW, (_event, payload: NaviCtxMenuPayload) =>
+  handleInvoke(IPC.NAVI_CTX_SHOW, (_event, payload) =>
     showNaviContextMenu(mainWindow, payload),
   )
 
-  ipcMain.handle(IPC.MENU_INVOKE_ROLE, (_event, role: string) => {
+  handleInvoke(IPC.MENU_INVOKE_ROLE, (_event, role) => {
     const wc = mainWindow.webContents
     switch (role) {
       case 'reload': wc.reload(); break

--- a/tritium/react-gui/src/main/menu.ts
+++ b/tritium/react-gui/src/main/menu.ts
@@ -107,7 +107,7 @@ export function createMenu(mainWindow: BrowserWindow): void {
         {
           label: app.name,
           submenu: [
-            { id: 'about-mac', label: `About ${app.name}`, ipcChannel: 'menu:about' },
+            { id: 'about-mac', label: `About ${app.name}`, ipcChannel: IPC.MENU_ABOUT },
             { type: 'separator' },
             { id: 'mac-prefs', label: 'Preferences...', accelerator: 'Cmd+,', ipcChannel: 'menu:options' },
             { type: 'separator' },

--- a/tritium/react-gui/src/preload/index.ts
+++ b/tritium/react-gui/src/preload/index.ts
@@ -1,130 +1,37 @@
 /**
- * Electron preload script — bridges the sandboxed renderer process to the
- * privileged main process via IPC.
+ * Electron preload script — bridges the sandboxed renderer to the privileged
+ * main process via IPC.
  *
- * All types are imported from `shared/ipcTypes` and all channel names from
- * `shared/ipcChannels` so there is a single source of truth for the contract.
- * The API is exposed on `window.electronAPI`.
+ * The renderer-facing API is two generic helpers (`invoke` for renderer→main
+ * request/reply and `onPush` for main→renderer notifications) backed by the
+ * typed channel maps in `shared/ipcContract.ts`. There is no per-channel
+ * method; every new channel is one entry in the map.
  */
 
 import { contextBridge, ipcRenderer } from 'electron'
 import type {
-  FileOpenedData,
-  FileErrorData,
-  FileDialogOptions,
-  LayoutState,
-  UiState,
   ElectronAPI,
-  NaviCtxMenuPayload,
-  MenuState,
-} from '../shared/ipcTypes'
-import { IPC } from '../shared/ipcChannels'
-
-// ─────────────────────────────────────────────
-// API implementation
-// ─────────────────────────────────────────────
+  InvokeArgs,
+  InvokeChannel,
+  InvokeRes,
+  PushCallback,
+  PushChannel,
+} from '../shared/ipcContract'
 
 const api: ElectronAPI = {
   platform: process.platform,
 
-  // App path info
-  getAppPathInfo: () => ipcRenderer.invoke(IPC.APP_PATH),
-
-  // File operations
-  openFile: (options: FileDialogOptions) => ipcRenderer.invoke(IPC.DIALOG_OPEN, options),
-
-  // Menu event listeners
-  onObjFileOpened: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: FileOpenedData) => callback(data)
-    ipcRenderer.on(IPC.OBJ_FILE_OPENED, handler)
-    return () => ipcRenderer.removeListener(IPC.OBJ_FILE_OPENED, handler)
+  invoke<C extends InvokeChannel>(channel: C, ...args: InvokeArgs<C>): Promise<InvokeRes<C>> {
+    return ipcRenderer.invoke(channel, ...args) as Promise<InvokeRes<C>>
   },
 
-  onSceneFileOpened: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: FileOpenedData) => callback(data)
-    ipcRenderer.on(IPC.SCENE_FILE_OPENED, handler)
-    return () => ipcRenderer.removeListener(IPC.SCENE_FILE_OPENED, handler)
+  onPush<C extends PushChannel>(channel: C, callback: PushCallback<C>): () => void {
+    const handler = (_event: Electron.IpcRendererEvent, ...payload: unknown[]) => {
+      ;(callback as (...a: unknown[]) => void)(...payload)
+    }
+    ipcRenderer.on(channel, handler)
+    return () => ipcRenderer.removeListener(channel, handler)
   },
-
-  onFileError: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: FileErrorData) => callback(data)
-    ipcRenderer.on(IPC.FILE_ERROR, handler)
-    return () => ipcRenderer.removeListener(IPC.FILE_ERROR, handler)
-  },
-
-  onMenuNewTab: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_NEW_TAB, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_NEW_TAB, handler)
-  },
-
-  onMenuCloseTab: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_CLOSE_TAB, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_CLOSE_TAB, handler)
-  },
-
-  onMenuSave: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_SAVE, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_SAVE, handler)
-  },
-
-  onMenuNewScene: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_NEW_SCENE, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_NEW_SCENE, handler)
-  },
-
-  onMenuOpenFile: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_OPEN_FILE, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_OPEN_FILE, handler)
-  },
-
-  onMenuOpenScene: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_OPEN_SCENE, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_OPEN_SCENE, handler)
-  },
-
-  onMenuUndo: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_UNDO, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_UNDO, handler)
-  },
-
-  onMenuRedo: (callback) => {
-    const handler = () => callback()
-    ipcRenderer.on(IPC.MENU_REDO, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_REDO, handler)
-  },
-
-  onMenuGeneric: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, channel: string) => callback(channel)
-    ipcRenderer.on(IPC.MENU_GENERIC, handler)
-    return () => ipcRenderer.removeListener(IPC.MENU_GENERIC, handler)
-  },
-
-  invokeMenuRole: (role: string) => ipcRenderer.invoke(IPC.MENU_INVOKE_ROLE, role),
-  updateMenuState: (state: MenuState) => ipcRenderer.invoke(IPC.MENU_UPDATE_STATE, state),
-
-  showNaviContextMenu: (payload: NaviCtxMenuPayload) =>
-    ipcRenderer.invoke(IPC.NAVI_CTX_SHOW, payload),
-
-  onRotateGesture: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, rotation: number) => callback(rotation)
-    ipcRenderer.on(IPC.ROTATE_GESTURE, handler)
-    return () => ipcRenderer.removeListener(IPC.ROTATE_GESTURE, handler)
-  },
-
-  // Layout persistence
-  loadLayout: () => ipcRenderer.invoke(IPC.LAYOUT_LOAD),
-  saveLayout: (state: LayoutState) => ipcRenderer.invoke(IPC.LAYOUT_SAVE, state),
-
-  // UI preferences persistence
-  loadUi: () => ipcRenderer.invoke(IPC.UI_LOAD),
-  saveUi: (state: Partial<UiState>) => ipcRenderer.invoke(IPC.UI_SAVE, state),
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -2,10 +2,14 @@
  * Root component of the CueMol desktop application.
  *
  * Layout: Toolbar / [ActivityBar | SidePanel | [ContentArea / BottomPanel] | InspectorPanel] / StatusBar
+ *
+ * Most domain wiring lives in extracted hooks:
+ *   - useAppInitialization      — first scene/view on launch (StrictMode guarded)
+ *   - useActiveViewState        — viewProjection / centerMark / bgColor cache + menu sync
+ *   - useCommandRegistrations   — registers all CmdId handlers + Electron IPC bridge
  */
 
-import React, { useState, useCallback, useEffect, useRef } from "react";
-import type { SceneManager } from "@cuemol/core/src/wrappers/SceneManager";
+import React, { useState, useCallback, useEffect } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 
@@ -19,7 +23,6 @@ import { StatusBar } from "./components/StatusBar";
 import { InspectorPanel } from "./components/panels/InspectorPanel";
 
 import type { AlignmentData, AnimationData } from "./types";
-import type { SceneBgColor, ViewCenterMark } from "../shared/ipcTypes";
 
 import { SAMPLE_ALIGNMENT, SAMPLE_ANIMATION } from "./data/alignmentData";
 
@@ -31,17 +34,13 @@ import { useInspectorState } from "./hooks/useInspectorState";
 import { useTabManager } from "./hooks/useTabManager";
 import { useCueMol } from "./hooks/useCueMol";
 import { useMolTabDispatch } from "./hooks/useMolTab";
-import { useElectronIpc } from "./hooks/useElectronIpc";
-import { useSceneCommands } from "./commands/useSceneCommands";
-import { useUiDialogCommands } from "./commands/useUiDialogCommands";
-import { useTabCommands } from "./commands/useTabCommands";
-import { useNewTabCommand } from "./commands/useNewTabCommand";
-import { useEditCommands } from "./commands/useEditCommands";
-import { useViewCommands } from "./commands/useViewCommands";
+import { useAppInitialization } from "./hooks/useAppInitialization";
+import { useActiveViewState } from "./hooks/useActiveViewState";
+import { useCommandRegistrations } from "./hooks/useCommandRegistrations";
 import { useCommands } from "./commands/CommandRegistry";
 import { CmdId } from "./commands/ids";
 import { useCueMolBusy } from "./hooks/useCueMolBusy";
-import { useDialog } from "./contexts/DialogContext";
+import { useShowConfirmCloseTabDialog } from "./components/dialogs/ConfirmCloseTabDialogProvider";
 
 const App: React.FC = () => {
 
@@ -96,11 +95,11 @@ const App: React.FC = () => {
     resolveNodeName,
   });
 
-  // --- CueMol core ready: create initial scene/view ---
+  // --- CueMol core / tabs ---
 
   const { cueMolReady, cm } = useCueMol();
   const { addMolTab, removeMolTab, getActiveSceneInfo, setActiveViewByID } = useMolTabDispatch();
-  const { showConfirmCloseTabDialog } = useDialog();
+  const showConfirmCloseTabDialog = useShowConfirmCloseTabDialog();
 
   const handleMolViewClose = useCallback((viewId: number) => {
     removeMolTab(viewId);
@@ -135,34 +134,10 @@ const App: React.FC = () => {
     handleSave,
   } = useTabManager({ onMolViewClose: handleMolViewClose, confirmCloseTab });
 
-  // Guard to prevent duplicate initial scene creation (React StrictMode)
-  const initialSceneCreatedRef = useRef(false);
+  // First scene/view on launch (StrictMode guarded)
+  useAppInitialization({ cm, cueMolReady, addMolTab, addMolViewTab });
 
-  useEffect(() => {
-    if (!cueMolReady || !cm) return;
-    if (initialSceneCreatedRef.current) return;
-    initialSceneCreatedRef.current = true;
-
-    let cancelled = false;
-    (async () => {
-      const sceMgr = (await cm.getService('SceneManager')) as SceneManager;
-      if (!sceMgr || cancelled) return;
-      const scene = await sceMgr.createScene();
-      const scene_uid = await scene.getUID();
-      const view = await scene.createView();
-      const view_uid = await view.getUID();
-      if (cancelled) return;
-      const title = `Scene ${scene_uid}`;
-      // Register in MolTabState first so MolViewPane can read getActiveViewID()
-      addMolTab(title, view_uid, scene_uid);
-      // Open the outer tab (causes ContentPane to mount MolViewPane)
-      addMolViewTab(title, view_uid);
-    })();
-    return () => { cancelled = true; };
-  }, [cueMolReady, cm, addMolTab, addMolViewTab]);
-
-  // --- Activate view when molview tab becomes active ---
-
+  // Activate worker view when a molview tab becomes active.
   useEffect(() => {
     const tab = tabs.find((t) => t.id === activeTab);
     if (tab?.type === 'molview' && tab.viewId !== undefined && cm && cueMolReady) {
@@ -171,76 +146,36 @@ const App: React.FC = () => {
     }
   }, [activeTab, tabs, cm, cueMolReady, setActiveViewByID]);
 
-  // --- Sample data ---
-
-  const [alignment] = useState<AlignmentData | null>(SAMPLE_ALIGNMENT);
-  const [animation] = useState<AnimationData | null>(SAMPLE_ANIMATION);
-  const [viewProjection, setViewProjection] = useState<boolean | null>(null);
-  const [viewCenterMark, setViewCenterMark] = useState<ViewCenterMark | null>(null);
-  const [sceneBgColor, setSceneBgColor] = useState<SceneBgColor | null>(null);
   const activeMolViewId = tabs.find((t) => t.id === activeTab && t.type === 'molview')?.viewId;
 
-  const syncNativeViewMenu = useCallback((state: {
-    perspective?: boolean | null;
-    centerMark?: ViewCenterMark | null;
-    bgColor?: SceneBgColor | null;
-  }) => {
-    window.electronAPI?.updateMenuState({
-      ...(state.perspective !== undefined
-        ? { viewProjection: { enabled: state.perspective !== null, perspective: state.perspective } }
-        : {}),
-      ...(state.centerMark !== undefined
-        ? { viewCenterMark: { enabled: state.centerMark !== null, centerMark: state.centerMark } }
-        : {}),
-      ...(state.bgColor !== undefined
-        ? { sceneBgColor: { enabled: state.bgColor !== null, bgColor: state.bgColor } }
-        : {}),
-    }).catch((err: unknown) => {
-      console.warn('update menu state failed:', err);
-    });
-  }, []);
+  // --- View-state cache for the active molview tab ---
+  const {
+    viewProjection,
+    viewCenterMark,
+    sceneBgColor,
+    onProjectionChanged,
+    onCenterMarkChanged,
+    onBgColorChanged,
+  } = useActiveViewState({ cm, activeMolViewId, getActiveSceneInfo });
 
-  const handleProjectionChanged = useCallback((perspective: boolean) => {
-    setViewProjection(perspective);
-    syncNativeViewMenu({ perspective });
-  }, [syncNativeViewMenu]);
-
-  const handleCenterMarkChanged = useCallback((centerMark: ViewCenterMark) => {
-    setViewCenterMark(centerMark);
-    syncNativeViewMenu({ centerMark });
-  }, [syncNativeViewMenu]);
-
-  const handleBgColorChanged = useCallback((bgColor: SceneBgColor) => {
-    setSceneBgColor(bgColor);
-    syncNativeViewMenu({ bgColor });
-  }, [syncNativeViewMenu]);
-
-  // --- Command registrations and IPC wiring ---
-
-  useSceneCommands({
+  // --- All command handlers + Electron IPC bridge ---
+  useCommandRegistrations({
     cm,
     addMolTab,
     addMolViewTab,
     getActiveSceneInfo,
-    onBgColorChanged: handleBgColorChanged,
+    handleCloseTab,
+    handleSave,
+    activeTab,
+    activeMolViewId,
+    onProjectionChanged,
+    onCenterMarkChanged,
+    onBgColorChanged,
   });
 
-  useUiDialogCommands({ cm });
-
-  useTabCommands({ handleCloseTab });
-
-  useNewTabCommand({ cm, addMolTab, addMolViewTab, getActiveSceneInfo });
-
-  useEditCommands({ cm, getActiveSceneInfo, handleSave });
-
-  useViewCommands({
-    cm,
-    getActiveViewId: () => activeMolViewId,
-    onProjectionChanged: handleProjectionChanged,
-    onCenterMarkChanged: handleCenterMarkChanged,
-  });
-
-  useElectronIpc(activeTab);
+  // --- Sample data ---
+  const [alignment] = useState<AlignmentData | null>(SAMPLE_ALIGNMENT);
+  const [animation] = useState<AnimationData | null>(SAMPLE_ANIMATION);
 
   const cueMolBusy = useCueMolBusy();
   const { dispatch: dispatchCommand } = useCommands();
@@ -254,45 +189,6 @@ const App: React.FC = () => {
       document.documentElement.style.setProperty("--titlebar-inset", "78px");
     }
   }, []);
-
-  useEffect(() => {
-    if (!cm || activeMolViewId === undefined) {
-      setViewProjection(null);
-      setViewCenterMark(null);
-      setSceneBgColor(null);
-      syncNativeViewMenu({ perspective: null, centerMark: null, bgColor: null });
-      return;
-    }
-
-    const sceneInfo = getActiveSceneInfo();
-    const sceneId = sceneInfo?.scene_uid;
-
-    let cancelled = false;
-    Promise.all([
-      cm.getViewProjection(activeMolViewId),
-      cm.getViewCenterMark(activeMolViewId),
-      sceneId !== undefined ? cm.getSceneBgColor(sceneId) : Promise.resolve(null),
-    ]).then(([projectionResult, centerMarkResult, bgColorResult]) => {
-      if (cancelled) return;
-      const perspective = projectionResult?.ok ? projectionResult.perspective : null;
-      const centerMark = centerMarkResult?.ok ? centerMarkResult.centerMark : null;
-      const bgColor = bgColorResult?.ok ? bgColorResult.bgColor : null;
-      setViewProjection(perspective);
-      setViewCenterMark(centerMark);
-      setSceneBgColor(bgColor);
-      syncNativeViewMenu({ perspective, centerMark, bgColor });
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        console.warn('get view state failed:', err);
-        setViewProjection(null);
-        setViewCenterMark(null);
-        setSceneBgColor(null);
-        syncNativeViewMenu({ perspective: null, centerMark: null, bgColor: null });
-      }
-    });
-
-    return () => { cancelled = true; };
-  }, [activeMolViewId, cm, syncNativeViewMenu, getActiveSceneInfo]);
 
   // --- Derived sidebar sub-panel state ---
 

--- a/tritium/react-gui/src/renderer/__test__/NaviContextMenu.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/NaviContextMenu.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
 import { useNaviContextMenu } from '../hooks/useNaviContextMenu';
+import { IPC } from '../../shared/ipcChannels';
 
 vi.mock('@cuemol/core/src/wrappers/wrapper-loader', () => ({ wrapper_map: {} }));
 vi.mock('@cuemol/core/src/BaseWrapper', () => ({ BaseWrapper: class {} }));
@@ -68,8 +69,14 @@ let hookHandle: ReturnType<typeof makeRenderHook<ReturnType<typeof useNaviContex
 beforeEach(() => {
     vi.clearAllMocks();
     mockShowMenu.mockResolvedValue(null);
-    // In jsdom window === globalThis, so set electronAPI directly on window
-    (window as any).electronAPI = { showNaviContextMenu: mockShowMenu };
+    // After B, electronAPI exposes a generic `invoke(channel, payload)`. Route
+    // NAVI_CTX_SHOW through to mockShowMenu so existing assertions on the
+    // payload object remain valid.
+    (window as any).electronAPI = {
+      invoke: vi.fn((channel: string, payload: unknown) =>
+        channel === IPC.NAVI_CTX_SHOW ? mockShowMenu(payload) : Promise.resolve(),
+      ),
+    };
     hookHandle = makeRenderHook(() => useNaviContextMenu());
 });
 

--- a/tritium/react-gui/src/renderer/__test__/activeViewState.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/activeViewState.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Degrade-detection test for useActiveViewState (extracted in E from
+ * App.tsx's inline view-state polling).
+ *
+ * Pins the contract that App.tsx and MenuBar rely on:
+ *   1. No active molview tab → all three values are null and the native menu
+ *      is told all three controls are disabled (`enabled: false`).
+ *   2. Active molview tab → cm.getView{Projection,CenterMark} and
+ *      cm.getSceneBgColor are called, results update the cache and a single
+ *      `MENU_UPDATE_STATE` invoke is issued with the fetched values.
+ *   3. onProjectionChanged / onCenterMarkChanged / onBgColorChanged callbacks
+ *      update only their own slice of the cache and send a partial
+ *      MENU_UPDATE_STATE.
+ *
+ * After E's optional subscribe-pattern follow-up (worker-side per-property
+ * change events), the *internals* of useActiveViewState change but the
+ * observable contract above must still hold for these tests to keep passing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import type { AsyncCueMol } from '../worker/client/AsyncCueMol'
+import { useActiveViewState } from '../hooks/useActiveViewState'
+import { IPC } from '../../shared/ipcChannels'
+import { makeRenderHook, flushPromises, setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
+
+interface MockCm {
+  getViewProjection: ReturnType<typeof vi.fn>
+  getViewCenterMark: ReturnType<typeof vi.fn>
+  getSceneBgColor: ReturnType<typeof vi.fn>
+}
+
+function makeMockCm(overrides: Partial<MockCm> = {}): MockCm {
+  return {
+    getViewProjection: vi.fn().mockResolvedValue({ ok: true, perspective: true }),
+    getViewCenterMark: vi.fn().mockResolvedValue({ ok: true, centerMark: 'crosshair' }),
+    getSceneBgColor: vi.fn().mockResolvedValue({ ok: true, bgColor: 'white' }),
+    ...overrides,
+  }
+}
+
+describe('useActiveViewState', () => {
+  let api: ReturnType<typeof setupElectronAPI>
+
+  beforeEach(() => {
+    api = setupElectronAPI()
+  })
+
+  afterEach(() => {
+    teardownElectronAPI()
+    vi.restoreAllMocks()
+  })
+
+  it('no active molview tab → all nulls + menu state disabled', async () => {
+    const cm = makeMockCm()
+    const h = makeRenderHook(() =>
+      useActiveViewState({
+        cm: cm as unknown as AsyncCueMol,
+        activeMolViewId: undefined,
+        getActiveSceneInfo: () => null,
+      }),
+    )
+
+    await flushPromises()
+
+    expect(h.result.viewProjection).toBeNull()
+    expect(h.result.viewCenterMark).toBeNull()
+    expect(h.result.sceneBgColor).toBeNull()
+    expect(cm.getViewProjection).not.toHaveBeenCalled()
+
+    const lastInvoke = api.invoke.mock.calls.at(-1)
+    expect(lastInvoke?.[0]).toBe(IPC.MENU_UPDATE_STATE)
+    const state = lastInvoke?.[1] as Record<string, { enabled: boolean }>
+    expect(state.viewProjection.enabled).toBe(false)
+    expect(state.viewCenterMark.enabled).toBe(false)
+    expect(state.sceneBgColor.enabled).toBe(false)
+
+    h.unmount()
+  })
+
+  it('active molview tab → fetches all three, updates cache, syncs menu', async () => {
+    const cm = makeMockCm({
+      getViewProjection: vi.fn().mockResolvedValue({ ok: true, perspective: false }),
+      getViewCenterMark: vi.fn().mockResolvedValue({ ok: true, centerMark: 'axis' }),
+      getSceneBgColor: vi.fn().mockResolvedValue({ ok: true, bgColor: 'black' }),
+    })
+    const h = makeRenderHook(() =>
+      useActiveViewState({
+        cm: cm as unknown as AsyncCueMol,
+        activeMolViewId: 5,
+        getActiveSceneInfo: () => ({ scene_uid: 1, view_id: 5 }),
+      }),
+    )
+
+    await flushPromises()
+
+    expect(cm.getViewProjection).toHaveBeenCalledWith(5)
+    expect(cm.getViewCenterMark).toHaveBeenCalledWith(5)
+    expect(cm.getSceneBgColor).toHaveBeenCalledWith(1)
+
+    expect(h.result.viewProjection).toBe(false)
+    expect(h.result.viewCenterMark).toBe('axis')
+    expect(h.result.sceneBgColor).toBe('black')
+
+    const menuStateInvoke = api.invoke.mock.calls.find(
+      (c: unknown[]) => c[0] === IPC.MENU_UPDATE_STATE
+        && (c[1] as Record<string, { centerMark?: string }>)?.viewCenterMark?.centerMark === 'axis',
+    )
+    expect(menuStateInvoke).toBeTruthy()
+    const state = menuStateInvoke![1] as Record<string, { enabled: boolean; perspective?: boolean; centerMark?: string; bgColor?: string }>
+    expect(state.viewProjection).toEqual({ enabled: true, perspective: false })
+    expect(state.viewCenterMark).toEqual({ enabled: true, centerMark: 'axis' })
+    expect(state.sceneBgColor).toEqual({ enabled: true, bgColor: 'black' })
+
+    h.unmount()
+  })
+
+  it('failed fetch (rejection) → all nulls + disabled menu', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const cm = makeMockCm({
+      getViewProjection: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const h = makeRenderHook(() =>
+      useActiveViewState({
+        cm: cm as unknown as AsyncCueMol,
+        activeMolViewId: 5,
+        getActiveSceneInfo: () => ({ scene_uid: 1, view_id: 5 }),
+      }),
+    )
+
+    await flushPromises()
+
+    expect(h.result.viewProjection).toBeNull()
+    expect(h.result.viewCenterMark).toBeNull()
+    expect(h.result.sceneBgColor).toBeNull()
+
+    h.unmount()
+  })
+
+  it('onProjectionChanged updates only viewProjection + sends partial menu state', async () => {
+    const cm = makeMockCm()
+    const h = makeRenderHook(() =>
+      useActiveViewState({
+        cm: cm as unknown as AsyncCueMol,
+        activeMolViewId: 5,
+        getActiveSceneInfo: () => ({ scene_uid: 1, view_id: 5 }),
+      }),
+    )
+
+    await flushPromises()
+    api.invoke.mockClear()
+
+    await act(async () => {
+      h.result.onProjectionChanged(false)
+    })
+    await flushPromises()
+
+    expect(h.result.viewProjection).toBe(false)
+    // The other two values should not be re-fetched on a setter callback
+    const projInvoke = api.invoke.mock.calls.at(-1)
+    expect(projInvoke?.[0]).toBe(IPC.MENU_UPDATE_STATE)
+    const state = projInvoke?.[1] as Record<string, unknown>
+    expect(state.viewProjection).toEqual({ enabled: true, perspective: false })
+    expect(state.viewCenterMark).toBeUndefined()
+    expect(state.sceneBgColor).toBeUndefined()
+
+    h.unmount()
+  })
+
+  it('onBgColorChanged updates only sceneBgColor', async () => {
+    const cm = makeMockCm()
+    const h = makeRenderHook(() =>
+      useActiveViewState({
+        cm: cm as unknown as AsyncCueMol,
+        activeMolViewId: 5,
+        getActiveSceneInfo: () => ({ scene_uid: 1, view_id: 5 }),
+      }),
+    )
+
+    await flushPromises()
+    api.invoke.mockClear()
+
+    await act(async () => {
+      h.result.onBgColorChanged('black')
+    })
+    await flushPromises()
+
+    expect(h.result.sceneBgColor).toBe('black')
+    const lastInvoke = api.invoke.mock.calls.at(-1)
+    const state = lastInvoke?.[1] as Record<string, unknown>
+    expect(state.sceneBgColor).toEqual({ enabled: true, bgColor: 'black' })
+    expect(state.viewProjection).toBeUndefined()
+    expect(state.viewCenterMark).toBeUndefined()
+
+    h.unmount()
+  })
+
+  it('failed `ok: false` projection → null without throwing', async () => {
+    const cm = makeMockCm({
+      getViewProjection: vi.fn().mockResolvedValue({ ok: false, perspective: false }),
+    })
+    const h = makeRenderHook(() =>
+      useActiveViewState({
+        cm: cm as unknown as AsyncCueMol,
+        activeMolViewId: 5,
+        getActiveSceneInfo: () => ({ scene_uid: 1, view_id: 5 }),
+      }),
+    )
+
+    await flushPromises()
+
+    expect(h.result.viewProjection).toBeNull()
+    // CenterMark and bgColor still resolve normally
+    expect(h.result.viewCenterMark).toBe('crosshair')
+    expect(h.result.sceneBgColor).toBe('white')
+
+    h.unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/asyncCueMolInvoke.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/asyncCueMolInvoke.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Degrade-detection test for AsyncCueMol invokeWorker contract.
+ *
+ * Refactor target: C (ServiceMap + MethodMap typing). After C, invokeWorker
+ * becomes generic over a ServiceMap. The runtime wire format
+ * (postMessage payload, response shape [method, seqno, ok, ...result]) must
+ * stay identical so that the worker side is unaffected.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@cuemol/core/src/wrappers/wrapper-loader', () => ({ wrapper_map: {} }))
+vi.mock('@cuemol/core/src/BaseWrapper', () => ({ BaseWrapper: class { constructor() {} } }))
+
+let capturedWorker: MockWorker | null = null
+
+class MockWorker {
+  onmessage: ((ev: MessageEvent) => any) | null = null
+  postMessage = vi.fn()
+  terminate = vi.fn()
+  constructor(_url: any) { capturedWorker = this }
+  respond(method: string, seqno: number, ok: boolean, ...result: any[]): void {
+    this.onmessage?.({ data: [method, seqno, ok, ...result] } as MessageEvent)
+  }
+}
+
+import { AsyncCueMol } from '../worker/client/AsyncCueMol'
+
+function lastSent(): { method: string; seqno: number; args: unknown[] } {
+  const calls = capturedWorker!.postMessage.mock.calls
+  const payload = calls[calls.length - 1][0] as any[]
+  return { method: payload[0], seqno: payload[1], args: payload.slice(2) }
+}
+
+describe('AsyncCueMol.invokeWorker -- wire contract', () => {
+  let cm: AsyncCueMol
+
+  beforeEach(() => {
+    capturedWorker = null
+    vi.stubGlobal('Worker', MockWorker)
+    cm = new AsyncCueMol()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('postMessage payload is [method, seqno, ...args]', () => {
+    cm.invokeWorker('myService', { foo: 1 }, 42)
+    const sent = lastSent()
+    expect(sent.method).toBe('myService')
+    expect(typeof sent.seqno).toBe('number')
+    expect(sent.args).toEqual([{ foo: 1 }, 42])
+  })
+
+  it('successful response resolves with the full result tail array', async () => {
+    const promise = cm.invokeWorker('svc')
+    const sent = lastSent()
+    capturedWorker!.respond(sent.method, sent.seqno, true, 'a', 'b', 3)
+    const result = await promise
+    expect(result).toEqual(['a', 'b', 3])
+  })
+
+  it('failed response rejects with the error message', async () => {
+    const promise = cm.invokeWorker('svc')
+    const sent = lastSent()
+    capturedWorker!.respond(sent.method, sent.seqno, false, 'boom')
+    await expect(promise).rejects.toBeDefined()
+  })
+
+  it('seqno increments per call', () => {
+    cm.invokeWorker('a')
+    const s1 = lastSent().seqno
+    cm.invokeWorker('b')
+    const s2 = lastSent().seqno
+    expect(s2).toBeGreaterThan(s1)
+  })
+
+  it('concurrent calls resolve independently in any order', async () => {
+    const p1 = cm.invokeWorker('first')
+    const sent1 = lastSent()
+    const p2 = cm.invokeWorker('second')
+    const sent2 = lastSent()
+
+    capturedWorker!.respond(sent2.method, sent2.seqno, true, 'second-result')
+    capturedWorker!.respond(sent1.method, sent1.seqno, true, 'first-result')
+
+    expect(await p1).toEqual(['first-result'])
+    expect(await p2).toEqual(['second-result'])
+  })
+
+  it('invokeWorkerWithTransfer routes the same wire format with transfer list', () => {
+    const buf = new ArrayBuffer(8)
+    // Per WorkerTransport.postMessage, the `transfer` arg is a single
+    // transferable that the implementation wraps as [transfer] for postMessage.
+    cm.invokeWorkerWithTransfer('bind', buf, buf, 1)
+    const calls = capturedWorker!.postMessage.mock.calls
+    const lastCall = calls[calls.length - 1]
+    const payload = lastCall[0] as any[]
+    expect(payload[0]).toBe('bind')
+    expect(typeof payload[1]).toBe('number')
+    expect(payload.slice(2)).toEqual([buf, 1])
+    // second arg to postMessage is the transfer list (always [xfer]).
+    expect(lastCall[1]).toEqual([buf])
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/commandRegistry.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/commandRegistry.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Degrade-detection test for CommandRegistry (post-D).
+ *
+ * After D, register/dispatch are generic over CommandMap. The tests below
+ * exercise the runtime mechanics through real CmdIds:
+ *   - SceneNew:  args=void, result=void
+ *   - TabClose:  args=string, result=void
+ *   - Undo:      args=void, result=void (async handler shape)
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { CommandProvider, useCommands, useRegisterCommand } from '../commands/CommandRegistry'
+import { CmdId } from '../commands/ids'
+import { makeRenderHook, flushPromises } from './helpers/testHarness'
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+  React.createElement(CommandProvider, null, children)
+
+describe('CommandRegistry', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  afterEach(() => {
+    warnSpy?.mockRestore()
+  })
+
+  it('dispatch invokes the registered sync handler', async () => {
+    const calls: string[] = []
+    const h = makeRenderHook(() => {
+      useRegisterCommand(CmdId.SceneNew, () => { calls.push('called') })
+      return useCommands()
+    }, Wrapper)
+
+    await h.result.dispatch(CmdId.SceneNew)
+    expect(calls).toEqual(['called'])
+    h.unmount()
+  })
+
+  it('dispatch awaits Promise-returning handler', async () => {
+    const calls: number[] = []
+    const h = makeRenderHook(() => {
+      useRegisterCommand(CmdId.Undo, async () => {
+        await Promise.resolve()
+        calls.push(1)
+      })
+      return useCommands()
+    }, Wrapper)
+
+    await h.result.dispatch(CmdId.Undo)
+    expect(calls).toEqual([1])
+    h.unmount()
+  })
+
+  it('dispatch forwards typed args (TabClose: string)', async () => {
+    let received: string | undefined
+    const h = makeRenderHook(() => {
+      useRegisterCommand(CmdId.TabClose, (id) => { received = id })
+      return useCommands()
+    }, Wrapper)
+
+    await h.result.dispatch(CmdId.TabClose, 'tab-42')
+    expect(received).toBe('tab-42')
+    h.unmount()
+  })
+
+  it('dispatch on unregistered id rejects', async () => {
+    const h = makeRenderHook(() => useCommands(), Wrapper)
+    await expect(h.result.dispatch(CmdId.SceneNew)).rejects.toThrow(/unknown command/i)
+    h.unmount()
+  })
+
+  it('has() reflects registration state', async () => {
+    const h = makeRenderHook(() => {
+      useRegisterCommand(CmdId.FileSave, () => undefined)
+      return useCommands()
+    }, Wrapper)
+    await flushPromises()
+    expect(h.result.has(CmdId.FileSave)).toBe(true)
+    expect(h.result.has(CmdId.SceneNew)).toBe(false)
+    h.unmount()
+  })
+
+  it('unmount removes the registered command', async () => {
+    const h = makeRenderHook(() => {
+      useRegisterCommand(CmdId.FileSave, () => undefined)
+      return useCommands()
+    }, Wrapper)
+    await flushPromises()
+    const cmds = h.result
+    expect(cmds.has(CmdId.FileSave)).toBe(true)
+    h.unmount()
+    expect(cmds.has(CmdId.FileSave)).toBe(false)
+  })
+
+  it('overriding an existing id warns; latest handler wins', async () => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const calls: number[] = []
+    const h = makeRenderHook(() => {
+      const cmds = useCommands()
+      cmds.register(CmdId.SceneNew, () => { calls.push(1) })
+      cmds.register(CmdId.SceneNew, () => { calls.push(2) })
+      return cmds
+    }, Wrapper)
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already registered'))
+    await h.result.dispatch(CmdId.SceneNew)
+    expect(calls).toEqual([2])
+    h.unmount()
+  })
+
+  it('useCommands throws when used outside provider', () => {
+    expect(() => makeRenderHook(() => useCommands())).toThrow(/inside <CommandProvider>/)
+  })
+
+  it('handler closure sees latest value via useRegisterCommand ref', async () => {
+    let counter = 0
+    const captures: number[] = []
+    const h = makeRenderHook(() => {
+      counter += 1
+      const local = counter
+      useRegisterCommand(CmdId.SceneNew, () => { captures.push(local) })
+      return useCommands()
+    }, Wrapper)
+    h.rerender()
+    h.rerender()
+    await flushPromises()
+    await h.result.dispatch(CmdId.SceneNew)
+    expect(captures).toEqual([counter])
+    h.unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/dialogContext.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogContext.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Degrade-detection test for the per-dialog hook factory (post-F).
+ *
+ * After F, each dialog ships its own `<XxxDialogProvider>` and
+ * `useShowXxxDialog()` hook (`createDialogHook` factory). The composite
+ * `<DialogProvider>` mounts all four. The observable contract pinned here:
+ *   - `showXxx(args)` opens the dialog (Blueprint Dialog visible in the DOM)
+ *   - User clicks Confirm/Cancel/etc → Promise resolves with the right value
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+
+vi.mock('@cuemol/core/src/wrappers/wrapper-loader', () => ({ wrapper_map: {} }))
+vi.mock('@cuemol/core/src/BaseWrapper', () => ({ BaseWrapper: class {} }))
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'light' }),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}))
+vi.mock('../hooks/useCueMol', () => ({
+  useCueMol: () => ({ cueMolReady: false, cm: null }),
+}))
+
+const { DialogProvider } = await import('../contexts/DialogContext')
+const { useShowAboutDialog } = await import('../components/dialogs/AboutDialogProvider')
+const { useShowNewTabDialog } = await import('../components/dialogs/NewTabDialogProvider')
+const { useShowConfirmCloseTabDialog } = await import('../components/dialogs/ConfirmCloseTabDialogProvider')
+const { useShowFileOpenOptionDialog } = await import('../components/fopen-opt-dlgs/FileOpenOptionDialogProvider')
+
+import { mountTree, flushPromises, setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
+
+function findButtonByText(root: ParentNode, text: string): HTMLButtonElement | null {
+  const buttons = Array.from(root.querySelectorAll('button')) as HTMLButtonElement[]
+  return buttons.find((b: HTMLButtonElement) => (b.textContent ?? '').trim() === text) ?? null
+}
+
+let showAbout: () => Promise<void>
+let showNewTab: (args: { currentSceneName: string | null; defaultSceneName: string; defaultViewName: string }) => Promise<unknown>
+let showConfirmClose: (args: { sceneName: string }) => Promise<unknown>
+let showFileOpenOption: (args: { filePath: string; rendererTypes?: string[] }) => Promise<unknown>
+
+const Probe: React.FC = () => {
+  showAbout = useShowAboutDialog()
+  showNewTab = useShowNewTabDialog()
+  showConfirmClose = useShowConfirmCloseTabDialog()
+  showFileOpenOption = useShowFileOpenOptionDialog()
+  return null
+}
+
+function mount() {
+  return mountTree(
+    React.createElement(
+      DialogProvider as React.FC<{ children: React.ReactNode }>,
+      null,
+      React.createElement(Probe),
+    ),
+  )
+}
+
+describe('DialogProvider (per-dialog factory)', () => {
+  beforeEach(() => {
+    setupElectronAPI()
+  })
+  afterEach(() => {
+    teardownElectronAPI()
+    vi.restoreAllMocks()
+  })
+
+  it('useShowAboutDialog: opens, OK resolves the Promise', async () => {
+    const handle = mount()
+    let resolved = false
+    const p = showAbout().then(() => { resolved = true })
+    await flushPromises()
+
+    const okBtn = findButtonByText(document.body, 'OK')
+    expect(okBtn).toBeTruthy()
+    okBtn!.click()
+
+    await p
+    expect(resolved).toBe(true)
+    handle.unmount()
+  })
+
+  it('useShowConfirmCloseTabDialog: Cancel resolves with "cancel"', async () => {
+    const handle = mount()
+    const p = showConfirmClose({ sceneName: 'Scene_1' })
+    await flushPromises()
+
+    const cancelBtn = findButtonByText(document.body, 'Cancel')
+    expect(cancelBtn).toBeTruthy()
+    cancelBtn!.click()
+
+    expect(await p).toBe('cancel')
+    handle.unmount()
+  })
+
+  it('useShowConfirmCloseTabDialog: Don\'t Save resolves with "discard"', async () => {
+    const handle = mount()
+    const p = showConfirmClose({ sceneName: 'Scene_1' })
+    await flushPromises()
+
+    const discardBtn = findButtonByText(document.body, "Don't Save")
+    expect(discardBtn).toBeTruthy()
+    discardBtn!.click()
+
+    expect(await p).toBe('discard')
+    handle.unmount()
+  })
+
+  it('useShowNewTabDialog: Cancel resolves with null', async () => {
+    const handle = mount()
+    const p = showNewTab({
+      currentSceneName: null,
+      defaultSceneName: 'Scene_1',
+      defaultViewName: 'View_1',
+    })
+    await flushPromises()
+
+    const cancelBtn = findButtonByText(document.body, 'Cancel')
+    expect(cancelBtn).toBeTruthy()
+    cancelBtn!.click()
+
+    expect(await p).toBeNull()
+    handle.unmount()
+  })
+
+  it('useShowNewTabDialog: OK resolves with { mode: new-scene, name, inheritViewProps }', async () => {
+    const handle = mount()
+    const p = showNewTab({
+      currentSceneName: null,
+      defaultSceneName: 'Scene_1',
+      defaultViewName: 'View_1',
+    })
+    await flushPromises()
+
+    const okBtn = findButtonByText(document.body, 'OK')
+    expect(okBtn).toBeTruthy()
+    okBtn!.click()
+
+    const result = await p
+    expect(result).toEqual({ mode: 'new-scene', name: 'Scene_1', inheritViewProps: true })
+    handle.unmount()
+  })
+
+  it('useShowFileOpenOptionDialog: Cancel resolves with null', async () => {
+    const handle = mount()
+    const p = showFileOpenOption({ filePath: '/tmp/foo.pdb', rendererTypes: ['*default'] })
+    await flushPromises()
+
+    const cancelBtn = findButtonByText(document.body, 'Cancel')
+    expect(cancelBtn).toBeTruthy()
+    cancelBtn!.click()
+
+    expect(await p).toBeNull()
+    handle.unmount()
+  })
+
+  it('useShowAboutDialog throws outside its provider', () => {
+    expect(() =>
+      mountTree(React.createElement(Probe)),
+    ).toThrow(/AboutDialogProvider/)
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/helpers/testHarness.tsx
+++ b/tritium/react-gui/src/renderer/__test__/helpers/testHarness.tsx
@@ -1,0 +1,120 @@
+/**
+ * Shared test helpers for renderer-side Vitest tests.
+ *
+ * No @testing-library/react: we follow the project's existing convention of
+ * driving React via `createRoot` + `act()` directly (see useActiveTool.test.ts
+ * and MenuBar.test.tsx).
+ */
+
+import React from 'react'
+import { vi } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+
+export interface RenderHookHandle<T> {
+  readonly result: T
+  rerender(): void
+  unmount(): void
+}
+
+/**
+ * Mount a hook in a throwaway component and expose its current return value.
+ * Optionally wrap the test component in a Provider chain.
+ */
+export function makeRenderHook<T>(
+  useHookFn: () => T,
+  wrapper?: React.FC<{ children: React.ReactNode }>,
+): RenderHookHandle<T> {
+  let result!: T
+  let root!: Root
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let unmounted = false
+
+  const Probe: React.FC = () => {
+    result = useHookFn()
+    return null
+  }
+
+  const tree = wrapper
+    ? React.createElement(wrapper, null, React.createElement(Probe))
+    : React.createElement(Probe)
+
+  act(() => {
+    root = createRoot(container)
+    root.render(tree)
+  })
+
+  return {
+    get result() {
+      return result
+    },
+    rerender() {
+      act(() => {
+        root.render(tree)
+      })
+    },
+    unmount() {
+      if (unmounted) return
+      unmounted = true
+      act(() => root.unmount())
+      if (container.parentNode) container.parentNode.removeChild(container)
+    },
+  }
+}
+
+/**
+ * Mount a JSX tree under createRoot/act and return helpers to query / unmount.
+ */
+export function mountTree(node: React.ReactNode): {
+  container: HTMLElement
+  root: Root
+  unmount(): void
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  let root!: Root
+  act(() => {
+    root = createRoot(container)
+    root.render(node as React.ReactElement)
+  })
+  return {
+    container,
+    root,
+    unmount() {
+      act(() => root.unmount())
+      if (container.parentNode) container.parentNode.removeChild(container)
+    },
+  }
+}
+
+/**
+ * Install a mock window.electronAPI matching the post-B generic surface
+ * (`invoke` + `onPush`) and return it for assertion / further mock.
+ *
+ * jsdom: window === globalThis. Mirrors the pattern used by MenuBar.test.tsx.
+ */
+export function setupElectronAPI(overrides: Record<string, unknown> = {}): Record<string, any> {
+  const api: Record<string, any> = {
+    platform: 'linux',
+    invoke: vi.fn().mockResolvedValue(undefined),
+    onPush: vi.fn().mockReturnValue(() => undefined),
+    ...overrides,
+  }
+  ;(window as any).electronAPI = api
+  return api
+}
+
+export function teardownElectronAPI(): void {
+  delete (window as any).electronAPI
+}
+
+/** Yield to the microtask queue so awaited Promises settle inside act(). */
+export async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}

--- a/tritium/react-gui/src/renderer/__test__/menuDispatch.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/menuDispatch.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Degrade-detection test for useMenuDispatch.
+ *
+ * Refactor target: A (IPC channel literal cleanup). After A, the 5 string
+ * literals ('menu:center-mark-cross', 'menu:center-mark-axis',
+ * 'menu:center-mark-none', 'menu:bg-white', 'menu:bg-black', 'menu:about')
+ * become IPC.MENU_CENTER_MARK_*, IPC.MENU_BG_*, IPC.MENU_ABOUT constants.
+ *
+ * This test pins the channel-string -> CmdId mapping using the LITERAL
+ * channel strings on purpose, so that a wrong channel-name change in A is
+ * detected. Pre-existing channels are exercised via the IPC constant.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { CommandProvider, useCommands } from '../commands/CommandRegistry'
+import { CmdId } from '../commands/ids'
+import type { CommandKey } from '../commands/CommandMap'
+import { IPC } from '../../shared/ipcChannels'
+import { useMenuDispatch } from '../hooks/useMenuDispatch'
+import { makeRenderHook } from './helpers/testHarness'
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+  React.createElement(CommandProvider, null, children)
+
+interface Captured { id: string; args: unknown }
+
+function setupHarness(activeTab: string | null = 'molview-1') {
+  const captured: Captured[] = []
+
+  const h = makeRenderHook(() => {
+    const cmds = useCommands()
+    const { dispatchMenuChannel } = useMenuDispatch(activeTab)
+    return { cmds, dispatchMenuChannel }
+  }, Wrapper)
+
+  // Register a wildcard catcher for every CmdId in use.
+  const allCmds = Object.values(CmdId) as CommandKey[]
+  for (const id of allCmds) {
+    h.result.cmds.register(id, ((args: unknown) => {
+      captured.push({ id, args })
+    }) as never)
+  }
+
+  return { h, captured }
+}
+
+describe('useMenuDispatch -- channel to CmdId mapping', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  let errSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    errSpy.mockRestore()
+  })
+
+  // Each row: [channel string passed to dispatchMenuChannel, expected CmdId, args]
+  // The channel column intentionally mixes IPC.* constants and the bare strings
+  // that A will replace. Using literals on the LHS for the to-be-replaced rows
+  // documents the current channel name so that A's renaming is detected.
+  const cases: Array<[string, string, unknown]> = [
+    [IPC.MENU_OPEN_FILE,        CmdId.UiOpenObjDialog,    undefined],
+    [IPC.MENU_SAVE,             CmdId.FileSave,           undefined],
+    [IPC.MENU_NEW_TAB,          CmdId.TabNew,             undefined],
+    [IPC.MENU_CLOSE_TAB,        CmdId.TabClose,           'molview-1'],
+    [IPC.MENU_UNDO,             CmdId.Undo,               undefined],
+    [IPC.MENU_REDO,             CmdId.Redo,               undefined],
+    [IPC.MENU_NEW_SCENE,        CmdId.SceneNew,           undefined],
+    [IPC.MENU_OPEN_SCENE,       CmdId.UiOpenSceneDialog,  undefined],
+    [IPC.MENU_VIEW_PERSPECTIVE, CmdId.ViewPerspective,    undefined],
+    [IPC.MENU_VIEW_ORTHOGRAPHIC,CmdId.ViewOrthographic,   undefined],
+    // The following 6 strings are currently bare literals in useMenuDispatch.
+    // After A they become IPC.MENU_CENTER_MARK_*, IPC.MENU_BG_*, IPC.MENU_ABOUT.
+    // The literal channel string itself must NOT change (only the source of the
+    // string should move to ipcChannels.ts).
+    ['menu:center-mark-cross',  CmdId.ViewCenterMarkCross, undefined],
+    ['menu:center-mark-axis',   CmdId.ViewCenterMarkAxis,  undefined],
+    ['menu:center-mark-none',   CmdId.ViewCenterMarkNone,  undefined],
+    ['menu:bg-white',           CmdId.SceneBgWhite,        undefined],
+    ['menu:bg-black',           CmdId.SceneBgBlack,        undefined],
+    ['menu:about',              CmdId.UiAboutDialog,       undefined],
+  ]
+
+  for (const [channel, expectedId, expectedArgs] of cases) {
+    it(`dispatches ${channel} -> ${expectedId}`, async () => {
+      const { h, captured } = setupHarness()
+      h.result.dispatchMenuChannel(channel)
+      await Promise.resolve()
+      expect(captured.length).toBe(1)
+      expect(captured[0].id).toBe(expectedId)
+      expect(captured[0].args).toBe(expectedArgs)
+      h.unmount()
+    })
+  }
+
+  it('MENU_CLOSE_TAB without active tab dispatches nothing', async () => {
+    const { h, captured } = setupHarness(null)
+    h.result.dispatchMenuChannel(IPC.MENU_CLOSE_TAB)
+    await Promise.resolve()
+    expect(captured.length).toBe(0)
+    h.unmount()
+  })
+
+  it('unknown channel logs warning and dispatches nothing', () => {
+    const { h, captured } = setupHarness()
+    h.result.dispatchMenuChannel('menu:never-existed')
+    expect(captured.length).toBe(0)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('not yet implemented'),
+      'menu:never-existed',
+    )
+    h.unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/preloadElectronApi.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/preloadElectronApi.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Degrade-detection test for the preload electronAPI surface.
+ *
+ * After B, the surface is a typed pair of generics: `invoke(channel, payload)`
+ * and `onPush(channel, callback)` driven by the InvokeChannels / PushChannels
+ * maps in `shared/ipcContract.ts`. The wire calls into `ipcRenderer` MUST
+ * stay byte-for-byte identical to the pre-B per-channel methods so the main
+ * side keeps working.
+ *
+ * This test pins:
+ *   - `invoke(IPC.X, payload)` -> `ipcRenderer.invoke(IPC.X, payload)`
+ *   - `onPush(IPC.X, cb)` -> `ipcRenderer.on(IPC.X, handler)` and unsubscribe
+ *     calls `ipcRenderer.removeListener(IPC.X, handler)`
+ *   - Push handler strips the IpcRendererEvent and forwards only the payload.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+type Handler = (...args: unknown[]) => void
+// Minimal stand-in for Electron's IpcRendererEvent (we never read its fields).
+type IpcRendererEventLike = Record<string, unknown>
+
+const ipcRenderer = {
+  invoke: vi.fn().mockResolvedValue(undefined),
+  on: vi.fn(),
+  removeListener: vi.fn(),
+  send: vi.fn(),
+} as {
+  invoke: ReturnType<typeof vi.fn>
+  on: ReturnType<typeof vi.fn>
+  removeListener: ReturnType<typeof vi.fn>
+  send: ReturnType<typeof vi.fn>
+}
+
+const exposeInMainWorld = vi.fn()
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld },
+  ipcRenderer,
+}))
+
+import { IPC } from '../../shared/ipcChannels'
+import type { ElectronAPI } from '../../shared/ipcContract'
+
+let api: ElectronAPI
+
+beforeEach(async () => {
+  vi.resetModules()
+  exposeInMainWorld.mockReset()
+  ipcRenderer.invoke.mockReset().mockResolvedValue(undefined)
+  ipcRenderer.on.mockReset()
+  ipcRenderer.removeListener.mockReset()
+
+  // preload/index lives outside this tsconfig project (it belongs to
+  // tsconfig.node.json). Vite/Vitest resolves it at runtime; a string
+  // variable bypasses tsc's TS6307 cross-project check.
+  const preloadEntry = '../../preload/index'
+  await import(preloadEntry)
+  expect(exposeInMainWorld).toHaveBeenCalledWith('electronAPI', expect.any(Object))
+  api = exposeInMainWorld.mock.calls[0][1] as ElectronAPI
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('preload electronAPI -- shape', () => {
+  it('exposes platform from process.platform', () => {
+    expect(api.platform).toBe(process.platform)
+  })
+  it('exposes invoke and onPush as functions', () => {
+    expect(typeof api.invoke).toBe('function')
+    expect(typeof api.onPush).toBe('function')
+  })
+})
+
+describe('preload electronAPI -- invoke routes through ipcRenderer.invoke', () => {
+  it.each([
+    [IPC.APP_PATH,         []],
+    [IPC.DIALOG_OPEN,      [{ dialogType: 'open-obj', filters: [] }]],
+    [IPC.LAYOUT_LOAD,      []],
+    [IPC.LAYOUT_SAVE,      [{ mainSizes: [100, 200] }]],
+    [IPC.UI_LOAD,          []],
+    [IPC.UI_SAVE,          [{ theme: 'dark' }]],
+    [IPC.MENU_UPDATE_STATE,[{ viewProjection: { enabled: true, perspective: true } }]],
+    [IPC.MENU_INVOKE_ROLE, ['close']],
+    [IPC.NAVI_CTX_SHOW,    [{ x: 1, y: 2, isSymm: false, atomLabel: '', rendLabel: '' }]],
+  ])('invoke(%s) -> ipcRenderer.invoke(%s, ...args)', (channel, args) => {
+    ;(api.invoke as (...a: unknown[]) => unknown)(channel, ...args)
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(channel, ...args)
+  })
+
+  it('invoke forwards the resolved value', async () => {
+    ipcRenderer.invoke.mockResolvedValueOnce({ ok: true })
+    const result = await (api.invoke as (...a: unknown[]) => Promise<unknown>)(IPC.LAYOUT_LOAD)
+    expect(result).toEqual({ ok: true })
+  })
+})
+
+describe('preload electronAPI -- onPush routes through ipcRenderer.on', () => {
+  it.each([
+    IPC.OBJ_FILE_OPENED,
+    IPC.SCENE_FILE_OPENED,
+    IPC.FILE_ERROR,
+    IPC.MENU_NEW_TAB,
+    IPC.MENU_CLOSE_TAB,
+    IPC.MENU_SAVE,
+    IPC.MENU_NEW_SCENE,
+    IPC.MENU_OPEN_FILE,
+    IPC.MENU_OPEN_SCENE,
+    IPC.MENU_UNDO,
+    IPC.MENU_REDO,
+    IPC.MENU_GENERIC,
+    IPC.ROTATE_GESTURE,
+  ])('onPush(%s) registers and unsubscribes', (channel) => {
+    const cb = vi.fn()
+    const unsubscribe = (api.onPush as (c: unknown, h: Handler) => () => void)(channel, cb)
+
+    expect(ipcRenderer.on).toHaveBeenCalledWith(channel, expect.any(Function))
+    const handler = ipcRenderer.on.mock.calls.at(-1)![1] as Handler
+
+    unsubscribe()
+    expect(ipcRenderer.removeListener).toHaveBeenCalledWith(channel, handler)
+  })
+
+  it('handler strips IpcRendererEvent and forwards single payload', () => {
+    const cb = vi.fn()
+    ;(api.onPush as (c: unknown, h: Handler) => () => void)(IPC.OBJ_FILE_OPENED, cb)
+    const handler = ipcRenderer.on.mock.calls.at(-1)![1] as Handler
+    const event: IpcRendererEventLike = {}
+    const data = { name: 'foo', path: '/tmp/foo' }
+    handler(event, data)
+    expect(cb).toHaveBeenCalledWith(data)
+  })
+
+  it('handler forwards no payload for void channels', () => {
+    const cb = vi.fn()
+    ;(api.onPush as (c: unknown, h: Handler) => () => void)(IPC.MENU_NEW_TAB, cb)
+    const handler = ipcRenderer.on.mock.calls.at(-1)![1] as Handler
+    handler({} as IpcRendererEventLike)
+    expect(cb).toHaveBeenCalledWith()
+  })
+
+  it('MENU_GENERIC handler forwards channel string', () => {
+    const cb = vi.fn()
+    ;(api.onPush as (c: unknown, h: Handler) => () => void)(IPC.MENU_GENERIC, cb)
+    const handler = ipcRenderer.on.mock.calls.at(-1)![1] as Handler
+    handler({} as IpcRendererEventLike, 'menu:about')
+    expect(cb).toHaveBeenCalledWith('menu:about')
+  })
+})

--- a/tritium/react-gui/src/renderer/commands/CommandMap.ts
+++ b/tritium/react-gui/src/renderer/commands/CommandMap.ts
@@ -1,0 +1,72 @@
+/**
+ * Typed contract that pairs each `CmdId` with its dispatch args and handler
+ * result. `useRegisterCommand` and `useCommands().dispatch` are generic over
+ * this map so that mismatched args (e.g. forgetting the tab id when
+ * dispatching `CmdId.TabClose`) become compile errors.
+ *
+ * Adding a CmdId: add the constant in `ids.ts` AND a row here. The
+ * `_CommandMapMatchesCmdId` assertion below catches `ids.ts` entries that
+ * lack a CommandMap row.
+ */
+
+import type { FileOpenedData } from '../../shared/ipcTypes'
+import { CmdId } from './ids'
+
+export interface CommandMap {
+  // Scene
+  [CmdId.SceneNew]:            { args: void;            result: void }
+  [CmdId.OpenObjByPath]:       { args: FileOpenedData;  result: void }
+  [CmdId.OpenSceneByPath]:     { args: string;          result: void }
+
+  // Dialogs
+  [CmdId.UiOpenObjDialog]:     { args: void;            result: void }
+  [CmdId.UiOpenSceneDialog]:   { args: void;            result: void }
+  [CmdId.UiAboutDialog]:       { args: void;            result: void }
+
+  // Tabs
+  [CmdId.TabNew]:              { args: void;            result: void }
+  [CmdId.TabClose]:            { args: string;          result: void }
+
+  // File
+  [CmdId.FileSave]:            { args: void;            result: void }
+
+  // Edit
+  [CmdId.Undo]:                { args: void;            result: void }
+  [CmdId.Redo]:                { args: void;            result: void }
+
+  // View
+  [CmdId.ViewPerspective]:     { args: void;            result: void }
+  [CmdId.ViewOrthographic]:    { args: void;            result: void }
+  [CmdId.ViewCenterMarkCross]: { args: void;            result: void }
+  [CmdId.ViewCenterMarkAxis]:  { args: void;            result: void }
+  [CmdId.ViewCenterMarkNone]:  { args: void;            result: void }
+
+  // Scene background
+  [CmdId.SceneBgWhite]:        { args: void;            result: void }
+  [CmdId.SceneBgBlack]:        { args: void;            result: void }
+}
+
+export type CommandKey = keyof CommandMap
+export type CommandArgs<K extends CommandKey> = CommandMap[K]['args']
+export type CommandResult<K extends CommandKey> = CommandMap[K]['result']
+
+/** Variadic argument list for `dispatch`: void-args commands take no payload. */
+export type CommandDispatchArgs<K extends CommandKey> = CommandArgs<K> extends void
+  ? []
+  : [CommandArgs<K>]
+
+/** Handler signature for `register` / `useRegisterCommand`. */
+export type CommandHandler<K extends CommandKey> = (
+  args: CommandArgs<K>,
+) => CommandResult<K> | Promise<CommandResult<K>>
+
+// ────────────────────────────────────────────────────────────
+// Type-level assertion: every CmdId has a CommandMap row.
+// If a new CmdId is added without a row here, `_CommandMapMatchesCmdId`
+// becomes `false`, producing a compile error on the line below.
+// ────────────────────────────────────────────────────────────
+
+type _ExactKeys<A extends string, B extends string> = [A, B] extends [B, A] ? true : false
+type _CommandMapMatchesCmdId = _ExactKeys<CommandKey, CmdId>
+const _commandMapMatchesCmdId: _CommandMapMatchesCmdId = true
+void _commandMapMatchesCmdId

--- a/tritium/react-gui/src/renderer/commands/CommandRegistry.tsx
+++ b/tritium/react-gui/src/renderer/commands/CommandRegistry.tsx
@@ -6,44 +6,63 @@
  *   - Wrap the app in <CommandProvider>.
  *   - Register handlers with useRegisterCommand(id, handler).
  *   - Dispatch commands with useCommands().dispatch(id, args).
+ *
+ * Type contracts come from `CommandMap`: each `CmdId` is paired with its
+ * `args` and `result` types. `dispatch` and `register` are both generic over
+ * the map, so the args / handler shape is enforced at every call site.
  */
 
 import React, { createContext, useContext, useEffect, useMemo, useRef } from 'react'
+import type {
+  CommandArgs,
+  CommandDispatchArgs,
+  CommandHandler,
+  CommandKey,
+  CommandResult,
+} from './CommandMap'
 
+// Erased handler shape stored in the per-id map (per-key types are enforced
+// by the generic register / dispatch entry points).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type CommandHandler<A = unknown, R = unknown> = (args?: A) => R | Promise<R>
+type AnyHandler = (args: any) => any
 
 interface CommandRegistryValue {
-  /** Register a handler for a command ID. Returns an unregister function. */
-  register(id: string, handler: CommandHandler): () => void
+  /** Register a typed handler for a command ID. Returns an unregister function. */
+  register<K extends CommandKey>(id: K, handler: CommandHandler<K>): () => void
   /** Dispatch a command by ID. Rejects if the ID is not registered. */
-  dispatch<A = unknown, R = unknown>(id: string, args?: A): Promise<R>
+  dispatch<K extends CommandKey>(
+    id: K,
+    ...args: CommandDispatchArgs<K>
+  ): Promise<CommandResult<K>>
   /** Returns true if a handler is currently registered for id. */
-  has(id: string): boolean
+  has(id: CommandKey): boolean
 }
 
 const CommandContext = createContext<CommandRegistryValue | null>(null)
 
 export function CommandProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
-  const map = useRef(new Map<string, CommandHandler>())
+  const map = useRef(new Map<CommandKey, AnyHandler>())
 
   const value = useMemo<CommandRegistryValue>(() => ({
-    register(id, handler) {
+    register<K extends CommandKey>(id: K, handler: CommandHandler<K>): () => void {
       if (map.current.has(id)) {
         console.warn(`[CommandRegistry] command "${id}" already registered - overwriting`)
       }
-      map.current.set(id, handler)
+      map.current.set(id, handler as AnyHandler)
       return () => {
-        if (map.current.get(id) === handler) {
+        if (map.current.get(id) === (handler as AnyHandler)) {
           map.current.delete(id)
         }
       }
     },
 
-    dispatch<A, R>(id: string, args?: A): Promise<R> {
+    dispatch<K extends CommandKey>(
+      id: K,
+      ...args: CommandDispatchArgs<K>
+    ): Promise<CommandResult<K>> {
       const h = map.current.get(id)
       if (!h) return Promise.reject(new Error(`[CommandRegistry] unknown command: ${id}`))
-      return Promise.resolve(h(args) as R)
+      return Promise.resolve(h(args[0]) as CommandResult<K>)
     },
 
     has(id) { return map.current.has(id) },
@@ -69,17 +88,17 @@ export function useCommands(): CommandRegistryValue {
  * The handler is stored in a ref so it always sees the latest closure
  * without requiring re-registration on every render.
  */
-export function useRegisterCommand<A = unknown, R = unknown>(
-  id: string,
-  handler: CommandHandler<A, R>,
+export function useRegisterCommand<K extends CommandKey>(
+  id: K,
+  handler: CommandHandler<K>,
 ): void {
-  const ref = useRef<CommandHandler<A, R>>(handler)
+  const ref = useRef<CommandHandler<K>>(handler)
   ref.current = handler
 
   const { register } = useCommands()
 
   useEffect(
-    () => register(id, ((a) => ref.current(a as A)) as CommandHandler),
+    () => register(id, ((a: CommandArgs<K>) => ref.current(a)) as CommandHandler<K>),
     // register is stable (created once in useMemo); id changes trigger re-registration.
     [id, register],
   )

--- a/tritium/react-gui/src/renderer/commands/useNewTabCommand.ts
+++ b/tritium/react-gui/src/renderer/commands/useNewTabCommand.ts
@@ -9,7 +9,7 @@ import { useCallback } from 'react'
 import type { AsyncCueMol } from '../worker/client/AsyncCueMol'
 import { useRegisterCommand } from './CommandRegistry'
 import { CmdId } from './ids'
-import { useDialog } from '../contexts/DialogContext'
+import { useShowNewTabDialog } from '../components/dialogs/NewTabDialogProvider'
 
 interface UseNewTabCommandOptions {
     cm: AsyncCueMol | null
@@ -24,7 +24,7 @@ export function useNewTabCommand({
     addMolViewTab,
     getActiveSceneInfo,
 }: UseNewTabCommandOptions): void {
-    const { showNewTabDialog } = useDialog()
+    const showNewTabDialog = useShowNewTabDialog()
 
     const openNewTab = useCallback(async (): Promise<void> => {
         if (!cm) return

--- a/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
@@ -12,7 +12,7 @@ import type { SceneBgColor } from '../../shared/ipcTypes'
 import type { AsyncCueMol } from '../worker/client/AsyncCueMol'
 import { useRegisterCommand } from './CommandRegistry'
 import { CmdId } from './ids'
-import { useDialog } from '../contexts/DialogContext'
+import { useShowFileOpenOptionDialog } from '../components/fopen-opt-dlgs/FileOpenOptionDialogProvider'
 
 interface UseSceneCommandsOptions {
     cm: AsyncCueMol | null
@@ -30,7 +30,7 @@ export function useSceneCommands({
     onBgColorChanged,
 }: UseSceneCommandsOptions): void {
 
-    const { showFileOpenOptionDialog } = useDialog()
+    const showFileOpenOptionDialog = useShowFileOpenOptionDialog()
 
     const openNewScene = useCallback(async (filePath?: string): Promise<void> => {
         if (!cm) return
@@ -68,7 +68,7 @@ export function useSceneCommands({
             if (!info) return
             ;(async () => {
                 const rendererTypes = await cm.getCompatibleRendererNames(data.path)
-                const options = await showFileOpenOptionDialog(data.path, rendererTypes)
+                const options = await showFileOpenOptionDialog({ filePath: data.path, rendererTypes })
                 if (options === null) return
                 await cm.loadObject(data.path, info.scene_uid, options)
             })().catch((e: unknown) => console.error('OpenObjByPath failed:', e))

--- a/tritium/react-gui/src/renderer/commands/useUiDialogCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useUiDialogCommands.ts
@@ -7,7 +7,8 @@ import { useCallback } from 'react'
 import type { AsyncCueMol } from '../worker/client/AsyncCueMol'
 import { useRegisterCommand } from './CommandRegistry'
 import { CmdId } from './ids'
-import { useDialog } from '../contexts/DialogContext'
+import { useShowAboutDialog } from '../components/dialogs/AboutDialogProvider'
+import { IPC } from '../../shared/ipcChannels'
 
 // Category IDs from src/qsys/InOutHandler.hpp (IOH_CAT_*)
 const IOH_CAT_OBJREADER = 0
@@ -18,7 +19,7 @@ interface UseUiDialogCommandsOptions {
 }
 
 export function useUiDialogCommands({ cm }: UseUiDialogCommandsOptions): void {
-    const { showAboutDialog } = useDialog()
+    const showAboutDialog = useShowAboutDialog()
 
     const getOpenFilters = useCallback(async (catId: number): Promise<ElectronFileFilter[]> => {
         if (!cm) return []
@@ -28,13 +29,13 @@ export function useUiDialogCommands({ cm }: UseUiDialogCommandsOptions): void {
     useRegisterCommand(CmdId.UiOpenObjDialog, async () => {
         if (!cm) return
         const filters = await getOpenFilters(IOH_CAT_OBJREADER)
-        await window.electronAPI.openFile({ dialogType: 'open-obj', filters })
+        await window.electronAPI.invoke(IPC.DIALOG_OPEN, { dialogType: 'open-obj', filters })
     })
 
     useRegisterCommand(CmdId.UiOpenSceneDialog, async () => {
         if (!cm) return
         const filters = await getOpenFilters(IOH_CAT_SCEREADER)
-        await window.electronAPI.openFile({ dialogType: 'open-scene', filters })
+        await window.electronAPI.invoke(IPC.DIALOG_OPEN, { dialogType: 'open-scene', filters })
     })
 
     useRegisterCommand(CmdId.UiAboutDialog, () => showAboutDialog())

--- a/tritium/react-gui/src/renderer/components/MenuBar.tsx
+++ b/tritium/react-gui/src/renderer/components/MenuBar.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { APP_MENU, getRoleLabel } from '../../shared/menuTemplate'
 import type { AppMenuItem, AppMenuRole } from '../../shared/menuTemplate'
 import type { SceneBgColor, ViewCenterMark } from '../../shared/ipcTypes'
+import { IPC } from '../../shared/ipcChannels'
 import { useMenuDispatch } from '../hooks/useMenuDispatch'
 
 interface MenuBarProps {
@@ -260,6 +261,6 @@ function handleRole(role: AppMenuRole): void {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     document.execCommand(role === 'selectAll' ? 'selectAll' : role)
   } else {
-    window.electronAPI?.invokeMenuRole(role)
+    window.electronAPI?.invoke(IPC.MENU_INVOKE_ROLE, role)
   }
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/AboutDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/AboutDialogProvider.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { AboutDialog } from './AboutDialog'
+
+// React import is required by the JSX runtime used at test time; do not remove.
+void React
+import { createDialogHook } from '../../hooks/useDialogFactory'
+
+export const { Provider: AboutDialogProvider, useShow: useShowAboutDialog } =
+  createDialogHook<void, void>({
+    name: 'AboutDialog',
+    render: ({ visible, resolve }) => (
+      <AboutDialog visible={visible} onClose={() => resolve()} />
+    ),
+  })

--- a/tritium/react-gui/src/renderer/components/dialogs/ConfirmCloseTabDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ConfirmCloseTabDialogProvider.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { ConfirmCloseTabDialog, type ConfirmCloseResult } from './ConfirmCloseTabDialog'
+
+// React import is required by the JSX runtime used at test time; do not remove.
+void React
+import { createDialogHook } from '../../hooks/useDialogFactory'
+
+export interface ConfirmCloseTabDialogArgs {
+  sceneName: string
+}
+
+export const {
+  Provider: ConfirmCloseTabDialogProvider,
+  useShow: useShowConfirmCloseTabDialog,
+} = createDialogHook<ConfirmCloseTabDialogArgs, ConfirmCloseResult>({
+  name: 'ConfirmCloseTabDialog',
+  render: ({ visible, args, resolve }) => (
+    <ConfirmCloseTabDialog
+      visible={visible}
+      sceneName={args?.sceneName ?? ''}
+      saveDisabled
+      onResult={(result) => resolve(result)}
+    />
+  ),
+})

--- a/tritium/react-gui/src/renderer/components/dialogs/NewTabDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/NewTabDialogProvider.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { NewTabDialog, type NewTabDialogResult } from './NewTabDialog'
+
+// React import is required by the JSX runtime used at test time; do not remove.
+void React
+import { createDialogHook } from '../../hooks/useDialogFactory'
+
+export interface NewTabDialogArgs {
+  currentSceneName: string | null
+  defaultSceneName: string
+  defaultViewName: string
+}
+
+export const { Provider: NewTabDialogProvider, useShow: useShowNewTabDialog } =
+  createDialogHook<NewTabDialogArgs, NewTabDialogResult | null>({
+    name: 'NewTabDialog',
+    render: ({ visible, args, resolve }) => (
+      <NewTabDialog
+        visible={visible}
+        currentSceneName={args?.currentSceneName ?? null}
+        defaultSceneName={args?.defaultSceneName ?? 'Scene_1'}
+        defaultViewName={args?.defaultViewName ?? 'View_1'}
+        onConfirm={(result) => resolve(result)}
+        onCancel={() => resolve(null)}
+      />
+    ),
+  })

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialogProvider.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { FileOpenOptionDialog } from './FileOpenOptionDialog'
+
+// React import is required by the JSX runtime used at test time; do not remove.
+void React
+import type { FileOpenOptions } from './types'
+import { createDialogHook } from '../../hooks/useDialogFactory'
+
+export interface FileOpenOptionDialogArgs {
+  filePath: string
+  rendererTypes?: string[]
+}
+
+export const {
+  Provider: FileOpenOptionDialogProvider,
+  useShow: useShowFileOpenOptionDialog,
+} = createDialogHook<FileOpenOptionDialogArgs, FileOpenOptions | null>({
+  name: 'FileOpenOptionDialog',
+  render: ({ visible, args, resolve }) => (
+    <FileOpenOptionDialog
+      visible={visible}
+      filePath={args?.filePath ?? ''}
+      rendererTypes={args?.rendererTypes ?? []}
+      onConfirm={(options) => resolve(options)}
+      onCancel={() => resolve(null)}
+    />
+  ),
+})

--- a/tritium/react-gui/src/renderer/components/panes/MolViewPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/MolViewPane.tsx
@@ -4,6 +4,7 @@ import styles from './MolViewPane.module.css'
 import { useMolTabDispatch } from '../../hooks/useMolTab'
 import { useCueMol } from '../../hooks/useCueMol'
 import { GES_PINCH, GES_ROTATE } from '../../worker/shared/gestureAxes'
+import { IPC } from '../../../shared/ipcChannels'
 
 /**
  * Tab content pane for "molview" tabs — WebGL canvas for molecular visualization.
@@ -149,7 +150,7 @@ export const MolViewPane = React.memo((): React.JSX.Element => {
   // Forwarded via GES_ROTATE axis so ViewInputConfig bindings can route it
   // (e.g. conf_rotz = "...,GES_ROTATE" in default_style.xml).
   useEffect(() => {
-    const unsubscribe = window.electronAPI.onRotateGesture((rotation) => {
+    const unsubscribe = window.electronAPI.onPush(IPC.ROTATE_GESTURE, (rotation) => {
       const viewID = getActiveViewIDRef.current()
       if (viewID === undefined || !cmRef.current) return
       cmRef.current.onGestureEvent(viewID, GES_ROTATE, rotation)

--- a/tritium/react-gui/src/renderer/contexts/DialogContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/DialogContext.tsx
@@ -1,195 +1,28 @@
 /**
  * @file contexts/DialogContext.tsx
- * @description React context that provides imperative dialog APIs.
+ * @description Composite Provider that mounts every per-dialog Provider in
+ * one place. Each individual dialog ships its own `<XxxDialogProvider>` and
+ * `useShowXxxDialog()` hook (see `components/dialogs/*Provider.tsx`).
  *
- * Encapsulates the state management and rendering of modal dialogs so that
- * command handlers can show dialogs via simple async calls without leaking
- * UI state into the root component.
- *
- * New dialogs can be added by extending DialogContextValue with a new method,
- * adding internal state, and rendering the dialog component inside the provider.
+ * Adding a new dialog: add its provider component beneath, then export the
+ * matching `useShowXxx` hook from the dialog's own file. No code change here
+ * apart from the one-line `<XxxDialogProvider>` wrapping.
  */
 
-import React, { createContext, useContext, useState, useCallback, useRef, useMemo } from 'react'
-import { FileOpenOptionDialog } from '../components/fopen-opt-dlgs'
-import type { FileOpenOptions } from '../components/fopen-opt-dlgs'
-import { AboutDialog } from '../components/dialogs/AboutDialog'
-import { NewTabDialog } from '../components/dialogs/NewTabDialog'
-import type { NewTabDialogResult } from '../components/dialogs/NewTabDialog'
-import { ConfirmCloseTabDialog } from '../components/dialogs/ConfirmCloseTabDialog'
-import type { ConfirmCloseResult } from '../components/dialogs/ConfirmCloseTabDialog'
+import React from 'react'
+import { AboutDialogProvider } from '../components/dialogs/AboutDialogProvider'
+import { NewTabDialogProvider } from '../components/dialogs/NewTabDialogProvider'
+import { ConfirmCloseTabDialogProvider } from '../components/dialogs/ConfirmCloseTabDialogProvider'
+import { FileOpenOptionDialogProvider } from '../components/fopen-opt-dlgs/FileOpenOptionDialogProvider'
 
-// ────────────────────────────────────────────────────────────
-// Types
-// ────────────────────────────────────────────────────────────
-
-export interface NewTabDialogArgs {
-  currentSceneName: string | null;
-  defaultSceneName: string;
-  defaultViewName: string;
-}
-
-interface DialogContextValue {
-  /** Show the file-open option dialog and wait for user input. */
-  showFileOpenOptionDialog(filePath: string, rendererTypes?: string[]): Promise<FileOpenOptions | null>
-  /** Show the About dialog. */
-  showAboutDialog(): Promise<void>
-  /** Show the new-tab dialog and wait for user selection. */
-  showNewTabDialog(args: NewTabDialogArgs): Promise<NewTabDialogResult | null>
-  /** Show the close-tab confirmation dialog and wait for user selection. */
-  showConfirmCloseTabDialog(args: { sceneName: string }): Promise<ConfirmCloseResult>
-}
-
-type DialogResolve = (options: FileOpenOptions | null) => void
-type NewTabResolve = (result: NewTabDialogResult | null) => void
-type ConfirmCloseResolve = (result: ConfirmCloseResult) => void
-
-// ────────────────────────────────────────────────────────────
-// Context
-// ────────────────────────────────────────────────────────────
-
-const DialogContext = createContext<DialogContextValue | null>(null)
-
-// ────────────────────────────────────────────────────────────
-// Provider
-// ────────────────────────────────────────────────────────────
-
-export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [optionDlgState, setOptionDlgState] = useState<{ visible: boolean; filePath: string }>({
-    visible: false,
-    filePath: '',
-  })
-  const resolveRef = useRef<DialogResolve | null>(null)
-  const rendererTypesRef = useRef<string[]>([])
-
-  const showFileOpenOptionDialog = useCallback((filePath: string, rendererTypes: string[] = []): Promise<FileOpenOptions | null> => {
-    return new Promise((resolve) => {
-      resolveRef.current = resolve
-      rendererTypesRef.current = rendererTypes
-      setOptionDlgState({ visible: true, filePath })
-    })
-  }, [])
-
-  const handleConfirm = useCallback((options: FileOpenOptions) => {
-    setOptionDlgState((s) => ({ ...s, visible: false }))
-    resolveRef.current?.(options)
-    resolveRef.current = null
-  }, [])
-
-  const handleCancel = useCallback(() => {
-    setOptionDlgState((s) => ({ ...s, visible: false }))
-    resolveRef.current?.(null)
-    resolveRef.current = null
-  }, [])
-
-  const [aboutDlgVisible, setAboutDlgVisible] = useState(false)
-  const aboutResolveRef = useRef<(() => void) | null>(null)
-
-  const showAboutDialog = useCallback((): Promise<void> => {
-    return new Promise((resolve) => {
-      aboutResolveRef.current = resolve
-      setAboutDlgVisible(true)
-    })
-  }, [])
-
-  const handleAboutClose = useCallback(() => {
-    setAboutDlgVisible(false)
-    aboutResolveRef.current?.()
-    aboutResolveRef.current = null
-  }, [])
-
-  const [newTabDlgState, setNewTabDlgState] = useState<NewTabDialogArgs & { visible: boolean }>({
-    visible: false,
-    currentSceneName: null,
-    defaultSceneName: 'Scene_1',
-    defaultViewName: 'View_1',
-  })
-  const newTabResolveRef = useRef<NewTabResolve | null>(null)
-
-  const showNewTabDialog = useCallback((args: NewTabDialogArgs): Promise<NewTabDialogResult | null> => {
-    return new Promise((resolve) => {
-      newTabResolveRef.current = resolve
-      setNewTabDlgState({ visible: true, ...args })
-    })
-  }, [])
-
-  const handleNewTabConfirm = useCallback((result: NewTabDialogResult) => {
-    setNewTabDlgState((s) => ({ ...s, visible: false }))
-    newTabResolveRef.current?.(result)
-    newTabResolveRef.current = null
-  }, [])
-
-  const handleNewTabCancel = useCallback(() => {
-    setNewTabDlgState((s) => ({ ...s, visible: false }))
-    newTabResolveRef.current?.(null)
-    newTabResolveRef.current = null
-  }, [])
-
-  const [confirmCloseDlgState, setConfirmCloseDlgState] = useState<{ visible: boolean; sceneName: string }>({
-    visible: false,
-    sceneName: '',
-  })
-  const confirmCloseResolveRef = useRef<ConfirmCloseResolve | null>(null)
-
-  const showConfirmCloseTabDialog = useCallback((args: { sceneName: string }): Promise<ConfirmCloseResult> => {
-    return new Promise((resolve) => {
-      confirmCloseResolveRef.current = resolve
-      setConfirmCloseDlgState({ visible: true, sceneName: args.sceneName })
-    })
-  }, [])
-
-  const handleConfirmCloseResult = useCallback((result: ConfirmCloseResult) => {
-    setConfirmCloseDlgState((s) => ({ ...s, visible: false }))
-    confirmCloseResolveRef.current?.(result)
-    confirmCloseResolveRef.current = null
-  }, [])
-
-  const value = useMemo<DialogContextValue>(
-    () => ({ showFileOpenOptionDialog, showAboutDialog, showNewTabDialog, showConfirmCloseTabDialog }),
-    [showFileOpenOptionDialog, showAboutDialog, showNewTabDialog, showConfirmCloseTabDialog],
-  )
-
-  return (
-    <DialogContext.Provider value={value}>
-      {children}
-      <FileOpenOptionDialog
-        visible={optionDlgState.visible}
-        filePath={optionDlgState.filePath}
-        rendererTypes={rendererTypesRef.current}
-        onConfirm={handleConfirm}
-        onCancel={handleCancel}
-      />
-      <AboutDialog visible={aboutDlgVisible} onClose={handleAboutClose} />
-      <NewTabDialog
-        visible={newTabDlgState.visible}
-        currentSceneName={newTabDlgState.currentSceneName}
-        defaultSceneName={newTabDlgState.defaultSceneName}
-        defaultViewName={newTabDlgState.defaultViewName}
-        onConfirm={handleNewTabConfirm}
-        onCancel={handleNewTabCancel}
-      />
-      <ConfirmCloseTabDialog
-        visible={confirmCloseDlgState.visible}
-        sceneName={confirmCloseDlgState.sceneName}
-        saveDisabled
-        onResult={handleConfirmCloseResult}
-      />
-    </DialogContext.Provider>
-  )
-}
-
-// ────────────────────────────────────────────────────────────
-// Hook
-// ────────────────────────────────────────────────────────────
-
-/**
- * Access the dialog service.
- * Must be called inside a `<DialogProvider>`.
- */
-export function useDialog(): DialogContextValue {
-  const ctx = useContext(DialogContext)
-  if (!ctx) {
-    throw new Error('useDialog() must be used within a <DialogProvider>.')
-  }
-  return ctx
-}
+export const DialogProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <AboutDialogProvider>
+    <NewTabDialogProvider>
+      <ConfirmCloseTabDialogProvider>
+        <FileOpenOptionDialogProvider>
+          {children}
+        </FileOpenOptionDialogProvider>
+      </ConfirmCloseTabDialogProvider>
+    </NewTabDialogProvider>
+  </AboutDialogProvider>
+)

--- a/tritium/react-gui/src/renderer/contexts/ThemeContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/ThemeContext.tsx
@@ -35,6 +35,7 @@ import React, {
   useEffect,
   useMemo,
 } from "react";
+import { IPC } from "../../shared/ipcChannels";
 
 // ────────────────────────────────────────────────────────────
 // Types
@@ -89,7 +90,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
 
     (async () => {
       try {
-        const ui = await window.electronAPI?.loadUi();
+        const ui = await window.electronAPI?.invoke(IPC.UI_LOAD);
         if (!cancelled && ui?.theme) {
           setThemeState(ui.theme);
           applyThemeToDOM(ui.theme);
@@ -113,13 +114,13 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const setTheme = useCallback((t: Theme) => {
     setThemeState(t);
     // Persist immediately — theme changes are infrequent; no debounce needed.
-    window.electronAPI?.saveUi({ theme: t });
+    window.electronAPI?.invoke(IPC.UI_SAVE, { theme: t });
   }, []);
 
   const toggleTheme = useCallback(() => {
     setThemeState((prev) => {
       const next = prev === "dark" ? "light" : "dark";
-      window.electronAPI?.saveUi({ theme: next });
+      window.electronAPI?.invoke(IPC.UI_SAVE, { theme: next });
       return next;
     });
   }, []);

--- a/tritium/react-gui/src/renderer/createAndInitCueMol.ts
+++ b/tritium/react-gui/src/renderer/createAndInitCueMol.ts
@@ -1,4 +1,5 @@
 import { AsyncCueMol } from './worker/client/AsyncCueMol'
+import { IPC } from '../shared/ipcChannels'
 
 // Create a CueMol instance and initialize the underlying C++ library.
 //
@@ -10,7 +11,7 @@ import { AsyncCueMol } from './worker/client/AsyncCueMol'
 // cuemol_internal.initCueMol(path) before any scene operations are performed.
 export async function createAndInitCueMol(): Promise<AsyncCueMol> {
     const { sysConfigPath, userStylePath, userStyleExists } =
-        await window.electronAPI.getAppPathInfo()
+        await window.electronAPI.invoke(IPC.APP_PATH)
     const cm = new AsyncCueMol()
     await cm.initCueMol(sysConfigPath || undefined)
 

--- a/tritium/react-gui/src/renderer/hooks/useActiveViewState.ts
+++ b/tritium/react-gui/src/renderer/hooks/useActiveViewState.ts
@@ -1,0 +1,138 @@
+/**
+ * @file hooks/useActiveViewState.ts
+ * @description Owns the renderer-side cache of three view-scoped properties
+ * (`viewProjection`, `viewCenterMark`, `sceneBgColor`) for the currently
+ * active molview tab, and keeps the native menu in sync via IPC.
+ *
+ * Update flow (one direction: write → read-back → cache):
+ *   - Tab switch (`activeMolViewId` change): pull all three from worker.
+ *   - User action via command: corresponding `onXxxChanged` callback writes
+ *     the new value into the cache and syncs the native menu.
+ *
+ * The polling on tab switch is the residual two-way path; once the C++
+ * Scene/View emit per-property change events, this hook can subscribe via
+ * `cm.addEventListener` and drop the Promise.all fetch.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { IPC } from '../../shared/ipcChannels';
+import type { SceneBgColor, ViewCenterMark } from '../../shared/ipcTypes';
+import type { AsyncCueMol } from '../worker/client/AsyncCueMol';
+
+interface UseActiveViewStateOptions {
+  cm: AsyncCueMol | null;
+  activeMolViewId: number | undefined;
+  /** Returns the active scene/view ids, used to fetch sceneBgColor. */
+  getActiveSceneInfo: () => { scene_uid: number; view_id: number } | null | undefined;
+}
+
+export interface ActiveViewState {
+  viewProjection: boolean | null;
+  viewCenterMark: ViewCenterMark | null;
+  sceneBgColor: SceneBgColor | null;
+  onProjectionChanged: (perspective: boolean) => void;
+  onCenterMarkChanged: (centerMark: ViewCenterMark) => void;
+  onBgColorChanged: (bgColor: SceneBgColor) => void;
+}
+
+export function useActiveViewState({
+  cm,
+  activeMolViewId,
+  getActiveSceneInfo,
+}: UseActiveViewStateOptions): ActiveViewState {
+  const [viewProjection, setViewProjection] = useState<boolean | null>(null);
+  const [viewCenterMark, setViewCenterMark] = useState<ViewCenterMark | null>(null);
+  const [sceneBgColor, setSceneBgColor] = useState<SceneBgColor | null>(null);
+
+  const syncNativeViewMenu = useCallback((state: {
+    perspective?: boolean | null;
+    centerMark?: ViewCenterMark | null;
+    bgColor?: SceneBgColor | null;
+  }) => {
+    window.electronAPI?.invoke(IPC.MENU_UPDATE_STATE, {
+      ...(state.perspective !== undefined
+        ? { viewProjection: { enabled: state.perspective !== null, perspective: state.perspective } }
+        : {}),
+      ...(state.centerMark !== undefined
+        ? { viewCenterMark: { enabled: state.centerMark !== null, centerMark: state.centerMark } }
+        : {}),
+      ...(state.bgColor !== undefined
+        ? { sceneBgColor: { enabled: state.bgColor !== null, bgColor: state.bgColor } }
+        : {}),
+    }).catch((err: unknown) => {
+      console.warn('update menu state failed:', err);
+    });
+  }, []);
+
+  const onProjectionChanged = useCallback((perspective: boolean) => {
+    setViewProjection(perspective);
+    syncNativeViewMenu({ perspective });
+  }, [syncNativeViewMenu]);
+
+  const onCenterMarkChanged = useCallback((centerMark: ViewCenterMark) => {
+    setViewCenterMark(centerMark);
+    syncNativeViewMenu({ centerMark });
+  }, [syncNativeViewMenu]);
+
+  const onBgColorChanged = useCallback((bgColor: SceneBgColor) => {
+    setSceneBgColor(bgColor);
+    syncNativeViewMenu({ bgColor });
+  }, [syncNativeViewMenu]);
+
+  // Stabilize getActiveSceneInfo via a ref so a fresh function reference on
+  // every render does not retrigger the polling effect (which would re-fetch
+  // and overwrite state set by `onXxxChanged` callbacks).
+  const getActiveSceneInfoRef = useRef(getActiveSceneInfo);
+  getActiveSceneInfoRef.current = getActiveSceneInfo;
+
+  // Tab-switch fetch: when the active view changes, pull all three values
+  // from the worker. On cancellation or error, reset to nulls (disables the
+  // related menu items via `enabled: false`).
+  useEffect(() => {
+    if (!cm || activeMolViewId === undefined) {
+      setViewProjection(null);
+      setViewCenterMark(null);
+      setSceneBgColor(null);
+      syncNativeViewMenu({ perspective: null, centerMark: null, bgColor: null });
+      return;
+    }
+
+    const sceneInfo = getActiveSceneInfoRef.current();
+    const sceneId = sceneInfo?.scene_uid;
+
+    let cancelled = false;
+    Promise.all([
+      cm.getViewProjection(activeMolViewId),
+      cm.getViewCenterMark(activeMolViewId),
+      sceneId !== undefined ? cm.getSceneBgColor(sceneId) : Promise.resolve(null),
+    ]).then(([projectionResult, centerMarkResult, bgColorResult]) => {
+      if (cancelled) return;
+      const perspective = projectionResult?.ok ? projectionResult.perspective : null;
+      const centerMark = centerMarkResult?.ok ? centerMarkResult.centerMark : null;
+      const bgColor = bgColorResult?.ok ? bgColorResult.bgColor : null;
+      setViewProjection(perspective);
+      setViewCenterMark(centerMark);
+      setSceneBgColor(bgColor);
+      syncNativeViewMenu({ perspective, centerMark, bgColor });
+    }).catch((err: unknown) => {
+      if (!cancelled) {
+        console.warn('get view state failed:', err);
+        setViewProjection(null);
+        setViewCenterMark(null);
+        setSceneBgColor(null);
+        syncNativeViewMenu({ perspective: null, centerMark: null, bgColor: null });
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [activeMolViewId, cm, syncNativeViewMenu]);
+
+  return {
+    viewProjection,
+    viewCenterMark,
+    sceneBgColor,
+    onProjectionChanged,
+    onCenterMarkChanged,
+    onBgColorChanged,
+  };
+}

--- a/tritium/react-gui/src/renderer/hooks/useAppInitialization.ts
+++ b/tritium/react-gui/src/renderer/hooks/useAppInitialization.ts
@@ -1,0 +1,52 @@
+/**
+ * @file hooks/useAppInitialization.ts
+ * @description Creates the initial scene and view once CueMol is ready, and
+ * registers them as the first molview tab. Guarded against React 18 StrictMode
+ * double-invocation via a module-level ref.
+ *
+ * Extracted verbatim from App.tsx (pre-E) so that the side effect of "first
+ * scene appears on launch" is preserved through E's structural refactor.
+ */
+
+import { useEffect, useRef } from 'react';
+import type { SceneManager } from '@cuemol/core/src/wrappers/SceneManager';
+import type { AsyncCueMol } from '../worker/client/AsyncCueMol';
+
+interface UseAppInitializationOptions {
+  cm: AsyncCueMol | null;
+  cueMolReady: boolean;
+  addMolTab: (title: string, viewId: number, sceneId: number) => void;
+  addMolViewTab: (title: string, viewId: number) => void;
+}
+
+export function useAppInitialization({
+  cm,
+  cueMolReady,
+  addMolTab,
+  addMolViewTab,
+}: UseAppInitializationOptions): void {
+  const initialSceneCreatedRef = useRef(false);
+
+  useEffect(() => {
+    if (!cueMolReady || !cm) return;
+    if (initialSceneCreatedRef.current) return;
+    initialSceneCreatedRef.current = true;
+
+    let cancelled = false;
+    (async () => {
+      const sceMgr = (await cm.getService('SceneManager')) as SceneManager;
+      if (!sceMgr || cancelled) return;
+      const scene = await sceMgr.createScene();
+      const scene_uid = await scene.getUID();
+      const view = await scene.createView();
+      const view_uid = await view.getUID();
+      if (cancelled) return;
+      const title = `Scene ${scene_uid}`;
+      // Register in MolTabState first so MolViewPane can read getActiveViewID()
+      addMolTab(title, view_uid, scene_uid);
+      // Open the outer tab (causes ContentPane to mount MolViewPane)
+      addMolViewTab(title, view_uid);
+    })();
+    return () => { cancelled = true; };
+  }, [cueMolReady, cm, addMolTab, addMolViewTab]);
+}

--- a/tritium/react-gui/src/renderer/hooks/useCommandRegistrations.ts
+++ b/tritium/react-gui/src/renderer/hooks/useCommandRegistrations.ts
@@ -1,0 +1,60 @@
+/**
+ * @file hooks/useCommandRegistrations.ts
+ * @description Composes the per-domain command-registration hooks
+ * (scene / dialog / tab / new-tab / edit / view) plus the Electron IPC bridge
+ * into a single call so App.tsx stays focused on layout.
+ *
+ * Each underlying hook keeps its own typed options surface; this composer
+ * merely passes through.
+ */
+
+import type { SceneBgColor, ViewCenterMark } from '../../shared/ipcTypes';
+import type { AsyncCueMol } from '../worker/client/AsyncCueMol';
+import { useSceneCommands } from '../commands/useSceneCommands';
+import { useUiDialogCommands } from '../commands/useUiDialogCommands';
+import { useTabCommands } from '../commands/useTabCommands';
+import { useNewTabCommand } from '../commands/useNewTabCommand';
+import { useEditCommands } from '../commands/useEditCommands';
+import { useViewCommands } from '../commands/useViewCommands';
+import { useElectronIpc } from './useElectronIpc';
+
+interface UseCommandRegistrationsOptions {
+  cm: AsyncCueMol | null;
+  addMolTab: (title: string, viewId: number, sceneId: number) => void;
+  addMolViewTab: (title: string, viewId: number) => void;
+  getActiveSceneInfo: () => { scene_uid: number; view_id: number } | null | undefined;
+  handleCloseTab: (id: string) => void | Promise<void>;
+  handleSave: () => void;
+  activeTab: string | null;
+  activeMolViewId: number | undefined;
+  onProjectionChanged: (perspective: boolean) => void;
+  onCenterMarkChanged: (centerMark: ViewCenterMark) => void;
+  onBgColorChanged: (bgColor: SceneBgColor) => void;
+}
+
+export function useCommandRegistrations({
+  cm,
+  addMolTab,
+  addMolViewTab,
+  getActiveSceneInfo,
+  handleCloseTab,
+  handleSave,
+  activeTab,
+  activeMolViewId,
+  onProjectionChanged,
+  onCenterMarkChanged,
+  onBgColorChanged,
+}: UseCommandRegistrationsOptions): void {
+  useSceneCommands({ cm, addMolTab, addMolViewTab, getActiveSceneInfo, onBgColorChanged });
+  useUiDialogCommands({ cm });
+  useTabCommands({ handleCloseTab });
+  useNewTabCommand({ cm, addMolTab, addMolViewTab, getActiveSceneInfo });
+  useEditCommands({ cm, getActiveSceneInfo, handleSave });
+  useViewCommands({
+    cm,
+    getActiveViewId: () => activeMolViewId,
+    onProjectionChanged,
+    onCenterMarkChanged,
+  });
+  useElectronIpc(activeTab);
+}

--- a/tritium/react-gui/src/renderer/hooks/useDialogFactory.tsx
+++ b/tritium/react-gui/src/renderer/hooks/useDialogFactory.tsx
@@ -1,0 +1,89 @@
+/**
+ * @file hooks/useDialogFactory.tsx
+ * @description Generic factory that turns a render-prop dialog component into
+ * an imperative `show(args) => Promise<result>` hook. Each dialog gets its own
+ * `Provider` and `useShow` pair so adding a new dialog is one file.
+ *
+ * Usage:
+ *   const { Provider: AboutDialogProvider, useShow: useShowAboutDialog } =
+ *     createDialogHook<void, void>({
+ *       name: 'AboutDialog',
+ *       render: ({ visible, resolve }) => (
+ *         <AboutDialog visible={visible} onClose={() => resolve()} />
+ *       ),
+ *     })
+ *
+ *   // In a command handler:
+ *   const showAbout = useShowAboutDialog()
+ *   await showAbout()
+ */
+
+import React, { createContext, useCallback, useContext, useRef, useState } from 'react'
+
+interface DialogState<TArgs> {
+  visible: boolean
+  args: TArgs | undefined
+}
+
+export interface DialogRenderProps<TArgs, TResult> {
+  visible: boolean
+  args: TArgs | undefined
+  resolve: (result: TResult) => void
+}
+
+export interface CreateDialogHookOptions<TArgs, TResult> {
+  /** Renders the dialog component for the current `visible`/`args` state. */
+  render: (props: DialogRenderProps<TArgs, TResult>) => React.ReactNode
+  /** Optional human label used in error messages. */
+  name?: string
+}
+
+export interface DialogHookHandle<TArgs, TResult> {
+  Provider: React.FC<{ children: React.ReactNode }>
+  useShow: () => (args: TArgs) => Promise<TResult>
+}
+
+export function createDialogHook<TArgs, TResult>(
+  options: CreateDialogHookOptions<TArgs, TResult>,
+): DialogHookHandle<TArgs, TResult> {
+  const Context = createContext<((args: TArgs) => Promise<TResult>) | null>(null)
+  const displayName = options.name ?? 'Dialog'
+  Context.displayName = `${displayName}Context`
+
+  const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [state, setState] = useState<DialogState<TArgs>>({ visible: false, args: undefined })
+    const resolveRef = useRef<((result: TResult) => void) | null>(null)
+
+    const show = useCallback((args: TArgs): Promise<TResult> => {
+      return new Promise<TResult>((resolve) => {
+        resolveRef.current = resolve
+        setState({ visible: true, args })
+      })
+    }, [])
+
+    const handleResolve = useCallback((result: TResult) => {
+      setState((prev) => ({ ...prev, visible: false }))
+      const r = resolveRef.current
+      resolveRef.current = null
+      r?.(result)
+    }, [])
+
+    return (
+      <Context.Provider value={show}>
+        {children}
+        {options.render({ visible: state.visible, args: state.args, resolve: handleResolve })}
+      </Context.Provider>
+    )
+  }
+  Provider.displayName = `${displayName}Provider`
+
+  function useShow(): (args: TArgs) => Promise<TResult> {
+    const ctx = useContext(Context)
+    if (!ctx) {
+      throw new Error(`use${displayName}: must be used inside <${displayName}Provider>.`)
+    }
+    return ctx
+  }
+
+  return { Provider, useShow }
+}

--- a/tritium/react-gui/src/renderer/hooks/useElectronIpc.ts
+++ b/tritium/react-gui/src/renderer/hooks/useElectronIpc.ts
@@ -19,6 +19,18 @@ import { CmdId } from '../commands/ids'
 import { IPC } from '../../shared/ipcChannels'
 import { useMenuDispatch } from './useMenuDispatch'
 
+/** Push channels whose only effect is to forward themselves to dispatchMenuChannel. */
+const MENU_PASS_THROUGH = [
+  IPC.MENU_NEW_TAB,
+  IPC.MENU_CLOSE_TAB,
+  IPC.MENU_SAVE,
+  IPC.MENU_NEW_SCENE,
+  IPC.MENU_OPEN_FILE,
+  IPC.MENU_OPEN_SCENE,
+  IPC.MENU_UNDO,
+  IPC.MENU_REDO,
+] as const
+
 export function useElectronIpc(activeTab: string | null): void {
   const { dispatch } = useCommands()
   const { dispatchMenuChannel } = useMenuDispatch(activeTab)
@@ -30,24 +42,17 @@ export function useElectronIpc(activeTab: string | null): void {
     const logErr = (prefix: string) => (e: unknown) => console.error(prefix, e)
 
     const unsubs = [
-      api.onObjFileOpened((d) =>
+      api.onPush(IPC.OBJ_FILE_OPENED, (d) =>
         dispatch(CmdId.OpenObjByPath, d).catch(logErr('obj open:')),
       ),
-      api.onSceneFileOpened((d) =>
+      api.onPush(IPC.SCENE_FILE_OPENED, (d) =>
         dispatch(CmdId.OpenSceneByPath, d.path).catch(logErr('scene open:')),
       ),
-      api.onFileError((d) =>
+      api.onPush(IPC.FILE_ERROR, (d) =>
         console.error(`Failed to open ${d.path}: ${d.error}`),
       ),
-      api.onMenuNewTab(() => dispatchMenuChannel(IPC.MENU_NEW_TAB)),
-      api.onMenuCloseTab(() => dispatchMenuChannel(IPC.MENU_CLOSE_TAB)),
-      api.onMenuSave(() => dispatchMenuChannel(IPC.MENU_SAVE)),
-      api.onMenuNewScene(() => dispatchMenuChannel(IPC.MENU_NEW_SCENE)),
-      api.onMenuOpenFile(() => dispatchMenuChannel(IPC.MENU_OPEN_FILE)),
-      api.onMenuOpenScene(() => dispatchMenuChannel(IPC.MENU_OPEN_SCENE)),
-      api.onMenuUndo(() => dispatchMenuChannel(IPC.MENU_UNDO)),
-      api.onMenuRedo(() => dispatchMenuChannel(IPC.MENU_REDO)),
-      api.onMenuGeneric((ch) => dispatchMenuChannel(ch)),
+      api.onPush(IPC.MENU_GENERIC, (ch) => dispatchMenuChannel(ch)),
+      ...MENU_PASS_THROUGH.map((ch) => api.onPush(ch, () => dispatchMenuChannel(ch))),
     ]
 
     return () => unsubs.forEach((u) => u())

--- a/tritium/react-gui/src/renderer/hooks/useLayoutPersistence.ts
+++ b/tritium/react-gui/src/renderer/hooks/useLayoutPersistence.ts
@@ -28,6 +28,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { PaneCollapseState, LayoutState, UiState } from "../../shared/ipcTypes";
+import { IPC } from "../../shared/ipcChannels";
 
 export type { PaneCollapseState, LayoutState, UiState };
 
@@ -83,7 +84,7 @@ export function useLayoutPersistence() {
       return;
     }
 
-    Promise.all([api.loadLayout(), api.loadUi()]).then(([savedLayout, savedUi]) => {
+    Promise.all([api.invoke(IPC.LAYOUT_LOAD), api.invoke(IPC.UI_LOAD)]).then(([savedLayout, savedUi]) => {
       if (savedLayout) setLayout((prev) => ({ ...prev, ...savedLayout }));
       if (savedUi) setUi((prev) => ({ ...prev, ...savedUi }));
       setLoaded(true);
@@ -96,7 +97,7 @@ export function useLayoutPersistence() {
     if (!api) return;
     if (layoutTimerRef.current) clearTimeout(layoutTimerRef.current);
     layoutTimerRef.current = setTimeout(() => {
-      api.saveLayout(layoutRef.current);
+      api.invoke(IPC.LAYOUT_SAVE, layoutRef.current);
     }, SAVE_DEBOUNCE_MS);
   }, []);
 
@@ -105,7 +106,7 @@ export function useLayoutPersistence() {
     if (!api) return;
     if (uiTimerRef.current) clearTimeout(uiTimerRef.current);
     uiTimerRef.current = setTimeout(() => {
-      api.saveUi(uiRef.current);
+      api.invoke(IPC.UI_SAVE, uiRef.current);
     }, SAVE_DEBOUNCE_MS);
   }, []);
 
@@ -207,11 +208,11 @@ export function useLayoutPersistence() {
     return () => {
       if (layoutTimerRef.current) {
         clearTimeout(layoutTimerRef.current);
-        window.electronAPI?.saveLayout(layoutRef.current);
+        window.electronAPI?.invoke(IPC.LAYOUT_SAVE, layoutRef.current);
       }
       if (uiTimerRef.current) {
         clearTimeout(uiTimerRef.current);
-        window.electronAPI?.saveUi(uiRef.current);
+        window.electronAPI?.invoke(IPC.UI_SAVE, uiRef.current);
       }
     };
   }, []);

--- a/tritium/react-gui/src/renderer/hooks/useMenuDispatch.ts
+++ b/tritium/react-gui/src/renderer/hooks/useMenuDispatch.ts
@@ -50,22 +50,22 @@ export function useMenuDispatch(activeTab: string | null): {
         case IPC.MENU_VIEW_ORTHOGRAPHIC:
           dispatch(CmdId.ViewOrthographic).catch(logErr('view.orthographic:'))
           break
-        case 'menu:center-mark-cross':
+        case IPC.MENU_CENTER_MARK_CROSS:
           dispatch(CmdId.ViewCenterMarkCross).catch(logErr('view.centerMark.cross:'))
           break
-        case 'menu:center-mark-axis':
+        case IPC.MENU_CENTER_MARK_AXIS:
           dispatch(CmdId.ViewCenterMarkAxis).catch(logErr('view.centerMark.axis:'))
           break
-        case 'menu:center-mark-none':
+        case IPC.MENU_CENTER_MARK_NONE:
           dispatch(CmdId.ViewCenterMarkNone).catch(logErr('view.centerMark.none:'))
           break
-        case 'menu:bg-white':
+        case IPC.MENU_BG_WHITE:
           dispatch(CmdId.SceneBgWhite).catch(logErr('scene.bg.white:'))
           break
-        case 'menu:bg-black':
+        case IPC.MENU_BG_BLACK:
           dispatch(CmdId.SceneBgBlack).catch(logErr('scene.bg.black:'))
           break
-        case 'menu:about':
+        case IPC.MENU_ABOUT:
           dispatch(CmdId.UiAboutDialog).catch(logErr('about dialog:'))
           break
         default:

--- a/tritium/react-gui/src/renderer/hooks/useNaviContextMenu.ts
+++ b/tritium/react-gui/src/renderer/hooks/useNaviContextMenu.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useCueMol } from './useCueMol';
 import type { HitTestResult } from '../types';
 import type { NaviCtxAction } from '../../shared/ipcTypes';
+import { IPC } from '../../shared/ipcChannels';
 
 export function useNaviContextMenu(): {
     openContextMenu: (hit: HitTestResult, viewId: number, x: number, y: number) => Promise<void>;
@@ -18,7 +19,7 @@ export function useNaviContextMenu(): {
         const atomLabel = hit.obj_name ? `${hit.obj_name}: ${hit.message}` : hit.message;
         const rendLabel = `${hit.rend_name} (${hit.rendtype})`;
 
-        const action: NaviCtxAction | null = await window.electronAPI.showNaviContextMenu({
+        const action: NaviCtxAction | null = await window.electronAPI.invoke(IPC.NAVI_CTX_SHOW, {
             x,
             y,
             isSymm,

--- a/tritium/react-gui/src/renderer/hooks/useTabManager.ts
+++ b/tritium/react-gui/src/renderer/hooks/useTabManager.ts
@@ -36,13 +36,6 @@ export function useTabManager(opts?: {
   const tabsRef = useRef<TabData[]>(tabs);
   useEffect(() => { tabsRef.current = tabs; }, [tabs]);
 
-  // ── Open via dialog ──────────────────────────────────────
-
-  /** Trigger the native file-open dialog (Electron). */
-  const handleOpenFile = useCallback(() => {
-    window.electronAPI?.openFile();
-  }, []);
-
   // ── Settings tab (singleton) ─────────────────────────────
 
   const openSettingsTab = useCallback(() => {
@@ -140,7 +133,6 @@ export function useTabManager(opts?: {
     setActiveTab,
     openSettingsTab,
     addMolViewTab,
-    handleOpenFile,
     handleCloseTab,
     handleReorderTabs,
     handleSave,

--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -17,6 +17,17 @@ import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../server/s
 import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../server/services/proposeNewTabNames.service';
 import type { GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service';
 import * as naviApi from './apis/naviApi';
+import type {
+    MethodArgs,
+    MethodKey,
+    MethodResult,
+    RpcArgs,
+    RpcKey,
+    RpcResult,
+    ServiceArgs,
+    ServiceKey,
+    ServiceResult,
+} from '../shared/WorkerCalls';
 
 const log = console;
 
@@ -42,6 +53,15 @@ export class AsyncCueMol {
     }
     invokeWorkerWithTransfer(method: string, transfer: any, ...args: any[]): Promise<any[]> {
         return this._transport.invokeWorkerWithTransfer(method, transfer, ...args);
+    }
+    invokeService<K extends ServiceKey>(name: K, args: ServiceArgs<K>): Promise<ServiceResult<K>> {
+        return this._transport.invokeService(name, args);
+    }
+    invokeMethodTyped<K extends MethodKey>(name: K, ...args: MethodArgs<K>): Promise<MethodResult<K>> {
+        return this._transport.invokeMethod(name, ...args);
+    }
+    invokeRpc<K extends RpcKey>(name: K, ...args: RpcArgs<K>): Promise<RpcResult<K>> {
+        return this._transport.invokeRpc(name, ...args);
     }
     postMessage(method: string, seq: number, args: any[], xfer: any = null): void {
         this._transport.postMessage(method, seq, args, xfer);

--- a/tritium/react-gui/src/renderer/worker/client/ObjProxy.ts
+++ b/tritium/react-gui/src/renderer/worker/client/ObjProxy.ts
@@ -22,58 +22,43 @@ export class ObjProxy {
         return this._obj;
     }
 
-    async getProp(propName: string): Promise<any> {
+    async getProp(propName: string): Promise<unknown> {
         try {
-            const result = await this._acm.invokeWorker(
-                "getProp",
-                this._obj,
-                propName,
-            );
-            log.info('NativeObj.getProp(',propName,') OK, result:', result);
-            if (isObjTuple(result[0])) {
-                const objTup = result[0] as ObjTuple;
-                return new ObjProxy(objTup._obj_id, objTup._class_name,
-                    this._acm);
-            } else {
-                return result[0];
+            const result = await this._acm.invokeRpc('getProp', this._obj, propName);
+            log.info('NativeObj.getProp(', propName, ') OK, result:', result);
+            if (isObjTuple(result)) {
+                const objTup = result as ObjTuple;
+                return new ObjProxy(objTup._obj_id, objTup._class_name, this._acm);
             }
+            return result;
         } catch (e) {
             log.error(`getProp failed: ${propName},`, e);
             throw e;
         }
     }
 
-    async setProp(propName: string, value: any): Promise<void> {
+    async setProp(propName: string, value: unknown): Promise<void> {
         try {
-            await this._acm.invokeWorker(
-                "setProp",
-                this._obj,
-                propName,
-                value,
-            );
-            log.info('NativeObj.setProp(',propName,') OK');
+            await this._acm.invokeRpc('setProp', this._obj, propName, value);
+            log.info('NativeObj.setProp(', propName, ') OK');
         } catch (e) {
             log.error(`setProp failed: ${propName},`, e);
             throw e;
         }
     }
 
-    async invokeMethod(method: string, ...args: any[]): Promise<any> {
+    async invokeMethod(method: string, ...args: unknown[]): Promise<unknown> {
         try {
-            const result = await this._acm.invokeWorker("invokeMethod",
-                method, this._obj, args);
-            log.info('NativeObj.invokeMethod(', method,') OK, result:', result);
-            if (isObjTuple(result[0])) {
-                const objTup = result[0] as ObjTuple;
-                return new ObjProxy(objTup._obj_id, objTup._class_name,
-                    this._acm);
-            } else {
-                return result[0];
+            const result = await this._acm.invokeRpc('invokeMethod', method, this._obj, args);
+            log.info('NativeObj.invokeMethod(', method, ') OK, result:', result);
+            if (isObjTuple(result)) {
+                const objTup = result as ObjTuple;
+                return new ObjProxy(objTup._obj_id, objTup._class_name, this._acm);
             }
+            return result;
         } catch (e) {
             log.error(`invokeMethod failed: ${method},`, e);
             throw e;
         }
-
     }
 }

--- a/tritium/react-gui/src/renderer/worker/client/WorkerTransport.ts
+++ b/tritium/react-gui/src/renderer/worker/client/WorkerTransport.ts
@@ -1,3 +1,15 @@
+import type {
+    MethodArgs,
+    MethodKey,
+    MethodResult,
+    RpcArgs,
+    RpcKey,
+    RpcResult,
+    ServiceArgs,
+    ServiceKey,
+    ServiceResult,
+} from '../shared/WorkerCalls';
+
 const log = console;
 
 function makeMethodSeq(method: string, seqno: number): string {
@@ -119,6 +131,27 @@ export class WorkerTransport {
         });
         this.postMessage(method, cur_seq, args, transfer);
         return promise;
+    }
+
+    // ───────────────────────────────────────────────────────────
+    // Typed call helpers (preferred over invokeWorker for new code).
+    // Each helper wraps invokeWorker's array-tail response into the
+    // single-value contract documented by the corresponding map.
+    // ───────────────────────────────────────────────────────────
+
+    async invokeService<K extends ServiceKey>(name: K, args: ServiceArgs<K>): Promise<ServiceResult<K>> {
+        const result = await this.invokeWorker(name, args);
+        return result[0] as ServiceResult<K>;
+    }
+
+    async invokeMethod<K extends MethodKey>(name: K, ...args: MethodArgs<K>): Promise<MethodResult<K>> {
+        const result = await this.invokeWorker(name, ...args);
+        return result[0] as MethodResult<K>;
+    }
+
+    async invokeRpc<K extends RpcKey>(name: K, ...args: RpcArgs<K>): Promise<RpcResult<K>> {
+        const result = await this.invokeWorker(name, ...args);
+        return result[0] as RpcResult<K>;
     }
 
     terminate(): void {

--- a/tritium/react-gui/src/renderer/worker/client/apis/editApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/editApi.ts
@@ -1,16 +1,16 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
+// Runs in renderer thread. Calls cross to worker via transport.invokeService.
 import { WorkerTransport } from '../WorkerTransport';
 
 export async function undo(
     transport: WorkerTransport, scene_id: number, depth = 0,
 ): Promise<boolean> {
-    const result = await transport.invokeWorker('undo', { sceneId: scene_id, depth });
-    return result?.[0]?.ok ?? false;
+    const result = await transport.invokeService('undo', { sceneId: scene_id, depth });
+    return result?.ok ?? false;
 }
 
 export async function redo(
     transport: WorkerTransport, scene_id: number, depth = 0,
 ): Promise<boolean> {
-    const result = await transport.invokeWorker('redo', { sceneId: scene_id, depth });
-    return result?.[0]?.ok ?? false;
+    const result = await transport.invokeService('redo', { sceneId: scene_id, depth });
+    return result?.ok ?? false;
 }

--- a/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
@@ -1,4 +1,4 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
+// Runs in renderer thread. Calls cross to worker via transport.invokeService.
 import { WorkerTransport } from '../WorkerTransport';
 import type { ElectronFileFilter } from '../../../../shared/ipcTypes';
 import type { FileOpenOptions } from '../../../components/fopen-opt-dlgs/types';
@@ -9,8 +9,7 @@ export async function getCompatibleRendererNames(
     transport: WorkerTransport, filePath: string,
 ): Promise<string[]> {
     try {
-        const result = await transport.invokeWorker('getCompatibleRendererNames', { filePath });
-        return result?.[0] ?? [];
+        return await transport.invokeService('getCompatibleRendererNames', { filePath });
     } catch (e) {
         log.warn('getCompatibleRendererNames failed:', e);
         return [];
@@ -21,8 +20,7 @@ export async function getOpenFilters(
     transport: WorkerTransport, catId: number,
 ): Promise<ElectronFileFilter[]> {
     try {
-        const result = await transport.invokeWorker('getOpenFilters', { catId });
-        return result?.[0] ?? [];
+        return await transport.invokeService('getOpenFilters', { catId });
     } catch (e) {
         log.warn('getOpenFilters failed:', e);
         return [];
@@ -33,8 +31,7 @@ export async function createNewSceneAndView(
     transport: WorkerTransport, dpr: number, name?: string,
 ): Promise<{ scene_uid: number; view_uid: number } | null> {
     try {
-        const result = await transport.invokeWorker('createNewSceneAndView', { dpr, name });
-        return result?.[0] ?? null;
+        return await transport.invokeService('createNewSceneAndView', { dpr, name });
     } catch (e) {
         log.error('createNewSceneAndView failed:', e);
         return null;
@@ -45,14 +42,14 @@ export async function loadScene(
     transport: WorkerTransport, filePath: string, scene_id: number,
 ): Promise<boolean> {
     log.info(`loading QSC scene: ${filePath}`);
-    const result = await transport.invokeWorker('loadScene', { filePath, sceneId: scene_id });
-    return result?.[0]?.ok ?? true;
+    const result = await transport.invokeService('loadScene', { filePath, sceneId: scene_id });
+    return result?.ok ?? true;
 }
 
 export async function loadObject(
     transport: WorkerTransport, filePath: string, scene_id: number, options: FileOpenOptions,
 ): Promise<boolean> {
     log.info(`loading object file: ${filePath}`);
-    const result = await transport.invokeWorker('loadObject', { filePath, sceneId: scene_id, options });
-    return result?.[0]?.ok ?? true;
+    const result = await transport.invokeService('loadObject', { filePath, sceneId: scene_id, options });
+    return result?.ok ?? true;
 }

--- a/tritium/react-gui/src/renderer/worker/client/apis/lifecycleApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/lifecycleApi.ts
@@ -1,4 +1,4 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
+// Runs in renderer thread. Calls cross to worker via transport.invoke{Service,Method}.
 import { WorkerTransport } from '../WorkerTransport';
 
 const log = console;
@@ -6,7 +6,7 @@ const log = console;
 export async function initCueMol(transport: WorkerTransport, sysConfigPath?: string): Promise<void> {
     log.info(`initCueMol sysConfigPath=<${sysConfigPath}>`);
     try {
-        await transport.invokeWorker('initCueMol', sysConfigPath);
+        await transport.invokeMethod('initCueMol', sysConfigPath);
         log.info('initCueMol OK');
     } catch (e) {
         log.error('initCueMol failed:', e);
@@ -15,8 +15,7 @@ export async function initCueMol(transport: WorkerTransport, sysConfigPath?: str
 
 export async function loadUserStyle(transport: WorkerTransport, userStylePath?: string): Promise<boolean> {
     try {
-        const result = await transport.invokeWorker('loadUserStyle', userStylePath);
-        return result[0] as boolean;
+        return await transport.invokeMethod('loadUserStyle', userStylePath);
     } catch (e) {
         log.error('loadUserStyle failed:', e);
         return false;
@@ -25,8 +24,7 @@ export async function loadUserStyle(transport: WorkerTransport, userStylePath?: 
 
 export async function setViewInputConfigStyle(transport: WorkerTransport, styleName: string): Promise<boolean> {
     try {
-        const result = await transport.invokeWorker('setViewInputConfigStyle', styleName);
-        return result[0] as boolean;
+        return await transport.invokeMethod('setViewInputConfigStyle', styleName);
     } catch (e) {
         log.error('setViewInputConfigStyle failed:', e);
         return false;
@@ -35,7 +33,7 @@ export async function setViewInputConfigStyle(transport: WorkerTransport, styleN
 
 export async function terminateWorker(transport: WorkerTransport): Promise<void> {
     try {
-        await transport.invokeWorker('terminateWorker');
+        await transport.invokeMethod('terminateWorker');
         log.info('terminateWorker OK');
         transport.terminate();
     } catch (e) {
@@ -45,8 +43,7 @@ export async function terminateWorker(transport: WorkerTransport): Promise<void>
 
 export async function getAppInfo(transport: WorkerTransport): Promise<{ version: string; build: string }> {
     try {
-        const result = await transport.invokeWorker('appInfo', {});
-        return result?.[0] ?? { version: '', build: '' };
+        return await transport.invokeService('appInfo', {});
     } catch (e) {
         log.warn('getAppInfo failed:', e);
         return { version: '', build: '' };

--- a/tritium/react-gui/src/renderer/worker/client/apis/naviApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/naviApi.ts
@@ -1,18 +1,17 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
+// Runs in renderer thread. Calls cross to worker via transport.invokeService.
 import { WorkerTransport } from '../WorkerTransport';
+import type { NaviClickAtomResult, NaviHitTestResult, NaviResidSelResult } from '../../server/services/naviTool.service';
 
 export async function naviHitTest(
     transport: WorkerTransport, args: { viewId: number; x: number; y: number },
-): Promise<{ hit: boolean; raw?: any } | null> {
-    const result = await transport.invokeWorker('naviHitTest', args);
-    return result?.[0] ?? null;
+): Promise<NaviHitTestResult | null> {
+    return await transport.invokeService('naviHitTest', args);
 }
 
 export async function naviClickAtom(
     transport: WorkerTransport, args: { viewId: number; x: number; y: number },
-): Promise<{ handled: boolean; statusMessage?: string; hitres?: any } | null> {
-    const result = await transport.invokeWorker('naviClickAtom', args);
-    return result?.[0] ?? null;
+): Promise<NaviClickAtomResult | null> {
+    return await transport.invokeService('naviClickAtom', args);
 }
 
 export async function naviResidSel(
@@ -22,67 +21,58 @@ export async function naviResidSel(
         mode: 'toggle' | 'extend';
         prevObjId?: number; prevAtomId?: number;
     },
-): Promise<{ handled: boolean; objId?: number; atomId?: number } | null> {
-    const result = await transport.invokeWorker('naviResidSel', args);
-    return result?.[0] ?? null;
+): Promise<NaviResidSelResult | null> {
+    return await transport.invokeService('naviResidSel', args);
 }
 
 export async function naviCenterAt(
     transport: WorkerTransport, args: { viewId: number; x: number; y: number; z: number },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCenterAt', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCenterAt', args);
 }
 
 export async function naviCenterAtSymm(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; rendId: number; atomId: number; symmId: number },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCenterAtSymm', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCenterAtSymm', args);
 }
 
 export async function naviCtxSelect(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; atomId: number; mode: 'atom' | 'residue' | 'chain' | 'mol' },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCtxSelect', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCtxSelect', args);
 }
 
 export async function naviCtxAddSelect(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; atomId: number; mode: 'atom' | 'residue' | 'chain' | 'mol' },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCtxAddSelect', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCtxAddSelect', args);
 }
 
 export async function naviCtxUnselect(
     transport: WorkerTransport, args: { viewId: number; objId: number },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCtxUnselect', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCtxUnselect', args);
 }
 
 export async function naviCtxInvertSel(
     transport: WorkerTransport, args: { viewId: number; objId: number },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCtxInvertSel', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCtxInvertSel', args);
 }
 
 export async function naviCtxToggleSidechain(
     transport: WorkerTransport, args: { viewId: number; objId: number },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCtxToggleSidechain', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCtxToggleSidechain', args);
 }
 
 export async function naviCtxAround(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; distance: number; byres: boolean },
 ): Promise<{ ok: boolean } | null> {
-    const result = await transport.invokeWorker('naviCtxAround', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('naviCtxAround', args);
 }

--- a/tritium/react-gui/src/renderer/worker/client/apis/sceneViewApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/sceneViewApi.ts
@@ -1,77 +1,67 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
-import type { ProposeUniqNameArgs, ProposeUniqNameResult } from '../../../worker/server/services/proposeUniqName.service';
-import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../../../worker/server/services/createViewInScene.service';
-import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../../../worker/server/services/proposeNewTabNames.service';
-import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../../../worker/server/services/getSceneCloseInfo.service';
+// Runs in renderer thread. Calls cross to worker via transport.invokeService.
+import type { ProposeUniqNameArgs, ProposeUniqNameResult } from '../../server/services/proposeUniqName.service';
+import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../../server/services/createViewInScene.service';
+import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../../server/services/proposeNewTabNames.service';
+import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../../server/services/getSceneCloseInfo.service';
 import { WorkerTransport } from '../WorkerTransport';
 import type { SceneBgColor, ViewCenterMark } from '../../../../shared/ipcTypes';
 
 export async function getViewProjection(
     transport: WorkerTransport, viewId: number,
 ): Promise<{ ok: boolean; perspective: boolean } | null> {
-    const result = await transport.invokeWorker('getViewProjection', { viewId });
-    return result?.[0] ?? null;
+    return await transport.invokeService('getViewProjection', { viewId });
 }
 
 export async function setViewProjection(
     transport: WorkerTransport, viewId: number, perspective: boolean,
 ): Promise<{ ok: boolean; perspective: boolean } | null> {
-    const result = await transport.invokeWorker('setViewProjection', { viewId, perspective });
-    return result?.[0] ?? null;
+    return await transport.invokeService('setViewProjection', { viewId, perspective });
 }
 
 export async function getViewCenterMark(
     transport: WorkerTransport, viewId: number,
 ): Promise<{ ok: boolean; centerMark: ViewCenterMark } | null> {
-    const result = await transport.invokeWorker('getViewCenterMark', { viewId });
-    return result?.[0] ?? null;
+    return await transport.invokeService('getViewCenterMark', { viewId });
 }
 
 export async function setViewCenterMark(
     transport: WorkerTransport, viewId: number, centerMark: ViewCenterMark,
 ): Promise<{ ok: boolean; centerMark: ViewCenterMark } | null> {
-    const result = await transport.invokeWorker('setViewCenterMark', { viewId, centerMark });
-    return result?.[0] ?? null;
+    return await transport.invokeService('setViewCenterMark', { viewId, centerMark });
 }
 
 export async function getSceneBgColor(
     transport: WorkerTransport, sceneId: number,
 ): Promise<{ ok: boolean; bgColor: SceneBgColor } | null> {
-    const result = await transport.invokeWorker('getSceneBgColor', { sceneId });
-    return result?.[0] ?? null;
+    return await transport.invokeService('getSceneBgColor', { sceneId });
 }
 
 export async function setSceneBgColor(
     transport: WorkerTransport, sceneId: number, colorName: 'white' | 'black',
 ): Promise<{ ok: boolean; bgColor: SceneBgColor } | null> {
-    const result = await transport.invokeWorker('setSceneBgColor', { sceneId, colorName });
-    return result?.[0] ?? null;
+    return await transport.invokeService('setSceneBgColor', { sceneId, colorName });
 }
 
 export async function proposeUniqName(
     transport: WorkerTransport, args: ProposeUniqNameArgs,
 ): Promise<ProposeUniqNameResult | null> {
-    const result = await transport.invokeWorker('proposeUniqName', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('proposeUniqName', args);
 }
 
 export async function createViewInScene(
     transport: WorkerTransport, args: CreateViewInSceneArgs,
 ): Promise<CreateViewInSceneResult | null> {
-    const result = await transport.invokeWorker('createViewInScene', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('createViewInScene', args);
 }
 
 export async function proposeNewTabNames(
     transport: WorkerTransport, args: ProposeNewTabNamesArgs,
 ): Promise<ProposeNewTabNamesResult | null> {
-    const result = await transport.invokeWorker('proposeNewTabNames', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('proposeNewTabNames', args);
 }
 
 export async function getSceneCloseInfo(
     transport: WorkerTransport, args: GetSceneCloseInfoArgs,
 ): Promise<GetSceneCloseInfoResult | null> {
-    const result = await transport.invokeWorker('getSceneCloseInfo', args);
-    return result?.[0] ?? null;
+    return await transport.invokeService('getSceneCloseInfo', args);
 }

--- a/tritium/react-gui/src/renderer/worker/client/apis/viewApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/viewApi.ts
@@ -1,4 +1,4 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
+// Runs in renderer thread. Calls cross to worker via transport.invokeMethod.
 import { WorkerTransport } from '../WorkerTransport';
 
 const log = console;
@@ -15,20 +15,20 @@ export async function bindCanvas(
 export async function addView(
     transport: WorkerTransport, view_id: number, dpr: number,
 ): Promise<boolean> {
-    const result = await transport.invokeWorker('addView', view_id, dpr);
-    if (result === null) {
-        log.warn(`addView failed for view_id: ${view_id}`);
+    try {
+        return await transport.invokeMethod('addView', view_id, dpr);
+    } catch (e) {
+        log.warn(`addView failed for view_id: ${view_id}`, e);
         return false;
     }
-    return result[0] as boolean;
 }
 
 export async function activateView(transport: WorkerTransport, view_id: number): Promise<void> {
-    await transport.invokeWorker('activateView', view_id);
+    await transport.invokeMethod('activateView', view_id);
 }
 
 export async function removeView(transport: WorkerTransport, view_id: number): Promise<void> {
-    await transport.invokeWorker('removeView', view_id);
+    await transport.invokeMethod('removeView', view_id);
 }
 
 export function resized(

--- a/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
+++ b/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
@@ -19,12 +19,20 @@ import type { TextImgBuf } from '@cuemol/core/src/wrappers/TextImgBuf';
 import type { ByteArray } from '@cuemol/core/src/wrappers/ByteArray';
 import type { WorkerContext } from './types/WorkerContext';
 
+import type {
+    MethodKey,
+    RpcKey,
+    ServiceFn,
+    ServiceKey,
+} from '../shared/WorkerCalls';
+
 // import { createLogger } from '@cuemol/core/src/logger';
 // const log = createLogger(import.meta.url);
 const log = console;
 
-type ServiceMethod = (...args: any[]) => any;
-type ServiceFn = (ctx: WorkerContext, args: any) => any | Promise<any>;
+/** Erased dispatch-table value types (per-key types are enforced by the maps). */
+type AnyMethodFn = (...args: any[]) => any;
+type AnyServiceFn = (ctx: WorkerContext, args: any) => any | Promise<any>;
 
 const makeModif = (event: any): number => {
     let modif = 0;
@@ -42,8 +50,8 @@ const makeModif = (event: any): number => {
 
 export class WorkerService {
 
-    private _methods: { [key: string]: ServiceMethod };
-    private _registered: { [name: string]: ServiceFn } = {};
+    private _methods: { [K in MethodKey | RpcKey]: AnyMethodFn };
+    private _registered: { [K in ServiceKey]?: AnyServiceFn } = {};
     private _internal: CueMolInternal;
     private _cm: CueMol;
     private _gfx_mgr: GfxManager | null = null;
@@ -94,11 +102,11 @@ export class WorkerService {
         }
     }
 
-    register(name: string, fn: ServiceFn): void {
+    register<K extends ServiceKey>(name: K, fn: ServiceFn<K>): void {
         if (name in this._registered) {
             log.warn(`WorkerService.register: overwriting "${name}"`);
         }
-        this._registered[name] = fn;
+        this._registered[name] = fn as AnyServiceFn;
     }
 
     createObj(className: string): any | null {
@@ -125,9 +133,11 @@ export class WorkerService {
 
     invoke(method: string, seqno: number, args: any[]): void {
         // log.info(`Worker> invoke called: ${method} seqno: ${seqno} args:`, args);
-        if (method in this._methods) {
+        const methodFn = (this._methods as Record<string, AnyMethodFn>)[method];
+        const serviceFn = (this._registered as Record<string, AnyServiceFn | undefined>)[method];
+        if (methodFn) {
             try {
-                const result = this._methods[method].apply(this, args);
+                const result = methodFn.apply(this, args);
                 if (Array.isArray(result)) {
                     this._postMessage([method, seqno, true, ...result]);
                 } else {
@@ -137,9 +147,9 @@ export class WorkerService {
                 log.error(`Worker> call method failed: ${method},`, e);
                 this._postMessage([method, seqno, false, e]);
             }
-        } else if (method in this._registered) {
+        } else if (serviceFn) {
             Promise.resolve()
-                .then(() => this._registered[method](this._buildContext(), args[0]))
+                .then(() => serviceFn(this._buildContext(), args[0]))
                 .then((result) => this._postMessage([method, seqno, true, result]))
                 .catch((e) => this._postMessage([method, seqno, false, String(e)]));
         } else {

--- a/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
@@ -39,7 +39,7 @@ function wrapGL(gl: any) {
     get(target, prop) {
       const orig = target[prop];
       if (typeof orig === 'function') {
-        return function (...args) {
+        return function (...args: unknown[]) {
           if (PERF_MEASURE) perfCounters.wrappedGlCalls++;
           const result = orig.apply(target, args);
           const err = target.getError();
@@ -141,7 +141,7 @@ export class GfxManager {
 
     removeView(view_id: number): void {
         this.stopViewLoop(view_id);
-        this.bound_views = this.bound_views.filter(x => x !== view_id);
+        this.bound_views = this.bound_views.filter((x: number) => x !== view_id);
     }
 
     startViewLoop(view_id: number): void {
@@ -501,7 +501,7 @@ export class GfxManager {
         gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
 
         const stride = nsize / num_elems;
-        elem_info.forEach((value) => {
+        elem_info.forEach((value: any) => {
             const aloc = value['nloc'];
             const atype = value['itype'];
             const gltype = convertType(gl, atype);

--- a/tritium/react-gui/src/renderer/worker/server/services/index.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/index.ts
@@ -1,12 +1,13 @@
 import type { WorkerService } from '../WorkerService';
+import type { ServiceFn, ServiceKey } from '../../shared/WorkerCalls';
 
-type ServiceFn = (ctx: any, args: any) => any;
+type AnyServiceFn = ServiceFn<ServiceKey>;
 
-type ServiceModule = {
+interface ServiceModule {
     name?: string;
-    default?: ServiceFn;
-    services?: Record<string, ServiceFn>;
-};
+    default?: AnyServiceFn;
+    services?: Record<string, AnyServiceFn>;
+}
 
 const modules = import.meta.glob('./*.service.ts', { eager: true }) as Record<
     string,
@@ -21,9 +22,12 @@ export function registerAllServices(svc: WorkerService): void {
             continue;
         }
         for (const [serviceName, fn] of Object.entries(m.services)) {
-            if (typeof fn === 'function') {
-                svc.register(serviceName, fn);
-            }
+            if (typeof fn !== 'function') continue;
+            // The glob iterates over string keys at runtime; cast to the typed
+            // ServiceKey domain so `svc.register` enforces ServiceFn<K>. A name
+            // not in ServiceMap would compile but produce a runtime warning at
+            // first invocation (unknown method).
+            svc.register(serviceName as ServiceKey, fn as ServiceFn<ServiceKey>);
         }
     }
 }

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -1,0 +1,187 @@
+/**
+ * Typed contract for the renderer ↔ Web Worker boundary.
+ *
+ * Three categories of calls flow over the same wire (`postMessage` with
+ * `[method, seqno, ...args]`) but have distinct dispatch semantics on the
+ * worker side; we mirror that split with three maps:
+ *
+ *   - ServiceMap  → business-logic services registered via `register(name, fn)`.
+ *                   Wire form: `invokeService(name, args)`. Worker side:
+ *                   `fn(ctx, args[0])` (single-arg).
+ *   - MethodMap   → infrastructure / hot-path methods declared in
+ *                   `WorkerService._methods`. Wire form:
+ *                   `invokeMethod(name, ...positional)`. Worker side:
+ *                   `fn.apply(this, args)` (variadic).
+ *   - RpcMap      → ObjProxy bridge handlers (createObj, getProp, …). Same
+ *                   variadic dispatch as MethodMap, kept separate to
+ *                   document the proxy intent.
+ *
+ * Adding a service / method / RPC: add an entry here, then implement on the
+ * worker side. Type-checking flows from this file outward.
+ */
+
+import type { ObjTuple } from './ObjTuple'
+
+import type { AppInfoResult } from '../server/services/appInfo.service'
+import type { CreateNewSceneAndViewArgs, CreateNewSceneAndViewResult } from '../server/services/createNewSceneAndView.service'
+import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../server/services/createViewInScene.service'
+import type { GetCompatibleRendererNamesArgs } from '../server/services/getCompatibleRendererNames.service'
+import type { GetOpenFiltersArgs } from '../server/services/getOpenFilters.service'
+import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service'
+import type { LoadObjectArgs } from '../server/services/loadObject.service'
+import type { LoadSceneArgs } from '../server/services/loadScene.service'
+import type {
+  NaviCenterAtArgs,
+  NaviCenterAtSymmArgs,
+  NaviCtxAroundArgs,
+  NaviCtxObjArgs,
+  NaviCtxSelectArgs,
+} from '../server/services/naviCtxtMenu.service'
+import type {
+  NaviClickAtomArgs, NaviClickAtomResult,
+  NaviHitTestArgs, NaviHitTestResult,
+  NaviResidSelArgs, NaviResidSelResult,
+} from '../server/services/naviTool.service'
+import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../server/services/proposeNewTabNames.service'
+import type { ProposeUniqNameArgs, ProposeUniqNameResult } from '../server/services/proposeUniqName.service'
+import type { RedoArgs } from '../server/services/redo.service'
+import type {
+  SceneBgColorArgs,
+  SceneBgColorResult,
+  SetSceneBgColorArgs,
+} from '../server/services/sceneBgColor.service'
+import type { UndoArgs } from '../server/services/undo.service'
+import type {
+  ViewCenterMarkArgs,
+  ViewCenterMarkResult,
+  ViewProjectionArgs,
+  ViewProjectionResult,
+} from '../server/services/viewProjection.service'
+import type { ElectronFileFilter } from '../../../shared/ipcTypes'
+import type { WorkerContext } from '../server/types/WorkerContext'
+
+// ────────────────────────────────────────────────────────────
+// Serialized DOM events (worker side cannot read live DOM events)
+// ────────────────────────────────────────────────────────────
+
+/** Mouse event fields that inputApi forwards to the worker. */
+export interface SerializedMouseEvent {
+  clientX: number; clientY: number
+  screenX: number; screenY: number
+  offsetX: number; offsetY: number
+  buttons: number; button: number
+  ctrlKey: boolean; shiftKey: boolean
+}
+
+/** Wheel event fields that inputApi forwards to the worker. */
+export interface SerializedWheelEvent {
+  offsetX: number; offsetY: number
+  screenX: number; screenY: number
+  deltaX: number; deltaY: number
+  ctrlKey: boolean; shiftKey: boolean; altKey: boolean
+}
+
+/** Synthetic gesture event built by inputApi (axisID + delta). */
+export interface SerializedGestureEvent {
+  offsetX: number; offsetY: number
+  screenX: number; screenY: number
+  ctrlKey: boolean; shiftKey: boolean; altKey: boolean
+  axisID: number; delta: number
+}
+
+// ────────────────────────────────────────────────────────────
+// ServiceMap (registered services — `_registered` table)
+// ────────────────────────────────────────────────────────────
+
+export interface ServiceMap {
+  appInfo:                    { args: Record<string, never>;          result: AppInfoResult }
+  createNewSceneAndView:      { args: CreateNewSceneAndViewArgs;       result: CreateNewSceneAndViewResult }
+  createViewInScene:          { args: CreateViewInSceneArgs;           result: CreateViewInSceneResult }
+  getCompatibleRendererNames: { args: GetCompatibleRendererNamesArgs;  result: string[] }
+  getOpenFilters:             { args: GetOpenFiltersArgs;              result: ElectronFileFilter[] }
+  getSceneCloseInfo:          { args: GetSceneCloseInfoArgs;           result: GetSceneCloseInfoResult }
+  loadObject:                 { args: LoadObjectArgs;                  result: { ok: boolean } }
+  loadScene:                  { args: LoadSceneArgs;                   result: { ok: boolean } }
+  proposeNewTabNames:         { args: ProposeNewTabNamesArgs;          result: ProposeNewTabNamesResult }
+  proposeUniqName:            { args: ProposeUniqNameArgs;             result: ProposeUniqNameResult }
+  redo:                       { args: RedoArgs;                        result: { ok: boolean } }
+  undo:                       { args: UndoArgs;                        result: { ok: boolean } }
+  getSceneBgColor:            { args: SceneBgColorArgs;                result: SceneBgColorResult }
+  setSceneBgColor:            { args: SetSceneBgColorArgs;             result: SceneBgColorResult }
+  getViewProjection:          { args: ViewProjectionArgs;              result: ViewProjectionResult }
+  setViewProjection:          { args: ViewProjectionArgs;              result: ViewProjectionResult }
+  getViewCenterMark:          { args: ViewCenterMarkArgs;              result: ViewCenterMarkResult }
+  setViewCenterMark:          { args: ViewCenterMarkArgs;              result: ViewCenterMarkResult }
+  naviHitTest:                { args: NaviHitTestArgs;                 result: NaviHitTestResult }
+  naviClickAtom:              { args: NaviClickAtomArgs;               result: NaviClickAtomResult }
+  naviResidSel:               { args: NaviResidSelArgs;                result: NaviResidSelResult }
+  naviCenterAt:               { args: NaviCenterAtArgs;                result: { ok: boolean } }
+  naviCenterAtSymm:           { args: NaviCenterAtSymmArgs;            result: { ok: boolean } }
+  naviCtxSelect:              { args: NaviCtxSelectArgs;               result: { ok: boolean } }
+  naviCtxAddSelect:           { args: NaviCtxSelectArgs;               result: { ok: boolean } }
+  naviCtxUnselect:            { args: NaviCtxObjArgs;                  result: { ok: boolean } }
+  naviCtxInvertSel:           { args: NaviCtxObjArgs;                  result: { ok: boolean } }
+  naviCtxToggleSidechain:     { args: NaviCtxObjArgs;                  result: { ok: boolean } }
+  naviCtxAround:              { args: NaviCtxAroundArgs;               result: { ok: boolean } }
+}
+
+export type ServiceKey = keyof ServiceMap
+export type ServiceArgs<K extends ServiceKey> = ServiceMap[K]['args']
+export type ServiceResult<K extends ServiceKey> = ServiceMap[K]['result']
+
+/** Worker-side service implementation signature. */
+export type ServiceFn<K extends ServiceKey> = (
+  ctx: WorkerContext,
+  args: ServiceArgs<K>,
+) => ServiceResult<K> | Promise<ServiceResult<K>>
+
+// ────────────────────────────────────────────────────────────
+// MethodMap (infrastructure / hot-path — `_methods` table)
+// ────────────────────────────────────────────────────────────
+
+export interface MethodMap {
+  initCueMol:              { args: [loadPath?: string];                                                    result: boolean }
+  loadUserStyle:           { args: [userStylePath?: string];                                               result: boolean }
+  setViewInputConfigStyle: { args: [styleName: string];                                                    result: boolean }
+  terminateWorker:         { args: [];                                                                      result: void }
+  addEventListener:        { args: [aCatStr: string, aSrcType: number, aEvtType: number, aSrcID: number]; result: number }
+  removeEventListener:     { args: [nID: number];                                                           result: unknown }
+  bindCanvas:              { args: [canvas: OffscreenCanvas, view_id: number, dpr: number];               result: boolean }
+  addView:                 { args: [view_id: number, dpr: number];                                          result: boolean }
+  activateView:            { args: [view_id: number];                                                       result: void }
+  removeView:              { args: [view_id: number];                                                       result: boolean }
+  resized:                 { args: [view_id: number, w: number, h: number, dpr: number];                   result: void }
+  mouseDown:               { args: [view_id: number, event: SerializedMouseEvent];                         result: void }
+  mouseUp:                 { args: [view_id: number, event: SerializedMouseEvent];                         result: void }
+  mouseMove:               { args: [view_id: number, event: SerializedMouseEvent];                         result: void }
+  wheel:                   { args: [view_id: number, event: SerializedWheelEvent];                         result: void }
+  gesture:                 { args: [view_id: number, event: SerializedGestureEvent];                       result: void }
+}
+
+export type MethodKey = keyof MethodMap
+export type MethodArgs<K extends MethodKey> = MethodMap[K]['args']
+export type MethodResult<K extends MethodKey> = MethodMap[K]['result']
+
+/** Worker-side method implementation signature (variadic positional). */
+export type MethodFn<K extends MethodKey> = (
+  ...args: MethodArgs<K>
+) => MethodResult<K> | Promise<MethodResult<K>>
+
+// ────────────────────────────────────────────────────────────
+// RpcMap (ObjProxy bridge — `_methods` table, dispatched as RPCs)
+// ────────────────────────────────────────────────────────────
+
+export interface RpcMap {
+  createObj:            { args: [className: string];                                                  result: ObjTuple | null }
+  getService:           { args: [className: string];                                                  result: ObjTuple | null }
+  hasClass:             { args: [className: string];                                                  result: boolean }
+  getAllClassNamesJSON: { args: [];                                                                    result: string }
+  getProp:              { args: [thisobj: ObjTuple, propName: string];                                result: unknown }
+  setProp:              { args: [thisobj: ObjTuple, propName: string, value: unknown];                result: boolean }
+  invokeMethod:         { args: [methodName: string, thisobj: ObjTuple, args: unknown[]];             result: unknown }
+}
+
+export type RpcKey = keyof RpcMap
+export type RpcArgs<K extends RpcKey> = RpcMap[K]['args']
+export type RpcResult<K extends RpcKey> = RpcMap[K]['result']
+

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -29,6 +29,12 @@ export const IPC = {
   MENU_REDO:      'menu:redo',
   MENU_VIEW_PERSPECTIVE:  'menu:view-perspective',
   MENU_VIEW_ORTHOGRAPHIC: 'menu:view-orthographic',
+  MENU_CENTER_MARK_CROSS: 'menu:center-mark-cross',
+  MENU_CENTER_MARK_AXIS:  'menu:center-mark-axis',
+  MENU_CENTER_MARK_NONE:  'menu:center-mark-none',
+  MENU_BG_WHITE:  'menu:bg-white',
+  MENU_BG_BLACK:  'menu:bg-black',
+  MENU_ABOUT:     'menu:about',
 
   // invoke channels (renderer → main, with reply) — menu role actions
   MENU_INVOKE_ROLE: 'menu:invoke-role',

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -1,0 +1,85 @@
+/**
+ * Typed contract for all IPC channels exchanged between Electron main,
+ * preload, and renderer.
+ *
+ * Two channel kinds are tracked:
+ *   - InvokeChannels: renderer → main, with reply (Promise)
+ *   - PushChannels:   main → renderer, no reply
+ *
+ * Adding a channel: extend either map below; the preload `invoke`/`onPush`
+ * helpers and the main `handleInvoke` wrapper pick up the new entry through
+ * the generic signatures.
+ */
+
+import { IPC } from './ipcChannels'
+import type {
+  AppPathInfo,
+  FileDialogOptions,
+  FileErrorData,
+  FileOpenedData,
+  LayoutState,
+  MenuState,
+  NaviCtxAction,
+  NaviCtxMenuPayload,
+  UiState,
+} from './ipcTypes'
+
+export interface InvokeChannels {
+  [IPC.APP_PATH]:          { req: void;                  res: AppPathInfo }
+  [IPC.DIALOG_OPEN]:       { req: FileDialogOptions;     res: void }
+  [IPC.LAYOUT_LOAD]:       { req: void;                  res: LayoutState | null }
+  [IPC.LAYOUT_SAVE]:       { req: LayoutState;           res: void }
+  [IPC.UI_LOAD]:           { req: void;                  res: UiState }
+  [IPC.UI_SAVE]:           { req: Partial<UiState>;      res: void }
+  [IPC.MENU_UPDATE_STATE]: { req: MenuState;             res: void }
+  [IPC.MENU_INVOKE_ROLE]:  { req: string;                res: void }
+  [IPC.NAVI_CTX_SHOW]:     { req: NaviCtxMenuPayload;    res: NaviCtxAction | null }
+}
+
+export interface PushChannels {
+  [IPC.OBJ_FILE_OPENED]:   FileOpenedData
+  [IPC.SCENE_FILE_OPENED]: FileOpenedData
+  [IPC.FILE_ERROR]:        FileErrorData
+  [IPC.MENU_NEW_TAB]:      void
+  [IPC.MENU_CLOSE_TAB]:    void
+  [IPC.MENU_SAVE]:         void
+  [IPC.MENU_NEW_SCENE]:    void
+  [IPC.MENU_OPEN_FILE]:    void
+  [IPC.MENU_OPEN_SCENE]:   void
+  [IPC.MENU_UNDO]:         void
+  [IPC.MENU_REDO]:         void
+  [IPC.MENU_GENERIC]:      string
+  [IPC.ROTATE_GESTURE]:    number
+}
+
+export type InvokeChannel = keyof InvokeChannels
+export type PushChannel = keyof PushChannels
+
+export type InvokeReq<C extends InvokeChannel> = InvokeChannels[C]['req']
+export type InvokeRes<C extends InvokeChannel> = InvokeChannels[C]['res']
+export type PushPayload<C extends PushChannel> = PushChannels[C]
+
+/** Variadic argument list for `invoke`: void requests take no arg. */
+export type InvokeArgs<C extends InvokeChannel> = InvokeReq<C> extends void
+  ? []
+  : [InvokeReq<C>]
+
+/** Callback signature for `onPush`: void payloads receive no argument. */
+export type PushCallback<C extends PushChannel> = PushPayload<C> extends void
+  ? () => void
+  : (payload: PushPayload<C>) => void
+
+/** The contextBridge API exposed on `window.electronAPI`. */
+export interface ElectronAPI {
+  /** Operating-system platform string (forwarded from `process.platform`). */
+  platform: string
+
+  /** Send an invoke request to main and await the typed response. */
+  invoke<C extends InvokeChannel>(channel: C, ...args: InvokeArgs<C>): Promise<InvokeRes<C>>
+
+  /**
+   * Subscribe to a push channel. Returns an unsubscribe function.
+   * The callback shape matches the channel's payload type.
+   */
+  onPush<C extends PushChannel>(channel: C, callback: PushCallback<C>): () => void
+}

--- a/tritium/react-gui/src/shared/ipcTypes.ts
+++ b/tritium/react-gui/src/shared/ipcTypes.ts
@@ -135,46 +135,8 @@ export interface MenuState {
   }
 }
 
-// ── ElectronAPI (the contextBridge contract) ────────────────────────────────
+// ── ElectronAPI ─────────────────────────────────────────────────────────────
+// The ElectronAPI interface lives in ./ipcContract (it's defined in terms of
+// the InvokeChannels / PushChannels maps). Re-exported here for convenience.
 
-export interface ElectronAPI {
-  platform: string
-
-  // App path info (for CueMol core init)
-  getAppPathInfo: () => Promise<AppPathInfo>
-
-  // File operations
-  openFile: (options: FileDialogOptions) => Promise<void>
-
-  // Menu event listeners (return unsubscribe function)
-  onObjFileOpened:   (callback: (data: FileOpenedData) => void) => () => void
-  onSceneFileOpened: (callback: (data: FileOpenedData) => void) => () => void
-  onFileError: (callback: (data: FileErrorData) => void) => () => void
-  onMenuNewTab: (callback: () => void) => () => void
-  onMenuCloseTab: (callback: () => void) => () => void
-  onMenuSave: (callback: () => void) => () => void
-  onMenuNewScene: (callback: () => void) => () => void
-  onMenuOpenFile: (callback: () => void) => () => void
-  onMenuOpenScene: (callback: () => void) => () => void
-  onMenuUndo: (callback: () => void) => () => void
-  onMenuRedo: (callback: () => void) => () => void
-  onMenuGeneric: (callback: (channel: string) => void) => () => void
-
-  // Invoke a native menu role action from the renderer (non-macOS custom menu)
-  invokeMenuRole: (role: string) => Promise<void>
-  updateMenuState: (state: MenuState) => Promise<void>
-
-  // Show native viewport context menu; resolves with the chosen action or null
-  showNaviContextMenu: (payload: NaviCtxMenuPayload) => Promise<NaviCtxAction | null>
-
-  // macOS-specific gesture events (sourced from Electron BrowserWindow)
-  onRotateGesture: (callback: (rotation: number) => void) => () => void
-
-  // Layout persistence
-  loadLayout: () => Promise<LayoutState>
-  saveLayout: (state: LayoutState) => Promise<void>
-
-  // UI preferences persistence
-  loadUi: () => Promise<UiState>
-  saveUi: (state: Partial<UiState>) => Promise<void>
-}
+export type { ElectronAPI } from './ipcContract'

--- a/tritium/react-gui/src/shared/menuTemplate.ts
+++ b/tritium/react-gui/src/shared/menuTemplate.ts
@@ -3,6 +3,8 @@
  * (native menu) and the renderer (React MenuBar on Windows/Linux).
  */
 
+import { IPC } from './ipcChannels'
+
 export type AppMenuRole =
   | 'cut' | 'copy' | 'paste' | 'selectAll'
   | 'reload' | 'forceReload' | 'toggleDevTools'
@@ -43,7 +45,7 @@ export const APP_MENU: AppMenuGroup[] = [
     label: 'CueMol2',
     darwinOnly: true,
     submenu: [
-      { id: 'about-mac', label: 'About CueMol3-tritium', ipcChannel: 'menu:about', darwinOnly: true },
+      { id: 'about-mac', label: 'About CueMol3-tritium', ipcChannel: IPC.MENU_ABOUT, darwinOnly: true },
       { type: 'separator' },
       { id: 'mac-prefs', label: 'Preferences...', accelerator: 'Cmd+,', ipcChannel: 'menu:options', darwinOnly: true },
       { type: 'separator' },
@@ -124,8 +126,8 @@ export const APP_MENU: AppMenuGroup[] = [
       {
         id: 'background', label: 'Background',
         submenu: [
-          { id: 'bg-white', label: 'White', type: 'radio', enabled: false, ipcChannel: 'menu:bg-white' },
-          { id: 'bg-black', label: 'Black', type: 'radio', enabled: false, ipcChannel: 'menu:bg-black' },
+          { id: 'bg-white', label: 'White', type: 'radio', enabled: false, ipcChannel: IPC.MENU_BG_WHITE },
+          { id: 'bg-black', label: 'Black', type: 'radio', enabled: false, ipcChannel: IPC.MENU_BG_BLACK },
         ],
       },
       { type: 'separator' },
@@ -144,9 +146,9 @@ export const APP_MENU: AppMenuGroup[] = [
       {
         id: 'center-mark', label: 'Center mark',
         submenu: [
-          { id: 'center-mark-cross', label: 'Cross', type: 'radio', checked: true, enabled: false, ipcChannel: 'menu:center-mark-cross' },
-          { id: 'center-mark-axis',  label: 'Axis',  type: 'radio', enabled: false, ipcChannel: 'menu:center-mark-axis' },
-          { id: 'center-mark-none',  label: 'None',  type: 'radio', enabled: false, ipcChannel: 'menu:center-mark-none' },
+          { id: 'center-mark-cross', label: 'Cross', type: 'radio', checked: true, enabled: false, ipcChannel: IPC.MENU_CENTER_MARK_CROSS },
+          { id: 'center-mark-axis',  label: 'Axis',  type: 'radio', enabled: false, ipcChannel: IPC.MENU_CENTER_MARK_AXIS },
+          { id: 'center-mark-none',  label: 'None',  type: 'radio', enabled: false, ipcChannel: IPC.MENU_CENTER_MARK_NONE },
         ],
       },
       { type: 'separator' },
@@ -188,7 +190,7 @@ export const APP_MENU: AppMenuGroup[] = [
   {
     label: 'Help',
     submenu: [
-      { id: 'about', label: 'About CueMol3-tritium', ipcChannel: 'menu:about', othersOnly: true },
+      { id: 'about', label: 'About CueMol3-tritium', ipcChannel: IPC.MENU_ABOUT, othersOnly: true },
       { type: 'separator' },
       { id: 'about-plugins',  label: 'About plugins...',  ipcChannel: 'menu:about-plugins' },
       { id: 'about-config',   label: 'About config...',   ipcChannel: 'menu:about-config' },

--- a/tritium/react-gui/tsconfig.web.json
+++ b/tritium/react-gui/tsconfig.web.json
@@ -3,6 +3,6 @@
   "include": ["src/renderer/**/*", "src/shared/**/*"],
   "compilerOptions": {
     "composite": true,
-    "noImplicitAny": false
+    "noImplicitAny": true
   }
 }


### PR DESCRIPTION
- Introduce three typed contract maps that drive type-checking across each inter-thread boundary: shared/ipcContract.ts (renderer<->main), worker/shared/WorkerCalls.ts (renderer<->Web Worker), and commands/CommandMap.ts (command bus). Adding a feature now starts by adding a row; producer and consumer sides are guided by compile errors.

- Replace per-channel preload methods (onMenuNewTab, getAppPathInfo, ...) with two generic helpers invoke<C> / onPush<C>. Adding an IPC channel drops from 4 files to 2 (constant + map row). Main side gains a typed handleInvoke wrapper that consumes the same map.

- Replace per-dialog state-and-handler in DialogContext with a createDialogHook factory. Each dialog now ships a Provider/useShow pair in one file; the composite DialogProvider mounts them. Adding a dialog drops from 5-7 files to 1 file + 3 lines.

- Decompose App.tsx (446 -> 342 lines) into useAppInitialization, useActiveViewState (single source of truth for cached view-state + menu sync), and useCommandRegistrations. Stabilize getActiveSceneInfo via useRef so a render-fresh callback identity does not retrigger the polling effect and overwrite state set by user-action callbacks.

- Type CommandRegistry register/dispatch over CmdId with a variadic-tuple helper for void-args commands; add a compile-time assertion that CommandMap covers exactly the CmdId enum.

- Enable noImplicitAny and replace IPC channel string literals with IPC.MENU_* constants from shared/ipcChannels.ts.

- Add testHarness helpers and 7 contract-pinning tests (commandRegistry, menuDispatch, preloadElectronApi, dialogContext, asyncCueMolInvoke, activeViewState, plus the helper file) that pin the observable contract of each boundary (wire format, channel name, payload shape) so internals can be replaced without behavioural drift.

- Update CLAUDE.md and tritium/CLAUDE.md to reflect the new boundary-map workflow, the per-dialog factory, the React-import-required-at-vitest caveat, and the npm test -> tsc -> task build_tritium -> task run_tritium validation chain.