### PR TITLE
Align file-open renderer options with UXP

### DIFF
--- a/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
@@ -147,6 +147,7 @@ describe('Modal dialog: backdrop click + close button are disabled', () => {
         filePath: '/tmp/foo.pdb',
         sceneId: 0,
         rendererTypes: ['*default'],
+        objType: '',
         onConfirm: () => {},
         onCancel: () => {},
       }),

--- a/tritium/react-gui/src/renderer/__test__/fileOpenOptionDialog.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/fileOpenOptionDialog.test.tsx
@@ -1,0 +1,375 @@
+/**
+ * Pin UXP-parity behaviors for FileOpenOptionDialog (renderer options):
+ *   1. Renderer name auto-updates on renderer-type change while flag=true.
+ *   2. Once the user edits renderer name, type change does NOT overwrite it.
+ *   3. Clearing the renderer name re-arms the auto-update.
+ *   4. Initial renderer type is restored from per-objType localStorage history.
+ *   5. History value not present in rendererTypes falls back to rendererTypes[0].
+ *   6. Open (confirm) writes the chosen renderer type back to history.
+ *   7. Initial object-name fetch uses { kind: 'object', tryBare: true, suffix: 'parens' }.
+ *   8. Stale proposeUniqName response (older type-change) is discarded by request-seq guard.
+ *
+ * All against the pdb file path so isMolFormat=true exercises the same code
+ * path as the real OpenObjByPath flow. MolSelList children are isolated via
+ * the cm mock returning empty for getSelDefs/validateSelection.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+
+void React
+
+vi.mock('@cuemol/core/src/wrappers/wrapper-loader', () => ({ wrapper_map: {} }))
+vi.mock('@cuemol/core/src/BaseWrapper', () => ({ BaseWrapper: class {} }))
+vi.mock('../contexts/ThemeContext', () => ({
+    useTheme: () => ({ theme: 'light' }),
+}))
+
+const mockCm = {
+    proposeUniqName: vi.fn(),
+    invokeService: vi.fn(),
+}
+
+vi.mock('../hooks/useCueMol', () => ({
+    useCueMol: () => ({ cueMolReady: true, cm: mockCm }),
+}))
+
+import { FileOpenOptionDialog } from '../components/fopen-opt-dlgs/FileOpenOptionDialog'
+import {
+    STORAGE_KEY,
+    getDefaultRendType,
+    setDefaultRendType,
+} from '../components/fopen-opt-dlgs/rendTypeHistory'
+import type { FileOpenOptions } from '../components/fopen-opt-dlgs/types'
+import { mountTree, flushPromises } from './helpers/testHarness'
+
+function findByText(root: ParentNode, tag: string, text: string): HTMLElement | null {
+    const els = Array.from(root.querySelectorAll(tag)) as HTMLElement[]
+    return els.find((b) => (b.textContent ?? '').trim() === text) ?? null
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype, 'value',
+    )!.set!
+    setter.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+function setSelectValue(select: HTMLSelectElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        HTMLSelectElement.prototype, 'value',
+    )!.set!
+    setter.call(select, value)
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+function getById<T extends HTMLElement>(id: string): T {
+    const el = document.body.querySelector('#' + id) as T | null
+    if (!el) throw new Error(`#${id} not found in mounted tree`)
+    return el
+}
+
+function mount(props: Partial<React.ComponentProps<typeof FileOpenOptionDialog>> = {}) {
+    let captured: FileOpenOptions | null = null
+    let canceled = false
+    const handle = mountTree(
+        React.createElement(FileOpenOptionDialog, {
+            visible: true,
+            filePath: '/path/1mbn.pdb',
+            sceneId: 7,
+            rendererTypes: ['simple', 'ribbon', 'cartoon'],
+            objType: 'MolCoord',
+            onConfirm: (o: FileOpenOptions) => { captured = o },
+            onCancel: () => { canceled = true },
+            ...props,
+        }),
+    )
+    return {
+        ...handle,
+        get captured() { return captured },
+        get canceled() { return canceled },
+    }
+}
+
+describe('FileOpenOptionDialog (UXP parity)', () => {
+    beforeEach(() => {
+        globalThis.localStorage.clear()
+        mockCm.proposeUniqName.mockReset()
+        mockCm.invokeService.mockReset()
+        mockCm.invokeService.mockImplementation((name: string) => {
+            if (name === 'getSelDefs') return Promise.resolve({ scene: [], global: [] })
+            if (name === 'validateSelection') return Promise.resolve({ ok: true })
+            return Promise.resolve(null)
+        })
+        // Default: return { name: prefix + (suffix style applied) } based on args
+        mockCm.proposeUniqName.mockImplementation((args: any) => {
+            if (args.kind === 'sceneRenderer') {
+                return Promise.resolve({ name: args.prefix + '1' })
+            }
+            if (args.kind === 'object') {
+                return Promise.resolve({ name: args.tryBare ? args.prefix : args.prefix + '1' })
+            }
+            return Promise.resolve({ name: args.prefix + '1' })
+        })
+    })
+
+    afterEach(() => {
+        // No timers to restore here.
+    })
+
+    it('on mount: requests scene-wide unique renderer name for the default type', async () => {
+        const handle = mount()
+        await flushPromises()
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls.length).toBeGreaterThanOrEqual(1)
+        expect(sceneRendCalls[0][0]).toMatchObject({
+            kind: 'sceneRenderer',
+            prefix: 'simple',
+            sceneId: 7,
+        })
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        expect(rendNameInput.value).toBe('simple1')
+        handle.unmount()
+    })
+
+    it('on mount: requests unique object name with tryBare + suffix:parens', async () => {
+        const handle = mount()
+        await flushPromises()
+        const objCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'object',
+        )
+        expect(objCalls.length).toBeGreaterThanOrEqual(1)
+        expect(objCalls[0][0]).toMatchObject({
+            kind: 'object',
+            prefix: '1mbn',
+            sceneId: 7,
+            tryBare: true,
+            suffix: 'parens',
+        })
+        const objNameInput = getById<HTMLInputElement>('rend-objname')
+        expect(objNameInput.value).toBe('1mbn')
+        handle.unmount()
+    })
+
+    it('renderer name auto-updates on type change while flag=true', async () => {
+        const handle = mount()
+        await flushPromises()
+        mockCm.proposeUniqName.mockClear()
+
+        const select = getById<HTMLSelectElement>('rend-type')
+        await act(async () => { setSelectValue(select, 'ribbon') })
+        await flushPromises()
+
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls.length).toBeGreaterThanOrEqual(1)
+        expect(sceneRendCalls[sceneRendCalls.length - 1][0]).toMatchObject({
+            kind: 'sceneRenderer', prefix: 'ribbon', sceneId: 7,
+        })
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        expect(rendNameInput.value).toBe('ribbon1')
+        handle.unmount()
+    })
+
+    it('renderer name does NOT auto-update on type change after user edits it', async () => {
+        const handle = mount()
+        await flushPromises()
+
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        await act(async () => { setInputValue(rendNameInput, 'myrend') })
+        await flushPromises()
+        expect(rendNameInput.value).toBe('myrend')
+
+        mockCm.proposeUniqName.mockClear()
+        const select = getById<HTMLSelectElement>('rend-type')
+        await act(async () => { setSelectValue(select, 'ribbon') })
+        await flushPromises()
+
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls.length).toBe(0)
+        expect(rendNameInput.value).toBe('myrend')
+        handle.unmount()
+    })
+
+    it('clearing the renderer name re-arms auto-update on next type change', async () => {
+        const handle = mount()
+        await flushPromises()
+
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        // user types
+        await act(async () => { setInputValue(rendNameInput, 'myrend') })
+        await flushPromises()
+        // user clears
+        await act(async () => { setInputValue(rendNameInput, '') })
+        await flushPromises()
+
+        mockCm.proposeUniqName.mockClear()
+        const select = getById<HTMLSelectElement>('rend-type')
+        await act(async () => { setSelectValue(select, 'cartoon') })
+        await flushPromises()
+
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls.length).toBeGreaterThanOrEqual(1)
+        expect(rendNameInput.value).toBe('cartoon1')
+        handle.unmount()
+    })
+
+    // Regression: emptying the field mid-edit must NOT trigger a re-fetch.
+    // UXP's XUL <textbox> only fires "change" on commit, so users never see
+    // an in-progress empty state replaced. React onChange fires per keystroke,
+    // so the auto-fill effect must not depend on the "is default" flag —
+    // otherwise the field gets reset while the user is mid-edit.
+    it('clearing the renderer name does NOT trigger immediate auto-fill', async () => {
+        const handle = mount()
+        await flushPromises()
+
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        expect(rendNameInput.value).toBe('simple1')
+
+        // Ignore the initial mount fetches.
+        mockCm.proposeUniqName.mockClear()
+
+        // User clears the field (e.g. Ctrl-A, Delete) — purely a mid-edit
+        // step before typing a custom name.
+        await act(async () => { setInputValue(rendNameInput, '') })
+        await flushPromises()
+
+        // Critically: no sceneRenderer fetch should fire from the empty
+        // transition alone. The field must stay empty so the user can type.
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls.length).toBe(0)
+        expect(rendNameInput.value).toBe('')
+
+        handle.unmount()
+    })
+
+    // Regression companion: typing partial characters must not trigger
+    // any auto-fill either, even if the field briefly contains values
+    // that look unusual.
+    it('typing into the renderer name does NOT trigger sceneRenderer fetches', async () => {
+        const handle = mount()
+        await flushPromises()
+
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        mockCm.proposeUniqName.mockClear()
+
+        // Simulate three keystrokes: 'a', 'ab', 'abc'.
+        await act(async () => { setInputValue(rendNameInput, 'a') })
+        await act(async () => { setInputValue(rendNameInput, 'ab') })
+        await act(async () => { setInputValue(rendNameInput, 'abc') })
+        await flushPromises()
+
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls.length).toBe(0)
+        expect(rendNameInput.value).toBe('abc')
+
+        handle.unmount()
+    })
+
+    it('initial rendererType comes from history when the value is in rendererTypes', async () => {
+        setDefaultRendType('MolCoord', 'ribbon')
+        const handle = mount()
+        await flushPromises()
+        const select = getById<HTMLSelectElement>('rend-type')
+        expect(select.value).toBe('ribbon')
+        const sceneRendCalls = mockCm.proposeUniqName.mock.calls.filter(
+            (c) => c[0].kind === 'sceneRenderer',
+        )
+        expect(sceneRendCalls[0][0]).toMatchObject({
+            kind: 'sceneRenderer', prefix: 'ribbon',
+        })
+        handle.unmount()
+    })
+
+    it('falls back to rendererTypes[0] when history value is not in rendererTypes', async () => {
+        setDefaultRendType('MolCoord', 'spaghetti')
+        const handle = mount()
+        await flushPromises()
+        const select = getById<HTMLSelectElement>('rend-type')
+        expect(select.value).toBe('simple')
+        handle.unmount()
+    })
+
+    it('Open writes the selected rendererType to history (per objType)', async () => {
+        const handle = mount()
+        await flushPromises()
+
+        const select = getById<HTMLSelectElement>('rend-type')
+        await act(async () => { setSelectValue(select, 'ribbon') })
+        await flushPromises()
+
+        const openBtn = findByText(document.body, 'button', 'Open') as HTMLButtonElement
+        expect(openBtn).toBeTruthy()
+        await act(async () => { openBtn.click() })
+        await flushPromises()
+
+        expect(getDefaultRendType('MolCoord')).toBe('ribbon')
+        const raw = globalThis.localStorage.getItem(STORAGE_KEY)
+        expect(raw && JSON.parse(raw)).toEqual({ MolCoord: 'ribbon' })
+        handle.unmount()
+    })
+
+    it('Open with empty objType does not write history (no-op set)', async () => {
+        const handle = mount({ objType: '' })
+        await flushPromises()
+        const openBtn = findByText(document.body, 'button', 'Open') as HTMLButtonElement
+        await act(async () => { openBtn.click() })
+        await flushPromises()
+        expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBeNull()
+        handle.unmount()
+    })
+
+    it('discards stale proposeUniqName responses (older type-change wins by seq)', async () => {
+        // Manual-controlled promise resolvers per call so we can decide the order.
+        const resolvers: Array<(v: { name: string }) => void> = []
+        mockCm.proposeUniqName.mockImplementation((args: any) => {
+            return new Promise((resolve) => {
+                if (args.kind === 'sceneRenderer') {
+                    resolvers.push(resolve as (v: { name: string }) => void)
+                } else {
+                    // Resolve object-name probe immediately so it doesn't interfere.
+                    resolve({ name: args.tryBare ? args.prefix : args.prefix + '1' })
+                }
+            })
+        })
+
+        const handle = mount()
+        // Don't flush yet — initial sceneRenderer probe is pending.
+        // Switch type A → B without resolving A first.
+        const select = getById<HTMLSelectElement>('rend-type')
+        await act(async () => { setSelectValue(select, 'ribbon') })
+        await act(async () => { setSelectValue(select, 'cartoon') })
+
+        // Resolve oldest first (stale), then newest.
+        // resolvers may have entries for initial 'simple', then 'ribbon', then 'cartoon'.
+        // Resolve in reverse to make the "stale wins" path impossible.
+        expect(resolvers.length).toBeGreaterThanOrEqual(2)
+        // Resolve the second-to-last (older) AFTER the last with stale value.
+        // The dialog should keep the value from the LATEST request.
+        await act(async () => {
+            // Resolve newest last.
+            for (let i = 0; i < resolvers.length - 1; ++i) {
+                resolvers[i]({ name: 'STALE_' + i })
+            }
+            resolvers[resolvers.length - 1]({ name: 'cartoon1' })
+        })
+        await flushPromises()
+
+        const rendNameInput = getById<HTMLInputElement>('rend-name')
+        expect(rendNameInput.value).toBe('cartoon1')
+        handle.unmount()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/getCompatibleRendererNamesService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/getCompatibleRendererNamesService.test.ts
@@ -19,7 +19,10 @@ const { getCompatibleRendererNames } = services
 interface FakeReaderHandle {
     name: string;
     setPath: ReturnType<typeof vi.fn>;
-    createDefaultObj: () => { searchCompatibleRendererNames: () => string } | null;
+    createDefaultObj: () => {
+        searchCompatibleRendererNames: () => string;
+        getClassName?: () => string | undefined;
+    } | null;
 }
 
 function makeEnv(opts: {
@@ -27,12 +30,15 @@ function makeEnv(opts: {
     readerRendTypes: Record<string, string>;
     /** Reader info JSON used by ext fallback. Order matters (first hit wins). */
     info: Array<{ name: string; fext: string; category: number }>;
+    /** Optional reader name → object class name (returned by tmpObj.getClassName()). */
+    readerClassNames?: Record<string, string | undefined>;
 }) {
     const createHandler = vi.fn((name: string, _cat: number): FakeReaderHandle => ({
         name,
         setPath: vi.fn(),
         createDefaultObj: () => ({
             searchCompatibleRendererNames: () => opts.readerRendTypes[name] ?? '',
+            getClassName: () => opts.readerClassNames?.[name],
         }),
     }))
     const getInfoJSON2 = vi.fn(() => JSON.stringify(opts.info))
@@ -50,6 +56,7 @@ describe('getCompatibleRendererNames — explicit readerName branch', () => {
     it('uses createHandler(readerName, 0) directly without consulting getInfoJSON2', () => {
         const env = makeEnv({
             readerRendTypes: { mmcif: 'simple,cartoon,tube,ribbon' },
+            readerClassNames: { mmcif: 'MolCoord' },
             info: [],
         })
         const result = getCompatibleRendererNames(env.ctx, {
@@ -60,19 +67,36 @@ describe('getCompatibleRendererNames — explicit readerName branch', () => {
         expect(env.getInfoJSON2).not.toHaveBeenCalled()
         expect(env.createHandler).toHaveBeenCalledTimes(1)
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual(['simple', 'cartoon', 'tube', 'ribbon'])
+        expect(result).toEqual({
+            types: ['simple', 'cartoon', 'tube', 'ribbon'],
+            objType: 'MolCoord',
+        })
     })
 
     it('filters out test-renderers and *-prefixed special entries', () => {
         const env = makeEnv({
             readerRendTypes: { mmcif: 'simple,*selection,ms2test,symm,cartoon' },
+            readerClassNames: { mmcif: 'MolCoord' },
             info: [],
         })
         const result = getCompatibleRendererNames(env.ctx, {
             filePath: '1mbn.cif',
             readerName: 'mmcif',
         })
-        expect(result).toEqual(['simple', 'cartoon'])
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord' })
+    })
+
+    it('returns empty objType when tmpObj.getClassName() is undefined', () => {
+        const env = makeEnv({
+            readerRendTypes: { mmcif: 'simple,cartoon' },
+            readerClassNames: { mmcif: undefined },
+            info: [],
+        })
+        const result = getCompatibleRendererNames(env.ctx, {
+            filePath: '1mbn.cif',
+            readerName: 'mmcif',
+        })
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: '' })
     })
 })
 
@@ -82,6 +106,7 @@ describe('getCompatibleRendererNames — extension fallback branch', () => {
     it('looks up reader by extension when readerName is omitted', () => {
         const env = makeEnv({
             readerRendTypes: { pdb: 'simple,cartoon' },
+            readerClassNames: { pdb: 'MolCoord' },
             info: [
                 { name: 'pdb', fext: '*.pdb;*.ent', category: 0 },
             ],
@@ -89,21 +114,22 @@ describe('getCompatibleRendererNames — extension fallback branch', () => {
         const result = getCompatibleRendererNames(env.ctx, { filePath: '/x/foo.pdb' })
         expect(env.getInfoJSON2).toHaveBeenCalled()
         expect(env.createHandler).toHaveBeenCalledWith('pdb', 0)
-        expect(result).toEqual(['simple', 'cartoon'])
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord' })
     })
 
-    it('returns [] when no reader matches the extension', () => {
+    it('returns empty types and empty objType when no reader matches the extension', () => {
         const env = makeEnv({
             readerRendTypes: {},
             info: [{ name: 'pdb', fext: '*.pdb', category: 0 }],
         })
         const result = getCompatibleRendererNames(env.ctx, { filePath: '/x/unknown.xyz' })
-        expect(result).toEqual([])
+        expect(result).toEqual({ types: [], objType: '' })
     })
 
     it('respects category filter (only OBJECT_READER, category=0)', () => {
         const env = makeEnv({
             readerRendTypes: { mmcif: 'simple,cartoon' },
+            readerClassNames: { mmcif: 'MolCoord' },
             info: [
                 { name: 'mmcifWriter', fext: '*.cif', category: 1 }, // wrong category
                 { name: 'mmcif',        fext: '*.cif', category: 0 },
@@ -111,7 +137,7 @@ describe('getCompatibleRendererNames — extension fallback branch', () => {
         })
         const result = getCompatibleRendererNames(env.ctx, { filePath: '1mbn.cif' })
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual(['simple', 'cartoon'])
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord' })
     })
 })
 
@@ -130,20 +156,22 @@ describe('getCompatibleRendererNames — .cif ambiguity (regression)', () => {
         mmcifmap: 'contour,isosurf',
     }
 
+    const classNames = { mmcif: 'MolCoord', mmcifmap: 'DensityMap' }
+
     it('without readerName: extension lookup picks the first JSON hit (mmcifmap)', () => {
-        const env = makeEnv({ readerRendTypes: rendTypes, info: ambiguousInfo })
+        const env = makeEnv({ readerRendTypes: rendTypes, readerClassNames: classNames, info: ambiguousInfo })
         const result = getCompatibleRendererNames(env.ctx, { filePath: '1mbn.cif' })
         expect(env.createHandler).toHaveBeenCalledWith('mmcifmap', 0)
-        expect(result).toEqual(['contour', 'isosurf'])
+        expect(result).toEqual({ types: ['contour', 'isosurf'], objType: 'DensityMap' })
     })
 
     it('with readerName="mmcif": explicit override defeats the ambiguity', () => {
-        const env = makeEnv({ readerRendTypes: rendTypes, info: ambiguousInfo })
+        const env = makeEnv({ readerRendTypes: rendTypes, readerClassNames: classNames, info: ambiguousInfo })
         const result = getCompatibleRendererNames(env.ctx, {
             filePath: '1mbn.cif',
             readerName: 'mmcif',
         })
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual(['simple', 'cartoon', 'tube', 'ribbon'])
+        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord' })
     })
 })

--- a/tritium/react-gui/src/renderer/__test__/proposeUniqNameService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/proposeUniqNameService.test.ts
@@ -6,10 +6,11 @@ function makeCtx(options: {
     sceneNames?: string[];
     viewNames?: string[];
     objectNames?: string[];
+    rendNames?: string[];
     sceneId?: number;
     molId?: number;
 } = {}) {
-    const { sceneNames = [], viewNames = [], objectNames = [], sceneId = 1, molId = 10 } = options
+    const { sceneNames = [], viewNames = [], objectNames = [], rendNames = [], sceneId = 1, molId = 10 } = options
 
     const mockMol = {
         getRendererByName: vi.fn((_name: string) => {
@@ -23,6 +24,9 @@ function makeCtx(options: {
         }),
         getObjectByName: vi.fn((name: string) => {
             return objectNames.includes(name) ? { uid: 99 } : null
+        }),
+        getRendByName: vi.fn((name: string) => {
+            return rendNames.includes(name) ? { uid: 99 } : null
         }),
         getObject: vi.fn((uid: number) => {
             return uid === molId ? mockMol : null
@@ -82,6 +86,55 @@ describe('proposeUniqName service', () => {
         it('increments past existing object names', () => {
             const { ctx } = makeCtx({ sceneId: 1, objectNames: ['Mol_1', 'Mol_2'] })
             expect(services.proposeUniqName(ctx, { kind: 'object', prefix: 'Mol_', sceneId: 1 })).toEqual({ name: 'Mol_3' })
+        })
+
+        it('with tryBare and no conflict, returns the bare prefix', () => {
+            const { ctx } = makeCtx({ sceneId: 1 })
+            expect(services.proposeUniqName(ctx, {
+                kind: 'object', prefix: '1mbn', sceneId: 1, tryBare: true, suffix: 'parens',
+            })).toEqual({ name: '1mbn' })
+        })
+
+        it('with tryBare + suffix:parens and a bare-name conflict, falls through to "(N)" format', () => {
+            const { ctx } = makeCtx({ sceneId: 1, objectNames: ['1mbn'] })
+            expect(services.proposeUniqName(ctx, {
+                kind: 'object', prefix: '1mbn', sceneId: 1, tryBare: true, suffix: 'parens',
+            })).toEqual({ name: '1mbn(1)' })
+        })
+
+        it('with tryBare + suffix:parens climbs to the next free index', () => {
+            const { ctx } = makeCtx({ sceneId: 1, objectNames: ['1mbn', '1mbn(1)', '1mbn(2)'] })
+            expect(services.proposeUniqName(ctx, {
+                kind: 'object', prefix: '1mbn', sceneId: 1, tryBare: true, suffix: 'parens',
+            })).toEqual({ name: '1mbn(3)' })
+        })
+
+        it('without tryBare/suffix, behavior is unchanged (regression pin)', () => {
+            const { ctx } = makeCtx({ sceneId: 1, objectNames: ['Mol_1'] })
+            expect(services.proposeUniqName(ctx, { kind: 'object', prefix: 'Mol_', sceneId: 1 })).toEqual({ name: 'Mol_2' })
+        })
+    })
+
+    describe('kind: sceneRenderer', () => {
+        it('returns prefix+1 when no renderers exist in the scene', () => {
+            const { ctx } = makeCtx({ sceneId: 1 })
+            expect(services.proposeUniqName(ctx, {
+                kind: 'sceneRenderer', prefix: 'ribbon', sceneId: 1,
+            })).toEqual({ name: 'ribbon1' })
+        })
+
+        it('increments past existing scene-wide renderer names', () => {
+            const { ctx } = makeCtx({ sceneId: 1, rendNames: ['ribbon1', 'ribbon2'] })
+            expect(services.proposeUniqName(ctx, {
+                kind: 'sceneRenderer', prefix: 'ribbon', sceneId: 1,
+            })).toEqual({ name: 'ribbon3' })
+        })
+
+        it('falls back to prefix+1 when scene is not found', () => {
+            const { ctx } = makeCtx({ sceneId: 1 })
+            expect(services.proposeUniqName(ctx, {
+                kind: 'sceneRenderer', prefix: 'ribbon', sceneId: 999,
+            })).toEqual({ name: 'ribbon1' })
         })
     })
 })

--- a/tritium/react-gui/src/renderer/__test__/rendTypeHistory.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/rendTypeHistory.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pin contract for fopen-opt-dlgs/rendTypeHistory.ts.
+ *
+ * Mirrors UXP `pref.get/set("cuemol2.ui.histories.new_renderer_type" + obj_type)`
+ * semantics on top of localStorage: per-objType last-used renderer type,
+ * resilient to corrupt JSON, and a no-op on empty keys/values.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+    STORAGE_KEY,
+    getDefaultRendType,
+    setDefaultRendType,
+    clearRendTypeHistory,
+} from '../components/fopen-opt-dlgs/rendTypeHistory'
+
+describe('rendTypeHistory', () => {
+    beforeEach(() => {
+        globalThis.localStorage.clear()
+    })
+
+    it('returns undefined when storage is empty', () => {
+        expect(getDefaultRendType('MolCoord')).toBeUndefined()
+    })
+
+    it('round-trips a value per objType', () => {
+        setDefaultRendType('MolCoord', 'ribbon')
+        expect(getDefaultRendType('MolCoord')).toBe('ribbon')
+    })
+
+    it('keeps entries for different objTypes independent', () => {
+        setDefaultRendType('MolCoord', 'ribbon')
+        setDefaultRendType('DensityMap', 'contour')
+        expect(getDefaultRendType('MolCoord')).toBe('ribbon')
+        expect(getDefaultRendType('DensityMap')).toBe('contour')
+    })
+
+    it('overwrites the existing value for the same objType', () => {
+        setDefaultRendType('MolCoord', 'ribbon')
+        setDefaultRendType('MolCoord', 'cartoon')
+        expect(getDefaultRendType('MolCoord')).toBe('cartoon')
+    })
+
+    it('returns undefined when stored JSON is corrupt', () => {
+        globalThis.localStorage.setItem(STORAGE_KEY, 'not-json')
+        expect(getDefaultRendType('MolCoord')).toBeUndefined()
+    })
+
+    it('returns undefined when stored payload is not a plain object', () => {
+        globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(['ribbon']))
+        expect(getDefaultRendType('MolCoord')).toBeUndefined()
+    })
+
+    it('returns undefined for an objType key whose stored value is not a string', () => {
+        globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ MolCoord: 123 }))
+        expect(getDefaultRendType('MolCoord')).toBeUndefined()
+    })
+
+    it('set is a no-op when objType is empty', () => {
+        setDefaultRendType('', 'ribbon')
+        expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('set is a no-op when rendType is empty', () => {
+        setDefaultRendType('MolCoord', '')
+        expect(globalThis.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('clearRendTypeHistory removes the storage entry', () => {
+        setDefaultRendType('MolCoord', 'ribbon')
+        clearRendTypeHistory()
+        expect(getDefaultRendType('MolCoord')).toBeUndefined()
+    })
+})

--- a/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
@@ -68,8 +68,13 @@ export function useSceneCommands({
             const info = getActiveSceneInfo()
             if (!info) return
             ;(async () => {
-                const rendererTypes = await cm.getCompatibleRendererNames(data.path)
-                const options = await showFileOpenOptionDialog({ filePath: data.path, sceneId: info.scene_uid, rendererTypes })
+                const { types, objType } = await cm.getCompatibleRendererNames(data.path)
+                const options = await showFileOpenOptionDialog({
+                    filePath: data.path,
+                    sceneId: info.scene_uid,
+                    rendererTypes: types,
+                    objType,
+                })
                 if (options === null) return
                 await cm.loadObject(data.path, info.scene_uid, options)
             })().catch((e: unknown) => console.error('OpenObjByPath failed:', e))
@@ -109,7 +114,7 @@ export function useSceneCommands({
                     // Pass readerName explicitly so the renderer-list lookup matches the
                     // load reader. Skipping it re-introduces the .cif ambiguity
                     // (mmcifmap wins by JSON order).
-                    const rendererTypes = await cm.getCompatibleRendererNames(virtualFilename, readerName)
+                    const { types: rendererTypes, objType } = await cm.getCompatibleRendererNames(virtualFilename, readerName)
                     if (!rendererTypes || rendererTypes.length === 0) {
                         console.warn(`Get PDB: no compatible renderer for ${virtualFilename}`)
                     } else {
@@ -117,6 +122,7 @@ export function useSceneCommands({
                             filePath: virtualFilename,
                             sceneId: info.scene_uid,
                             rendererTypes,
+                            objType,
                         })
                         if (options !== null) {
                             tasks.push(() => streamWithProgress(

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialog.tsx
@@ -6,11 +6,21 @@
  *   1. File info bar (filename + format badge)
  *   2. Renderer options — always visible (object name, type, selection, etc.)
  *   3. Format-specific options — collapsed by default, revealed on demand
+ *
+ * UXP parity (uxp_gui/cuemol2/base/content/fopen-renderopt-page.js):
+ *   - Renderer name auto-tracks the selected renderer type until the user
+ *     manually edits it (`rendererNameIsDefault` flag).
+ *   - Renderer type defaults to the last used value for the same C++ object
+ *     class (`objType`), persisted in localStorage via `rendTypeHistory`.
+ *   - Object name and renderer name are scene-wide unique via the worker
+ *     `proposeUniqName` service (resp. `kind: 'object'+tryBare+parens`,
+ *     `kind: 'sceneRenderer'`).
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Dialog, DialogBody, DialogFooter, Button, Collapse, Icon } from '@blueprintjs/core';
 import { useTheme } from '../../contexts/ThemeContext';
+import { useCueMol } from '../../hooks/useCueMol';
 
 import {
   type FileOpenOptions,
@@ -22,6 +32,7 @@ import {
   isFormatOptionsModified,
   isMolFormat,
 } from './types';
+import { getDefaultRendType, setDefaultRendType } from './rendTypeHistory';
 
 import { PdbOptionsPane } from './panes/PdbOptionsPane';
 import { MtzOptionsPane } from './panes/MtzOptionsPane';
@@ -51,6 +62,10 @@ function basename(filePath: string): string {
   return filePath.split(/[\\/]/).pop() ?? filePath;
 }
 
+function baseNameNoExt(filePath: string): string {
+  return filePath.split(/[\\/]/).pop()?.replace(/\.[^.]+$/, '') ?? 'molecule';
+}
+
 // ---- props ----
 
 export interface FileOpenOptionDialogProps {
@@ -58,6 +73,12 @@ export interface FileOpenOptionDialogProps {
   filePath: string;
   sceneId: number;
   rendererTypes: string[];
+  /**
+   * C++ object class name (e.g. 'MolCoord', 'DensityMap') of the file
+   * about to be loaded. Used as the renderer-type history key. Empty
+   * string disables history get/set (a safe no-op).
+   */
+  objType: string;
   onConfirm: (options: FileOpenOptions) => void;
   onCancel: () => void;
 }
@@ -69,40 +90,132 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
   filePath,
   sceneId,
   rendererTypes,
+  objType,
   onConfirm,
   onCancel,
 }) => {
   const { theme } = useTheme();
+  const { cm } = useCueMol();
   const formatKind = detectFormatKind(filePath);
   const formatName = formatLabel(formatKind);
   const hasFormatOptions = formatKind !== 'unknown';
 
-  const defaultRendType = rendererTypes.length > 0 ? rendererTypes[0] : undefined;
+  // Resolve the initial renderer type: history value if still listed,
+  // otherwise the first compatible type.
+  const initialRendType = useMemo(() => {
+    if (rendererTypes.length === 0) return undefined;
+    const hist = getDefaultRendType(objType);
+    if (hist && rendererTypes.includes(hist)) return hist;
+    return rendererTypes[0];
+  }, [rendererTypes, objType]);
 
   // Option state
   const [formatOptions, setFormatOptions] = useState<FormatOptions>(() =>
     buildDefaultFormatOptions(formatKind)
   );
   const [rendererOptions, setRendererOptions] = useState<RendererOptions>(() =>
-    getDefaultRendererOptions(filePath, defaultRendType)
+    getDefaultRendererOptions(filePath, initialRendType)
   );
   const [isFormatExpanded, setIsFormatExpanded] = useState(false);
+
+  // Tracks whether the renderer name is still the auto-generated default
+  // (no user edits since the last reset). Mirrors UXP's mRendNameDefault.
+  //
+  // Stored in a ref — NOT a state — so transitions don't re-fire the
+  // auto-fill effect. UXP's XUL <textbox> only fires "change" on commit
+  // (blur), so emptying the field mid-edit never re-triggers auto-fill;
+  // React's onChange fires per keystroke, so we get the same effect by
+  // keeping the flag out of the effect's dependency list.
+  const rendererNameIsDefaultRef = useRef(true);
+
+  // Separate stale-response guards so one effect's request doesn't
+  // accidentally invalidate the other.
+  const objNameSeqRef = useRef(0);
+  const rendNameSeqRef = useRef(0);
 
   // Reset state when a new file is shown (filePath changes between opens)
   const [lastFilePath, setLastFilePath] = useState(filePath);
   if (filePath !== lastFilePath) {
     setLastFilePath(filePath);
     setFormatOptions(buildDefaultFormatOptions(detectFormatKind(filePath)));
-    setRendererOptions(getDefaultRendererOptions(filePath, defaultRendType));
+    setRendererOptions(getDefaultRendererOptions(filePath, initialRendType));
     setIsFormatExpanded(false);
+    rendererNameIsDefaultRef.current = true;
+    // Discard any in-flight responses for the previous file.
+    objNameSeqRef.current += 1;
+    rendNameSeqRef.current += 1;
   }
+
+  // Effect: resolve a scene-wide unique object name when the dialog opens or
+  // the target file/scene changes. UXP tries the bare name first and only
+  // falls back to "name(1)", "name(2)", ... on conflict.
+  useEffect(() => {
+    if (!visible || !cm) return;
+    const prefix = baseNameNoExt(filePath);
+    const seq = ++objNameSeqRef.current;
+    (async () => {
+      const res = await cm.proposeUniqName({
+        kind: 'object',
+        prefix,
+        sceneId,
+        tryBare: true,
+        suffix: 'parens',
+      });
+      if (seq !== objNameSeqRef.current) return; // stale
+      if (!res) return;
+      setRendererOptions((prev) => ({ ...prev, objectName: res.name }));
+    })();
+  }, [cm, visible, filePath, sceneId]);
+
+  // Effect: while the renderer name is still the auto-default, resolve a
+  // scene-wide unique name for the currently selected renderer type. UXP
+  // re-generates the suggestion every time the type changes (only when
+  // mRendNameDefault is true).
+  //
+  // The flag is intentionally read from a ref, NOT listed as a dep, so
+  // that toggling it during mid-edit keystrokes does not retrigger this
+  // effect. The effect only fires on real navigational changes (type
+  // pick, file/scene swap, dialog open).
+  useEffect(() => {
+    if (!visible || !cm) return;
+    if (!rendererOptions.rendererType) return;
+    if (!rendererNameIsDefaultRef.current) return;
+    const seq = ++rendNameSeqRef.current;
+    (async () => {
+      const res = await cm.proposeUniqName({
+        kind: 'sceneRenderer',
+        prefix: rendererOptions.rendererType,
+        sceneId,
+      });
+      if (seq !== rendNameSeqRef.current) return; // stale
+      // Re-check after the await: the user may have typed into the field
+      // while the worker was resolving. UXP doesn't need this because XUL
+      // is synchronous, but in React the fetch is async and the user can
+      // race it.
+      if (!rendererNameIsDefaultRef.current) return;
+      if (!res) return;
+      setRendererOptions((prev) => ({ ...prev, rendererName: res.name }));
+    })();
+  }, [cm, visible, rendererOptions.rendererType, sceneId, filePath]);
+
+  // User edits to the renderer name: propagate the new value into the
+  // shared rendererOptions state, and silently update the "is default"
+  // ref so the next type-pick respects the customization. Updating the
+  // ref does NOT re-fire the auto-fill effect (the flag is not a dep),
+  // so emptying the field mid-edit no longer overwrites the input — the
+  // bad UX the previous implementation had.
+  const handleRendererNameEdit = useCallback((newName: string) => {
+    setRendererOptions((prev) => ({ ...prev, rendererName: newName }));
+    rendererNameIsDefaultRef.current = newName.length === 0;
+  }, []);
 
   const handleConfirm = useCallback(() => {
     if (rendererOptions.selectionEnabled && rendererOptions.selection) {
       pushHistory(rendererOptions.selection);
     }
+    setDefaultRendType(objType, rendererOptions.rendererType);
     onConfirm({ format: formatOptions, renderer: rendererOptions });
-  }, [onConfirm, formatOptions, rendererOptions]);
+  }, [onConfirm, formatOptions, rendererOptions, objType]);
 
   const isModified = hasFormatOptions && isFormatOptionsModified(formatOptions);
 
@@ -133,6 +246,7 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
           rendererTypes={rendererTypes}
           sceneId={sceneId}
           isMolFormat={isMolFormat(formatKind)}
+          onRendererNameUserEdit={handleRendererNameEdit}
         />
 
         {/* Format-specific options — progressive disclosure */}

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialogProvider.tsx
@@ -10,6 +10,12 @@ export interface FileOpenOptionDialogArgs {
   filePath: string
   sceneId: number
   rendererTypes?: string[]
+  /**
+   * C++ class name of the object the file resolves to (e.g. 'MolCoord',
+   * 'DensityMap'). Used by the dialog as the renderer-type history key.
+   * Empty string is treated as "no history" (safe no-op).
+   */
+  objType?: string
 }
 
 export const {
@@ -23,6 +29,7 @@ export const {
       filePath={args?.filePath ?? ''}
       sceneId={args?.sceneId ?? 0}
       rendererTypes={args?.rendererTypes ?? []}
+      objType={args?.objType ?? ''}
       onConfirm={(options) => resolve(options)}
       onCancel={() => resolve(null)}
     />

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/RendererOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/RendererOptionsPane.tsx
@@ -9,9 +9,16 @@ interface RendererOptionsPaneProps {
   rendererTypes: string[];
   sceneId: number;
   isMolFormat: boolean;
+  /**
+   * Routes renderer-name keystrokes through the parent so it can track
+   * whether the value is still the auto-generated default (UXP
+   * mRendNameDefault). When omitted, falls back to setting the field
+   * directly via the standard onChange path.
+   */
+  onRendererNameUserEdit?: (newValue: string) => void;
 }
 
-export const RendererOptionsPane: React.FC<RendererOptionsPaneProps> = ({ options, onChange, rendererTypes, sceneId, isMolFormat }) => {
+export const RendererOptionsPane: React.FC<RendererOptionsPaneProps> = ({ options, onChange, rendererTypes, sceneId, isMolFormat, onRendererNameUserEdit }) => {
   const set = <K extends keyof RendererOptions>(key: K) =>
     (value: RendererOptions[K]) => onChange({ ...options, [key]: value });
 
@@ -23,7 +30,6 @@ export const RendererOptionsPane: React.FC<RendererOptionsPaneProps> = ({ option
           id="rend-objname"
           value={options.objectName}
           onChange={(e) => set('objectName')(e.target.value)}
-          placeholder="molecule"
         />
       </FormGroup>
       <Divider />
@@ -45,8 +51,10 @@ export const RendererOptionsPane: React.FC<RendererOptionsPaneProps> = ({ option
         <InputGroup
           id="rend-name"
           value={options.rendererName}
-          onChange={(e) => set('rendererName')(e.target.value)}
-          placeholder="simple1"
+          onChange={(e) => {
+            if (onRendererNameUserEdit) onRendererNameUserEdit(e.target.value);
+            else set('rendererName')(e.target.value);
+          }}
         />
       </FormGroup>
       {isMolFormat && (

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/rendTypeHistory.ts
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/rendTypeHistory.ts
@@ -1,0 +1,49 @@
+/**
+ * @file rendTypeHistory.ts
+ * @description localStorage-backed per-objType "last used renderer type" for
+ * the file open dialog. Mirrors UXP semantics of
+ *   pref.get/set("cuemol2.ui.histories.new_renderer_type" + obj_type)
+ * but stored as a single keyed record so it's easy to inspect/clear.
+ *
+ * Reads are defensive: corrupt JSON, non-object payloads, or non-string
+ * values for a key all return `undefined` rather than throwing.
+ */
+
+export const STORAGE_KEY = 'cuemol.fopenOptions.rendTypeByObjType';
+
+function isStorageAvailable(): boolean {
+    return typeof globalThis !== 'undefined' && !!globalThis.localStorage;
+}
+
+function readMap(): Record<string, string> {
+    if (!isStorageAvailable()) return {};
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+        return parsed as Record<string, string>;
+    } catch {
+        return {};
+    }
+}
+
+export function getDefaultRendType(objType: string): string | undefined {
+    if (!objType) return undefined;
+    const map = readMap();
+    const v = map[objType];
+    return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+export function setDefaultRendType(objType: string, rendType: string): void {
+    if (!isStorageAvailable()) return;
+    if (!objType || !rendType) return;
+    const map = readMap();
+    map[objType] = rendType;
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+}
+
+export function clearRendTypeHistory(): void {
+    if (!isStorageAvailable()) return;
+    globalThis.localStorage.removeItem(STORAGE_KEY);
+}

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/types.ts
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/types.ts
@@ -133,11 +133,12 @@ export function getDefaultNamdCoorOptions(): NamdCoorOptions {
 export function getDefaultRendererOptions(filePath: string, defaultRendType?: string): RendererOptions {
   const fileName = filePath.split(/[\\/]/).pop()?.replace(/\.[^.]+$/, '') ?? 'molecule';
   const rendererType = defaultRendType ?? 'simple';
+  // Initial placeholder values; scene-wide unique versions are filled in
+  // asynchronously by FileOpenOptionDialog via the worker `proposeUniqName`
+  // service (object name via tryBare+parens, renderer name scene-wide).
   return {
     objectName: fileName,
     rendererType,
-    // TODO: renderer name should be unique in the scene (rendererType + incrementing suffix);
-    //       uniqueness check against existing renderers is not implemented yet.
     rendererName: rendererType + '1',
     selectionEnabled: false,
     selection: '*',

--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -13,6 +13,7 @@ import * as fileApi from './apis/fileApi';
 import * as editApi from './apis/editApi';
 import * as sceneViewApi from './apis/sceneViewApi';
 import type { ProposeUniqNameArgs, ProposeUniqNameResult } from '../server/services/proposeUniqName.service';
+import type { GetCompatibleRendererNamesResult } from '../server/services/getCompatibleRendererNames.service';
 import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../server/services/createViewInScene.service';
 import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../server/services/proposeNewTabNames.service';
 import type { GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service';
@@ -127,7 +128,7 @@ export class AsyncCueMol {
     }
 
     // -------- File operations
-    getCompatibleRendererNames(filePath: string, readerName?: string): Promise<string[]> {
+    getCompatibleRendererNames(filePath: string, readerName?: string): Promise<GetCompatibleRendererNamesResult> {
         return fileApi.getCompatibleRendererNames(this._transport, filePath, readerName);
     }
     getOpenFilters(catId: number): Promise<ElectronFileFilter[]> { return fileApi.getOpenFilters(this._transport, catId); }

--- a/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
@@ -2,19 +2,20 @@
 import { WorkerTransport } from '../WorkerTransport';
 import type { ElectronFileFilter } from '../../../../shared/ipcTypes';
 import type { FileOpenOptions } from '../../../components/fopen-opt-dlgs/types';
+import type { GetCompatibleRendererNamesResult } from '../../server/services/getCompatibleRendererNames.service';
 
 const log = console;
 
 export async function getCompatibleRendererNames(
     transport: WorkerTransport, filePath: string, readerName?: string,
-): Promise<string[]> {
+): Promise<GetCompatibleRendererNamesResult> {
     try {
         return await transport.invokeService('getCompatibleRendererNames', {
             filePath, readerName,
         });
     } catch (e) {
         log.warn('getCompatibleRendererNames failed:', e);
-        return [];
+        return { types: [], objType: '' };
     }
 }
 

--- a/tritium/react-gui/src/renderer/worker/server/services/getCompatibleRendererNames.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/getCompatibleRendererNames.service.ts
@@ -17,10 +17,23 @@ export interface GetCompatibleRendererNamesArgs {
     readerName?: string;
 }
 
+export interface GetCompatibleRendererNamesResult {
+    types: string[];
+    /**
+     * C++ class name of the temp object created by the reader
+     * (e.g. 'MolCoord', 'DensityMap'). Used as a history key for the
+     * "remember last-used renderer type per object kind" feature in
+     * FileOpenOptionDialog. Empty string when not available.
+     */
+    objType: string;
+}
+
+const EMPTY_RESULT: GetCompatibleRendererNamesResult = { types: [], objType: '' };
+
 function getCompatibleRendererNames(
     ctx: WorkerContext,
     args: GetCompatibleRendererNamesArgs
-): string[] {
+): GetCompatibleRendererNamesResult {
     let readerName: string;
     if (args.readerName) {
         readerName = args.readerName;
@@ -33,24 +46,28 @@ function getCompatibleRendererNames(
             (e) => e.category === 0 &&
                 e.fext.split(';').map((s) => s.trim().replace(/^\*\./, '').toLowerCase()).includes(ext)
         );
-        if (!readerEntry) return [];
+        if (!readerEntry) return EMPTY_RESULT;
         readerName = readerEntry.name;
     }
 
     const reader = ctx.strMgr.createHandler(readerName, 0) as ObjReader;
-    if (!reader) return [];
+    if (!reader) return EMPTY_RESULT;
     reader.setPath(args.filePath);
 
     const tmpObj = reader.createDefaultObj();
-    if (!tmpObj) return [];
+    if (!tmpObj) return EMPTY_RESULT;
+
+    const objType = (tmpObj as any).getClassName?.() ?? '';
 
     const rendTypesStr = tmpObj.searchCompatibleRendererNames();
-    if (!rendTypesStr) return [];
+    if (!rendTypesStr) return { types: [], objType };
 
-    return rendTypesStr
+    const types = rendTypesStr
         .split(',')
         .map((s: string) => s.trim())
         .filter((s: string) => s.length > 0 && s.charAt(0) !== '*' && !RENDERER_TEST_TYPES.has(s));
+
+    return { types, objType };
 }
 
 export const services = { getCompatibleRendererNames };

--- a/tritium/react-gui/src/renderer/worker/server/services/proposeUniqName.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/proposeUniqName.service.ts
@@ -2,13 +2,13 @@
 import type { WorkerContext } from '../types/WorkerContext';
 
 export type ProposeUniqNameArgs =
-    | { kind: 'scene'; prefix: string }
-    | { kind: 'view'; prefix: string; sceneId: number }
-    | { kind: 'object'; prefix: string; sceneId: number }
-    | { kind: 'renderer'; prefix: string; sceneId: number; molId: number }
+    | { kind: 'scene';         prefix: string }
+    | { kind: 'view';          prefix: string; sceneId: number }
+    | { kind: 'object';        prefix: string; sceneId: number; tryBare?: boolean; suffix?: 'numeric' | 'parens' }
+    | { kind: 'renderer';      prefix: string; sceneId: number; molId: number }
     | { kind: 'sceneRenderer'; prefix: string; sceneId: number }
-    | { kind: 'styleSet'; prefix: string; sceneId: number }
-    | { kind: 'camera'; prefix: string; sceneId: number };
+    | { kind: 'styleSet';      prefix: string; sceneId: number }
+    | { kind: 'camera';        prefix: string; sceneId: number };
 
 export interface ProposeUniqNameResult {
     name: string;
@@ -16,10 +16,16 @@ export interface ProposeUniqNameResult {
 
 const MAX_ITER = 9999;
 
+function buildCandidate(prefix: string, i: number, suffix: 'numeric' | 'parens'): string {
+    return suffix === 'parens' ? `${prefix}(${i})` : `${prefix}${i}`;
+}
+
 function proposeUniqName(ctx: WorkerContext, args: ProposeUniqNameArgs): ProposeUniqNameResult {
     const { prefix } = args;
 
     let tryFunc: (name: string) => unknown;
+    let tryBare = false;
+    let suffix: 'numeric' | 'parens' = 'numeric';
 
     switch (args.kind) {
         case 'scene': {
@@ -36,8 +42,13 @@ function proposeUniqName(ctx: WorkerContext, args: ProposeUniqNameArgs): Propose
         }
         case 'object': {
             const scene = ctx.sceMgr.getScene(args.sceneId);
+            tryBare = args.tryBare === true;
+            suffix = args.suffix ?? 'numeric';
             if (!scene) {
-                return { name: prefix + '1' };
+                // Without a scene we can't probe — return the most user-friendly
+                // candidate the caller asked for: bare prefix when tryBare,
+                // otherwise prefix+1 (legacy fallback).
+                return { name: tryBare ? prefix : prefix + '1' };
             }
             tryFunc = (name) => scene.getObjectByName(name);
             break;
@@ -62,7 +73,7 @@ function proposeUniqName(ctx: WorkerContext, args: ProposeUniqNameArgs): Propose
             // Scene-wide rendgroup naming: matches UXP `onNewRendGrp`'s
             // `scene.getRendByName` lookup so group names don't collide
             // with sibling renderers on other objects.
-            tryFunc = (name) => scene.getRendByName(name);
+            tryFunc = (name) => (scene as any).getRendByName(name);
             break;
         }
         case 'camera': {
@@ -99,8 +110,15 @@ function proposeUniqName(ctx: WorkerContext, args: ProposeUniqNameArgs): Propose
         }
     }
 
+    if (tryBare) {
+        const bare = tryFunc(prefix);
+        if (bare === null || bare === undefined) {
+            return { name: prefix };
+        }
+    }
+
     for (let i = 1; i <= MAX_ITER; ++i) {
-        const candidate = prefix + i.toString();
+        const candidate = buildCandidate(prefix, i, suffix);
         const existing = tryFunc(candidate);
         if (existing === null || existing === undefined) {
             return { name: candidate };

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -25,7 +25,7 @@ import type { ObjTuple } from './ObjTuple'
 import type { AppInfoResult } from '../server/services/appInfo.service'
 import type { CreateNewSceneAndViewArgs, CreateNewSceneAndViewResult } from '../server/services/createNewSceneAndView.service'
 import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../server/services/createViewInScene.service'
-import type { GetCompatibleRendererNamesArgs } from '../server/services/getCompatibleRendererNames.service'
+import type { GetCompatibleRendererNamesArgs, GetCompatibleRendererNamesResult } from '../server/services/getCompatibleRendererNames.service'
 import type { GetOpenFiltersArgs } from '../server/services/getOpenFilters.service'
 import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service'
 import type { GetSelDefsArgs, GetSelDefsResult } from '../server/services/getSelDefs.service'
@@ -259,7 +259,7 @@ export interface ServiceMap {
   appInfo:                    { args: Record<string, never>;          result: AppInfoResult }
   createNewSceneAndView:      { args: CreateNewSceneAndViewArgs;       result: CreateNewSceneAndViewResult }
   createViewInScene:          { args: CreateViewInSceneArgs;           result: CreateViewInSceneResult }
-  getCompatibleRendererNames: { args: GetCompatibleRendererNamesArgs;  result: string[] }
+  getCompatibleRendererNames: { args: GetCompatibleRendererNamesArgs;  result: GetCompatibleRendererNamesResult }
   getOpenFilters:             { args: GetOpenFiltersArgs;              result: ElectronFileFilter[] }
   getSceneCloseInfo:          { args: GetSceneCloseInfoArgs;           result: GetSceneCloseInfoResult }
   getSelDefs:                 { args: GetSelDefsArgs;                  result: GetSelDefsResult }


### PR DESCRIPTION
- Renderer name auto-updates on renderer-type pick, mirroring UXP mRendNameDefault. The flag is held in a ref so React's per-keystroke onChange does not retrigger the auto-fill effect mid-edit (XUL change fires only on commit, so UXP never had this race).
- Renderer type defaults to the last-used value for the same C++ object class, persisted in localStorage (cuemol.fopenOptions.rendTypeByObjType).
- Renderer name resolves to a scene-wide unique candidate via a new sceneRenderer kind on proposeUniqName. Object name uses tryBare + parens suffix to match UXP's "name(1)", "name(2)" pattern.
- getCompatibleRendererNames now returns { types, objType } so the dialog has the C++ class name for the history key.
- Drop misleading default-name placeholders ("simple1", "molecule") from the renderer/object name inputs.