### PR TITLE
Add Render Settings inspector target (rendering UI phase 1)

### DIFF
--- a/docs/migration/adr/ADR-0017-povray-rendering-ui.md
+++ b/docs/migration/adr/ADR-0017-povray-rendering-ui.md
@@ -1,0 +1,85 @@
+# ADR-0017: POV-Ray rendering UI — Inspector settings, BottomPanel tab, Render Result tab
+
+- Status: accepted (single-frame; animation rendering deferred)
+- Date: 2026-05-18
+- Mapping rows: [`dialog.tool.render-pov`](../mapping/tool_dlgs.md)
+
+## Context
+
+The UXP `render-pov-dlg` is a modeless dialog with a "Main options" /
+"POV-Ray options" two-tab layout and ~38 controls: image size, projection,
+stereo, quality, output, POV-Ray-specific lighting/radiosity, a Start/Stop
+button, a progress bar, an inline result thumbnail, and Save/Copy buttons.
+Execution (`uxp_gui/.../povrender.js`) drives the C++ `ProcessManager` /
+`StreamManager`: the scene is exported to `.pov`/`.inc`, POV-Ray is spawned,
+its stdout is polled for progress, and `blendpng` composites layers.
+
+`docs/migration/option-ux-guidelines.md` routes a "one-shot rendering with
+many options" away from a single giant modal toward panel/drawer surfaces.
+Reproducing the modeless dialog verbatim would also fight tritium's docked
+layout (Allotment panes) and its single-worker C++ bridge.
+
+## Decision
+
+Re-design the dialog across three existing surfaces ("case C"):
+
+- **Inspector — `renderSettings` target.** A fifth `InspectorTarget` kind
+  (`InspectorPanel` / `RenderSettingsEditor`) holds the editable settings
+  (Image / Camera / Quality / Output / backend-specific groups). Non-persistent
+  per the plan.
+- **BottomPanel — "Render" tab.** `RenderPanel` owns the state-changing
+  operations: Start/Stop, an image-size preset dropdown, progress bar, phase
+  and render log.
+- **ContentArea — "Render Result" tab.** `RenderResultPane` shows the finished
+  image (zoom / fit / pan) with Save / Copy / Re-render / Show Source Scene
+  actions. One result tab per source scene — re-rendering overwrites it.
+
+The pipeline runs entirely in the Web Worker (`renderJob.service.ts`): the
+C++ exporter writes `.pov`/`.inc`, `ProcessManager` spawns POV-Ray and
+`blendpng`, a worker timer polls progress, and updates are pushed to the
+renderer over a dedicated `render-progress` channel. A `RenderBackend`
+interface (`PovrayBackend`) keeps the pipeline backend-agnostic for future
+renderers. Binary paths are configured in the SettingsPane
+(`RenderConfigContext`, persisted via electron-store).
+
+## Consequences
+
+- The render dialog no longer blocks; settings, execution and results each
+  live on the surface that fits them, and result tabs accumulate as history.
+- The `RenderBackend` abstraction means a second backend needs only a
+  descriptor + a worker implementation, not UI rework.
+- Worker file I/O uses Node `fs` directly (`nodeIntegrationInWorker: true`),
+  so no Electron-main round-trips for temp files or the output image.
+- Cost: render settings are not persisted (deliberate); the camera is
+  captured at start via `Scene.saveViewToCam`, so a render reflects the
+  view at Start time, not at completion.
+- Animation / sequential rendering (UXP `anim-render-dlg`) is out of scope —
+  it is a separate inventory entry and would extend the same pipeline.
+
+## Notes
+
+- Implementation pointers:
+  - Inspector: `hooks/useInspectorState.ts` (`InspectorTarget` discriminated
+    union), `components/inspector/RenderSettingsEditor.tsx`,
+    `data/renderSettings.ts` / `data/renderBackends.ts`.
+  - BottomPanel: `components/panels/RenderPanel.tsx`, `hooks/useRenderJob.ts`.
+  - Result tab: `components/panes/RenderResultPane.tsx` /
+    `RenderImageViewer.tsx`, `data/renderResult.ts`.
+  - Worker: `worker/server/services/renderJob.service.ts`,
+    `worker/server/services/renderBackends/{RenderBackend,PovrayBackend}.ts`,
+    `render-progress` push channel in `WorkerTransport` / `AsyncCueMol`.
+  - Config: `contexts/RenderConfigContext.tsx`, `DIALOG_PICK_PATH` IPC.
+- ProcessManager gotcha: `LProcMgr` advances its queue only on `queueTask`
+  (its `doIdleTask` pump is not driven inside the worker), and
+  `getResultOutput` is what frees an ended task's slot. The service therefore
+  runs in two phases — render tasks first, then the blendpng finalize task is
+  queued once they finish, so that `queueTask` call starts it.
+- `blendpng` runs even for single-layer renders (it stamps DPI and adjusts
+  gamma); the pre-blendpng POV-Ray output is intentionally brighter and
+  matches the UXP pre-blend output.
+- UXP parity reference: `uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/povrender.js`,
+  `uxp_gui/cuemol2/base/content/tools/render-pov-dlg.{xul,js}`.
+- Plan document: `docs/plans/raytrace-rendering-ui-plan.md` (phases 1–5).
+- Deferred: animation/sequential rendering; app-bundle packaging of the
+  POV-Ray / blendpng binaries (paths currently default to a dev location and
+  are user-overridable in Settings).

--- a/docs/migration/adr/_index.md
+++ b/docs/migration/adr/_index.md
@@ -45,3 +45,4 @@ Architecture Decision Records for the UXP → tritium migration.
 | [ADR-0014](ADR-0014-file-menu-save-reload.md) | File menu — Save File As, Save current view, Reload Scene | accepted | 2026-05-16 | `menu.cuemol2` (Save File As, Save current view, Reload Scene) |
 | [ADR-0015](ADR-0015-generic-property-inspector.md) | Generic property inspector — docked pane, live-apply, getPropsJSON bridge | accepted (color/vector/timeval/nested-object pending) | 2026-05-16 | `overlay.propeditor-generic` |
 | [ADR-0016](ADR-0016-window-close-quit-funnel.md) | Window close and app quit — single win.on('close') confirm funnel | accepted (supersedes ADR-0010) | 2026-05-17 | `menu.cuemol2` (Quit), `menu.cuemol2-macos` (Quit), `other.cuemol2` |
+| [ADR-0017](ADR-0017-povray-rendering-ui.md) | POV-Ray rendering UI — Inspector settings, BottomPanel tab, Render Result tab, worker pipeline | accepted (single-frame; animation deferred) | 2026-05-18 | `dialog.tool.render-pov` |

--- a/docs/migration/mapping/_index.md
+++ b/docs/migration/mapping/_index.md
@@ -1,6 +1,6 @@
 # Migration Mapping — Index
 
-- Updated: 2026-05-16 (Added option-specification UX guidelines reference)
+- Updated: 2026-05-18 (POV-Ray rendering dialog migrated — phases 1–5)
 - Source files: `docs/migration/mapping/*.md` (excluding this file)
 - Option-specification UX: see [`../option-ux-guidelines.md`](../option-ux-guidelines.md)
   for routing dialog migrations to modal / panel / drawer / popover patterns
@@ -16,11 +16,11 @@
 | Toolbar | [toolbars.md](toolbars.md) | 2 | 0 | 1 | 0 | 1 | 0 |
 | Dialog\_property | [prop\_dlgs.md](prop_dlgs.md) | 13 | 0 | 0 | 0 | 13 | 0 |
 | Dialog\_other | [other\_dlgs.md](other_dlgs.md) | 18 | 0 | 3 | 0 | 15 | 0 |
-| Dialog\_tool | [tool\_dlgs.md](tool_dlgs.md) | 21 | 0 | 0 | 0 | 21 | 0 |
+| Dialog\_tool | [tool\_dlgs.md](tool_dlgs.md) | 21 | 1 | 0 | 0 | 20 | 0 |
 | Custom Widget | [custom\_widgets.md](custom_widgets.md) | 13 | 0 | 1 | 0 | 12 | 0 |
 | Overlay | [overlay.md](overlay.md) | 28 | 0 | 1 | 0 | 27 | 0 |
 | Other | [other.md](other.md) | 4 | 0 | 1 | 0 | 3 | 0 |
-| **Total** | | **120** | **1** | **18** | **0** | **101** | **0** |
+| **Total** | | **120** | **2** | **18** | **0** | **100** | **0** |
 
 > frozen = `blocked` status in mapping files
 
@@ -38,10 +38,10 @@
 |---------|------:|
 | 1:1 (`direct`) | 3 |
 | merged | 1 |
-| split | 12 |
+| split | 13 |
 | redesign | 0 |
 | deprecated (`dropped`) | 1 |
-| *(not yet assigned)* | 103 |
+| *(not yet assigned)* | 102 |
 
 ---
 
@@ -70,4 +70,4 @@
 
 ## Unstarted
 
-**102 / 120** items are `todo` (not yet started).
+**100 / 120** items are `todo` (not yet started).

--- a/docs/migration/mapping/tool_dlgs.md
+++ b/docs/migration/mapping/tool_dlgs.md
@@ -38,7 +38,7 @@ Status values:
 | [`dialog.tool.netpdb-progress`](../uxp-inventory/tool_dlgs.md#dialogtoolnetpdb-progress) | | | todo | | | |
 | [`dialog.tool.open-pdb`](../uxp-inventory/tool_dlgs.md#dialogtoolopen-pdb) | | | todo | | | |
 | [`dialog.tool.prot2ndry-tool`](../uxp-inventory/tool_dlgs.md#dialogtoolprot2ndry-tool) | | | todo | | | |
-| [`dialog.tool.render-pov`](../uxp-inventory/tool_dlgs.md#dialogtoolrender-pov) | | | todo | | | |
+| [`dialog.tool.render-pov`](../uxp-inventory/tool_dlgs.md#dialogtoolrender-pov) | `InspectorPanel` (RenderSettingsEditor) / `RenderPanel` / `RenderResultPane` / `renderJob.service` / `PovrayBackend` / `useRenderJob` | split | done | | [ADR-0017](../adr/ADR-0017-povray-rendering-ui.md) | Re-designed as Inspector Render Settings + BottomPanel Render tab + ContentArea Render Result tab; worker pipeline drives POV-Ray / blendpng via ProcessManager. Single-frame only; animation rendering deferred. See ADR-0017. |
 | [`dialog.tool.ssm-sup`](../uxp-inventory/tool_dlgs.md#dialogtoolssm-sup) | | | todo | | | |
 | [`dialog.tool.surf-cutbyplane`](../uxp-inventory/tool_dlgs.md#dialogtoolsurf-cutbyplane) | | | todo | | | |
 | [`dialog.tool.symm-chg`](../uxp-inventory/tool_dlgs.md#dialogtoolsymm-chg) | | | todo | | | |

--- a/docs/plans/raytrace-rendering-ui-plan.md
+++ b/docs/plans/raytrace-rendering-ui-plan.md
@@ -1,0 +1,434 @@
+# 実装計画書: レイトレーシングレンダリング UI（案C）
+
+> 対象: `tritium/react-gui`
+> 設計方針: 案C（Inspector の対象種別拡張）+ アプローチ1（結果は新規タブ）
+> ステータス: ドラフト（実装着手前レビュー対象）
+> 関連: `docs/migration/mapping/` の `dialog.tool.render-pov`
+
+---
+
+## 0. 背景・前提・調査結果サマリ
+
+### 0.1 背景
+
+CueMol2 旧 UI（uxp_gui）の POV-Ray レンダリング機能は **モードレスダイアログ** `render-pov-dlg.xul` として実装されており、"Main options" / "POV-Ray options" の 2 タブ構成・UI コントロール **38 個** を持つ。tritium/react-gui への移行にあたり、巨大 modal をそのまま再現せず、現行アーキテクチャ（Inspector / BottomPanel / ContentArea）に機能を分散配置して再設計する。
+
+`docs/migration/mapping/_index.md` 上 `dialog.tool.render-pov` は `todo`。`docs/migration/option-ux-guidelines.md` は "one-shot export / rendering with many options" を巨大 modal でなく panel / drawer 型へ誘導しており、本計画の方針と整合する。
+
+### 0.2 確定した設計方針
+
+- **案C**: Inspector の責務を「現在フォーカスされているコンテキストのプロパティエディタ」と再定義し、既存4種別（renderer / object / scene / view）に5番目 `renderSettings` を追加する。Render Settings は**永続化しない**。Inspector ヘッダーで現在の対象種別を視覚的に明示する。
+- **アプローチ1**: レンダリング完了時、ContentArea に**新しいタブ**として結果画像を開く。MolView タブ内トグルは採用しない。結果タブは独立タブとして複数並べられ、元シーンへの参照を保持する。
+- POV-Ray の **exe / inc / blendpng パス等の環境依存設定はアプリ設定（SettingsPane、永続）に分離**する。Render Settings（Inspector、非永続）はシーン毎の表現設定に限定する。
+- スコープは**単フレームレンダリングのみ**。アニメ連番レンダリング（UXP `anim-render-dlg`）は将来拡張点として §10 に記録する。
+- 外部プロセス実行は libcuemol2 の `ProcessManager` を tritium/core 経由で再利用する（新規 spawn 機構は不要、§7）。
+- 将来複数のレンダリングバックエンドをサポートするため、POV-Ray を1実装とし、バックエンド切り替えを追加しやすい抽象化を入れる（§8）。
+
+### 0.3 移植元の実行パイプライン（`povrender.js`）
+
+実行ロジックの移植元は `uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/povrender.js`。確定パイプラインは以下:
+
+1. **入力ファイル生成** — `StreamManager.createHandler("pov", 2)` で exporter を生成し、`perspective` / `useClipZ` / `usePostBlend` / `showEdgeLines` / `usePixImgs` / `camera` / `width` / `height` 等を設定 → `attach(scene)` → `setPath(.pov)` → `setSubPath("inc", .inc)` → `write()` → `detach()`。post-blend 時は `exporter.blendTable`(JSON) と `imgFileNames` を取得。
+2. **プロセス投入** — post-blend 時はレイヤー数ぶん `ProcessManager.queueTask(povExe, args, "")` を投入し、最後に `queueTask(blendpng, args, depends)` で合成タスクを投入。単レイヤー時は POV-Ray タスク1個（DPI 指定時のみ後段タスク）。
+3. **進捗ポーリング** — 1 秒間隔タイマーで全タスクの `getTaskStatus(tid)` / `getResultOutput(tid)` を確認。stdout を正規表現 `Rendered (\d+) of (\d+) pixels \((\d+)%\)` で進捗 % に変換。
+4. **完了** — 全タスク done で最終 PNG（一時ファイル）が利用可能。`saveImage(file)` でコピー保存、`onCopyImage()` でクリップボードコピー。
+
+### 0.4 移植元の C++ バックエンド
+
+- `ProcessManager`（libcuemol2 サービス）— 外部プロセスのキュー実行。`queueTask(exe, args, depends) → tid` / `getTaskStatus(tid)` / `getResultOutput(tid)` / `waitForExit(tid)` / `killAll()`。
+- `StreamManager`（libcuemol2 サービス）— `createHandler("pov", 2)` で POV exporter を生成。
+- `src/modules/rendering/` — `PovSceneExporter` / `PovDisplayContext` / `PovSilBuilder`。`PovSceneExporter` の主プロパティ: `perspective` / `makeRelIncPath` / `useClipZ` / `usePostBlend` / `blendTable` / `showEdgeLines` / `creaseLimit` / `edgeRise` / `usePixImgs` / `imgFileNames`。
+
+---
+
+## 1. 機能の責務分担（論点1）
+
+### 1.1 判断原則
+
+| 原則 | 配置先 |
+|---|---|
+| 設定値の編集（次回も同じ値で再現したい表現パラメータ） | **Inspector / Render Settings** |
+| 状態遷移を伴う操作（実行・停止・進捗・ログ） | **BottomPanel / Render タブ** |
+| 完了後の成果物の閲覧・書き出し（結果画像・保存・コピー） | **ContentArea / Render Result タブ** |
+| 環境依存の永続設定（exe / inc / blendpng パス） | **SettingsPane**（責務表の枠外、参照のみ） |
+
+### 1.2 uxp_gui 38 機能の配置（網羅表）
+
+凡例: I=Inspector / B=BottomPanel Render タブ / R=Render Result タブ / S=SettingsPane
+
+| # | uxp_gui 機能 | uxp の所在 | 配置先 | グループ／備考 |
+|---|---|---|---|---|
+| 1 | 画像幅 (output-image-width) | render-pov-dlg Main | I | Image |
+| 2 | 画像高さ (output-image-height) | render-pov-dlg Main | I | Image |
+| 3 | サイズ単位 (output-image-unit: px/in/mm/cm) | render-pov-dlg Main | I | Image（単位変換の振る舞い注記） |
+| 4 | DPI (output-image-dpi) | render-pov-dlg Main | I | Image |
+| 5 | プリセットサイズ (preset-size-list) | render-pov-dlg Main | I | Image |
+| 6 | 画像スケール | （Blender 参考で追加） | I | Image |
+| 7 | 投影方式 (proj-mode-list: perspec/ortho) | render-pov-dlg Main | I | Camera |
+| 8 | ステレオモード (stereo-mode-list: none/left/right) | render-pov-dlg Main | I | Camera |
+| 9 | ステレオ深度 (stereo-depth) | render-pov-dlg Main | I | Camera |
+| 10 | CPU スレッド数 (num-threads) | render-pov-dlg Main | I | Quality |
+| 11 | エッジライン表示 (enable-edgelines) | render-pov-dlg Main | I | Quality |
+| 12 | crease limit（エッジ検出角度） | PovSceneExporter.creaseLimit | I | Quality |
+| 13 | edge rise | PovSceneExporter.edgeRise | I | Quality |
+| 14 | 出力ファイル形式 | render-pov-dlg | I | Output |
+| 15 | 保存先（既定保存ディレクトリ） | render-pov-dlg | I | Output |
+| 16 | 背景透過 (use-transp-bg) | render-pov-dlg Main | I | Output |
+| 17 | クリップ平面有効化 (enable-clip-plane) | render-pov-dlg Main | I | Output |
+| 18 | ポストブレンド有効化 (enable-post-blend) | render-pov-dlg Main | I | Output |
+| 19 | ピクセルラベル表示 (enable-pixlabels) | render-pov-dlg Main | I | Output |
+| 20 | バックエンド選択 | （新規。§8） | I | Render Settings 先頭セレクタ |
+| 21 | radiosity モード (radio-mode-list: -1〜10) | render-pov-dlg POV | I | Backend Options（POV-Ray） |
+| 22 | シャドウ有効化 (enable-shadow) | render-pov-dlg POV | I | Backend Options（POV-Ray） |
+| 23 | ライトデフォルト使用 (povopt-lightdefault) | render-pov-dlg POV | I | Backend Options（連動の振る舞い注記） |
+| 24 | ライトスプレッド (povopt-lightspread) | render-pov-dlg POV | I | Backend Options（POV-Ray） |
+| 25 | ライトインテンシティ (povopt-lightinten) | render-pov-dlg POV | I | Backend Options（POV-Ray） |
+| 26 | フラッシュ比率 (povopt-flashfrac) | render-pov-dlg POV | I | Backend Options（POV-Ray） |
+| 27 | アンビエント比率 (povopt-ambinten) | render-pov-dlg POV | I | Backend Options（POV-Ray） |
+| 28 | POV-Ray exe パス (povray-exe-path + btn) | render-pov-dlg POV | S | アプリ設定（永続） |
+| 29 | POV-Ray inc パス (povray-inc-path + btn) | render-pov-dlg POV | S | アプリ設定（永続） |
+| 30 | blendpng exe パス | preferences | S | アプリ設定（永続） |
+| 31 | Start / Stop ボタン (accept, ラベル動的) | render-pov-dlg Result | B | 実行操作 |
+| 32 | 進捗バー (progress) | render-pov-dlg Result | B / StatusBar | 詳細は B、概要は StatusBar（§4） |
+| 33 | レンダリングログ（POV-Ray stdout） | putLogMsg | B | フェーズ・ログ表示 |
+| 34 | 結果プレビュー画像 (image-box) | render-pov-dlg Result | R | 画像ビューア |
+| 35 | ズーム操作 (ZoomBtn/UnzoomBtn/ZoomList 10〜300%) | render-pov-dlg Result | R | ビューアツールバー |
+| 36 | Save Image ボタン (extra1) | render-pov-dlg Result | R | ビューアツールバー |
+| 37 | Copy to Clipboard ボタン (extra2) | render-pov-dlg Result | R | ビューアツールバー |
+| 38 | Close ボタン (cancel) | render-pov-dlg Result | — | tritium ではタブクローズに吸収 |
+
+> uxp_gui 調査での総数: render-pov-dlg = 38 コントロール。加えて `anim-render-dlg` 専用 4 コントロール（出力ディレクトリ / ベース名 / FFmpeg / フレームスライダー）はスコープ外（§10）。
+
+---
+
+## 2. Inspector における設定のグルーピング（論点2）
+
+### 2.1 方針
+
+既存 `RendererPropertyEditor` 系（`PropertiesTab.tsx`）と一貫させ、`AccordionSection` を `PROPERTY_GROUPS` 相当のグループ定義配列で順に描画する方式を踏襲する（SegmentedControl は採用しない）。Render Settings は項目数が多いため、先頭にバックエンドセレクタ、続いてアコーディオン群を置く。
+
+### 2.2 グループ構成
+
+| 順 | グループ | UI | 項目 | defaultExpanded |
+|---|---|---|---|---|
+| 0 | Backend セレクタ | 非アコーディオン（`HTMLSelect`） | バックエンド選択（#20） | — |
+| 1 | Image | AccordionSection | width / height / unit / dpi / preset / scale（#1-6） | `true` |
+| 2 | Camera | AccordionSection | projection / stereo mode / stereo depth（#7-9） | `true` |
+| 3 | Quality | AccordionSection | num threads / edge lines / crease limit / edge rise（#10-13） | `false` |
+| 4 | Output | AccordionSection | file format / 保存先 / 背景透過 / clip plane / post-blend / pixel labels（#14-19） | `false` |
+| 5 | Backend Options | AccordionSection（動的） | 選択中バックエンドの固有項目（POV-Ray: #21-27） | `false` |
+
+- Image〜Output はバックエンド非依存（共通）。**Backend Options のみ §8 のバックエンド記述子 `optionGroups` から動的生成**する。
+- バックエンドセレクタの選択肢が1個（POV-Ray のみ）の間も、将来の追加を見越してセレクタ自体は常設する。
+
+### 2.3 振る舞いの注記（計画段階で明示、実装フェーズ1で詳細化）
+
+- **単位変換**: `unit` 変更時、現在値を px 経由で新単位へ換算する（UXP `convImgSizeUnit` / `convPixToUnit` 相当）。`dpi` は in/mm/cm 換算に必要。
+- **プリセット**: 選択で width / height / dpi を一括設定（UXP の `view` / `100x100@72dpi` / … 相当）。
+- **radiosity 連動**: `radiosity mode` 変更時、ライト群の初期値をモードに応じて切り替える（UXP `setupLightDefault`）。
+- **lightdefault 連動**: 「ライトデフォルト使用」ON の間、light spread / intensity / flash / ambient のスライダーを無効化する（UXP `setupDisableState`）。
+
+---
+
+## 3. レンダリング起動経路（論点3）
+
+| 経路 | 挙動 | 確認ダイアログ |
+|---|---|---|
+| Toolbar の Render ボタン / メニュー | Inspector を `renderSettings` 対象で開き、BottomPanel の Render タブを表示。**実行はしない**（設定確認を促す） | なし |
+| F12 ショートカット | 即座に実行（直近 Render Settings、なければ既定値）。BottomPanel の Render タブを前面化 | なし |
+| BottomPanel / Render タブの Start ボタン | 即座に実行 | なし |
+| 結果タブの "Re-render with these settings" | 結果タブが保持する `settingsSnapshot` を Render Settings に流し込み、即座に実行 | なし |
+
+**原則**: 設定をいじってから実行したい経路（Toolbar）は Inspector を開く / 素早く回したい経路（F12・Start・Re-render）は即実行。停止・再実行が安価なため確認ダイアログは原則出さない。実行中に重複起動された場合は、進行中ジョブの存在を Render タブで明示し新規起動を抑止する。
+
+---
+
+## 4. 進捗表示の階層（論点4）
+
+**原則: 概要は StatusBar、詳細は BottomPanel。**
+
+| 表示先 | 表示内容 | 表示条件 |
+|---|---|---|
+| **StatusBar** | 「Rendering… 42%」相当の1行サマリ。`busy` 相当の表示も連動 | レンダリング中のみ。完了/キャンセルで消える |
+| **BottomPanel / Render タブ** | 進捗バー（%）、フェーズ表示（exporting / running / blending）、バックエンド stdout ログ、経過時間、Start/Stop | 常時（タブ選択時） |
+
+- `StatusBar` は `StatusBarProps` を拡張して対応（既存 `statusMessage` / `busy` の枠組みを利用）。
+- ジョブ状態 (`RenderJob`) は単一の source of truth とし、StatusBar と Render タブはともにそれを参照する。
+
+---
+
+## 5. Render Result タブの仕様（論点5）
+
+### 5.1 タブタイトル命名規則
+
+`🎬 <SceneName> — <W>×<H> (<elapsed>s)`
+例: `🎬 Scene1 — 1216×612 (15.2s)`。`TabData.title` に格納する。複数回レンダリングすると複数の結果タブが並ぶ。
+
+### 5.2 画像ビューア
+
+- 表示は静的画像（PNG）。**WebGL を使わない**ため、`MolViewPane` の OffscreenCanvas「一度だけマウント」制約とは無関係。
+- 機能: Fit-to-View / 100% 表示 / ズームイン・ズームアウト（UXP の 10〜300% 相当のステップ）/ Pan（ドラッグ）。
+
+### 5.3 ツールバーアクション
+
+| アクション | 動作 |
+|---|---|
+| Save Image | `IPC.DIALOG_OBJECT_SAVE` でファイルダイアログを開き PNG 保存 |
+| Copy to Clipboard | 画像をクリップボードへコピー（Electron `clipboard.writeImage`、main 側 IPC 経由） |
+| Show Settings | `settingsSnapshot` をポップオーバー / パネルで表示 |
+| Re-render | `settingsSnapshot` を Render Settings に流し込み再実行（§3） |
+| Show Source Scene | `sourceSceneId` の MolView タブへ遷移（なければ復元） |
+
+### 5.4 元シーン情報・設定スナップショット
+
+- 結果タブは `RenderResult` を保持し、`sourceSceneId` + `sourceSceneName`（Show Source Scene 用）と `settingsSnapshot`（`RenderSettings` の deep copy、Show Settings / Re-render 用）を持つ。
+- スナップショットはレンダリング開始時点の値を凍結する（その後 Render Settings を変更しても結果タブの記録は不変）。
+
+---
+
+## 6. 型定義と状態管理（論点6）
+
+### 6.1 `InspectorTarget` の discriminated union 化
+
+現状はフラット型 `{ sceneId; nodeId; nodeType: PropTargetType }`（`hooks/useInspectorState.ts`）。これを discriminated union へ再定義する:
+
+```
+type InspectorTarget =
+  | { kind: 'renderer';       sceneId: number; nodeId: number }
+  | { kind: 'object';         sceneId: number; nodeId: number }
+  | { kind: 'scene';          sceneId: number; nodeId: number }
+  | { kind: 'view';           sceneId: number; viewId: number }
+  | { kind: 'renderSettings'; sceneId: number }
+```
+
+`renderSettings` はシーンツリーノードではないため `nodeId` を持たない。
+
+### 6.2 Render Settings / Job / Result の型（要点）
+
+```
+type RenderBackendId = 'povray'   // 将来 'luxcore' | ... を追加
+
+interface CommonRenderSettings {   // バックエンド非依存（Image/Camera/Quality/Output）
+  width; height; unit; dpi; preset?; scale;
+  projection: 'perspec' | 'ortho'; stereoMode: 'none'|'left'|'right'; stereoDepth;
+  numThreads; edgeLines: boolean; creaseLimit; edgeRise;
+  fileFormat; outputDir?; transparentBg: boolean; clipPlane: boolean;
+  postBlend: boolean; pixelLabels: boolean;
+}
+
+interface PovraySettings {         // POV-Ray 固有
+  radiosityMode: number;           // -1〜10
+  shadow: boolean; lightDefault: boolean;
+  lightSpread; lightIntensity; flashFraction; ambientFraction;
+}
+
+type BackendSettingsUnion = { backend: 'povray'; povray: PovraySettings }
+
+interface RenderSettings {
+  backend: RenderBackendId;
+  common: CommonRenderSettings;
+  backendOptions: BackendSettingsUnion;
+}
+
+interface RenderJob {
+  jobId: string;
+  backend: RenderBackendId;
+  status: 'idle'|'exporting'|'running'|'blending'|'done'|'error'|'cancelled';
+  progress: number;                // 0..100
+  phase: string;
+  log: string[];
+  startedAt: number;
+}
+
+interface RenderResult {
+  id: string;
+  imageData: Uint8Array | string;  // PNG bytes または一時ファイルパス
+  width: number; height: number;
+  elapsedSec: number;
+  sourceSceneId: number;
+  sourceSceneName: string;
+  settingsSnapshot: RenderSettings;
+}
+```
+
+### 6.3 `TabData` の拡張
+
+現状 `TabType = "welcome" | "settings" | "molview"`（`types.ts`）。これに `"renderResult"` を追加し、`TabData` に `renderResult?: RenderResult` を持たせる。`ContentPane.tsx` の `switch (tab.type)` に `case "renderResult": return <RenderResultPane .../>` を追加する。
+
+### 6.4 custom hook
+
+| hook | 役割 |
+|---|---|
+| `useRenderSettings(sceneId)`（新規） | Render Settings の編集状態を保持（非永続、シーン毎）。バックエンド切替時は `common` を保持しつつ `backendOptions` を §8 記述子の `defaultOptions` で差し替える。`{ settings, update, setBackend }` を返す |
+| `useRenderJob()`（新規） | `renderStart` / `renderCancel` を呼び、進捗・完了イベントを購読。`{ job, start, cancel }` を返す |
+| `useInspectorState`（変更） | `InspectorTarget` を union 化。`handleShowRenderSettings(sceneId)` を新設。`renderSettings` も `targetsBySceneRef`（シーン毎の前回ターゲット記憶）に乗せる |
+| `useTabManager`（変更） | `addRenderResultTab(result: RenderResult)` を追加 |
+| `useLayoutPersistence` | **変更不要**（BottomPanel Render タブ高さは `centerSizes`、結果タブは ContentArea 既存機構に乗る） |
+
+### 6.5 主要コンポーネント（props 概形）
+
+| コンポーネント | 配置 | props 概形 |
+|---|---|---|
+| `RenderSettingsEditor` | InspectorPanel 内 | `{ settings: RenderSettings; onChange; onBackendChange }` |
+| `BackendOptionGroups` | RenderSettingsEditor 内 | `{ backend: RenderBackendId; options; onChange }`（§8 記述子から描画） |
+| `RenderPanel` | BottomPanel タブ | `{ job: RenderJob | null; onStart; onCancel }` |
+| `RenderResultPane` | ContentPane | `{ result: RenderResult; onReRender; onShowSource }` |
+| `RenderImageViewer` | RenderResultPane 内 | `{ imageData; width; height }`（ズーム/Fit/Pan） |
+
+---
+
+## 7. IPC / バックエンド連携の境界（論点7）
+
+### 7.1 重要な前提
+
+外部プロセス実行は libcuemol2 の `ProcessManager` 再利用で完結する。**Electron main process での新規プロセス spawn 機構は不要**。`povrender.js` と同じ経路（StreamManager → ProcessManager → ポーリング）を tritium の Web Worker から踏む。
+
+### 7.2 API 形
+
+レンダリングパイプラインは **Web Worker 内で完結**する（`ProcessManager` / `StreamManager` は C++ サービスで worker からアクセス可能）。
+
+| 境界 | API 形 | 追加先 |
+|---|---|---|
+| renderer → worker | `renderStart(settings: RenderSettings) => { jobId }` | `ServiceMap`（`worker/shared/WorkerCalls.ts`） |
+| renderer → worker | `renderCancel(jobId: string) => { ok: boolean }` | `ServiceMap` |
+| worker → renderer | `onRenderProgress(cb)` — `{ jobId; progress; phase; logChunk? }` | worker→renderer イベント転送機構 |
+| worker → renderer | `onRenderComplete(cb)` — `{ jobId; result: RenderResult } \| { jobId; error: string }` | worker→renderer イベント転送機構 |
+
+### 7.3 worker 側パイプライン
+
+`renderStart` サービスは: ① `StreamManager` で .pov/.inc を出力 → ② `ProcessManager.queueTask` でタスク投入 → ③ `jobId` を即返却。その後 worker 内で `setInterval` ポーリング（`povrender.js` の 1 秒タイマー相当）し、`getTaskStatus` / `getResultOutput` でフェーズ・%・ログを取得して renderer へ進捗イベントを送出。全タスク done で完了イベントを送出する。
+
+進捗・完了イベントの送出経路は既存の worker→renderer イベント転送機構（C++ scene event の購読経路）に乗せる。**具体的な hook 名・チャネルは実装フェーズ4着手時に確認する**（§10 未解決事項）。
+
+### 7.4 型契約マップへの追加（CLAUDE.md 準拠）
+
+追加の起点は `worker/shared/WorkerCalls.ts` の `ServiceMap` 行 → `commands/CommandMap.ts` + `commands/ids.ts`。SettingsPane のパス保存に IPC 永続化を使う場合のみ `shared/ipcChannels.ts` + `shared/ipcContract.ts` にも行追加する。
+
+---
+
+## 8. レンダリングバックエンドの抽象化（追加要件）
+
+将来 POV-Ray 以外のバックエンドを追加・切り替え可能にする。**設計目標: バックエンド追加 = 記述子1個 + worker 実装1個 + registry 登録の4ステップで完了し、Inspector / BottomPanel / 結果タブの構造は不変。**
+
+### 8.1 フロント側 — バックエンド記述子レジストリ
+
+```
+interface RenderBackendDescriptor {
+  id: RenderBackendId;
+  label: string;                 // Backend セレクタ表示名
+  defaultOptions: BackendSettingsUnion;
+  optionGroups: PropGroupDef[];   // Inspector の Backend Options を駆動する宣言データ
+}                                 // PropGroupDef は既存 PROPERTY_GROUPS/PropDef と同形式
+
+const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor>
+```
+
+- 1ファイル（例 `data/renderBackends.ts`）に集約する。
+- Inspector の Backend Options グループは「選択中バックエンドの `optionGroups`」を描画するだけ。共通グループ（Image〜Output）はバックエンド非依存で常に同一。
+- Backend セレクタの選択肢は `RENDER_BACKENDS` のキーから生成する。
+
+### 8.2 worker 側 — バックエンド実行インターフェース
+
+```
+interface RenderBackend {
+  id: RenderBackendId;
+  exportScene(ctx, scene, settings): ExportedInput;      // StreamManager で入力ファイル生成
+  buildTasks(input: ExportedInput, settings): TaskSpec[]; // ProcessManager.queueTask 用引数列
+  parseProgress(stdout: string): number;                  // stdout → 進捗 %
+  collectResult(input, tasks): { imagePath; width; height };
+}
+```
+
+- `PovrayBackend` がこれを実装する（`povrender.js` のロジックを移植）。
+- `renderStart` サービスは `settings.backend` で registry から `RenderBackend` 実装を引き、パイプライン（export → queueTask → ポーリング → complete）を**バックエンド非依存に**駆動する。
+
+### 8.3 新バックエンド追加の手順
+
+1. `RenderBackendId` の union に ID を追加。
+2. フロントの `RENDER_BACKENDS` に `RenderBackendDescriptor` を追加。
+3. worker の `RenderBackend` 実装を追加。
+4. worker 側 registry に実装を登録。
+
+---
+
+## 9. 実装フェーズ分割（step-by-step 動作確認前提）
+
+**進め方の原則**: 各フェーズは単独で動作確認可能な単位とし、フェーズ末で必ず**ユーザーレビュー checkpoint** を置く。レビュー通過まで次フェーズに着手しない。共通の型検証として各フェーズ末に `cd tritium/react-gui && npm test` と `npx tsc -p tsconfig.web.json --noEmit` を実行する。
+
+### フェーズ1 — Inspector に Render Settings 対象を追加
+
+- **内容**: `InspectorTarget` の union 化、`renderSettings` 対象、`RenderSettingsEditor`（§2 アコーディオン + Backend セレクタ）、バックエンド記述子レジストリ（§8 フロント側）、Toolbar の Render ボタン、`useRenderSettings`。データは mock。
+- **着手前（degrade 検出）**: `InspectorTarget` union 化は既存 renderer/object/scene/view Inspector に影響する構造変更。先に `__test__/` に既存 Inspector の観測契約（ターゲット切替時の挙動・`targetsBySceneRef` 復元）を pin するテストを追加する。
+- **動作確認手順**: `npm run dev` 起動 → Toolbar の Render ボタンで Inspector が `renderSettings` で開く → 全アコーディオンの展開/折畳、Backend セレクタ切替で Backend Options グループが入れ替わる → 既存ノードを選び renderer/scene/view Inspector が従来どおり動く。
+- **完了条件**: Render Settings が mock 値で全グループ編集でき、既存 Inspector に degrade なし（pin テスト緑、`npm test` / `tsc` 緑）。
+- ✅ **ユーザーレビュー checkpoint**
+
+### フェーズ2 — BottomPanel に Render タブを追加（mock ジョブ）
+
+- **内容**: `BottomTabType` に `"render"`、`RenderPanel`、Start/Stop ボタン、進捗バー、ログ表示、`useRenderJob`（タイマー駆動 mock）、StatusBar 連動。
+- **動作確認手順**: BottomPanel の Render タブ → Start で mock 進捗が 0→100% 進行、StatusBar に「Rendering… N%」、Stop でキャンセル、ログ行が増える。
+- **完了条件**: mock ジョブで進捗・停止・StatusBar 連動・フェーズ表示が動作（`npm test` / `tsc` 緑）。
+- ✅ **ユーザーレビュー checkpoint**
+
+### フェーズ3 — ContentArea に Render Result タブを追加（mock 画像）
+
+- **内容**: `TabType` に `"renderResult"`、`RenderResultPane`、`RenderImageViewer`（ズーム/Fit/100%/Pan）、ツールバー、Re-render、`useTabManager.addRenderResultTab`。
+- **動作確認手順**: mock 完了で結果タブが開く → タイトル命名規則を確認、ズーム/Fit/Pan、Re-render で再実行、Show Source Scene で元 MolView タブへ遷移。既存 molview/settings タブに degrade なし。
+- **完了条件**: mock 画像で結果タブ一式（ビューア・ツールバー・Re-render）が動作（`npm test` / `tsc` 緑）。
+- ✅ **ユーザーレビュー checkpoint**
+
+### フェーズ4 — worker サービス + バックエンド実装の結線
+
+- **内容**: `renderStart` / `renderCancel`（`ServiceMap`）、`RenderBackend` インターフェース（§8 worker 側）、`PovrayBackend`（`povrender.js` 移植）、`StreamManager` / `ProcessManager` 経由の実行、worker→renderer 進捗/完了イベント結線。
+- **着手前**: §10 未解決事項（worker→renderer イベント機構、`tritium/core` の wrapper 生成状況）を調査して確定する。
+- **動作確認手順**: `cd build_scripts && task build_tritium` → `task run_tritium` → 実シーンを単レイヤー設定でレンダリング → 実 POV-Ray 出力画像が結果タブに表示、進捗が実 stdout 由来で更新。
+- **完了条件**: 実 POV-Ray で単レイヤーレンダリングが端から端まで動作（mock を実装に差し替え完了）。
+- ✅ **ユーザーレビュー checkpoint**
+
+### フェーズ5 — post-blend / エラー処理 / SettingsPane 仕上げ
+
+- **内容**: blendpng レイヤー合成、stdout 進捗パース精緻化、エラーハンドリング（パス未設定・プロセス失敗）、SettingsPane の exe/inc/blendpng パス設定 UI。
+- **動作確認手順**: post-blend を要するシーンでレンダリング、パス未設定時のエラー表示、SettingsPane でパス変更が反映。
+- **完了条件**: UXP `render-pov` と機能 parity。`docs/migration/mapping/` の `dialog.tool.render-pov` を `done` 相当へ更新できる状態。
+- ✅ **最終ユーザーレビュー checkpoint**
+
+---
+
+## 10. アーキテクチャ制約 / 未解決事項
+
+### 10.1 遵守するアーキテクチャ制約
+
+- **`useLayoutPersistence`**: 新規キーは不要。BottomPanel の Render タブ高さは既存 `centerSizes`、結果タブは ContentArea 既存機構で扱う。
+- **Allotment ネスト構成**: `App.tsx` の3段 Allotment（main / right / center）には手を入れない。
+- **Inspector 表示制御**: `inspectorOpen` フラグと `targetsBySceneRef`（シーン毎の前回ターゲット記憶）を尊重し、`renderSettings` もこの記憶機構に乗せる。Inspector ヘッダーには対象種別バッジを表示する。
+- **MolViewPane の OffscreenCanvas 制約**: `canvas.transferControlToOffscreen()` は一度のみ実行可能。Render Result タブは静的画像のみで WebGL を使わないため本制約は無関係。`ContentPane.tsx` の `switch (tab.type)` に `renderResult` を正しく追加すること。
+
+### 10.2 未解決事項（実装フェーズ着手時に確認・要ユーザー判断）
+
+- worker→renderer の進捗イベント転送に使う既存機構（hook 名・チャネル）の特定 — フェーズ4着手時に `worker/server` と event 転送経路を調査する。
+- tritium/core の自動生成 wrapper（`tritium/core/src/wrappers/`）に `ProcessManager` / `StreamManager` が含まれるか — フェーズ4着手時に確認する。
+- `src/modules/rendering` の `.qif` インターフェースが tritium wrapper に生成済みか。
+- post-blend 用 `blendpng` バイナリの同梱・配布方法。
+- **アニメ連番レンダリング**（UXP `anim-render-dlg`: 出力ディレクトリ・連番ファイル・FFmpeg ムービー化）は本計画のスコープ外。将来 Render Settings に「フレーム範囲」グループを追加する拡張余地として記録する。
+
+---
+
+## 参照する既存ファイル
+
+| ファイル | 用途 |
+|---|---|
+| `tritium/react-gui/src/renderer/App.tsx` | 3段 Allotment 構成 |
+| `.../hooks/useInspectorState.ts` | `InspectorTarget`、`targetsBySceneRef` |
+| `.../components/panels/InspectorPanel.tsx` | Inspector ヘッダー・モード |
+| `.../components/inspector/PropertiesTab.tsx` / `AccordionSection.tsx` | アコーディオングルーピング |
+| `.../components/panels/BottomPanel.tsx` | `BottomTabType`、`TabButton` |
+| `.../components/ContentArea.tsx` / `panes/ContentPane.tsx` / `types.ts` | `TabData` / `TabType` |
+| `.../hooks/useTabManager.ts` / `useLayoutPersistence.ts` | タブ管理・レイアウト永続化 |
+| `.../worker/shared/WorkerCalls.ts` | `ServiceMap` |
+| `.../commands/CommandMap.ts` / `commands/ids.ts` | コマンド契約 |
+| `.../worker/server/services/*.service.ts` | service 実装パターン |
+| `src/modules/rendering/` | `PovSceneExporter` ほか |
+| `ProcessManager` / `StreamManager` の `.qif` | バックエンド API |
+| `uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/povrender.js` | 実行パイプライン移植元 |
+| `uxp_gui/cuemol2/base/content/tools/render-pov-dlg.xul` / `.js` | UI 移植元 |
+| `docs/migration/uxp-inventory/tool_dlgs.md` / `mapping/_index.md` / `option-ux-guidelines.md` | 移行管理 |

--- a/src/qsys/SceneManager.cpp
+++ b/src/qsys/SceneManager.cpp
@@ -290,6 +290,5 @@ LString SceneManager::getVerArchName() const
 
 void SceneManager::doIdleTask()
 {
-    MB_DPRINTLN("SceneManager::doIdleTask> called");
     checkAndUpdateScenes();
 }

--- a/tritium/react-gui/electron.vite.config.ts
+++ b/tritium/react-gui/electron.vite.config.ts
@@ -37,12 +37,21 @@ const workerExternal = [
   'node:module',
   'node:path',
   'node:url',
+
+  // --- Node.js built-ins used at runtime by the render pipeline ---
+  // (the worker runs with nodeIntegrationInWorker: true)
+  'fs',
+  'os',
+  'path',
 ]
 
 const workerGlobals: Record<string, string> = {
   // Map the external to a require() call executed at IIFE init time.
   // Electron's nodeIntegrationInWorker injects the global require.
   '@cuemol/core': 'require("@cuemol/core")',
+  fs: 'require("fs")',
+  os: 'require("os")',
+  path: 'require("path")',
 }
 
 export default defineConfig({

--- a/tritium/react-gui/src/main/handlers/fileDialogs.ts
+++ b/tritium/react-gui/src/main/handlers/fileDialogs.ts
@@ -128,6 +128,27 @@ export async function handleCameraSaveDialog(
 // surface the selected filter index back to the caller so the worker can
 // pass the matching writer name to `createHandler`.
 
+/**
+ * Generic "pick a file or directory" dialog. Used by the SettingsPane to
+ * choose external binary paths (POV-Ray executable, include directory,
+ * blendpng). Returns the resolved absolute path.
+ */
+export async function handlePickPathDialog(
+  mainWindow: BrowserWindow,
+  payload: { title: string; directory?: boolean },
+): Promise<{ canceled: boolean; filePath: string }> {
+  const result = await withMenuBlocked('native', () =>
+    dialog.showOpenDialog(mainWindow, {
+      title: payload.title,
+      properties: [payload.directory ? 'openDirectory' : 'openFile'],
+    }),
+  )
+  if (result.canceled || result.filePaths.length === 0) {
+    return { canceled: true, filePath: '' }
+  }
+  return { canceled: false, filePath: result.filePaths[0] }
+}
+
 export async function handleObjectSaveDialog(
   mainWindow: BrowserWindow,
   payload: {

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -30,6 +30,7 @@ import {
   handleCameraOpenDialog,
   handleCameraSaveDialog,
   handleObjectSaveDialog,
+  handlePickPathDialog,
 } from './handlers/fileDialogs'
 
 // ─────────────────────────────────────────────
@@ -173,6 +174,10 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
 
   handleInvoke(IPC.DIALOG_OBJECT_SAVE, async (_event, payload) =>
     handleObjectSaveDialog(mainWindow, payload),
+  )
+
+  handleInvoke(IPC.DIALOG_PICK_PATH, async (_event, payload) =>
+    handlePickPathDialog(mainWindow, payload),
   )
 
   handleInvoke(IPC.FILE_EXISTS, (_event, payload) => handleFileExists(payload.path))

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -33,6 +33,7 @@ import { useSceneTree } from "./hooks/useSceneTree";
 import { useSceneContextMenu } from "./hooks/useSceneContextMenu";
 import { useInspectorState } from "./hooks/useInspectorState";
 import { useRenderSettings } from "./hooks/useRenderSettings";
+import { useRenderJob, isRenderJobActive } from "./hooks/useRenderJob";
 import { RENDER_BACKEND_IDS } from "./data/renderBackends";
 import { useTabManager } from "./hooks/useTabManager";
 import { useCueMol } from "./hooks/useCueMol";
@@ -154,6 +155,9 @@ const App: React.FC = () => {
   // Render Settings editing state (non-persistent) for the inspector
   // `renderSettings` target.
   const renderSettings = useRenderSettings();
+
+  // Render job lifecycle for the BottomPanel Render tab.
+  const renderJob = useRenderJob();
 
   // --- CueMol core / tabs ---
 
@@ -436,6 +440,12 @@ const App: React.FC = () => {
   const sidebarVisible = activeView !== null;
   const settingsActive = tabs.find((t) => t.id === activeTab)?.type === "settings";
 
+  // StatusBar: a running render takes precedence over tool-hover messages.
+  const activeRenderJob = isRenderJobActive(renderJob.job) ? renderJob.job : null;
+  const statusBarMessage = activeRenderJob
+    ? `Rendering… ${activeRenderJob.progress}%`
+    : statusMessage;
+
   // --- Render ---
 
   return (
@@ -536,6 +546,9 @@ const App: React.FC = () => {
                           <BottomPanel
                             alignment={alignment}
                             animation={animation}
+                            renderJob={renderJob.job}
+                            onRenderStart={renderJob.start}
+                            onRenderCancel={renderJob.cancel}
                           />
                         </Allotment.Pane>
                       </Allotment>
@@ -583,8 +596,8 @@ const App: React.FC = () => {
         activeToolLabel={activeDef.label}
         activeToolShortcut={activeDef.shortcut}
         activeToolIcon={activeDef.icon}
-        busy={cueMolBusy}
-        statusMessage={statusMessage}
+        busy={cueMolBusy || activeRenderJob !== null}
+        statusMessage={statusBarMessage}
       />
     </div>
     </ActiveToolProvider>

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -49,6 +49,7 @@ import { useCommands } from "./commands/CommandRegistry";
 import { CmdId } from "./commands/ids";
 import { useCueMolBusy } from "./hooks/useCueMolBusy";
 import { useShowConfirmCloseTabDialog } from "./components/dialogs/ConfirmCloseTabDialogProvider";
+import { useRenderConfig } from "./contexts/RenderConfigContext";
 import { useWindowCloseHandler } from "./hooks/useWindowCloseHandler";
 
 const App: React.FC = () => {
@@ -158,6 +159,9 @@ const App: React.FC = () => {
   // `renderSettings` target.
   const renderSettings = useRenderSettings();
 
+  // Persistent render binary paths (POV-Ray / blendpng) from SettingsPane.
+  const { binaries: renderBinaries } = useRenderConfig();
+
   // --- CueMol core / tabs ---
 
   const showConfirmCloseTabDialog = useShowConfirmCloseTabDialog();
@@ -245,8 +249,9 @@ const App: React.FC = () => {
       viewId: info.view_id,
       snapshot: renderSettings.getSnapshot(),
       source,
+      binaries: renderBinaries,
     });
-  }, [getActiveSceneInfo, sceneTree, renderJob, renderSettings]);
+  }, [getActiveSceneInfo, sceneTree, renderJob, renderSettings, renderBinaries]);
 
   /** Re-render from a result tab's snapshot (also restores it into the editor). */
   const handleReRender = useCallback(
@@ -261,9 +266,10 @@ const App: React.FC = () => {
           sceneName: result.sourceSceneName,
           viewId: result.sourceViewId,
         },
+        binaries: renderBinaries,
       });
     },
-    [renderSettings, renderJob],
+    [renderSettings, renderJob, renderBinaries],
   );
 
   /** Switch to a result tab's source scene (its molview tab). */

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -9,7 +9,7 @@
  *   - useCommandRegistrations   — registers all CmdId handlers + Electron IPC bridge
  */
 
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 
@@ -35,6 +35,13 @@ import { useInspectorState } from "./hooks/useInspectorState";
 import { useRenderSettings } from "./hooks/useRenderSettings";
 import { useRenderJob, isRenderJobActive } from "./hooks/useRenderJob";
 import { RENDER_BACKEND_IDS } from "./data/renderBackends";
+import { RENDER_SIZE_PRESETS } from "./data/renderSettings";
+import { buildMockRenderResult } from "./data/renderResult";
+import type {
+  RenderResult,
+  RenderSource,
+  RenderSettingsSnapshot,
+} from "./data/renderResult";
 import { useTabManager } from "./hooks/useTabManager";
 import { useCueMol } from "./hooks/useCueMol";
 import { useMolTabDispatch, useMolTabState } from "./hooks/useMolTab";
@@ -195,6 +202,7 @@ const App: React.FC = () => {
     setActiveTab,
     openSettingsTab,
     addMolViewTab,
+    addRenderResultTab,
     handleCloseTab,
     handleReorderTabs,
   } = useTabManager({ onMolViewClose: handleMolViewClose, confirmCloseTab });
@@ -218,6 +226,111 @@ const App: React.FC = () => {
   }, [activeTab, tabs, cm, cueMolReady, setActiveViewByID]);
 
   const activeMolViewId = tabs.find((t) => t.id === activeTab && t.type === 'molview')?.viewId;
+
+  // --- Render: job start / completion -> Render Result tab ---
+
+  // Settings snapshot frozen for the in-flight job.
+  const pendingRenderSnapshotRef = useRef<RenderSettingsSnapshot | null>(null);
+  // jobId whose completion has already been turned into a result tab.
+  const handledRenderJobRef = useRef<string | null>(null);
+
+  /** Scene/view reference for a render started right now. */
+  const getRenderSource = useCallback((): RenderSource | undefined => {
+    if (activeSceneId === undefined) return undefined;
+    return {
+      sceneId: activeSceneId,
+      sceneName: sceneTree?.name ?? `Scene ${activeSceneId}`,
+      viewId: activeMolViewId,
+    };
+  }, [activeSceneId, sceneTree, activeMolViewId]);
+
+  /** Start a render, freezing the snapshot it will be recorded with. */
+  const startRenderWith = useCallback(
+    (snapshot: RenderSettingsSnapshot, source: RenderSource | undefined) => {
+      pendingRenderSnapshotRef.current = snapshot;
+      renderJob.start(source);
+    },
+    [renderJob],
+  );
+
+  /** Start a render from the current Render Settings (Start button / F12). */
+  const handleRenderStart = useCallback(() => {
+    startRenderWith(renderSettings.getSnapshot(), getRenderSource());
+  }, [startRenderWith, renderSettings, getRenderSource]);
+
+  /** Re-render from a result tab's snapshot (also restores it into the editor). */
+  const handleReRender = useCallback(
+    (result: RenderResult) => {
+      renderSettings.restore(result.settingsSnapshot);
+      startRenderWith(result.settingsSnapshot, {
+        sceneId: result.sourceSceneId,
+        sceneName: result.sourceSceneName,
+        viewId: result.sourceViewId,
+      });
+    },
+    [renderSettings, startRenderWith],
+  );
+
+  /** Switch to a result tab's source scene (its molview tab). */
+  const handleShowSourceScene = useCallback(
+    (result: RenderResult) => {
+      if (result.sourceViewId === undefined) return;
+      const tab = tabs.find(
+        (t) => t.type === "molview" && t.viewId === result.sourceViewId,
+      );
+      if (tab) setActiveTab(tab.id);
+    },
+    [tabs, setActiveTab],
+  );
+
+  /**
+   * Apply an image-size preset from the Render tab. The "Current view"
+   * preset is resolved from the live molview canvas pixel size.
+   */
+  const handleApplyRenderPreset = useCallback(
+    (label: string) => {
+      const preset = RENDER_SIZE_PRESETS.find((p) => p.label === label);
+      if (preset?.dynamic) {
+        const canvas = document.querySelector("canvas");
+        if (canvas) {
+          const rect = canvas.getBoundingClientRect();
+          const dpr = window.devicePixelRatio || 1;
+          const width = Math.round(rect.width * dpr);
+          const height = Math.round(rect.height * dpr);
+          if (width > 0 && height > 0) {
+            renderSettings.applyPreset(label, { width, height });
+            return;
+          }
+        }
+      }
+      renderSettings.applyPreset(label);
+    },
+    [renderSettings],
+  );
+
+  // Open a Render Result tab when the job completes.
+  useEffect(() => {
+    const job = renderJob.job;
+    if (!job || job.status !== "done") return;
+    if (handledRenderJobRef.current === job.jobId) return;
+    handledRenderJobRef.current = job.jobId;
+
+    const snapshot =
+      pendingRenderSnapshotRef.current ?? renderSettings.getSnapshot();
+    const numOf = (key: string, fallback: number): number => {
+      const v = snapshot.commonProps.find((p) => p.key === key)?.value;
+      return typeof v === "number" ? v : fallback;
+    };
+    addRenderResultTab(
+      buildMockRenderResult({
+        width: numOf("width", 1200),
+        height: numOf("height", 900),
+        elapsedSec: ((job.finishedAt ?? Date.now()) - job.startedAt) / 1000,
+        source: job.source,
+        snapshot,
+      }),
+    );
+  }, [renderJob.job, renderSettings, addRenderResultTab]);
 
   // --- Scene-tree toolbar handlers (UXP workspace_panel onBtn*Cmd) ---
 
@@ -540,6 +653,9 @@ const App: React.FC = () => {
                             activeTool={activeTool}
                             onSelectTool={setActiveTool}
                             onStatusMessage={setStatusMessage}
+                            onReRender={handleReRender}
+                            onShowSourceScene={handleShowSourceScene}
+                            onOpenRenderSettings={handleShowRenderSettings}
                           />
                         </Allotment.Pane>
                         <Allotment.Pane minSize={100} preferredSize={200} snap>
@@ -547,8 +663,11 @@ const App: React.FC = () => {
                             alignment={alignment}
                             animation={animation}
                             renderJob={renderJob.job}
-                            onRenderStart={renderJob.start}
+                            renderPreset={renderSettings.preset}
+                            onRenderStart={handleRenderStart}
                             onRenderCancel={renderJob.cancel}
+                            onRenderApplyPreset={handleApplyRenderPreset}
+                            onOpenRenderSettings={handleShowRenderSettings}
                           />
                         </Allotment.Pane>
                       </Allotment>

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -32,6 +32,8 @@ import { ActiveToolProvider } from "./contexts/ActiveToolContext";
 import { useSceneTree } from "./hooks/useSceneTree";
 import { useSceneContextMenu } from "./hooks/useSceneContextMenu";
 import { useInspectorState } from "./hooks/useInspectorState";
+import { useRenderSettings } from "./hooks/useRenderSettings";
+import { RENDER_BACKEND_IDS } from "./data/renderBackends";
 import { useTabManager } from "./hooks/useTabManager";
 import { useCueMol } from "./hooks/useCueMol";
 import { useMolTabDispatch, useMolTabState } from "./hooks/useMolTab";
@@ -129,12 +131,14 @@ const App: React.FC = () => {
   const {
     inspectorOpen,
     inspectorTarget,
+    inspectorCategory,
     rendererProps,
     genericEntries,
     genericLoading,
     inspectorInfo,
     handleShowGeneric,
     handleShowViewProps,
+    handleShowRenderSettings,
     handleCloseInspector,
     handlePropertyChange,
     handleGenericSet,
@@ -146,6 +150,10 @@ const App: React.FC = () => {
     cm,
     sceneTree,
   });
+
+  // Render Settings editing state (non-persistent) for the inspector
+  // `renderSettings` target.
+  const renderSettings = useRenderSettings();
 
   // --- CueMol core / tabs ---
 
@@ -388,6 +396,7 @@ const App: React.FC = () => {
     onCenterMarkChanged,
     onBgColorChanged,
     showViewProperty: handleShowViewProps,
+    showRenderSettings: handleShowRenderSettings,
     newScene,
   });
 
@@ -541,11 +550,21 @@ const App: React.FC = () => {
                     >
                       <InspectorPanel
                         hasTarget={inspectorTarget !== null}
+                        targetKind={inspectorTarget?.kind ?? null}
+                        targetCategory={inspectorCategory}
                         nodeName={inspectorInfo.name}
                         nodeType={inspectorInfo.type}
                         properties={rendererProps}
                         genericEntries={genericEntries}
                         genericLoading={genericLoading}
+                        renderSettings={{
+                          backend: renderSettings.backend,
+                          backendIds: RENDER_BACKEND_IDS,
+                          commonProps: renderSettings.commonProps,
+                          backendProps: renderSettings.backendProps,
+                          onBackendChange: renderSettings.setBackend,
+                          onChange: renderSettings.handleChange,
+                        }}
                         onPropertyChange={handlePropertyChange}
                         onGenericSet={handleGenericSet}
                         onGenericReset={handleGenericReset}

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -9,7 +9,7 @@
  *   - useCommandRegistrations   — registers all CmdId handlers + Electron IPC bridge
  */
 
-import React, { useState, useCallback, useEffect, useRef } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 
@@ -36,12 +36,7 @@ import { useRenderSettings } from "./hooks/useRenderSettings";
 import { useRenderJob, isRenderJobActive } from "./hooks/useRenderJob";
 import { RENDER_BACKEND_IDS } from "./data/renderBackends";
 import { RENDER_SIZE_PRESETS } from "./data/renderSettings";
-import { buildMockRenderResult } from "./data/renderResult";
-import type {
-  RenderResult,
-  RenderSource,
-  RenderSettingsSnapshot,
-} from "./data/renderResult";
+import type { RenderResult, RenderSource } from "./data/renderResult";
 import { useTabManager } from "./hooks/useTabManager";
 import { useCueMol } from "./hooks/useCueMol";
 import { useMolTabDispatch, useMolTabState } from "./hooks/useMolTab";
@@ -163,9 +158,6 @@ const App: React.FC = () => {
   // `renderSettings` target.
   const renderSettings = useRenderSettings();
 
-  // Render job lifecycle for the BottomPanel Render tab.
-  const renderJob = useRenderJob();
-
   // --- CueMol core / tabs ---
 
   const showConfirmCloseTabDialog = useShowConfirmCloseTabDialog();
@@ -227,48 +219,51 @@ const App: React.FC = () => {
 
   const activeMolViewId = tabs.find((t) => t.id === activeTab && t.type === 'molview')?.viewId;
 
-  // --- Render: job start / completion -> Render Result tab ---
+  // --- Render: job lifecycle + Render Result tab ---
 
-  // Settings snapshot frozen for the in-flight job.
-  const pendingRenderSnapshotRef = useRef<RenderSettingsSnapshot | null>(null);
-  // jobId whose completion has already been turned into a result tab.
-  const handledRenderJobRef = useRef<string | null>(null);
+  // Render job for the BottomPanel Render tab. On completion the worker
+  // sends the rendered image; `addRenderResultTab` opens (or overwrites)
+  // the source scene's result tab.
+  const renderJob = useRenderJob({ cm, onComplete: addRenderResultTab });
 
-  /** Scene/view reference for a render started right now. */
-  const getRenderSource = useCallback((): RenderSource | undefined => {
-    if (activeSceneId === undefined) return undefined;
-    return {
-      sceneId: activeSceneId,
-      sceneName: sceneTree?.name ?? `Scene ${activeSceneId}`,
-      viewId: activeMolViewId,
-    };
-  }, [activeSceneId, sceneTree, activeMolViewId]);
-
-  /** Start a render, freezing the snapshot it will be recorded with. */
-  const startRenderWith = useCallback(
-    (snapshot: RenderSettingsSnapshot, source: RenderSource | undefined) => {
-      pendingRenderSnapshotRef.current = snapshot;
-      renderJob.start(source);
-    },
-    [renderJob],
-  );
-
-  /** Start a render from the current Render Settings (Start button / F12). */
+  /**
+   * Start a render from the current Render Settings (Start button / F12).
+   * Uses the active molview's scene/view from `getActiveSceneInfo` — this
+   * stays correct even when a Render Result tab is the active content tab
+   * (so the render captures the latest camera via `saveViewToCam`).
+   */
   const handleRenderStart = useCallback(() => {
-    startRenderWith(renderSettings.getSnapshot(), getRenderSource());
-  }, [startRenderWith, renderSettings, getRenderSource]);
+    const info = getActiveSceneInfo();
+    if (!info) return;
+    const source: RenderSource = {
+      sceneId: info.scene_uid,
+      sceneName: sceneTree?.name ?? `Scene ${info.scene_uid}`,
+      viewId: info.view_id,
+    };
+    void renderJob.start({
+      sceneId: info.scene_uid,
+      viewId: info.view_id,
+      snapshot: renderSettings.getSnapshot(),
+      source,
+    });
+  }, [getActiveSceneInfo, sceneTree, renderJob, renderSettings]);
 
   /** Re-render from a result tab's snapshot (also restores it into the editor). */
   const handleReRender = useCallback(
     (result: RenderResult) => {
       renderSettings.restore(result.settingsSnapshot);
-      startRenderWith(result.settingsSnapshot, {
+      void renderJob.start({
         sceneId: result.sourceSceneId,
-        sceneName: result.sourceSceneName,
         viewId: result.sourceViewId,
+        snapshot: result.settingsSnapshot,
+        source: {
+          sceneId: result.sourceSceneId,
+          sceneName: result.sourceSceneName,
+          viewId: result.sourceViewId,
+        },
       });
     },
-    [renderSettings, startRenderWith],
+    [renderSettings, renderJob],
   );
 
   /** Switch to a result tab's source scene (its molview tab). */
@@ -307,30 +302,6 @@ const App: React.FC = () => {
     },
     [renderSettings],
   );
-
-  // Open a Render Result tab when the job completes.
-  useEffect(() => {
-    const job = renderJob.job;
-    if (!job || job.status !== "done") return;
-    if (handledRenderJobRef.current === job.jobId) return;
-    handledRenderJobRef.current = job.jobId;
-
-    const snapshot =
-      pendingRenderSnapshotRef.current ?? renderSettings.getSnapshot();
-    const numOf = (key: string, fallback: number): number => {
-      const v = snapshot.commonProps.find((p) => p.key === key)?.value;
-      return typeof v === "number" ? v : fallback;
-    };
-    addRenderResultTab(
-      buildMockRenderResult({
-        width: numOf("width", 1200),
-        height: numOf("height", 900),
-        elapsedSec: ((job.finishedAt ?? Date.now()) - job.startedAt) / 1000,
-        source: job.source,
-        snapshot,
-      }),
-    );
-  }, [renderJob.job, renderSettings, addRenderResultTab]);
 
   // --- Scene-tree toolbar handlers (UXP workspace_panel onBtn*Cmd) ---
 

--- a/tritium/react-gui/src/renderer/__test__/renderConfigContext.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/renderConfigContext.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @file __test__/renderConfigContext.test.tsx
+ * @description Contract tests for RenderConfigContext: persisted render
+ * binary paths are loaded over the defaults on mount, and `setBinary`
+ * updates state and persists via the UI_SAVE channel.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act } from 'react';
+import { makeRenderHook, setupElectronAPI, teardownElectronAPI, flushPromises } from './helpers/testHarness';
+import { IPC } from '../../shared/ipcChannels';
+import { RenderConfigProvider, useRenderConfig } from '../contexts/RenderConfigContext';
+import { DEFAULT_RENDER_BINARIES } from '../worker/shared/renderTypes';
+
+void React;
+
+describe('RenderConfigContext', () => {
+    afterEach(() => teardownElectronAPI());
+
+    it('loads persisted paths over the defaults', async () => {
+        setupElectronAPI({
+            invoke: vi.fn((channel: string) =>
+                channel === IPC.UI_LOAD
+                    ? Promise.resolve({ povrayExe: '/custom/povray' })
+                    : Promise.resolve(undefined),
+            ),
+        });
+        const h = makeRenderHook(() => useRenderConfig(), RenderConfigProvider);
+        await flushPromises();
+
+        expect(h.result.binaries.povrayExe).toBe('/custom/povray');
+        // Fields absent from the persisted state fall back to defaults.
+        expect(h.result.binaries.blendpng).toBe(DEFAULT_RENDER_BINARIES.blendpng);
+        h.unmount();
+    });
+
+    it('setBinary updates state and persists via UI_SAVE', async () => {
+        const api = setupElectronAPI();
+        const h = makeRenderHook(() => useRenderConfig(), RenderConfigProvider);
+        await flushPromises();
+
+        act(() => h.result.setBinary('blendpng', '/opt/blendpng'));
+
+        expect(h.result.binaries.blendpng).toBe('/opt/blendpng');
+        expect(api.invoke).toHaveBeenCalledWith(IPC.UI_SAVE, { blendpng: '/opt/blendpng' });
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/useInspectorState.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useInspectorState.test.ts
@@ -174,7 +174,7 @@ describe('useInspectorState', () => {
         });
         await settle();
         expect(h.result.inspectorTarget).toEqual({
-            sceneId: 1, nodeId: 42, nodeType: 'view',
+            kind: 'node', sceneId: 1, nodeId: 42, nodeType: 'view',
         });
         expect(cm.invokeService).toHaveBeenCalledWith('getGenericProps', {
             sceneId: 1, nodeId: 42, nodeType: 'view',
@@ -214,7 +214,40 @@ describe('useInspectorState', () => {
 
         await h.setSceneTree(makeTree(1, 5));
         expect(h.result.inspectorTarget).toEqual({
-            sceneId: 1, nodeId: 42, nodeType: 'view',
+            kind: 'node', sceneId: 1, nodeId: 42, nodeType: 'view',
+        });
+        h.unmount();
+    });
+
+    it('handleShowRenderSettings targets render settings without a worker call', async () => {
+        const h = mountHook(cm, makeTree(1, 5));
+        act(() => {
+            h.result.handleShowRenderSettings();
+        });
+        await settle();
+        expect(h.result.inspectorTarget).toEqual({
+            kind: 'renderSettings', sceneId: 1,
+        });
+        expect(h.result.inspectorOpen).toBe(true);
+        expect(h.result.inspectorCategory).toBe('Render Settings');
+        // Render Settings is not backed by the C++ property bridge.
+        expect(cm.invokeService).not.toHaveBeenCalled();
+        h.unmount();
+    });
+
+    it('per-scene memory restores a render-settings target too', async () => {
+        const h = mountHook(cm, makeTree(1, 5));
+        act(() => {
+            h.result.handleShowRenderSettings();
+        });
+        await settle();
+
+        await h.setSceneTree(makeTree(2, 9));
+        expect(h.result.inspectorTarget).toBeNull();
+
+        await h.setSceneTree(makeTree(1, 5));
+        expect(h.result.inspectorTarget).toEqual({
+            kind: 'renderSettings', sceneId: 1,
         });
         h.unmount();
     });

--- a/tritium/react-gui/src/renderer/__test__/useRenderJob.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderJob.test.ts
@@ -1,73 +1,112 @@
 /**
  * @file __test__/useRenderJob.test.ts
- * @description Contract tests for the render-job hook: start creates an
- * active job, timer ticks advance progress through its phases to
- * completion, and cancel stops an in-progress job.
- *
- * The interval callback is captured (vi.useFakeTimers does not reliably
- * flush setState from timer callbacks via act) and invoked manually.
+ * @description Contract tests for the render-job hook: starting calls the
+ * `renderStart` service, `render-progress` updates advance the job,
+ * completion emits a result, and cancel calls `renderCancel`.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { act } from 'react';
 import { makeRenderHook } from './helpers/testHarness';
 import { useRenderJob, isRenderJobActive } from '../hooks/useRenderJob';
+import type { RenderUpdate, RenderStartResult } from '../worker/shared/renderTypes';
+import type {
+    RenderResult,
+    RenderSettingsSnapshot,
+    RenderSource,
+} from '../data/renderResult';
+
+const snapshot: RenderSettingsSnapshot = {
+    backend: 'povray',
+    commonProps: [],
+    backendProps: [],
+};
+const source: RenderSource = { sceneId: 1, sceneName: 'Scene1', viewId: 7 };
+const startParams = { sceneId: 1, viewId: 7, snapshot, source };
+
+/** Fake AsyncCueMol exposing an `emit` to push render-progress updates. */
+function makeCm(startResult: RenderStartResult = { ok: true, jobId: 'job-1' }) {
+    let listener: ((u: RenderUpdate) => void) | null = null;
+    const cm = {
+        subscribeRenderProgress: vi.fn((cb: (u: RenderUpdate) => void) => {
+            listener = cb;
+            return () => { listener = null; };
+        }),
+        invokeService: vi.fn((name: string) => {
+            if (name === 'renderStart') return Promise.resolve(startResult);
+            if (name === 'renderCancel') return Promise.resolve({ ok: true });
+            return Promise.resolve(undefined);
+        }),
+    };
+    return { cm, emit: (u: RenderUpdate) => listener?.(u) };
+}
 
 describe('useRenderJob', () => {
-    let timerCb: (() => void) | null;
+    it('start issues renderStart and records the worker jobId', async () => {
+        const { cm } = makeCm();
+        const h = makeRenderHook(() => useRenderJob({ cm: cm as never, onComplete: vi.fn() }));
+        await act(async () => { await h.result.start(startParams); });
 
-    beforeEach(() => {
-        timerCb = null;
-        vi.spyOn(globalThis, 'setInterval').mockImplementation(
-            ((cb: () => void) => {
-                timerCb = cb;
-                return 1 as unknown as ReturnType<typeof setInterval>;
-            }) as typeof setInterval,
-        );
-        vi.spyOn(globalThis, 'clearInterval').mockImplementation(() => {});
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
-    it('start creates an active exporting job at 0%', () => {
-        const h = makeRenderHook(() => useRenderJob());
-        act(() => h.result.start());
+        expect(cm.invokeService).toHaveBeenCalledWith('renderStart', {
+            sceneId: 1, viewId: 7, snapshot,
+        });
         expect(h.result.job?.status).toBe('exporting');
-        expect(h.result.job?.progress).toBe(0);
-        expect(isRenderJobActive(h.result.job)).toBe(true);
+        expect(h.result.job?.jobId).toBe('job-1');
         h.unmount();
     });
 
-    it('timer ticks advance progress and phases to completion', () => {
-        const h = makeRenderHook(() => useRenderJob());
-        act(() => h.result.start());
+    it('progress updates advance the job', async () => {
+        const { cm, emit } = makeCm();
+        const h = makeRenderHook(() => useRenderJob({ cm: cm as never, onComplete: vi.fn() }));
+        await act(async () => { await h.result.start(startParams); });
 
-        const seen = new Set<string>();
-        for (let i = 0; i < 20 && timerCb; i++) {
-            act(() => timerCb!());
-            if (h.result.job) seen.add(h.result.job.status);
-        }
+        act(() => emit({
+            type: 'progress', jobId: 'job-1', progress: 42, phase: 'running',
+            logChunk: 'Rendered 42%',
+        }));
+        expect(h.result.job?.status).toBe('running');
+        expect(h.result.job?.progress).toBe(42);
+        expect(h.result.job?.log).toContain('Rendered 42%');
+        h.unmount();
+    });
 
-        expect(seen.has('running')).toBe(true);
-        expect(seen.has('blending')).toBe(true);
+    it('completion marks the job done and emits a result', async () => {
+        const { cm, emit } = makeCm();
+        const onComplete = vi.fn();
+        const h = makeRenderHook(() => useRenderJob({ cm: cm as never, onComplete }));
+        await act(async () => { await h.result.start(startParams); });
+
+        act(() => emit({
+            type: 'complete', jobId: 'job-1',
+            imageDataUrl: 'data:image/png;base64,AA', width: 800, height: 600, elapsedSec: 3.5,
+        }));
         expect(h.result.job?.status).toBe('done');
-        expect(h.result.job?.progress).toBe(100);
-        expect(h.result.job?.finishedAt).toBeTypeOf('number');
-        // Log grows as the job progresses.
-        expect((h.result.job?.log.length ?? 0)).toBeGreaterThan(2);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+        const result = onComplete.mock.calls[0][0] as RenderResult;
+        expect(result.imageDataUrl).toBe('data:image/png;base64,AA');
+        expect(result.sourceSceneName).toBe('Scene1');
         h.unmount();
     });
 
-    it('cancel stops an in-progress job', () => {
-        const h = makeRenderHook(() => useRenderJob());
-        act(() => h.result.start());
-        act(() => timerCb!());
-        act(() => h.result.cancel());
+    it('a failed renderStart marks the job as error', async () => {
+        const { cm } = makeCm({ ok: false, jobId: '', error: 'Scene not found' });
+        const h = makeRenderHook(() => useRenderJob({ cm: cm as never, onComplete: vi.fn() }));
+        await act(async () => { await h.result.start(startParams); });
+
+        expect(h.result.job?.status).toBe('error');
+        expect(h.result.job?.log.join(' ')).toContain('Scene not found');
+        h.unmount();
+    });
+
+    it('cancel stops an active job and calls renderCancel', async () => {
+        const { cm } = makeCm();
+        const h = makeRenderHook(() => useRenderJob({ cm: cm as never, onComplete: vi.fn() }));
+        await act(async () => { await h.result.start(startParams); });
+        await act(async () => { await h.result.cancel(); });
 
         expect(h.result.job?.status).toBe('cancelled');
         expect(isRenderJobActive(h.result.job)).toBe(false);
+        expect(cm.invokeService).toHaveBeenCalledWith('renderCancel', { jobId: 'job-1' });
         h.unmount();
     });
 });

--- a/tritium/react-gui/src/renderer/__test__/useRenderJob.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderJob.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @file __test__/useRenderJob.test.ts
+ * @description Contract tests for the render-job hook: start creates an
+ * active job, timer ticks advance progress through its phases to
+ * completion, and cancel stops an in-progress job.
+ *
+ * The interval callback is captured (vi.useFakeTimers does not reliably
+ * flush setState from timer callbacks via act) and invoked manually.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { makeRenderHook } from './helpers/testHarness';
+import { useRenderJob, isRenderJobActive } from '../hooks/useRenderJob';
+
+describe('useRenderJob', () => {
+    let timerCb: (() => void) | null;
+
+    beforeEach(() => {
+        timerCb = null;
+        vi.spyOn(globalThis, 'setInterval').mockImplementation(
+            ((cb: () => void) => {
+                timerCb = cb;
+                return 1 as unknown as ReturnType<typeof setInterval>;
+            }) as typeof setInterval,
+        );
+        vi.spyOn(globalThis, 'clearInterval').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('start creates an active exporting job at 0%', () => {
+        const h = makeRenderHook(() => useRenderJob());
+        act(() => h.result.start());
+        expect(h.result.job?.status).toBe('exporting');
+        expect(h.result.job?.progress).toBe(0);
+        expect(isRenderJobActive(h.result.job)).toBe(true);
+        h.unmount();
+    });
+
+    it('timer ticks advance progress and phases to completion', () => {
+        const h = makeRenderHook(() => useRenderJob());
+        act(() => h.result.start());
+
+        const seen = new Set<string>();
+        for (let i = 0; i < 20 && timerCb; i++) {
+            act(() => timerCb!());
+            if (h.result.job) seen.add(h.result.job.status);
+        }
+
+        expect(seen.has('running')).toBe(true);
+        expect(seen.has('blending')).toBe(true);
+        expect(h.result.job?.status).toBe('done');
+        expect(h.result.job?.progress).toBe(100);
+        expect(h.result.job?.finishedAt).toBeTypeOf('number');
+        // Log grows as the job progresses.
+        expect((h.result.job?.log.length ?? 0)).toBeGreaterThan(2);
+        h.unmount();
+    });
+
+    it('cancel stops an in-progress job', () => {
+        const h = makeRenderHook(() => useRenderJob());
+        act(() => h.result.start());
+        act(() => timerCb!());
+        act(() => h.result.cancel());
+
+        expect(h.result.job?.status).toBe('cancelled');
+        expect(isRenderJobActive(h.result.job)).toBe(false);
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/useRenderJob.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderJob.test.ts
@@ -10,6 +10,7 @@ import { act } from 'react';
 import { makeRenderHook } from './helpers/testHarness';
 import { useRenderJob, isRenderJobActive } from '../hooks/useRenderJob';
 import type { RenderUpdate, RenderStartResult } from '../worker/shared/renderTypes';
+import { DEFAULT_RENDER_BINARIES } from '../worker/shared/renderTypes';
 import type {
     RenderResult,
     RenderSettingsSnapshot,
@@ -22,7 +23,13 @@ const snapshot: RenderSettingsSnapshot = {
     backendProps: [],
 };
 const source: RenderSource = { sceneId: 1, sceneName: 'Scene1', viewId: 7 };
-const startParams = { sceneId: 1, viewId: 7, snapshot, source };
+const startParams = {
+    sceneId: 1,
+    viewId: 7,
+    snapshot,
+    source,
+    binaries: DEFAULT_RENDER_BINARIES,
+};
 
 /** Fake AsyncCueMol exposing an `emit` to push render-progress updates. */
 function makeCm(startResult: RenderStartResult = { ok: true, jobId: 'job-1' }) {
@@ -48,7 +55,7 @@ describe('useRenderJob', () => {
         await act(async () => { await h.result.start(startParams); });
 
         expect(cm.invokeService).toHaveBeenCalledWith('renderStart', {
-            sceneId: 1, viewId: 7, snapshot,
+            sceneId: 1, viewId: 7, snapshot, binaries: DEFAULT_RENDER_BINARIES,
         });
         expect(h.result.job?.status).toBe('exporting');
         expect(h.result.job?.jobId).toBe('job-1');

--- a/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @file __test__/useRenderSettings.test.ts
+ * @description Contract tests for the render-settings editing hook: value
+ * edits land on the right list, and switching backend keeps the common
+ * settings while resetting the backend-specific ones.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { act } from 'react';
+import { makeRenderHook } from './helpers/testHarness';
+import { useRenderSettings } from '../hooks/useRenderSettings';
+
+const valueOf = (props: { key: string; value: unknown }[], key: string) =>
+    props.find((p) => p.key === key)?.value;
+
+describe('useRenderSettings', () => {
+    it('starts on the default backend with common + backend props', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        expect(h.result.backend).toBe('povray');
+        expect(valueOf(h.result.commonProps, 'width')).toBe(1200);
+        expect(valueOf(h.result.backendProps, 'shadow')).toBe(false);
+        h.unmount();
+    });
+
+    it('handleChange updates a common setting value', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.handleChange('width', 800));
+        expect(valueOf(h.result.commonProps, 'width')).toBe(800);
+        h.unmount();
+    });
+
+    it('handleChange updates a backend-specific setting value', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.handleChange('shadow', true));
+        expect(valueOf(h.result.backendProps, 'shadow')).toBe(true);
+        h.unmount();
+    });
+
+    it('setBackend keeps common settings but resets backend-specific ones', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.handleChange('width', 800));
+        act(() => h.result.handleChange('shadow', true));
+
+        act(() => h.result.setBackend('povray'));
+
+        // Common edit survives; backend-specific edit is reset to default.
+        expect(valueOf(h.result.commonProps, 'width')).toBe(800);
+        expect(valueOf(h.result.backendProps, 'shadow')).toBe(false);
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
@@ -48,4 +48,58 @@ describe('useRenderSettings', () => {
         expect(valueOf(h.result.backendProps, 'shadow')).toBe(false);
         h.unmount();
     });
+
+    it('getSnapshot returns the current settings', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.handleChange('width', 333));
+        const snap = h.result.getSnapshot();
+        expect(snap.backend).toBe('povray');
+        expect(valueOf(snap.commonProps, 'width')).toBe(333);
+        h.unmount();
+    });
+
+    it('restore loads settings from a snapshot', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() =>
+            h.result.restore({
+                backend: 'povray',
+                commonProps: [
+                    { key: 'width', label: 'Width', type: 'integer', value: 640, group: 'Image' },
+                ],
+                backendProps: [
+                    { key: 'shadow', label: 'Shadow', type: 'boolean', value: true, group: 'POV-Ray' },
+                ],
+            }),
+        );
+        expect(valueOf(h.result.commonProps, 'width')).toBe(640);
+        expect(valueOf(h.result.backendProps, 'shadow')).toBe(true);
+        h.unmount();
+    });
+
+    it('applyPreset sets the preset label, image size and dpi', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.applyPreset('600×600 (300dpi)'));
+        expect(h.result.preset).toBe('600×600 (300dpi)');
+        expect(valueOf(h.result.commonProps, 'width')).toBe(600);
+        expect(valueOf(h.result.commonProps, 'height')).toBe(600);
+        expect(valueOf(h.result.commonProps, 'dpi')).toBe(300);
+        h.unmount();
+    });
+
+    it('the "Current view" preset uses the supplied dynamic size', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.applyPreset('Current view', { width: 1024, height: 768 }));
+        expect(h.result.preset).toBe('Current view');
+        expect(valueOf(h.result.commonProps, 'width')).toBe(1024);
+        expect(valueOf(h.result.commonProps, 'height')).toBe(768);
+        h.unmount();
+    });
+
+    it('a manual size edit resets the preset to Custom', () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.applyPreset('600×600 (300dpi)'));
+        act(() => h.result.handleChange('width', 1024));
+        expect(h.result.preset).toBe('Custom');
+        h.unmount();
+    });
 });

--- a/tritium/react-gui/src/renderer/__test__/useTabManager.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useTabManager.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @file __test__/useTabManager.test.ts
+ * @description Contract tests for render-result tab creation: a completed
+ * render opens at most one tab per source scene — re-rendering the same
+ * scene overwrites that tab rather than spawning a new one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { act } from 'react';
+import { makeRenderHook } from './helpers/testHarness';
+import { useTabManager } from '../hooks/useTabManager';
+import type { RenderResult } from '../data/renderResult';
+
+const fixtureResult = (id: string, sourceSceneId = 1): RenderResult => ({
+    id,
+    imageDataUrl: '',
+    width: 1200,
+    height: 900,
+    elapsedSec: 5.2,
+    sourceSceneId,
+    sourceSceneName: `Scene${sourceSceneId}`,
+    sourceViewId: 7,
+    settingsSnapshot: { backend: 'povray', commonProps: [], backendProps: [] },
+});
+
+describe('useTabManager — render result tabs', () => {
+    it('addRenderResultTab opens a scene-keyed renderResult tab and activates it', () => {
+        const h = makeRenderHook(() => useTabManager());
+
+        act(() => h.result.addRenderResultTab(fixtureResult('rr-1', 1)));
+
+        const tab = h.result.tabs.find((t) => t.id === 'render-result-scene-1');
+        expect(tab?.type).toBe('renderResult');
+        expect(tab?.renderResult?.id).toBe('rr-1');
+        // Title follows the `🎬 Scene — W×H (Ns)` convention.
+        expect(tab?.title).toContain('Scene1');
+        expect(tab?.title).toContain('1200×900');
+        expect(h.result.activeTab).toBe('render-result-scene-1');
+        h.unmount();
+    });
+
+    it('re-rendering the same scene overwrites the existing result tab', () => {
+        const h = makeRenderHook(() => useTabManager());
+
+        act(() => h.result.addRenderResultTab(fixtureResult('rr-1', 1)));
+        act(() => h.result.addRenderResultTab(fixtureResult('rr-2', 1)));
+
+        const rrTabs = h.result.tabs.filter((t) => t.type === 'renderResult');
+        expect(rrTabs.length).toBe(1);
+        expect(rrTabs[0].renderResult?.id).toBe('rr-2');
+        h.unmount();
+    });
+
+    it('different source scenes get separate result tabs', () => {
+        const h = makeRenderHook(() => useTabManager());
+
+        act(() => h.result.addRenderResultTab(fixtureResult('rr-a', 1)));
+        act(() => h.result.addRenderResultTab(fixtureResult('rr-b', 2)));
+
+        expect(h.result.tabs.filter((t) => t.type === 'renderResult').length).toBe(2);
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/commands/CommandMap.ts
+++ b/tritium/react-gui/src/renderer/commands/CommandMap.ts
@@ -50,6 +50,9 @@ export interface CommandMap {
   // Scene background
   [CmdId.SceneBgWhite]:        { args: void;            result: void }
   [CmdId.SceneBgBlack]:        { args: void;            result: void }
+
+  // Rendering
+  [CmdId.UiRenderSettings]:    { args: void;            result: void }
 }
 
 export type CommandKey = keyof CommandMap

--- a/tritium/react-gui/src/renderer/commands/ids.ts
+++ b/tritium/react-gui/src/renderer/commands/ids.ts
@@ -43,6 +43,9 @@ export const CmdId = {
   // Scene style
   SceneBgWhite: 'scene.bg.white', // no args
   SceneBgBlack: 'scene.bg.black', // no args
+
+  // Rendering
+  UiRenderSettings:   'ui.renderSettings', // no args -- open Render Settings in inspector
 } as const
 
 export type CmdId = typeof CmdId[keyof typeof CmdId]

--- a/tritium/react-gui/src/renderer/commands/useRenderCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useRenderCommands.ts
@@ -1,0 +1,22 @@
+/**
+ * @file commands/useRenderCommands.ts
+ * @description Registers rendering-related commands.
+ *
+ * Phase 1 wires only `UiRenderSettings`, which opens the Render Settings
+ * editor in the Inspector. Render execution commands are added in later
+ * phases (BottomPanel Render tab).
+ */
+
+import { useRegisterCommand } from "./CommandRegistry";
+import { CmdId } from "./ids";
+
+export function useRenderCommands(opts: {
+  /** Open the Render Settings editor in the inspector. */
+  showRenderSettings: () => void;
+}): void {
+  const { showRenderSettings } = opts;
+
+  useRegisterCommand(CmdId.UiRenderSettings, () => {
+    showRenderSettings();
+  });
+}

--- a/tritium/react-gui/src/renderer/components/ContentArea.tsx
+++ b/tritium/react-gui/src/renderer/components/ContentArea.tsx
@@ -31,6 +31,7 @@
 import React from "react";
 import type { TabData } from "../types";
 import type { ToolId } from "../data/viewportTools";
+import type { RenderResult } from "../data/renderResult";
 import { useTabDragDrop } from "../hooks/useTabDragDrop";
 import { TabBar } from "./TabBar";
 import { ContentPane } from "./panes/ContentPane";
@@ -55,6 +56,12 @@ interface ContentAreaProps {
   activeTool: ToolId;
   onSelectTool: (id: ToolId) => void;
   onStatusMessage?: (msg: string | null) => void;
+  /** Re-render from a render-result tab's settings snapshot. */
+  onReRender: (result: RenderResult) => void;
+  /** Switch to a render-result tab's source scene. */
+  onShowSourceScene: (result: RenderResult) => void;
+  /** Open the Render Settings editor in the Inspector. */
+  onOpenRenderSettings: () => void;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -70,6 +77,9 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
   activeTool,
   onSelectTool,
   onStatusMessage,
+  onReRender,
+  onShowSourceScene,
+  onOpenRenderSettings,
 }) => {
   const active = tabs.find((t) => t.id === activeTab);
 
@@ -94,6 +104,11 @@ export const ContentArea: React.FC<ContentAreaProps> = ({
         activeTool={activeTool}
         onSelectTool={onSelectTool}
         onStatusMessage={onStatusMessage}
+        renderResultActions={{
+          onReRender,
+          onShowSourceScene,
+          onOpenSettings: onOpenRenderSettings,
+        }}
       />
     </div>
   );

--- a/tritium/react-gui/src/renderer/components/TabBar.tsx
+++ b/tritium/react-gui/src/renderer/components/TabBar.tsx
@@ -20,9 +20,9 @@
 
 import React from "react";
 import { Icon } from "@blueprintjs/core";
+import type { IconName } from "@blueprintjs/icons";
 import type { TabData } from "../types";
 import type { DropTarget, TabDragDropAPI } from "../hooks/useTabDragDrop";
-import { getFileIcon } from "../utils";
 
 // ────────────────────────────────────────────────────────────
 // Types
@@ -128,8 +128,9 @@ export const TabBar: React.FC<TabBarProps> = ({
             onDrop={(e) => handleDrop(e, tab.id)}
             onDragEnd={handleDragEnd}
           >
+            {/* Per-type icon: home / cog / cube / media — one icon per tab. */}
             <Icon
-              icon={getFileIcon(tab.title)}
+              icon={tab.icon as IconName}
               size={14}
               className="tab-icon"
             />

--- a/tritium/react-gui/src/renderer/components/Toolbar.tsx
+++ b/tritium/react-gui/src/renderer/components/Toolbar.tsx
@@ -37,6 +37,8 @@ const TOOLBAR_ITEMS: ToolbarItem[] = [
   { kind: "divider", id: "d3" },
   { kind: "cmd", id: "get-pdb", icon: "cloud-download", text: "Get PDB", cmd: CmdId.UiGetPdbDialog },
   { kind: "divider", id: "d4" },
+  { kind: "cmd", id: "render", icon: "media", text: "Render", cmd: CmdId.UiRenderSettings },
+  { kind: "divider", id: "d5" },
   { kind: "undo", id: "undo" },
   { kind: "redo", id: "redo" },
 ];

--- a/tritium/react-gui/src/renderer/components/inspector/PropGroupedEditor.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/PropGroupedEditor.tsx
@@ -1,0 +1,111 @@
+/**
+ * @file components/inspector/PropGroupedEditor.tsx
+ * @description Reusable grouped property editor.
+ *
+ * Groups `PropDef` entries into collapsible accordion sections and renders
+ * the editor widget appropriate to each property's `type`. The accordion
+ * ordering is driven by the supplied `groups` list. Shared by the renderer
+ * Properties tab and the Render Settings editor.
+ */
+
+import React, { useMemo } from "react";
+import { AccordionSection } from "./AccordionSection";
+import {
+  StringEditor,
+  NumericEditor,
+  BooleanEditor,
+  EnumEditor,
+  ColorEditor,
+} from "./PropEditors";
+import type { PropDef } from "../../data/rendererProperties";
+
+// ────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────
+
+/** An accordion group: display key plus default expanded state. */
+export interface PropGroupDef {
+  key: string;
+  defaultExpanded?: boolean;
+}
+
+interface PropGroupedEditorProps {
+  /** Property definitions to render, each tagged with a `group`. */
+  properties: PropDef[];
+  /** Accordion groups, in display order. */
+  groups: PropGroupDef[];
+  /** Called when a property value changes. */
+  onChange: (key: string, value: string | number | boolean) => void;
+}
+
+// ────────────────────────────────────────────────────────────
+// Editor dispatcher
+// ────────────────────────────────────────────────────────────
+
+/** Render the editor widget matching a property's `type`. */
+export const renderPropEditor = (
+  prop: PropDef,
+  onChange: (key: string, value: string | number | boolean) => void,
+): React.ReactNode => {
+  switch (prop.type) {
+    case "string":
+      return <StringEditor key={prop.key} prop={prop} onChange={onChange} />;
+    case "integer":
+    case "real":
+      return <NumericEditor key={prop.key} prop={prop} onChange={onChange} />;
+    case "boolean":
+      return <BooleanEditor key={prop.key} prop={prop} onChange={onChange} />;
+    case "enum":
+      return <EnumEditor key={prop.key} prop={prop} onChange={onChange} />;
+    case "color":
+      return <ColorEditor key={prop.key} prop={prop} onChange={onChange} />;
+    default:
+      return (
+        <div key={prop.key} className="insp-prop-row">
+          <span className="insp-prop-label">{prop.label}</span>
+          <span className="insp-prop-control insp-prop-readonly">
+            {String(prop.value)}
+          </span>
+        </div>
+      );
+  }
+};
+
+// ────────────────────────────────────────────────────────────
+// Component
+// ────────────────────────────────────────────────────────────
+
+export const PropGroupedEditor: React.FC<PropGroupedEditorProps> = ({
+  properties,
+  groups,
+  onChange,
+}) => {
+  /** Group properties by their `group` field. */
+  const grouped = useMemo(() => {
+    const map = new Map<string, PropDef[]>();
+    for (const prop of properties) {
+      const list = map.get(prop.group) ?? [];
+      list.push(prop);
+      map.set(prop.group, list);
+    }
+    return map;
+  }, [properties]);
+
+  return (
+    <>
+      {groups.map((grp) => {
+        const props = grouped.get(grp.key);
+        if (!props || props.length === 0) return null;
+        return (
+          <AccordionSection
+            key={grp.key}
+            title={grp.key}
+            defaultExpanded={grp.defaultExpanded}
+          >
+            {props.map((prop) => renderPropEditor(prop, onChange))}
+          </AccordionSection>
+        );
+      })}
+    </>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/inspector/PropertiesTab.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/PropertiesTab.tsx
@@ -2,98 +2,29 @@
  * @file components/inspector/PropertiesTab.tsx
  * @description Properties tab for the inspector panel.
  *
- * Groups renderer properties into collapsible accordion sections and
- * renders the appropriate editor widget for each property based on its
- * `type` field.  The accordion ordering is driven by `PROPERTY_GROUPS`.
+ * Groups renderer properties into collapsible accordion sections via
+ * `PropGroupedEditor`. The accordion ordering is driven by `PROPERTY_GROUPS`.
  */
 
-import React, { useMemo } from "react";
-import { AccordionSection } from "./AccordionSection";
-import {
-  StringEditor,
-  NumericEditor,
-  BooleanEditor,
-  EnumEditor,
-  ColorEditor,
-} from "./PropEditors";
+import React from "react";
+import { PropGroupedEditor } from "./PropGroupedEditor";
 import type { PropDef } from "../../data/rendererProperties";
 import { PROPERTY_GROUPS } from "../../data/rendererProperties";
-
-// ────────────────────────────────────────────────────────────
-// Types
-// ────────────────────────────────────────────────────────────
 
 interface PropertiesTabProps {
   properties: PropDef[];
   onChange: (key: string, value: string | number | boolean) => void;
 }
 
-// ────────────────────────────────────────────────────────────
-// Editor dispatcher
-// ────────────────────────────────────────────────────────────
-
-const renderEditor = (
-  prop: PropDef,
-  onChange: (key: string, value: string | number | boolean) => void
-) => {
-  switch (prop.type) {
-    case "string":
-      return <StringEditor key={prop.key} prop={prop} onChange={onChange} />;
-    case "integer":
-    case "real":
-      return <NumericEditor key={prop.key} prop={prop} onChange={onChange} />;
-    case "boolean":
-      return <BooleanEditor key={prop.key} prop={prop} onChange={onChange} />;
-    case "enum":
-      return <EnumEditor key={prop.key} prop={prop} onChange={onChange} />;
-    case "color":
-      return <ColorEditor key={prop.key} prop={prop} onChange={onChange} />;
-    default:
-      return (
-        <div key={prop.key} className="insp-prop-row">
-          <span className="insp-prop-label">{prop.label}</span>
-          <span className="insp-prop-control insp-prop-readonly">
-            {String(prop.value)}
-          </span>
-        </div>
-      );
-  }
-};
-
-// ────────────────────────────────────────────────────────────
-// Component
-// ────────────────────────────────────────────────────────────
-
 export const PropertiesTab: React.FC<PropertiesTabProps> = ({
   properties,
   onChange,
-}) => {
-  /** Group properties by their `group` field. */
-  const grouped = useMemo(() => {
-    const map = new Map<string, PropDef[]>();
-    for (const prop of properties) {
-      const list = map.get(prop.group) ?? [];
-      list.push(prop);
-      map.set(prop.group, list);
-    }
-    return map;
-  }, [properties]);
-
-  return (
-    <div className="insp-properties-tab">
-      {PROPERTY_GROUPS.map((grp) => {
-        const props = grouped.get(grp.key);
-        if (!props || props.length === 0) return null;
-        return (
-          <AccordionSection
-            key={grp.key}
-            title={grp.key}
-            defaultExpanded={grp.defaultExpanded}
-          >
-            {props.map((prop) => renderEditor(prop, onChange))}
-          </AccordionSection>
-        );
-      })}
-    </div>
-  );
-};
+}) => (
+  <div className="insp-properties-tab">
+    <PropGroupedEditor
+      properties={properties}
+      groups={PROPERTY_GROUPS}
+      onChange={onChange}
+    />
+  </div>
+);

--- a/tritium/react-gui/src/renderer/components/inspector/RenderSettingsEditor.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/RenderSettingsEditor.tsx
@@ -1,0 +1,85 @@
+/**
+ * @file components/inspector/RenderSettingsEditor.tsx
+ * @description Inspector body for the `renderSettings` target.
+ *
+ * Shows a backend selector followed by the backend-independent setting
+ * groups (Image / Camera / Quality / Output) and the active backend's own
+ * groups. Phase 1 is mock-only: edits update local state but no rendering
+ * is performed yet.
+ */
+
+import React, { useCallback } from "react";
+import { HTMLSelect } from "@blueprintjs/core";
+
+import { PropGroupedEditor } from "./PropGroupedEditor";
+import type { PropDef } from "../../data/rendererProperties";
+import { RENDER_COMMON_GROUPS, type RenderBackendId } from "../../data/renderSettings";
+import { RENDER_BACKENDS } from "../../data/renderBackends";
+
+interface RenderSettingsEditorProps {
+  /** Currently selected backend. */
+  backend: RenderBackendId;
+  /** Backend ids available in the selector. */
+  backendIds: RenderBackendId[];
+  /** Backend-independent property definitions. */
+  commonProps: PropDef[];
+  /** Active backend's property definitions. */
+  backendProps: PropDef[];
+  /** Called when the user picks a different backend. */
+  onBackendChange: (id: RenderBackendId) => void;
+  /** Called when any setting value changes. */
+  onChange: (key: string, value: string | number | boolean) => void;
+}
+
+export const RenderSettingsEditor: React.FC<RenderSettingsEditorProps> = ({
+  backend,
+  backendIds,
+  commonProps,
+  backendProps,
+  onBackendChange,
+  onChange,
+}) => {
+  const handleBackendChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onBackendChange(e.currentTarget.value as RenderBackendId);
+    },
+    [onBackendChange],
+  );
+
+  const backendGroups = RENDER_BACKENDS[backend].groups;
+
+  return (
+    <div className="insp-properties-tab">
+      {/* ── Backend selector ── */}
+      <div className="insp-render-backend-bar">
+        <span className="insp-prop-label">Backend</span>
+        <HTMLSelect
+          className="insp-select"
+          fill
+          value={backend}
+          onChange={handleBackendChange}
+        >
+          {backendIds.map((id) => (
+            <option key={id} value={id}>
+              {RENDER_BACKENDS[id].label}
+            </option>
+          ))}
+        </HTMLSelect>
+      </div>
+
+      {/* ── Backend-independent groups ── */}
+      <PropGroupedEditor
+        properties={commonProps}
+        groups={RENDER_COMMON_GROUPS}
+        onChange={onChange}
+      />
+
+      {/* ── Backend-specific groups ── */}
+      <PropGroupedEditor
+        properties={backendProps}
+        groups={backendGroups}
+        onChange={onChange}
+      />
+    </div>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/panels/BottomPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/panels/BottomPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * Bottom panel with VSCode-style tabbed switching between Output,
- * Sequence alignment, and Animation timeline views.
+ * Sequence alignment, Animation timeline and Render views.
  *
  * The Output tab uses `LogView` (pre-element based) backed by
  * `useLogEvent` so it receives cuemol3 core log events via IPC.
@@ -12,13 +12,15 @@ import type { IconName } from "@blueprintjs/icons";
 import { LogView } from "../../LogView";
 import { SequencePanel } from "./SequencePanel";
 import { AnimationPanel } from "./AnimationPanel";
+import { RenderPanel } from "./RenderPanel";
+import type { RenderJob } from "../../hooks/useRenderJob";
 import type { AlignmentData, AnimationData } from "../../types";
 
 // ─────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────
 
-type BottomTabType = "output" | "sequence" | "animation";
+type BottomTabType = "output" | "sequence" | "animation" | "render";
 
 interface TabButtonProps {
   tab: BottomTabType;
@@ -49,9 +51,21 @@ const TabButton: React.FC<TabButtonProps> = ({ tab, activeTab, icon, label, onCl
 interface BottomPanelProps {
   alignment: AlignmentData | null;
   animation: AnimationData | null;
+  /** Current render job (Render tab). */
+  renderJob: RenderJob | null;
+  /** Start a render. */
+  onRenderStart: () => void;
+  /** Cancel the active render. */
+  onRenderCancel: () => void;
 }
 
-export const BottomPanel: React.FC<BottomPanelProps> = ({ alignment, animation }) => {
+export const BottomPanel: React.FC<BottomPanelProps> = ({
+  alignment,
+  animation,
+  renderJob,
+  onRenderStart,
+  onRenderCancel,
+}) => {
   const [activeTab, setActiveTab] = useState<BottomTabType>("output");
 
   const renderContent = () => {
@@ -62,6 +76,14 @@ export const BottomPanel: React.FC<BottomPanelProps> = ({ alignment, animation }
         return <SequencePanel alignment={alignment} />;
       case "animation":
         return <AnimationPanel animation={animation} />;
+      case "render":
+        return (
+          <RenderPanel
+            job={renderJob}
+            onStart={onRenderStart}
+            onCancel={onRenderCancel}
+          />
+        );
     }
   };
 
@@ -71,6 +93,7 @@ export const BottomPanel: React.FC<BottomPanelProps> = ({ alignment, animation }
         <TabButton tab="output" activeTab={activeTab} icon="console" label="Output" onClick={setActiveTab} />
         <TabButton tab="sequence" activeTab={activeTab} icon="align-left" label="Sequence" onClick={setActiveTab} />
         <TabButton tab="animation" activeTab={activeTab} icon="timeline-events" label="Animation" onClick={setActiveTab} />
+        <TabButton tab="render" activeTab={activeTab} icon="media" label="Render" onClick={setActiveTab} />
       </div>
       <div className="bottom-panel-content">{renderContent()}</div>
     </div>

--- a/tritium/react-gui/src/renderer/components/panels/BottomPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/panels/BottomPanel.tsx
@@ -53,18 +53,27 @@ interface BottomPanelProps {
   animation: AnimationData | null;
   /** Current render job (Render tab). */
   renderJob: RenderJob | null;
+  /** Selected image-size preset label. */
+  renderPreset: string;
   /** Start a render. */
   onRenderStart: () => void;
   /** Cancel the active render. */
   onRenderCancel: () => void;
+  /** Apply an image-size preset. */
+  onRenderApplyPreset: (label: string) => void;
+  /** Open the Render Settings editor in the Inspector. */
+  onOpenRenderSettings: () => void;
 }
 
 export const BottomPanel: React.FC<BottomPanelProps> = ({
   alignment,
   animation,
   renderJob,
+  renderPreset,
   onRenderStart,
   onRenderCancel,
+  onRenderApplyPreset,
+  onOpenRenderSettings,
 }) => {
   const [activeTab, setActiveTab] = useState<BottomTabType>("output");
 
@@ -80,8 +89,11 @@ export const BottomPanel: React.FC<BottomPanelProps> = ({
         return (
           <RenderPanel
             job={renderJob}
+            preset={renderPreset}
             onStart={onRenderStart}
             onCancel={onRenderCancel}
+            onApplyPreset={onRenderApplyPreset}
+            onOpenSettings={onOpenRenderSettings}
           />
         );
     }

--- a/tritium/react-gui/src/renderer/components/panels/InspectorPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/panels/InspectorPanel.tsx
@@ -1,33 +1,36 @@
 /**
  * @file components/InspectorPanel.tsx
- * @description Right-side inspector panel for editing node properties.
+ * @description Right-side inspector panel — the property editor for whatever
+ * context currently has focus.
  *
  * ## Layout
  *
  * ```
  * ┌──────────────────────────┐
- * │  ribbon1          [×]   │  ← header (node name + type + close)
+ * │ [Renderer] ribbon1   [×] │  ← header (category badge + name + close)
  * ├──────────────────────────┤
- * │ [ Properties │ Generic ] │  ← SegmentedControl
+ * │ [ Properties │ Generic ] │  ← SegmentedControl (node targets only)
  * ├──────────────────────────┤
- * │  (Generic) flat table +  │
- * │   type-aware detail edit │
+ * │  body: Generic table OR  │
+ * │   Render Settings editor │
  * └──────────────────────────┘
  * ```
  *
- * The "Generic" tab is the migrated UXP `generic-propdlg` - a flat,
- * type-aware editor for every property of the selected scene-tree node.
- * The "Properties" tab is a structured per-type view still on sample data.
+ * The inspector targets one of several context kinds. `node` targets (a
+ * scene-tree node or the View) use the migrated UXP `generic-propdlg`
+ * editor; the `renderSettings` target uses `RenderSettingsEditor`.
  *
  * @module InspectorPanel
  */
 
 import React, { useState, useCallback, useEffect } from "react";
-import { Icon, Button, SegmentedControl } from "@blueprintjs/core";
+import { Icon, Button, SegmentedControl, Tag } from "@blueprintjs/core";
 
 import { PropertiesTab } from "../inspector/PropertiesTab";
 import { GenericTab } from "../inspector/GenericTab";
+import { RenderSettingsEditor } from "../inspector/RenderSettingsEditor";
 import type { PropDef } from "../../data/rendererProperties";
+import type { RenderBackendId } from "../../data/renderSettings";
 import type { GenericPropEntry } from "../../worker/server/services/genericProps.service";
 
 // ────────────────────────────────────────────────────────────
@@ -36,10 +39,27 @@ import type { GenericPropEntry } from "../../worker/server/services/genericProps
 
 type InspectorMode = "properties" | "generic";
 
+/** Kind of context the inspector is currently editing. */
+export type InspectorTargetKind = "node" | "renderSettings";
+
+/** Props passed through to the Render Settings editor. */
+export interface RenderSettingsView {
+  backend: RenderBackendId;
+  backendIds: RenderBackendId[];
+  commonProps: PropDef[];
+  backendProps: PropDef[];
+  onBackendChange: (id: RenderBackendId) => void;
+  onChange: (key: string, value: string | number | boolean) => void;
+}
+
 interface InspectorPanelProps {
-  /** Whether a scene-tree node is currently being inspected. */
+  /** Whether something is currently being inspected. */
   hasTarget: boolean;
-  /** Display name shown in the header (node name). */
+  /** Kind of the current target (null when nothing is inspected). */
+  targetKind: InspectorTargetKind | null;
+  /** Conceptual category label shown as a header badge. */
+  targetCategory: string;
+  /** Display name shown in the header. */
   nodeName: string;
   /** Type label shown in the header (renderer type / class name). */
   nodeType: string;
@@ -49,6 +69,8 @@ interface InspectorPanelProps {
   genericEntries: GenericPropEntry[];
   /** True while the Generic property list is being (re)fetched. */
   genericLoading: boolean;
+  /** Render Settings state, present only for the `renderSettings` target. */
+  renderSettings: RenderSettingsView | null;
   /** Called when a structured (sample) property value changes. */
   onPropertyChange: (key: string, value: string | number | boolean) => void;
   /** Called to write a Generic property value (live-apply). */
@@ -65,11 +87,14 @@ interface InspectorPanelProps {
 
 export const InspectorPanel: React.FC<InspectorPanelProps> = ({
   hasTarget,
+  targetKind,
+  targetCategory,
   nodeName,
   nodeType,
   properties,
   genericEntries,
   genericLoading,
+  renderSettings,
   onPropertyChange,
   onGenericSet,
   onGenericReset,
@@ -87,6 +112,8 @@ export const InspectorPanel: React.FC<InspectorPanelProps> = ({
     if (hasTarget) setMode("generic");
   }, [hasTarget, nodeName]);
 
+  const isRenderSettings = targetKind === "renderSettings";
+
   return (
     <div className="inspector-panel">
       {/* ── Header ── */}
@@ -94,8 +121,19 @@ export const InspectorPanel: React.FC<InspectorPanelProps> = ({
         <div className="inspector-header-left">
           <Icon icon="properties" size={14} className="inspector-header-icon" />
           <div className="inspector-header-info">
-            <span className="inspector-header-name">{nodeName || "Inspector"}</span>
-            <span className="inspector-header-type">{nodeType}</span>
+            {hasTarget && targetCategory && (
+              <Tag minimal className="inspector-header-badge">
+                {targetCategory}
+              </Tag>
+            )}
+            {nodeName ? (
+              <span className="inspector-header-name">{nodeName}</span>
+            ) : !hasTarget ? (
+              <span className="inspector-header-name">Inspector</span>
+            ) : null}
+            {nodeType && (
+              <span className="inspector-header-type">{nodeType}</span>
+            )}
           </div>
         </div>
         <Button
@@ -109,7 +147,20 @@ export const InspectorPanel: React.FC<InspectorPanelProps> = ({
 
       {!hasTarget ? (
         <div className="inspector-empty">No node selected.</div>
+      ) : isRenderSettings && renderSettings ? (
+        /* ── Render Settings target ── */
+        <div className="inspector-body">
+          <RenderSettingsEditor
+            backend={renderSettings.backend}
+            backendIds={renderSettings.backendIds}
+            commonProps={renderSettings.commonProps}
+            backendProps={renderSettings.backendProps}
+            onBackendChange={renderSettings.onBackendChange}
+            onChange={renderSettings.onChange}
+          />
+        </div>
       ) : (
+        /* ── Node target (scene-tree node / View) ── */
         <>
           {/* ── Mode switcher ── */}
           <div className="inspector-mode-bar">

--- a/tritium/react-gui/src/renderer/components/panels/RenderPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/panels/RenderPanel.tsx
@@ -1,0 +1,107 @@
+/**
+ * @file components/panels/RenderPanel.tsx
+ * @description BottomPanel "Render" tab — render execution controls,
+ * progress and log.
+ *
+ * Settings live in the Inspector (`renderSettings` target); this panel owns
+ * the state-changing operations: Start / Stop, the progress bar, the phase
+ * label and the render log. Phase 2 is mock-driven (see `useRenderJob`).
+ */
+
+import React from "react";
+import { Button, Icon, ProgressBar, type Intent } from "@blueprintjs/core";
+import { type RenderJob, isRenderJobActive } from "../../hooks/useRenderJob";
+
+interface RenderPanelProps {
+  /** Current render job, or null when none has run yet. */
+  job: RenderJob | null;
+  /** Start a new render. */
+  onStart: () => void;
+  /** Cancel the active render. */
+  onCancel: () => void;
+}
+
+/** Progress-bar intent for the job's status. */
+const intentForJob = (job: RenderJob): Intent => {
+  switch (job.status) {
+    case "done":
+      return "success";
+    case "error":
+      return "danger";
+    case "cancelled":
+      return "warning";
+    default:
+      return "primary";
+  }
+};
+
+/** Elapsed seconds, frozen once the job finishes. */
+const elapsedSec = (job: RenderJob): string =>
+  (((job.finishedAt ?? Date.now()) - job.startedAt) / 1000).toFixed(1);
+
+export const RenderPanel: React.FC<RenderPanelProps> = ({
+  job,
+  onStart,
+  onCancel,
+}) => {
+  const active = isRenderJobActive(job);
+
+  return (
+    <div className="render-panel">
+      {/* ── Action bar ── */}
+      <div className="render-panel-bar">
+        {active ? (
+          <Button
+            small
+            intent="danger"
+            className="render-action-btn"
+            icon={<Icon icon="stop" size={11} />}
+            text="Stop"
+            onClick={onCancel}
+          />
+        ) : (
+          <Button
+            small
+            intent="primary"
+            className="render-action-btn"
+            icon={<Icon icon="play" size={11} />}
+            text="Start Render"
+            onClick={onStart}
+          />
+        )}
+        {job && (
+          <span className="render-panel-status">
+            {job.phase} · {job.progress}% · {elapsedSec(job)}s
+          </span>
+        )}
+      </div>
+
+      {/* ── Progress ── */}
+      {job && (
+        <div className="render-panel-progress">
+          <ProgressBar
+            value={job.progress / 100}
+            intent={intentForJob(job)}
+            stripes={active}
+            animate={active}
+          />
+        </div>
+      )}
+
+      {/* ── Log ── */}
+      <div className="render-panel-log">
+        {job && job.log.length > 0 ? (
+          job.log.map((line, i) => (
+            <div className="render-log-line" key={i}>
+              {line}
+            </div>
+          ))
+        ) : (
+          <div className="render-panel-empty">
+            No render yet. Press Start Render to begin.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/panels/RenderPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/panels/RenderPanel.tsx
@@ -3,22 +3,30 @@
  * @description BottomPanel "Render" tab — render execution controls,
  * progress and log.
  *
- * Settings live in the Inspector (`renderSettings` target); this panel owns
- * the state-changing operations: Start / Stop, the progress bar, the phase
- * label and the render log. Phase 2 is mock-driven (see `useRenderJob`).
+ * Detailed settings live in the Inspector (`renderSettings` target); this
+ * panel owns the state-changing operations (Start / Stop), a quick
+ * image-size preset, a shortcut to the Inspector settings, the progress
+ * bar and the render log. Phase 2/3 is mock-driven (see `useRenderJob`).
  */
 
 import React from "react";
-import { Button, Icon, ProgressBar, type Intent } from "@blueprintjs/core";
+import { Button, Icon, HTMLSelect, ProgressBar, type Intent } from "@blueprintjs/core";
 import { type RenderJob, isRenderJobActive } from "../../hooks/useRenderJob";
+import { RENDER_SIZE_PRESETS } from "../../data/renderSettings";
 
 interface RenderPanelProps {
   /** Current render job, or null when none has run yet. */
   job: RenderJob | null;
+  /** Selected image-size preset label. */
+  preset: string;
   /** Start a new render. */
   onStart: () => void;
   /** Cancel the active render. */
   onCancel: () => void;
+  /** Apply an image-size preset. */
+  onApplyPreset: (label: string) => void;
+  /** Open the Render Settings editor in the Inspector. */
+  onOpenSettings: () => void;
 }
 
 /** Progress-bar intent for the job's status. */
@@ -41,8 +49,11 @@ const elapsedSec = (job: RenderJob): string =>
 
 export const RenderPanel: React.FC<RenderPanelProps> = ({
   job,
+  preset,
   onStart,
   onCancel,
+  onApplyPreset,
+  onOpenSettings,
 }) => {
   const active = isRenderJobActive(job);
 
@@ -69,6 +80,30 @@ export const RenderPanel: React.FC<RenderPanelProps> = ({
             onClick={onStart}
           />
         )}
+
+        <span className="render-panel-preset">
+          <span className="render-panel-preset-label">Image size</span>
+          <HTMLSelect
+            className="insp-select render-panel-preset-select"
+            value={preset}
+            onChange={(e) => onApplyPreset(e.currentTarget.value)}
+          >
+            {RENDER_SIZE_PRESETS.map((p) => (
+              <option key={p.label} value={p.label}>
+                {p.label}
+              </option>
+            ))}
+          </HTMLSelect>
+        </span>
+
+        <Button
+          small
+          minimal
+          icon={<Icon icon="cog" size={12} />}
+          text="Render Settings"
+          onClick={onOpenSettings}
+        />
+
         {job && (
           <span className="render-panel-status">
             {job.phase} · {job.progress}% · {elapsedSec(job)}s

--- a/tritium/react-gui/src/renderer/components/panes/ContentPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/ContentPane.tsx
@@ -18,9 +18,11 @@
 import React, { useCallback, useRef } from "react";
 import type { TabData } from "../../types";
 import type { ToolId } from "../../data/viewportTools";
+import type { RenderResult } from "../../data/renderResult";
 import { WelcomePane } from "./WelcomePane";
 import { SettingsPane } from "./SettingsPane";
 import { MolViewPane } from "./MolViewPane";
+import { RenderResultPane } from "./RenderResultPane";
 import { ViewportToolPalette } from "../ViewportToolPalette";
 import { useNaviClickHandler } from "../../hooks/useNaviClickHandler";
 import { useNaviContextMenu } from "../../hooks/useNaviContextMenu";
@@ -29,6 +31,13 @@ import type { HitTestResult } from "../../types";
 // ─────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────
+
+/** Render-result tab callbacks routed down from App. */
+interface RenderResultActions {
+  onReRender: (result: RenderResult) => void;
+  onShowSourceScene: (result: RenderResult) => void;
+  onOpenSettings: () => void;
+}
 
 interface ContentPaneProps {
   /** All open tabs — used to detect whether a MolViewPane tab exists. */
@@ -41,6 +50,8 @@ interface ContentPaneProps {
   onSelectTool: (id: ToolId) => void;
   /** Callback to push atom/pick status messages to the app status bar. */
   onStatusMessage?: (msg: string | null) => void;
+  /** Render-result tab actions. */
+  renderResultActions: RenderResultActions;
 }
 
 // ─────────────────────────────────────────────
@@ -48,10 +59,24 @@ interface ContentPaneProps {
 // ─────────────────────────────────────────────
 
 /** Map a tab to its content node. Returns null for molview (handled separately). */
-const renderContent = (tab: TabData | undefined): React.ReactNode => {
+const renderContent = (
+  tab: TabData | undefined,
+  renderResultActions: RenderResultActions,
+): React.ReactNode => {
   if (!tab) return <WelcomePane />;
   switch (tab.type) {
     case "settings": return <SettingsPane />;
+    case "renderResult":
+      return tab.renderResult ? (
+        <RenderResultPane
+          result={tab.renderResult}
+          onReRender={renderResultActions.onReRender}
+          onShowSourceScene={renderResultActions.onShowSourceScene}
+          onOpenSettings={renderResultActions.onOpenSettings}
+        />
+      ) : (
+        <WelcomePane />
+      );
     case "welcome":
     default: return <WelcomePane />;
   }
@@ -67,10 +92,12 @@ export const ContentPane: React.FC<ContentPaneProps> = ({
   activeTool,
   onSelectTool,
   onStatusMessage,
+  renderResultActions,
 }) => {
   const hasMolViewTab = tabs.some((t) => t.type === "molview");
   const molViewVisible = activeTab?.type === "molview";
-  const showPalette = activeTab?.type !== "settings";
+  const showPalette =
+    activeTab?.type !== "settings" && activeTab?.type !== "renderResult";
 
   // Once a molview tab has existed, keep MolViewPane mounted permanently.
   // Unmounting the canvas destroys the WebGL context and the already-transferred
@@ -106,7 +133,7 @@ export const ContentPane: React.FC<ContentPaneProps> = ({
           <MolViewPane />
         </div>
       )}
-      {!molViewVisible && renderContent(activeTab)}
+      {!molViewVisible && renderContent(activeTab, renderResultActions)}
       {showPalette && (
         <ViewportToolPalette activeTool={activeTool} onSelect={onSelectTool} />
       )}

--- a/tritium/react-gui/src/renderer/components/panes/RenderImageViewer.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/RenderImageViewer.tsx
@@ -1,0 +1,114 @@
+/**
+ * @file components/panes/RenderImageViewer.tsx
+ * @description Zoomable / pannable image viewer for the Render Result tab.
+ *
+ * The image is laid out at `width × height × scale` inside a scrollable
+ * container; panning is drag-to-scroll. Fit-to-view and 100% are explicit
+ * actions, and the view fits once when the image first loads.
+ */
+
+import React, { useRef, useState, useCallback } from "react";
+import { Button, ButtonGroup } from "@blueprintjs/core";
+
+interface RenderImageViewerProps {
+  /** Image data URL. */
+  src: string;
+  /** Logical image width in pixels. */
+  imgWidth: number;
+  /** Logical image height in pixels. */
+  imgHeight: number;
+}
+
+const MIN_SCALE = 0.05;
+const MAX_SCALE = 8;
+const clamp = (v: number, lo: number, hi: number): number =>
+  Math.min(hi, Math.max(lo, v));
+
+export const RenderImageViewer: React.FC<RenderImageViewerProps> = ({
+  src,
+  imgWidth,
+  imgHeight,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  const fittedRef = useRef(false);
+
+  /** Scale that makes the image fit entirely within the viewport. */
+  const computeFit = useCallback((): number => {
+    const el = scrollRef.current;
+    if (!el || imgWidth <= 0 || imgHeight <= 0) return 1;
+    return clamp(
+      Math.min(el.clientWidth / imgWidth, el.clientHeight / imgHeight),
+      MIN_SCALE,
+      MAX_SCALE,
+    );
+  }, [imgWidth, imgHeight]);
+
+  const fit = useCallback(() => setScale(computeFit()), [computeFit]);
+  const zoom = useCallback(
+    (factor: number) => setScale((s) => clamp(s * factor, MIN_SCALE, MAX_SCALE)),
+    [],
+  );
+
+  // Fit once, when the image first loads (the tab is visible by then).
+  const handleImgLoad = useCallback(() => {
+    if (fittedRef.current) return;
+    fittedRef.current = true;
+    setScale(computeFit());
+  }, [computeFit]);
+
+  // Drag-to-pan via scroll offset.
+  const dragRef = useRef<{ x: number; y: number; sl: number; st: number } | null>(
+    null,
+  );
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    dragRef.current = { x: e.clientX, y: e.clientY, sl: el.scrollLeft, st: el.scrollTop };
+  }, []);
+  const onMouseMove = useCallback((e: React.MouseEvent) => {
+    const el = scrollRef.current;
+    const d = dragRef.current;
+    if (!el || !d) return;
+    el.scrollLeft = d.sl - (e.clientX - d.x);
+    el.scrollTop = d.st - (e.clientY - d.y);
+  }, []);
+  const endDrag = useCallback(() => {
+    dragRef.current = null;
+  }, []);
+
+  return (
+    <div className="riv">
+      <div className="riv-toolbar">
+        <ButtonGroup>
+          <Button small icon="zoom-out" title="Zoom out" onClick={() => zoom(0.8)} />
+          <Button small icon="zoom-in" title="Zoom in" onClick={() => zoom(1.25)} />
+        </ButtonGroup>
+        <Button small icon="zoom-to-fit" text="Fit" onClick={fit} />
+        <Button small text="100%" onClick={() => setScale(1)} />
+        <span className="riv-zoom-label">{Math.round(scale * 100)}%</span>
+      </div>
+      <div
+        className="riv-scroll"
+        ref={scrollRef}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={endDrag}
+        onMouseLeave={endDrag}
+      >
+        <div
+          className="riv-stage"
+          style={{ width: imgWidth * scale, height: imgHeight * scale }}
+        >
+          <img
+            className="riv-img"
+            src={src}
+            alt="Render result"
+            draggable={false}
+            onLoad={handleImgLoad}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/panes/RenderResultPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/RenderResultPane.tsx
@@ -1,0 +1,135 @@
+/**
+ * @file components/panes/RenderResultPane.tsx
+ * @description ContentArea tab body for a completed render.
+ *
+ * Top toolbar carries the result actions (Save / Copy / Show Settings /
+ * Re-render / Show Source Scene); below it a `RenderImageViewer` shows the
+ * image. The settings snapshot is shown in a popover.
+ */
+
+import React, { useCallback } from "react";
+import { Button, Divider, Popover } from "@blueprintjs/core";
+
+import { RenderImageViewer } from "./RenderImageViewer";
+import type { RenderResult } from "../../data/renderResult";
+import type { PropDef } from "../../data/rendererProperties";
+import { RENDER_BACKENDS } from "../../data/renderBackends";
+
+interface RenderResultPaneProps {
+  /** The render result shown in this tab. */
+  result: RenderResult;
+  /** Re-render using this result's settings snapshot. */
+  onReRender: (result: RenderResult) => void;
+  /** Switch to the source scene's molview tab. */
+  onShowSourceScene: (result: RenderResult) => void;
+  /** Open the live Render Settings editor in the Inspector. */
+  onOpenSettings: () => void;
+}
+
+/** Read-only list of a snapshot's property values, shown in the popover. */
+const SnapshotList: React.FC<{ title: string; props: PropDef[] }> = ({
+  title,
+  props,
+}) => (
+  <div className="rr-snapshot-group">
+    <div className="rr-snapshot-group-title">{title}</div>
+    {props.map((p) => (
+      <div className="rr-snapshot-row" key={p.key}>
+        <span className="rr-snapshot-key">{p.label}</span>
+        <span className="rr-snapshot-val">{String(p.value)}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const RenderResultPane: React.FC<RenderResultPaneProps> = ({
+  result,
+  onReRender,
+  onShowSourceScene,
+  onOpenSettings,
+}) => {
+  const handleSave = useCallback(() => {
+    const a = document.createElement("a");
+    a.href = result.imageDataUrl;
+    a.download = `${result.sourceSceneName}-${result.width}x${result.height}.png`;
+    a.click();
+  }, [result]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      const blob = await (await fetch(result.imageDataUrl)).blob();
+      await navigator.clipboard.write([
+        new ClipboardItem({ [blob.type]: blob }),
+      ]);
+    } catch (err) {
+      console.warn("copy render image to clipboard failed:", err);
+    }
+  }, [result]);
+
+  const settingsPopover = (
+    <div className="rr-snapshot-pop">
+      <div className="rr-snapshot-backend">
+        Backend: {RENDER_BACKENDS[result.settingsSnapshot.backend]?.label ??
+          result.settingsSnapshot.backend}
+      </div>
+      <SnapshotList title="Common" props={result.settingsSnapshot.commonProps} />
+      <SnapshotList
+        title={RENDER_BACKENDS[result.settingsSnapshot.backend]?.label ?? "Backend"}
+        props={result.settingsSnapshot.backendProps}
+      />
+    </div>
+  );
+
+  return (
+    <div className="render-result-pane">
+      {/* ── Toolbar — icon-only buttons, label on hover (title) ── */}
+      <div className="render-result-toolbar">
+        <Button
+          small
+          icon="floppy-disk"
+          title="Save image"
+          onClick={handleSave}
+        />
+        <Button
+          small
+          icon="duplicate"
+          title="Copy image to clipboard"
+          onClick={handleCopy}
+        />
+        <Popover content={settingsPopover} placement="bottom-start">
+          <Button small icon="properties" title="Settings used for this render" />
+        </Popover>
+        <Divider />
+        <Button
+          small
+          icon="cog"
+          title="Open Render Settings"
+          onClick={onOpenSettings}
+        />
+        <Button
+          small
+          icon="refresh"
+          title="Re-render"
+          onClick={() => onReRender(result)}
+        />
+        <Button
+          small
+          icon="cube"
+          title="Show source scene"
+          onClick={() => onShowSourceScene(result)}
+        />
+        <div className="render-result-info">
+          {result.sourceSceneName} · {result.width}×{result.height} ·{" "}
+          {result.elapsedSec.toFixed(1)}s
+        </div>
+      </div>
+
+      {/* ── Image viewer ── */}
+      <RenderImageViewer
+        src={result.imageDataUrl}
+        imgWidth={result.width}
+        imgHeight={result.height}
+      />
+    </div>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/panes/SettingsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/SettingsPane.tsx
@@ -31,18 +31,23 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { Icon, InputGroup } from '@blueprintjs/core'
 import { useTheme } from '../../contexts/ThemeContext'
+import { useRenderConfig } from '../../contexts/RenderConfigContext'
 import {
   CATEGORY_TREE,
   ALL_LEAF_IDS,
   SETTINGS,
   DEFAULTS,
   CATEGORY_LABELS,
+  RENDER_BINARY_SETTING_KEYS,
 } from './settings/settingsConfig'
 import { ConfigTreeNode } from './settings/ConfigTreeNode'
 import { SettingRow } from './settings/SettingRow'
 
 export const SettingsPane: React.FC = () => {
   const { theme, setTheme } = useTheme()
+  // Render binary paths are backed by RenderConfigContext (persistent),
+  // not the mock `values` state.
+  const { binaries, setBinary } = useRenderConfig()
 
   const [filter, setFilter] = useState('')
   const [values, setValues] = useState<Record<string, string | number | boolean>>(() => ({
@@ -62,6 +67,13 @@ export const SettingsPane: React.FC = () => {
 
   const handleChange = useCallback(
     (key: string, value: string | number | boolean) => {
+      // Render binary paths persist via RenderConfigContext.
+      const binaryKey = RENDER_BINARY_SETTING_KEYS[key]
+      if (binaryKey) {
+        setBinary(binaryKey, String(value))
+        return
+      }
+
       setValues((prev) => ({ ...prev, [key]: value }))
 
       // Sync theme toggle with the ThemeContext.
@@ -69,7 +81,7 @@ export const SettingsPane: React.FC = () => {
         setTheme(value ? 'dark' : 'light')
       }
     },
-    [setTheme],
+    [setTheme, setBinary],
   )
 
   // Keep the toggle in sync if theme changes externally.
@@ -218,14 +230,17 @@ export const SettingsPane: React.FC = () => {
               </div>
               {filtered
                 .filter((s) => s.category === catId)
-                .map((s) => (
-                  <SettingRow
-                    key={s.key}
-                    def={s}
-                    value={values[s.key]}
-                    onChange={handleChange}
-                  />
-                ))}
+                .map((s) => {
+                  const binaryKey = RENDER_BINARY_SETTING_KEYS[s.key]
+                  return (
+                    <SettingRow
+                      key={s.key}
+                      def={s}
+                      value={binaryKey ? binaries[binaryKey] : values[s.key]}
+                      onChange={handleChange}
+                    />
+                  )
+                })}
             </div>
           ))}
 

--- a/tritium/react-gui/src/renderer/components/panes/settings/SettingRow.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/settings/SettingRow.tsx
@@ -7,7 +7,8 @@
  */
 
 import React from 'react'
-import { HTMLSelect, NumericInput, Switch } from '@blueprintjs/core'
+import { Button, HTMLSelect, NumericInput, Switch } from '@blueprintjs/core'
+import { IPC } from '../../../../shared/ipcChannels'
 import type { SettingDef } from './settingsConfig'
 
 export interface SettingRowProps {
@@ -65,6 +66,32 @@ export const SettingRow: React.FC<SettingRowProps> = ({ def, value, onChange }) 
             <span className="config-setting-color-hex">{value as string}</span>
           </div>
         )
+      case 'path': {
+        const directory = control.directory === true
+        const handleBrowse = async (): Promise<void> => {
+          try {
+            const res = await window.electronAPI?.invoke(IPC.DIALOG_PICK_PATH, {
+              title: `Select ${label}`,
+              directory,
+            })
+            if (res && !res.canceled && res.filePath) onChange(key, res.filePath)
+          } catch {
+            /* dialog unavailable (e.g. Vite dev server) — ignore */
+          }
+        }
+        return (
+          <div className="config-setting-path-row">
+            <input
+              type="text"
+              className="config-setting-path-input"
+              value={value as string}
+              spellCheck={false}
+              onChange={(e) => onChange(key, e.target.value)}
+            />
+            <Button small text="Browse…" onClick={handleBrowse} />
+          </div>
+        )
+      }
       default:
         return null
     }

--- a/tritium/react-gui/src/renderer/components/panes/settings/settingsConfig.ts
+++ b/tritium/react-gui/src/renderer/components/panes/settings/settingsConfig.ts
@@ -10,6 +10,8 @@
  */
 
 import type { IconName } from '@blueprintjs/icons'
+import type { RenderBinaries } from '../../../worker/shared/renderTypes'
+import { DEFAULT_RENDER_BINARIES } from '../../../worker/shared/renderTypes'
 
 // ── Category tree ───────────────────────────────────────────────────────
 
@@ -73,6 +75,7 @@ export type SettingControl =
   | { kind: 'number'; min: number; max: number; step: number; minorStep?: number }
   | { kind: 'toggle' }
   | { kind: 'color' }
+  | { kind: 'path'; directory?: boolean }
 
 export interface SettingDef {
   key: string
@@ -165,6 +168,27 @@ export const SETTINGS: SettingDef[] = [
     description: 'Depth-cue fog intensity applied to distant objects.',
     category: 'display.rendering',
     control: { kind: 'number', min: 0, max: 1.0, step: 0.05, minorStep: 0.01 },
+  },
+  {
+    key: 'rendering.povrayExe',
+    label: 'POV-Ray Executable',
+    description: 'Path to the POV-Ray binary used for ray-traced rendering.',
+    category: 'display.rendering',
+    control: { kind: 'path' },
+  },
+  {
+    key: 'rendering.povrayInc',
+    label: 'POV-Ray Include Directory',
+    description: 'Directory containing the POV-Ray standard include files.',
+    category: 'display.rendering',
+    control: { kind: 'path', directory: true },
+  },
+  {
+    key: 'rendering.blendpng',
+    label: 'blendpng Executable',
+    description: 'Path to the blendpng tool that composites render layers.',
+    category: 'display.rendering',
+    control: { kind: 'path' },
   },
 
   // ── Display > Colors ──
@@ -322,6 +346,9 @@ export const DEFAULTS: Record<string, string | number | boolean> = {
   'rendering.shadows': false,
   'rendering.ambientOcclusion': false,
   'rendering.fogDensity': 0.3,
+  'rendering.povrayExe': DEFAULT_RENDER_BINARIES.povrayExe,
+  'rendering.povrayInc': DEFAULT_RENDER_BINARIES.povrayInc,
+  'rendering.blendpng': DEFAULT_RENDER_BINARIES.blendpng,
   'colors.background': '#1E2028',
   'colors.selectionHighlight': '#5FAFD7',
   'colors.labelBackground': '#000000',
@@ -356,3 +383,13 @@ function buildLabelMap(nodes: CategoryNode[]): Record<string, string> {
 }
 
 export const CATEGORY_LABELS = buildLabelMap(CATEGORY_TREE)
+
+// ── Render-binary settings ──────────────────────────────────────────────
+// These setting keys are backed by RenderConfigContext (persistent paths),
+// not the mock `values` state. SettingsPane routes them accordingly.
+
+export const RENDER_BINARY_SETTING_KEYS: Record<string, keyof RenderBinaries> = {
+  'rendering.povrayExe': 'povrayExe',
+  'rendering.povrayInc': 'povrayInc',
+  'rendering.blendpng': 'blendpng',
+}

--- a/tritium/react-gui/src/renderer/contexts/RenderConfigContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/RenderConfigContext.tsx
@@ -1,0 +1,90 @@
+/**
+ * @file contexts/RenderConfigContext.tsx
+ * @description React context for the (persistent) render binary paths —
+ * the POV-Ray executable, its include directory, and blendpng.
+ *
+ * The paths are app configuration: edited in the SettingsPane and consumed
+ * by `App` when starting a render. They are persisted to electron-store via
+ * the existing `UI_SAVE` / `UI_LOAD` IPC channels (same mechanism as the
+ * colour theme).
+ */
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+} from "react";
+import { IPC } from "../../shared/ipcChannels";
+import {
+  type RenderBinaries,
+  DEFAULT_RENDER_BINARIES,
+} from "../worker/shared/renderTypes";
+
+interface RenderConfigContextValue {
+  /** Current render binary paths. */
+  binaries: RenderBinaries;
+  /** Update one binary path and persist it. */
+  setBinary: (key: keyof RenderBinaries, value: string) => void;
+}
+
+const RenderConfigContext = createContext<RenderConfigContextValue | null>(null);
+
+interface RenderConfigProviderProps {
+  children: React.ReactNode;
+}
+
+export const RenderConfigProvider: React.FC<RenderConfigProviderProps> = ({
+  children,
+}) => {
+  const [binaries, setBinaries] = useState<RenderBinaries>(DEFAULT_RENDER_BINARIES);
+
+  // Load persisted paths on mount; absent fields fall back to defaults.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const ui = await window.electronAPI?.invoke(IPC.UI_LOAD);
+        if (cancelled || !ui) return;
+        setBinaries({
+          povrayExe: ui.povrayExe || DEFAULT_RENDER_BINARIES.povrayExe,
+          povrayInc: ui.povrayInc || DEFAULT_RENDER_BINARIES.povrayInc,
+          blendpng: ui.blendpng || DEFAULT_RENDER_BINARIES.blendpng,
+        });
+      } catch {
+        // Electron not available (Vite dev server) — keep defaults.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setBinary = useCallback((key: keyof RenderBinaries, value: string) => {
+    setBinaries((prev) => ({ ...prev, [key]: value }));
+    // Persist immediately — path changes are infrequent; no debounce needed.
+    window.electronAPI?.invoke(IPC.UI_SAVE, { [key]: value });
+  }, []);
+
+  const value = useMemo<RenderConfigContextValue>(
+    () => ({ binaries, setBinary }),
+    [binaries, setBinary],
+  );
+
+  return (
+    <RenderConfigContext.Provider value={value}>
+      {children}
+    </RenderConfigContext.Provider>
+  );
+};
+
+/** Access the render binary paths. Must be used inside `<RenderConfigProvider>`. */
+export function useRenderConfig(): RenderConfigContextValue {
+  const ctx = useContext(RenderConfigContext);
+  if (!ctx) {
+    throw new Error("useRenderConfig() must be used within a <RenderConfigProvider>.");
+  }
+  return ctx;
+}

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -1,0 +1,53 @@
+/**
+ * @file data/renderBackends.ts
+ * @description Registry of rendering backends.
+ *
+ * Each backend contributes its own accordion groups and property
+ * definitions to the Inspector `renderSettings` editor. Adding a backend is
+ * a matter of appending a `RenderBackendDescriptor` here (and, later, a
+ * matching worker-side executor) — the Inspector UI is backend-agnostic.
+ */
+
+import type { PropDef } from "./rendererProperties";
+import type { RenderBackendId, RenderGroupDef } from "./renderSettings";
+
+/** Static description of a rendering backend used to drive the editor UI. */
+export interface RenderBackendDescriptor {
+  /** Stable backend identifier. */
+  id: RenderBackendId;
+  /** Human-readable name shown in the backend selector. */
+  label: string;
+  /** Backend-specific accordion groups, rendered after the common groups. */
+  groups: RenderGroupDef[];
+  /** Backend-specific property definitions (mock defaults for now). */
+  props: PropDef[];
+}
+
+/** POV-Ray backend-specific options (UXP `render-pov-dlg` "POV-Ray" tab). */
+const POVRAY_PROPS: PropDef[] = [
+  { key: "radiosityMode", label: "Radiosity mode", type: "enum", value: "Disable", group: "POV-Ray",
+    options: ["Disable", "Default", "Debug", "Fast", "Normal", "2-Bounce", "Final",
+              "Outdoor LQ", "Outdoor HQ", "Outdoor Light", "Indoor LQ", "Indoor HQ"] },
+  { key: "shadow",          label: "Enable shadow",       type: "boolean", value: false, group: "POV-Ray" },
+  { key: "lightDefault",    label: "Use default lighting", type: "boolean", value: true,  group: "POV-Ray" },
+  { key: "lightSpread",     label: "Light spread",        type: "integer", value: 1,   group: "POV-Ray", min: 1, max: 10, step: 1 },
+  { key: "lightIntensity",  label: "Light intensity",     type: "real",    value: 1.3, group: "POV-Ray", min: 0, max: 2, step: 0.1 },
+  { key: "flashFraction",   label: "Flash fraction",      type: "real",    value: 0.6, group: "POV-Ray", min: 0, max: 1, step: 0.1 },
+  { key: "ambientFraction", label: "Ambient fraction",    type: "real",    value: 0.0, group: "POV-Ray", min: 0, max: 1, step: 0.1 },
+];
+
+/** All registered rendering backends, keyed by id. */
+export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> = {
+  povray: {
+    id: "povray",
+    label: "POV-Ray",
+    groups: [{ key: "POV-Ray", defaultExpanded: false }],
+    props: POVRAY_PROPS,
+  },
+};
+
+/** Default backend selected when the render-settings editor first opens. */
+export const DEFAULT_RENDER_BACKEND: RenderBackendId = "povray";
+
+/** Ordered list of registered backend ids (drives the backend selector). */
+export const RENDER_BACKEND_IDS = Object.keys(RENDER_BACKENDS) as RenderBackendId[];

--- a/tritium/react-gui/src/renderer/data/renderResult.ts
+++ b/tritium/react-gui/src/renderer/data/renderResult.ts
@@ -55,84 +55,24 @@ export interface RenderResult {
 export const renderResultTabTitle = (r: RenderResult): string =>
   `${r.sourceSceneName} — ${r.width}×${r.height} (${r.elapsedSec.toFixed(1)}s)`;
 
-/** Largest canvas dimension used when synthesising the mock image. */
-const MOCK_IMAGE_CAP = 1600;
-
-/**
- * Synthesise a placeholder render image as a PNG data URL. Returns an empty
- * string when a 2D context is unavailable (e.g. jsdom under test).
- */
-export function makeMockRenderImage(
-  width: number,
-  height: number,
-  label: string,
-): string {
-  const scale = Math.min(1, MOCK_IMAGE_CAP / Math.max(width, height, 1));
-  const cw = Math.max(1, Math.round(width * scale));
-  const ch = Math.max(1, Math.round(height * scale));
-
-  const canvas = document.createElement("canvas");
-  canvas.width = cw;
-  canvas.height = ch;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return "";
-
-  // Diagonal gradient background.
-  const grad = ctx.createLinearGradient(0, 0, cw, ch);
-  grad.addColorStop(0, "#1b2a4a");
-  grad.addColorStop(1, "#3a1b46");
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, cw, ch);
-
-  // Faint grid so zoom / fit / pan are visually obvious.
-  ctx.strokeStyle = "rgba(255,255,255,0.06)";
-  ctx.lineWidth = 1;
-  const step = Math.max(24, Math.round(Math.min(cw, ch) / 12));
-  for (let x = step; x < cw; x += step) {
-    ctx.beginPath();
-    ctx.moveTo(x, 0);
-    ctx.lineTo(x, ch);
-    ctx.stroke();
-  }
-  for (let y = step; y < ch; y += step) {
-    ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(cw, y);
-    ctx.stroke();
-  }
-
-  // Centred label and dimensions.
-  ctx.fillStyle = "rgba(255,255,255,0.9)";
-  ctx.textAlign = "center";
-  ctx.textBaseline = "middle";
-  const titleSize = Math.max(14, Math.round(ch / 14));
-  ctx.font = `600 ${titleSize}px sans-serif`;
-  ctx.fillText(label, cw / 2, ch / 2 - titleSize * 0.4);
-  ctx.fillStyle = "rgba(255,255,255,0.55)";
-  ctx.font = `${Math.round(titleSize * 0.6)}px sans-serif`;
-  ctx.fillText(`${width} × ${height}`, cw / 2, ch / 2 + titleSize * 0.7);
-
-  return canvas.toDataURL("image/png");
-}
-
-/** Build a mock render result from the job's source and settings snapshot. */
-export function buildMockRenderResult(args: {
+/** Build a render result from the rendered image and the job's context. */
+export function buildRenderResult(args: {
+  imageDataUrl: string;
   width: number;
   height: number;
   elapsedSec: number;
-  source: RenderSource | undefined;
+  source: RenderSource;
   snapshot: RenderSettingsSnapshot;
 }): RenderResult {
-  const sceneName = args.source?.sceneName || "Scene";
   return {
     id: `render-result-${Date.now()}`,
-    imageDataUrl: makeMockRenderImage(args.width, args.height, sceneName),
+    imageDataUrl: args.imageDataUrl,
     width: args.width,
     height: args.height,
     elapsedSec: args.elapsedSec,
-    sourceSceneId: args.source?.sceneId ?? -1,
-    sourceSceneName: sceneName,
-    sourceViewId: args.source?.viewId,
+    sourceSceneId: args.source.sceneId,
+    sourceSceneName: args.source.sceneName || "Scene",
+    sourceViewId: args.source.viewId,
     settingsSnapshot: args.snapshot,
   };
 }

--- a/tritium/react-gui/src/renderer/data/renderResult.ts
+++ b/tritium/react-gui/src/renderer/data/renderResult.ts
@@ -1,0 +1,138 @@
+/**
+ * @file data/renderResult.ts
+ * @description Types and mock helpers for a completed render result.
+ *
+ * A render result is opened as its own ContentArea tab. It carries the
+ * rendered image, the source-scene reference and a frozen snapshot of the
+ * settings used, so the result tab can be inspected and re-rendered.
+ *
+ * Phase 3 is mock-only: `makeMockRenderImage` synthesises a placeholder
+ * image so the result tab and viewer can be exercised before the real
+ * worker-side pipeline (phase 4) exists.
+ */
+
+import type { PropDef } from "./rendererProperties";
+import type { RenderBackendId } from "./renderSettings";
+
+/** Reference to the scene/view a render was started from. */
+export interface RenderSource {
+  sceneId: number;
+  sceneName: string;
+  /** Active molview tab's view id, used to navigate back to the source. */
+  viewId?: number;
+}
+
+/** Frozen copy of the render settings used for a result. */
+export interface RenderSettingsSnapshot {
+  backend: RenderBackendId;
+  commonProps: PropDef[];
+  backendProps: PropDef[];
+}
+
+/** A completed render, displayed in its own ContentArea tab. */
+export interface RenderResult {
+  /** Unique id (also used as the tab id). */
+  id: string;
+  /** Rendered image as a data URL. */
+  imageDataUrl: string;
+  /** Logical image width in pixels. */
+  width: number;
+  /** Logical image height in pixels. */
+  height: number;
+  /** Wall-clock render time in seconds. */
+  elapsedSec: number;
+  /** Source scene uid. */
+  sourceSceneId: number;
+  /** Source scene display name. */
+  sourceSceneName: string;
+  /** Source molview tab's view id (for "Show Source Scene"). */
+  sourceViewId?: number;
+  /** Settings used for this render. */
+  settingsSnapshot: RenderSettingsSnapshot;
+}
+
+/** Tab title for a render result: `Scene1 — 1216×612 (15.2s)`. */
+export const renderResultTabTitle = (r: RenderResult): string =>
+  `${r.sourceSceneName} — ${r.width}×${r.height} (${r.elapsedSec.toFixed(1)}s)`;
+
+/** Largest canvas dimension used when synthesising the mock image. */
+const MOCK_IMAGE_CAP = 1600;
+
+/**
+ * Synthesise a placeholder render image as a PNG data URL. Returns an empty
+ * string when a 2D context is unavailable (e.g. jsdom under test).
+ */
+export function makeMockRenderImage(
+  width: number,
+  height: number,
+  label: string,
+): string {
+  const scale = Math.min(1, MOCK_IMAGE_CAP / Math.max(width, height, 1));
+  const cw = Math.max(1, Math.round(width * scale));
+  const ch = Math.max(1, Math.round(height * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = cw;
+  canvas.height = ch;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return "";
+
+  // Diagonal gradient background.
+  const grad = ctx.createLinearGradient(0, 0, cw, ch);
+  grad.addColorStop(0, "#1b2a4a");
+  grad.addColorStop(1, "#3a1b46");
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, cw, ch);
+
+  // Faint grid so zoom / fit / pan are visually obvious.
+  ctx.strokeStyle = "rgba(255,255,255,0.06)";
+  ctx.lineWidth = 1;
+  const step = Math.max(24, Math.round(Math.min(cw, ch) / 12));
+  for (let x = step; x < cw; x += step) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, ch);
+    ctx.stroke();
+  }
+  for (let y = step; y < ch; y += step) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(cw, y);
+    ctx.stroke();
+  }
+
+  // Centred label and dimensions.
+  ctx.fillStyle = "rgba(255,255,255,0.9)";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  const titleSize = Math.max(14, Math.round(ch / 14));
+  ctx.font = `600 ${titleSize}px sans-serif`;
+  ctx.fillText(label, cw / 2, ch / 2 - titleSize * 0.4);
+  ctx.fillStyle = "rgba(255,255,255,0.55)";
+  ctx.font = `${Math.round(titleSize * 0.6)}px sans-serif`;
+  ctx.fillText(`${width} × ${height}`, cw / 2, ch / 2 + titleSize * 0.7);
+
+  return canvas.toDataURL("image/png");
+}
+
+/** Build a mock render result from the job's source and settings snapshot. */
+export function buildMockRenderResult(args: {
+  width: number;
+  height: number;
+  elapsedSec: number;
+  source: RenderSource | undefined;
+  snapshot: RenderSettingsSnapshot;
+}): RenderResult {
+  const sceneName = args.source?.sceneName || "Scene";
+  return {
+    id: `render-result-${Date.now()}`,
+    imageDataUrl: makeMockRenderImage(args.width, args.height, sceneName),
+    width: args.width,
+    height: args.height,
+    elapsedSec: args.elapsedSec,
+    sourceSceneId: args.source?.sceneId ?? -1,
+    sourceSceneName: sceneName,
+    sourceViewId: args.source?.viewId,
+    settingsSnapshot: args.snapshot,
+  };
+}

--- a/tritium/react-gui/src/renderer/data/renderSettings.ts
+++ b/tritium/react-gui/src/renderer/data/renderSettings.ts
@@ -1,0 +1,65 @@
+/**
+ * @file data/renderSettings.ts
+ * @description Backend-independent render settings shown in the Inspector
+ * `renderSettings` target (Image / Camera / Quality / Output groups).
+ *
+ * Phase 1 uses mock defaults; values are driven through the same `PropDef`
+ * descriptor format as the renderer Properties tab so the existing editor
+ * widgets (`PropEditors`) and accordion grouping can be reused as-is.
+ */
+
+import type { PropDef } from "./rendererProperties";
+
+/** Identifier of a rendering backend. Extended as backends are added. */
+export type RenderBackendId = "povray";
+
+/** Accordion group descriptor for the render-settings editor. */
+export interface RenderGroupDef {
+  /** Group key — also the value of each member `PropDef.group`. */
+  key: string;
+  /** Whether the accordion section starts expanded. */
+  defaultExpanded?: boolean;
+}
+
+/**
+ * Backend-independent accordion groups, in display order.
+ * Backend-specific groups are appended by the active `RenderBackendDescriptor`.
+ */
+export const RENDER_COMMON_GROUPS: RenderGroupDef[] = [
+  { key: "Image", defaultExpanded: true },
+  { key: "Camera", defaultExpanded: true },
+  { key: "Quality", defaultExpanded: false },
+  { key: "Output", defaultExpanded: false },
+];
+
+/** Backend-independent render-setting definitions (mock defaults). */
+export const RENDER_COMMON_PROPS: PropDef[] = [
+  // ── Image ────────────────────────────────────────────────
+  { key: "width",  label: "Width (px)",  type: "integer", value: 1200, group: "Image", min: 1, max: 10000, step: 1 },
+  { key: "height", label: "Height (px)", type: "integer", value: 900,  group: "Image", min: 1, max: 10000, step: 1 },
+  { key: "unit",   label: "Size unit",   type: "enum",    value: "px",  group: "Image", options: ["px", "in", "mm", "cm"] },
+  { key: "dpi",    label: "DPI",         type: "integer", value: 600,   group: "Image", min: 72, max: 1200, step: 1 },
+  { key: "preset", label: "Preset",      type: "enum",    value: "Custom", group: "Image",
+    options: ["Custom", "View size", "100×100 @72dpi", "300×300 @300dpi", "600×600 @300dpi", "1200×1200 @600dpi"] },
+  { key: "scale",  label: "Scale",       type: "real",    value: 1.0,   group: "Image", min: 0.1, max: 4, step: 0.1 },
+
+  // ── Camera ───────────────────────────────────────────────
+  { key: "projection",  label: "Projection",   type: "enum", value: "perspective", group: "Camera",
+    options: ["perspective", "orthographic"] },
+  { key: "stereoMode",  label: "Stereo mode",  type: "enum", value: "none", group: "Camera",
+    options: ["none", "left", "right"] },
+  { key: "stereoDepth", label: "Stereo depth", type: "real", value: 0.03, group: "Camera", min: 0, max: 1, step: 0.01 },
+
+  // ── Quality ──────────────────────────────────────────────
+  { key: "numThreads",  label: "CPU threads",        type: "integer", value: 2,  group: "Quality", min: 1, max: 32, step: 1 },
+  { key: "edgeLines",   label: "Edge lines",         type: "boolean", value: true, group: "Quality" },
+  { key: "creaseLimit", label: "Crease limit (deg)", type: "real",    value: 50, group: "Quality", min: 0, max: 180, step: 1 },
+  { key: "edgeRise",    label: "Edge rise",          type: "real",    value: 1.0, group: "Quality", min: 0, max: 10, step: 0.1 },
+
+  // ── Output ───────────────────────────────────────────────
+  { key: "fileFormat",    label: "File format",                type: "enum",    value: "png", group: "Output", options: ["png"] },
+  { key: "transparentBg", label: "Transparent background",     type: "boolean", value: false, group: "Output" },
+  { key: "clipPlane",     label: "Enable clip plane",          type: "boolean", value: true,  group: "Output" },
+  { key: "postBlend",     label: "Post-render alpha blending", type: "boolean", value: true,  group: "Output" },
+  { key: "pixelLabels",   label: "Pixel labels",               type: "boolean", value: false, group: "Output" },
+];

--- a/tritium/react-gui/src/renderer/data/renderSettings.ts
+++ b/tritium/react-gui/src/renderer/data/renderSettings.ts
@@ -32,6 +32,35 @@ export const RENDER_COMMON_GROUPS: RenderGroupDef[] = [
   { key: "Output", defaultExpanded: false },
 ];
 
+/** A named image-size preset (UXP `render-pov-dlg` preset list). */
+export interface RenderSizePreset {
+  label: string;
+  /** Width/height in px; `0` means "no static size" (see `dynamic`). */
+  width: number;
+  height: number;
+  /** Output DPI applied with the preset, when defined. */
+  dpi?: number;
+  /** When true the size is resolved from the current view at apply time. */
+  dynamic?: boolean;
+}
+
+/**
+ * Image-size presets offered as a quick dropdown in the BottomPanel Render
+ * tab (mirrors the UXP `render-pov-dlg` preset list). The Inspector keeps
+ * the free-form width / height / dpi controls.
+ */
+export const RENDER_SIZE_PRESETS: RenderSizePreset[] = [
+  { label: "Custom", width: 0, height: 0 },
+  { label: "Current view", width: 0, height: 0, dynamic: true },
+  { label: "100×100 (72dpi)", width: 100, height: 100, dpi: 72 },
+  { label: "300×300 (300dpi)", width: 300, height: 300, dpi: 300 },
+  { label: "600×600 (300dpi)", width: 600, height: 600, dpi: 300 },
+  { label: "1200×1200 (600dpi)", width: 1200, height: 1200, dpi: 600 },
+];
+
+/** Default preset label (no enforced size). */
+export const DEFAULT_RENDER_PRESET = "Custom";
+
 /** Backend-independent render-setting definitions (mock defaults). */
 export const RENDER_COMMON_PROPS: PropDef[] = [
   // ── Image ────────────────────────────────────────────────
@@ -39,8 +68,6 @@ export const RENDER_COMMON_PROPS: PropDef[] = [
   { key: "height", label: "Height (px)", type: "integer", value: 900,  group: "Image", min: 1, max: 10000, step: 1 },
   { key: "unit",   label: "Size unit",   type: "enum",    value: "px",  group: "Image", options: ["px", "in", "mm", "cm"] },
   { key: "dpi",    label: "DPI",         type: "integer", value: 600,   group: "Image", min: 72, max: 1200, step: 1 },
-  { key: "preset", label: "Preset",      type: "enum",    value: "Custom", group: "Image",
-    options: ["Custom", "View size", "100×100 @72dpi", "300×300 @300dpi", "600×600 @300dpi", "1200×1200 @600dpi"] },
   { key: "scale",  label: "Scale",       type: "real",    value: 1.0,   group: "Image", min: 0.1, max: 4, step: 0.1 },
 
   // ── Camera ───────────────────────────────────────────────

--- a/tritium/react-gui/src/renderer/data/renderSettings.ts
+++ b/tritium/react-gui/src/renderer/data/renderSettings.ts
@@ -78,10 +78,8 @@ export const RENDER_COMMON_PROPS: PropDef[] = [
   { key: "stereoDepth", label: "Stereo depth", type: "real", value: 0.03, group: "Camera", min: 0, max: 1, step: 0.01 },
 
   // ── Quality ──────────────────────────────────────────────
-  { key: "numThreads",  label: "CPU threads",        type: "integer", value: 2,  group: "Quality", min: 1, max: 32, step: 1 },
-  { key: "edgeLines",   label: "Edge lines",         type: "boolean", value: true, group: "Quality" },
-  { key: "creaseLimit", label: "Crease limit (deg)", type: "real",    value: 50, group: "Quality", min: 0, max: 180, step: 1 },
-  { key: "edgeRise",    label: "Edge rise",          type: "real",    value: 1.0, group: "Quality", min: 0, max: 10, step: 0.1 },
+  { key: "numThreads", label: "CPU threads", type: "integer", value: 2,    group: "Quality", min: 1, max: 32, step: 1 },
+  { key: "edgeLines",  label: "Edge lines",  type: "boolean", value: true, group: "Quality" },
 
   // ── Output ───────────────────────────────────────────────
   { key: "fileFormat",    label: "File format",                type: "enum",    value: "png", group: "Output", options: ["png"] },

--- a/tritium/react-gui/src/renderer/hooks/useCommandRegistrations.ts
+++ b/tritium/react-gui/src/renderer/hooks/useCommandRegistrations.ts
@@ -17,6 +17,7 @@ import { useNewTabCommand } from '../commands/useNewTabCommand';
 import { useEditCommands } from '../commands/useEditCommands';
 import { useFileCommands } from '../commands/useFileCommands';
 import { useViewCommands } from '../commands/useViewCommands';
+import { useRenderCommands } from '../commands/useRenderCommands';
 import { useElectronIpc } from './useElectronIpc';
 import type { NewSceneAction } from './useNewSceneAction';
 
@@ -33,6 +34,8 @@ interface UseCommandRegistrationsOptions {
   onBgColorChanged: (bgColor: SceneBgColor) => void;
   /** Open the active View in the generic property inspector. */
   showViewProperty: (viewId: number) => void;
+  /** Open the active scene's Render Settings in the inspector. */
+  showRenderSettings: () => void;
   newScene: NewSceneAction;
 }
 
@@ -48,6 +51,7 @@ export function useCommandRegistrations({
   onCenterMarkChanged,
   onBgColorChanged,
   showViewProperty,
+  showRenderSettings,
   newScene,
 }: UseCommandRegistrationsOptions): void {
   useSceneCommands({ cm, getActiveSceneInfo, onBgColorChanged, newScene });
@@ -63,5 +67,6 @@ export function useCommandRegistrations({
     onCenterMarkChanged,
     showViewProperty,
   });
+  useRenderCommands({ showRenderSettings });
   useElectronIpc(activeTab);
 }

--- a/tritium/react-gui/src/renderer/hooks/useInspectorState.ts
+++ b/tritium/react-gui/src/renderer/hooks/useInspectorState.ts
@@ -10,7 +10,7 @@
  * sample data pending its own migration.
  */
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import type { LayoutState } from "./useLayoutPersistence";
 import type { AsyncCueMol } from "../worker/client/AsyncCueMol";
 import type { SceneTreeNode } from "../worker/shared/sceneTreeTypes";
@@ -37,12 +37,26 @@ export interface InspectorInfo {
   type: string;
 }
 
-/** Resolved identity of the node currently shown in the inspector. */
-interface InspectorTarget {
-  sceneId: number;
-  nodeId: number;
-  nodeType: PropTargetType;
-}
+/**
+ * Identity of whatever is currently shown in the inspector.
+ *
+ * - `node` — a scene-tree node or the View, edited through the generic
+ *   C++ property bridge (`getGenericProps` / `setGenericProp`).
+ * - `renderSettings` — the scene's render output settings; not a scene-tree
+ *   node and not backed by the property bridge (see `RenderSettingsEditor`).
+ */
+export type InspectorTarget =
+  | { kind: "node"; sceneId: number; nodeId: number; nodeType: PropTargetType }
+  | { kind: "renderSettings"; sceneId: number };
+
+/** Header category label for each scene-tree node type. */
+const NODE_CATEGORY_LABELS: Record<string, string> = {
+  scene: "Scene",
+  object: "Object",
+  renderer: "Renderer",
+  rendGroup: "Renderer group",
+  view: "View",
+};
 
 export interface UseInspectorStateOptions {
   /** Persisted layout (used to restore open state on first load). */
@@ -131,6 +145,13 @@ export function useInspectorState({
       setInspectorInfo({ name: "", type: "" });
       return;
     }
+    // Render Settings is not a property-bridge node — it has its own editor.
+    // The header category badge already names it, so leave name/type blank.
+    if (target.kind === "renderSettings") {
+      setGenericEntries([]);
+      setInspectorInfo({ name: "", type: "" });
+      return;
+    }
     setGenericLoading(true);
     try {
       const res = await cm.invokeService("getGenericProps", {
@@ -167,7 +188,12 @@ export function useInspectorState({
       const sid = sceneTree ? Number(sceneTree.id) : undefined;
       const found = findTypedNode(sceneTree, id);
       if (sid === undefined || !found) return;
-      applyTarget({ sceneId: sid, nodeId: found.numId, nodeType: found.node.type });
+      applyTarget({
+        kind: "node",
+        sceneId: sid,
+        nodeId: found.numId,
+        nodeType: found.node.type,
+      });
     },
     [sceneTree, applyTarget],
   );
@@ -181,10 +207,21 @@ export function useInspectorState({
     (viewId: number) => {
       const sid = sceneTree ? Number(sceneTree.id) : undefined;
       if (sid === undefined) return;
-      applyTarget({ sceneId: sid, nodeId: viewId, nodeType: "view" });
+      applyTarget({ kind: "node", sceneId: sid, nodeId: viewId, nodeType: "view" });
     },
     [sceneTree, applyTarget],
   );
+
+  /**
+   * Open the inspector on the active scene's Render Settings (Toolbar
+   * Render button / F12). Render Settings belongs to the scene as a whole
+   * and has no scene-tree node.
+   */
+  const handleShowRenderSettings = useCallback(() => {
+    const sid = sceneTree ? Number(sceneTree.id) : undefined;
+    if (sid === undefined) return;
+    applyTarget({ kind: "renderSettings", sceneId: sid });
+  }, [sceneTree, applyTarget]);
 
   // Refetch whenever the target changes.
   useEffect(() => {
@@ -214,7 +251,7 @@ export function useInspectorState({
   const handleGenericSet = useCallback(
     async (key: string, valueType: string, value: string | number | boolean) => {
       const target = targetRef.current;
-      if (!cm || !target) return;
+      if (!cm || !target || target.kind !== "node") return;
       try {
         const res = await cm.invokeService("setGenericProp", {
           sceneId: target.sceneId,
@@ -239,7 +276,7 @@ export function useInspectorState({
   const handleGenericReset = useCallback(
     async (key: string) => {
       const target = targetRef.current;
-      if (!cm || !target) return;
+      if (!cm || !target || target.kind !== "node") return;
       try {
         const res = await cm.invokeService("setGenericProp", {
           sceneId: target.sceneId,
@@ -284,15 +321,24 @@ export function useInspectorState({
     debounceMs: REFETCH_DEBOUNCE_MS,
   });
 
+  // Conceptual category of the current target, shown as a header badge.
+  const inspectorCategory = useMemo(() => {
+    if (!inspectorTarget) return "";
+    if (inspectorTarget.kind === "renderSettings") return "Render Settings";
+    return NODE_CATEGORY_LABELS[inspectorTarget.nodeType] ?? "Node";
+  }, [inspectorTarget]);
+
   return {
     inspectorOpen,
     inspectorTarget,
+    inspectorCategory,
     rendererProps,
     genericEntries,
     genericLoading,
     inspectorInfo,
     handleShowGeneric,
     handleShowViewProps,
+    handleShowRenderSettings,
     handleCloseInspector,
     handlePropertyChange,
     handleGenericSet,

--- a/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
@@ -14,6 +14,7 @@ import type {
   RenderUpdate,
   RenderUpdatePhase,
   RenderStartResult,
+  RenderBinaries,
 } from "../worker/shared/renderTypes";
 import {
   type RenderSource,
@@ -49,6 +50,8 @@ export interface RenderStartParams {
   viewId?: number;
   snapshot: RenderSettingsSnapshot;
   source: RenderSource;
+  /** External binary paths (POV-Ray / blendpng). */
+  binaries: RenderBinaries;
 }
 
 const ACTIVE_STATUSES: RenderJobStatus[] = ["exporting", "running", "blending"];
@@ -168,6 +171,7 @@ export function useRenderJob(opts: {
           sceneId: params.sceneId,
           viewId: params.viewId,
           snapshot: params.snapshot,
+          binaries: params.binaries,
         });
       } catch (e) {
         setJob((prev) =>

--- a/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
@@ -9,6 +9,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from "react";
+import type { RenderSource } from "../data/renderResult";
 
 /** Lifecycle status of a render job. */
 export type RenderJobStatus =
@@ -35,6 +36,8 @@ export interface RenderJob {
   startedAt: number;
   /** Epoch ms when the job ended (done / error / cancelled). */
   finishedAt?: number;
+  /** Scene/view the render was started from (captured at start). */
+  source?: RenderSource;
 }
 
 /** Statuses in which the job is still progressing. */
@@ -93,7 +96,7 @@ export function useRenderJob() {
     }
   }, []);
 
-  const start = useCallback(() => {
+  const start = useCallback((source?: RenderSource) => {
     stopTimer();
     setJob({
       jobId: `render-${Date.now()}`,
@@ -102,6 +105,7 @@ export function useRenderJob() {
       phase: "Exporting scene",
       log: ["Render started", "Exporting scene..."],
       startedAt: Date.now(),
+      source,
     });
     timerRef.current = setInterval(() => {
       setJob((prev) => {

--- a/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
@@ -1,15 +1,26 @@
 /**
  * @file hooks/useRenderJob.ts
- * @description Drives a render job's lifecycle for the BottomPanel Render tab.
+ * @description Drives a render job from the renderer side.
  *
- * Phase 2 is mock-only: `start()` runs a timer that walks a fake job through
- * its phases (exporting → running → blending → done) so the panel, progress
- * bar and StatusBar wiring can be verified before the real worker-side
- * pipeline (phase 4) is connected.
+ * `start()` calls the `renderStart` worker service and then tracks the job
+ * via `render-progress` push updates; on completion the rendered image is
+ * handed to `onComplete` (which opens a Render Result tab). `cancel()` calls
+ * `renderCancel`.
  */
 
-import { useState, useCallback, useRef, useEffect } from "react";
-import type { RenderSource } from "../data/renderResult";
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { AsyncCueMol } from "../worker/client/AsyncCueMol";
+import type {
+  RenderUpdate,
+  RenderUpdatePhase,
+  RenderStartResult,
+} from "../worker/shared/renderTypes";
+import {
+  type RenderSource,
+  type RenderSettingsSnapshot,
+  type RenderResult,
+  buildRenderResult,
+} from "../data/renderResult";
 
 /** Lifecycle status of a render job. */
 export type RenderJobStatus =
@@ -22,25 +33,24 @@ export type RenderJobStatus =
 
 /** State of a single render job. */
 export interface RenderJob {
-  /** Unique id of this job. */
   jobId: string;
-  /** Current lifecycle status. */
   status: RenderJobStatus;
-  /** Completion percentage, 0..100. */
-  progress: number;
-  /** Human-readable label of the current phase. */
+  progress: number; // 0..100
   phase: string;
-  /** Accumulated log lines. */
   log: string[];
-  /** Epoch ms when the job started. */
   startedAt: number;
-  /** Epoch ms when the job ended (done / error / cancelled). */
   finishedAt?: number;
-  /** Scene/view the render was started from (captured at start). */
   source?: RenderSource;
 }
 
-/** Statuses in which the job is still progressing. */
+/** Parameters needed to start a render. */
+export interface RenderStartParams {
+  sceneId: number;
+  viewId?: number;
+  snapshot: RenderSettingsSnapshot;
+  source: RenderSource;
+}
+
 const ACTIVE_STATUSES: RenderJobStatus[] = ["exporting", "running", "blending"];
 
 /** True (and narrows) while the job is still progressing. */
@@ -48,92 +58,167 @@ export function isRenderJobActive(job: RenderJob | null): job is RenderJob {
   return job !== null && ACTIVE_STATUSES.includes(job.status);
 }
 
-/** Mock job tick interval and per-tick progress step. */
-const TICK_MS = 400;
-const PROGRESS_STEP = 7;
+/** Cap on retained log lines. */
+const LOG_CAP = 500;
 
-/** Advance the mock job by one tick. */
-function advanceMockJob(job: RenderJob): RenderJob {
-  const progress = Math.min(100, job.progress + PROGRESS_STEP);
-  const log = [...job.log];
-  let status = job.status;
-  let phase = job.phase;
+const appendLog = (log: string[], lines: string[]): string[] => {
+  if (lines.length === 0) return log;
+  const next = [...log, ...lines];
+  return next.length > LOG_CAP ? next.slice(-LOG_CAP) : next;
+};
 
-  if (progress >= 100) {
-    log.push("Render completed");
-    return { ...job, progress, status: "done", phase: "Completed", log, finishedAt: Date.now() };
-  }
-  if (progress >= 90) {
-    if (status !== "blending") {
-      status = "blending";
-      phase = "Blending layers";
-      log.push("Blending layers...");
-    }
-  } else if (progress >= 15) {
-    if (status !== "running") {
-      status = "running";
-      phase = "Rendering";
-      log.push("Rendering scene...");
-    }
-    log.push(`Rendered ${progress}%`);
-  }
-  return { ...job, progress, status, phase, log };
-}
+const splitLog = (chunk: string): string[] =>
+  chunk.split(/\r?\n/).filter((l) => l.trim().length > 0);
 
-/**
- * Owns the current render job. `start()` begins a new (mock) job; `cancel()`
- * stops the active one. The job object is the single source of truth read by
- * both the Render panel and the StatusBar.
- */
-export function useRenderJob() {
+const PHASE_LABELS: Record<RenderUpdatePhase, string> = {
+  exporting: "Exporting scene",
+  running: "Rendering",
+  blending: "Blending layers",
+};
+
+export function useRenderJob(opts: {
+  /** Worker bridge (null until CueMol is ready). */
+  cm: AsyncCueMol | null;
+  /** Called with the finished result when a job completes. */
+  onComplete: (result: RenderResult) => void;
+}) {
+  const { cm, onComplete } = opts;
   const [job, setJob] = useState<RenderJob | null>(null);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const stopTimer = useCallback(() => {
-    if (timerRef.current !== null) {
-      clearInterval(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
+  // Params of the in-flight job, keyed by the worker-assigned jobId.
+  const pendingRef = useRef<{ jobId: string; params: RenderStartParams } | null>(null);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
 
-  const start = useCallback((source?: RenderSource) => {
-    stopTimer();
-    setJob({
-      jobId: `render-${Date.now()}`,
-      status: "exporting",
-      progress: 0,
-      phase: "Exporting scene",
-      log: ["Render started", "Exporting scene..."],
-      startedAt: Date.now(),
-      source,
+  // Subscribe to worker render updates for the active job.
+  useEffect(() => {
+    if (!cm) return;
+    return cm.subscribeRenderProgress((u: RenderUpdate) => {
+      const pending = pendingRef.current;
+      if (!pending || u.jobId !== pending.jobId) return;
+
+      if (u.type === "progress") {
+        setJob((prev) =>
+          prev
+            ? {
+                ...prev,
+                status: "running",
+                progress: u.progress,
+                phase: PHASE_LABELS[u.phase],
+                log: u.logChunk ? appendLog(prev.log, splitLog(u.logChunk)) : prev.log,
+              }
+            : prev,
+        );
+      } else if (u.type === "complete") {
+        setJob((prev) =>
+          prev
+            ? {
+                ...prev,
+                status: "done",
+                progress: 100,
+                phase: "Completed",
+                finishedAt: Date.now(),
+                log: appendLog(prev.log, ["Render completed"]),
+              }
+            : prev,
+        );
+        pendingRef.current = null;
+        onCompleteRef.current(
+          buildRenderResult({
+            imageDataUrl: u.imageDataUrl,
+            width: u.width,
+            height: u.height,
+            elapsedSec: u.elapsedSec,
+            source: pending.params.source,
+            snapshot: pending.params.snapshot,
+          }),
+        );
+      } else {
+        setJob((prev) =>
+          prev
+            ? {
+                ...prev,
+                status: "error",
+                phase: "Error",
+                finishedAt: Date.now(),
+                log: appendLog(prev.log, [u.error]),
+              }
+            : prev,
+        );
+        pendingRef.current = null;
+      }
     });
-    timerRef.current = setInterval(() => {
-      setJob((prev) => {
-        if (!isRenderJobActive(prev)) return prev;
-        const next = advanceMockJob(prev);
-        if (!isRenderJobActive(next)) stopTimer();
-        return next;
-      });
-    }, TICK_MS);
-  }, [stopTimer]);
+  }, [cm]);
 
-  const cancel = useCallback(() => {
-    stopTimer();
+  const start = useCallback(
+    async (params: RenderStartParams) => {
+      if (!cm) return;
+      setJob({
+        jobId: "",
+        status: "exporting",
+        progress: 0,
+        phase: "Exporting scene",
+        log: ["Render started"],
+        startedAt: Date.now(),
+        source: params.source,
+      });
+      let res: RenderStartResult | undefined;
+      try {
+        res = await cm.invokeService("renderStart", {
+          sceneId: params.sceneId,
+          viewId: params.viewId,
+          snapshot: params.snapshot,
+        });
+      } catch (e) {
+        setJob((prev) =>
+          prev
+            ? { ...prev, status: "error", phase: "Error", finishedAt: Date.now(), log: appendLog(prev.log, [String(e)]) }
+            : prev,
+        );
+        return;
+      }
+      if (res?.ok) {
+        pendingRef.current = { jobId: res.jobId, params };
+        setJob((prev) => (prev ? { ...prev, jobId: res.jobId } : prev));
+      } else {
+        setJob((prev) =>
+          prev
+            ? {
+                ...prev,
+                status: "error",
+                phase: "Error",
+                finishedAt: Date.now(),
+                log: appendLog(prev.log, [res?.error ?? "Render failed to start"]),
+              }
+            : prev,
+        );
+      }
+    },
+    [cm],
+  );
+
+  const cancel = useCallback(async () => {
+    const pending = pendingRef.current;
+    pendingRef.current = null;
     setJob((prev) =>
       isRenderJobActive(prev)
         ? {
             ...prev,
             status: "cancelled",
             phase: "Cancelled",
-            log: [...prev.log, "Render cancelled"],
             finishedAt: Date.now(),
+            log: appendLog(prev.log, ["Render cancelled"]),
           }
         : prev,
     );
-  }, [stopTimer]);
-
-  // Stop the timer if the component unmounts mid-job.
-  useEffect(() => stopTimer, [stopTimer]);
+    if (cm && pending) {
+      try {
+        await cm.invokeService("renderCancel", { jobId: pending.jobId });
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [cm]);
 
   return { job, start, cancel } as const;
 }

--- a/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderJob.ts
@@ -1,0 +1,135 @@
+/**
+ * @file hooks/useRenderJob.ts
+ * @description Drives a render job's lifecycle for the BottomPanel Render tab.
+ *
+ * Phase 2 is mock-only: `start()` runs a timer that walks a fake job through
+ * its phases (exporting → running → blending → done) so the panel, progress
+ * bar and StatusBar wiring can be verified before the real worker-side
+ * pipeline (phase 4) is connected.
+ */
+
+import { useState, useCallback, useRef, useEffect } from "react";
+
+/** Lifecycle status of a render job. */
+export type RenderJobStatus =
+  | "exporting"
+  | "running"
+  | "blending"
+  | "done"
+  | "error"
+  | "cancelled";
+
+/** State of a single render job. */
+export interface RenderJob {
+  /** Unique id of this job. */
+  jobId: string;
+  /** Current lifecycle status. */
+  status: RenderJobStatus;
+  /** Completion percentage, 0..100. */
+  progress: number;
+  /** Human-readable label of the current phase. */
+  phase: string;
+  /** Accumulated log lines. */
+  log: string[];
+  /** Epoch ms when the job started. */
+  startedAt: number;
+  /** Epoch ms when the job ended (done / error / cancelled). */
+  finishedAt?: number;
+}
+
+/** Statuses in which the job is still progressing. */
+const ACTIVE_STATUSES: RenderJobStatus[] = ["exporting", "running", "blending"];
+
+/** True (and narrows) while the job is still progressing. */
+export function isRenderJobActive(job: RenderJob | null): job is RenderJob {
+  return job !== null && ACTIVE_STATUSES.includes(job.status);
+}
+
+/** Mock job tick interval and per-tick progress step. */
+const TICK_MS = 400;
+const PROGRESS_STEP = 7;
+
+/** Advance the mock job by one tick. */
+function advanceMockJob(job: RenderJob): RenderJob {
+  const progress = Math.min(100, job.progress + PROGRESS_STEP);
+  const log = [...job.log];
+  let status = job.status;
+  let phase = job.phase;
+
+  if (progress >= 100) {
+    log.push("Render completed");
+    return { ...job, progress, status: "done", phase: "Completed", log, finishedAt: Date.now() };
+  }
+  if (progress >= 90) {
+    if (status !== "blending") {
+      status = "blending";
+      phase = "Blending layers";
+      log.push("Blending layers...");
+    }
+  } else if (progress >= 15) {
+    if (status !== "running") {
+      status = "running";
+      phase = "Rendering";
+      log.push("Rendering scene...");
+    }
+    log.push(`Rendered ${progress}%`);
+  }
+  return { ...job, progress, status, phase, log };
+}
+
+/**
+ * Owns the current render job. `start()` begins a new (mock) job; `cancel()`
+ * stops the active one. The job object is the single source of truth read by
+ * both the Render panel and the StatusBar.
+ */
+export function useRenderJob() {
+  const [job, setJob] = useState<RenderJob | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    stopTimer();
+    setJob({
+      jobId: `render-${Date.now()}`,
+      status: "exporting",
+      progress: 0,
+      phase: "Exporting scene",
+      log: ["Render started", "Exporting scene..."],
+      startedAt: Date.now(),
+    });
+    timerRef.current = setInterval(() => {
+      setJob((prev) => {
+        if (!isRenderJobActive(prev)) return prev;
+        const next = advanceMockJob(prev);
+        if (!isRenderJobActive(next)) stopTimer();
+        return next;
+      });
+    }, TICK_MS);
+  }, [stopTimer]);
+
+  const cancel = useCallback(() => {
+    stopTimer();
+    setJob((prev) =>
+      isRenderJobActive(prev)
+        ? {
+            ...prev,
+            status: "cancelled",
+            phase: "Cancelled",
+            log: [...prev.log, "Render cancelled"],
+            finishedAt: Date.now(),
+          }
+        : prev,
+    );
+  }, [stopTimer]);
+
+  // Stop the timer if the component unmounts mid-job.
+  useEffect(() => stopTimer, [stopTimer]);
+
+  return { job, start, cancel } as const;
+}

--- a/tritium/react-gui/src/renderer/hooks/useRenderSettings.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderSettings.ts
@@ -1,0 +1,55 @@
+/**
+ * @file hooks/useRenderSettings.ts
+ * @description Holds the (non-persistent) render-settings editing state
+ * shown in the Inspector `renderSettings` target.
+ *
+ * Settings are split into a backend-independent set and the active
+ * backend's own set. Switching backend keeps the common settings and
+ * swaps in the new backend's defaults. Phase 1 keeps a single in-memory
+ * set; per-scene state is deferred to a later phase.
+ */
+
+import { useState, useCallback } from "react";
+import type { PropDef } from "../data/rendererProperties";
+import { RENDER_COMMON_PROPS, type RenderBackendId } from "../data/renderSettings";
+import { RENDER_BACKENDS, DEFAULT_RENDER_BACKEND } from "../data/renderBackends";
+
+/** Deep-copy a PropDef list so edits never mutate the shared defaults. */
+const cloneProps = (props: PropDef[]): PropDef[] => props.map((p) => ({ ...p }));
+
+/** Apply a value change to whichever list owns `key` (returns a new list). */
+const applyChange = (
+  props: PropDef[],
+  key: string,
+  value: string | number | boolean,
+): PropDef[] => {
+  if (!props.some((p) => p.key === key)) return props;
+  return props.map((p) => (p.key === key ? { ...p, value } : p));
+};
+
+export function useRenderSettings() {
+  const [backend, setBackendState] = useState<RenderBackendId>(DEFAULT_RENDER_BACKEND);
+  const [commonProps, setCommonProps] = useState<PropDef[]>(() =>
+    cloneProps(RENDER_COMMON_PROPS),
+  );
+  const [backendProps, setBackendProps] = useState<PropDef[]>(() =>
+    cloneProps(RENDER_BACKENDS[DEFAULT_RENDER_BACKEND].props),
+  );
+
+  /** Switch the active backend, keeping common settings, resetting backend ones. */
+  const setBackend = useCallback((id: RenderBackendId) => {
+    setBackendState(id);
+    setBackendProps(cloneProps(RENDER_BACKENDS[id].props));
+  }, []);
+
+  /** Update a single setting value by key (common or backend-specific). */
+  const handleChange = useCallback(
+    (key: string, value: string | number | boolean) => {
+      setCommonProps((prev) => applyChange(prev, key, value));
+      setBackendProps((prev) => applyChange(prev, key, value));
+    },
+    [],
+  );
+
+  return { backend, commonProps, backendProps, setBackend, handleChange } as const;
+}

--- a/tritium/react-gui/src/renderer/hooks/useRenderSettings.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderSettings.ts
@@ -5,14 +5,22 @@
  *
  * Settings are split into a backend-independent set and the active
  * backend's own set. Switching backend keeps the common settings and
- * swaps in the new backend's defaults. Phase 1 keeps a single in-memory
+ * swaps in the new backend's defaults. A separate `preset` selection (used
+ * by the BottomPanel Render tab) drives width / height; editing the size
+ * directly resets the preset to "Custom". Phase 1 keeps a single in-memory
  * set; per-scene state is deferred to a later phase.
  */
 
 import { useState, useCallback } from "react";
 import type { PropDef } from "../data/rendererProperties";
-import { RENDER_COMMON_PROPS, type RenderBackendId } from "../data/renderSettings";
+import {
+  RENDER_COMMON_PROPS,
+  RENDER_SIZE_PRESETS,
+  DEFAULT_RENDER_PRESET,
+  type RenderBackendId,
+} from "../data/renderSettings";
 import { RENDER_BACKENDS, DEFAULT_RENDER_BACKEND } from "../data/renderBackends";
+import type { RenderSettingsSnapshot } from "../data/renderResult";
 
 /** Deep-copy a PropDef list so edits never mutate the shared defaults. */
 const cloneProps = (props: PropDef[]): PropDef[] => props.map((p) => ({ ...p }));
@@ -35,6 +43,7 @@ export function useRenderSettings() {
   const [backendProps, setBackendProps] = useState<PropDef[]>(() =>
     cloneProps(RENDER_BACKENDS[DEFAULT_RENDER_BACKEND].props),
   );
+  const [preset, setPreset] = useState<string>(DEFAULT_RENDER_PRESET);
 
   /** Switch the active backend, keeping common settings, resetting backend ones. */
   const setBackend = useCallback((id: RenderBackendId) => {
@@ -47,9 +56,72 @@ export function useRenderSettings() {
     (key: string, value: string | number | boolean) => {
       setCommonProps((prev) => applyChange(prev, key, value));
       setBackendProps((prev) => applyChange(prev, key, value));
+      // A manual size edit no longer matches any preset.
+      if (key === "width" || key === "height") {
+        setPreset(DEFAULT_RENDER_PRESET);
+      }
     },
     [],
   );
 
-  return { backend, commonProps, backendProps, setBackend, handleChange } as const;
+  /**
+   * Apply a size preset (Render tab dropdown). "Custom" leaves the size
+   * unchanged; the "Current view" preset uses the supplied `dynamicSize`.
+   */
+  const applyPreset = useCallback(
+    (label: string, dynamicSize?: { width: number; height: number }) => {
+      setPreset(label);
+      const sized = RENDER_SIZE_PRESETS.find((p) => p.label === label);
+      if (!sized) return;
+
+      let size: { width: number; height: number } | undefined;
+      if (sized.dynamic) {
+        size = dynamicSize;
+      } else if (sized.width > 0) {
+        size = { width: sized.width, height: sized.height };
+      }
+      if (!size) return;
+
+      setCommonProps((prev) => {
+        let next = applyChange(prev, "width", size.width);
+        next = applyChange(next, "height", size.height);
+        if (sized.dpi !== undefined) {
+          next = applyChange(next, "dpi", sized.dpi);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  /** Frozen copy of the current settings, used for a render result. */
+  const getSnapshot = useCallback(
+    (): RenderSettingsSnapshot => ({
+      backend,
+      commonProps: cloneProps(commonProps),
+      backendProps: cloneProps(backendProps),
+    }),
+    [backend, commonProps, backendProps],
+  );
+
+  /** Load settings from a snapshot (used by "Re-render"). */
+  const restore = useCallback((snapshot: RenderSettingsSnapshot) => {
+    setBackendState(snapshot.backend);
+    setCommonProps(cloneProps(snapshot.commonProps));
+    setBackendProps(cloneProps(snapshot.backendProps));
+    // Restored sizes are explicit, so no preset is active.
+    setPreset(DEFAULT_RENDER_PRESET);
+  }, []);
+
+  return {
+    backend,
+    commonProps,
+    backendProps,
+    preset,
+    setBackend,
+    handleChange,
+    applyPreset,
+    getSnapshot,
+    restore,
+  } as const;
 }

--- a/tritium/react-gui/src/renderer/hooks/useTabManager.ts
+++ b/tritium/react-gui/src/renderer/hooks/useTabManager.ts
@@ -10,6 +10,7 @@
 
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { TabData } from "../types";
+import { type RenderResult, renderResultTabTitle } from "../data/renderResult";
 
 // ────────────────────────────────────────────────────────────
 // Constants
@@ -124,6 +125,32 @@ export function useTabManager(opts?: {
     setActiveTab(newTab.id);
   }, []);
 
+  // ── Render Result tabs ───────────────────────────────────
+
+  /**
+   * Open a completed render. There is at most one result tab per source
+   * scene: re-rendering the same scene overwrites that tab's image in
+   * place rather than spawning a new tab.
+   */
+  const addRenderResultTab = useCallback((result: RenderResult) => {
+    const tabId = `render-result-scene-${result.sourceSceneId}`;
+    const tab: TabData = {
+      id: tabId,
+      title: renderResultTabTitle(result),
+      icon: "media",
+      type: "renderResult",
+      renderResult: result,
+    };
+    setTabs((prev) => {
+      const idx = prev.findIndex((t) => t.id === tabId);
+      if (idx === -1) return [...prev, tab];
+      const next = [...prev];
+      next[idx] = tab;
+      return next;
+    });
+    setActiveTab(tabId);
+  }, []);
+
   return {
     tabs,
     tabsRef,
@@ -131,6 +158,7 @@ export function useTabManager(opts?: {
     setActiveTab,
     openSettingsTab,
     addMolViewTab,
+    addRenderResultTab,
     handleCloseTab,
     handleReorderTabs,
   } as const;

--- a/tritium/react-gui/src/renderer/index.tsx
+++ b/tritium/react-gui/src/renderer/index.tsx
@@ -14,6 +14,7 @@ import { ThemeProvider } from './contexts/ThemeContext'
 import { CommandProvider } from './commands/CommandRegistry'
 import { DialogProvider } from './contexts/DialogContext'
 import { ModalOpenCounterProvider } from './contexts/ModalOpenCounterContext'
+import { RenderConfigProvider } from './contexts/RenderConfigContext'
 
 const container = document.getElementById('root') as HTMLElement
 createRoot(container).render(
@@ -23,7 +24,9 @@ createRoot(container).render(
         <CommandProvider>
           <ModalOpenCounterProvider>
             <DialogProvider>
-              <App />
+              <RenderConfigProvider>
+                <App />
+              </RenderConfigProvider>
             </DialogProvider>
           </ModalOpenCounterProvider>
         </CommandProvider>

--- a/tritium/react-gui/src/renderer/styles/_config-pane.css
+++ b/tritium/react-gui/src/renderer/styles/_config-pane.css
@@ -353,6 +353,38 @@
   color: var(--text-secondary);
 }
 
+/* ── Path (file/directory) control ── */
+.config-setting-path-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 520px;
+}
+
+.config-setting-path-input {
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  padding: 0 8px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-md);
+  caret-color: var(--accent);
+}
+
+.config-setting-path-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.config-setting-path-row .bp5-button {
+  flex-shrink: 0;
+}
+
 /* ── Switch overrides ── */
 .config-setting-switch.bp5-switch {
   margin-bottom: 0;

--- a/tritium/react-gui/src/renderer/styles/_content-area.css
+++ b/tritium/react-gui/src/renderer/styles/_content-area.css
@@ -231,3 +231,128 @@
   min-width: 70px;
   text-align: center;
 }
+
+/* ═══════════════════════════════════════════════════════════
+   Render Result tab
+   ═══════════════════════════════════════════════════════════ */
+
+.render-result-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-surface);
+  overflow: hidden;
+}
+
+.render-result-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: var(--bg-panel-header);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* Icon-only buttons (label shown via the native title tooltip) keep a
+   fixed compact width so the bar never wraps or needs a scrollbar. */
+.render-result-toolbar .bp5-button,
+.render-result-toolbar .bp5-popover-target,
+.render-result-toolbar .bp5-divider {
+  flex-shrink: 0;
+}
+
+.render-result-info {
+  margin-left: auto;
+  padding-left: 6px;
+  font-size: var(--fs-base);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ── Image viewer ── */
+.riv {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.riv-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  background: var(--bg-panel-header);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.riv-zoom-label {
+  font-size: var(--fs-base);
+  color: var(--text-muted);
+  min-width: 42px;
+}
+
+.riv-scroll {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: auto;
+  background: var(--bg-inset, var(--bg-input));
+  cursor: grab;
+}
+
+.riv-scroll:active {
+  cursor: grabbing;
+}
+
+/* margin:auto centres the stage when smaller than the viewport without
+   clipping it when larger (the classic flex + overflow centring fix). */
+.riv-stage {
+  margin: auto;
+  flex-shrink: 0;
+}
+
+.riv-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  user-select: none;
+}
+
+/* ── Settings snapshot popover ── */
+.rr-snapshot-pop {
+  padding: 8px 10px;
+  max-height: 360px;
+  overflow-y: auto;
+  font-size: var(--fs-base);
+}
+
+.rr-snapshot-backend {
+  font-weight: var(--fw-semibold);
+  margin-bottom: 6px;
+}
+
+.rr-snapshot-group-title {
+  margin: 6px 0 2px;
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-tight);
+  color: var(--text-muted);
+}
+
+.rr-snapshot-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 1px 0;
+}
+
+.rr-snapshot-key {
+  color: var(--text-secondary);
+}
+
+.rr-snapshot-val {
+  color: var(--text-primary);
+}

--- a/tritium/react-gui/src/renderer/styles/_inspector-panel.css
+++ b/tritium/react-gui/src/renderer/styles/_inspector-panel.css
@@ -238,6 +238,18 @@
   font-size: var(--fs-lg);
   height: 22px;
   border-radius: 3px;
+  /* Reserve room for the caret icon so the value text never runs under it. */
+  padding-right: 24px;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+/* Caret icon — Blueprint positions it for the default 30px select; recenter
+   it within the compact 22px select so it stays inside the rounded border. */
+.insp-select.bp5-html-select .bp5-icon {
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
 }
 
 /* ── Numeric row (slider + input) ── */
@@ -348,6 +360,37 @@
 .insp-color-swatch::-webkit-color-swatch {
   border: none;
   border-radius: 2px;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   Render Settings target
+   ═══════════════════════════════════════════════════════════ */
+
+/* Header category badge (target kind) */
+.inspector-header-badge.bp5-tag {
+  flex-shrink: 0;
+  font-size: var(--fs-sm2);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+}
+
+/* Backend selector row above the render-settings accordions */
+.insp-render-backend-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-panel-header);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.insp-render-backend-bar .insp-prop-label {
+  flex-shrink: 0;
+}
+
+.insp-render-backend-bar .insp-select {
+  flex: 1;
+  min-width: 0;
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/tritium/react-gui/src/renderer/styles/_inspector-panel.css
+++ b/tritium/react-gui/src/renderer/styles/_inspector-panel.css
@@ -257,6 +257,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  /* Allow the row to shrink within the inspector body so the numeric
+     input never overflows the panel edge. */
+  min-width: 0;
 }
 
 .insp-slider {
@@ -264,10 +267,13 @@
   min-width: 0;
 }
 
-/* Blueprint slider overrides */
+/* Blueprint slider overrides. `min-width: 0` (high specificity) lets the
+   slider shrink and yield space to the fixed-width numeric input. */
 .insp-slider.bp5-slider {
   min-height: 16px;
   height: 16px;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .insp-slider .bp5-slider-track {
@@ -302,10 +308,17 @@
   box-shadow: 0 0 0 2px var(--accent), 0 1px 3px var(--slider-handle-shadow);
 }
 
-/* Numeric input — compact width */
+/* Numeric input — fixed compact column that never shrinks or overflows. */
 .insp-numeric-input.bp5-numeric-input {
-  width: 62px;
-  flex-shrink: 0;
+  flex: 0 0 68px;
+  width: 68px;
+  min-width: 68px;
+}
+
+/* Keep the inner field within the fixed numeric-input width. */
+.insp-numeric-input .bp5-input-group {
+  width: 100%;
+  min-width: 0;
 }
 
 .insp-numeric-input .bp5-input-group .bp5-input {
@@ -314,6 +327,7 @@
   color: var(--text-primary) !important;
   font-size: var(--fs-md);
   height: 20px;
+  width: 100%;
   text-align: right;
   padding-right: 4px;
   border-radius: 3px;

--- a/tritium/react-gui/src/renderer/styles/_log-panel.css
+++ b/tritium/react-gui/src/renderer/styles/_log-panel.css
@@ -135,7 +135,8 @@
   display: flex;
   align-items: center;
   gap: 0;
-  height: 26px;
+  /* Match the Side Panel / Inspector Panel header height (30px). */
+  height: 30px;
   background: var(--bg-panel-header);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -181,4 +182,68 @@
 .bottom-panel-content {
   flex: 1;
   overflow: hidden;
+}
+
+/* ─── Render Panel ─── */
+.render-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-surface);
+  overflow: hidden;
+}
+
+.render-panel-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  background: var(--bg-panel-header);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+/* Compact action button — kept visually subordinate to the panel tabs. */
+.render-action-btn.bp5-button {
+  min-height: 22px;
+  padding: 0 10px;
+  font-size: var(--fs-base);
+  font-weight: var(--fw-medium);
+}
+
+.render-panel-status {
+  font-size: var(--fs-base);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.render-panel-progress {
+  padding: 8px 12px;
+  flex-shrink: 0;
+}
+
+/* Log area — matches the Output tab (LogView) font, spacing and background. */
+.render-panel-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 10pt;
+  line-height: normal;
+}
+
+.render-log-line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.render-panel-empty {
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 10pt;
+  color: var(--text-muted);
 }

--- a/tritium/react-gui/src/renderer/styles/_log-panel.css
+++ b/tritium/react-gui/src/renderer/styles/_log-panel.css
@@ -211,7 +211,24 @@
   font-weight: var(--fw-medium);
 }
 
+/* Image-size preset (quick dropdown; full size controls live in Inspector). */
+.render-panel-preset {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.render-panel-preset-label {
+  font-size: var(--fs-base);
+  color: var(--text-muted);
+}
+
+.render-panel-preset-select {
+  width: 168px;
+}
+
 .render-panel-status {
+  margin-left: auto;
   font-size: var(--fs-base);
   color: var(--text-muted);
   white-space: nowrap;

--- a/tritium/react-gui/src/renderer/types.ts
+++ b/tritium/react-gui/src/renderer/types.ts
@@ -47,16 +47,19 @@ export interface TreeNodeData {
 // Editor tabs
 // ────────────────────────────────────────────────────────────
 
+import type { RenderResult } from "./data/renderResult";
+
 /**
  * Discriminator for tab types.
  *
- * | Type        | Rendered as                         |
- * |-------------|-------------------------------------|
- * | `"welcome"` | WelcomePane (start screen)          |
- * | `"settings"` | SettingsPane (application settings) |
- * | `"molview"` | MolViewPane (WebGL molecule view)   |
+ * | Type             | Rendered as                              |
+ * |------------------|------------------------------------------|
+ * | `"welcome"`      | WelcomePane (start screen)               |
+ * | `"settings"`     | SettingsPane (application settings)      |
+ * | `"molview"`      | MolViewPane (WebGL molecule view)        |
+ * | `"renderResult"` | RenderResultPane (completed render)      |
  */
-export type TabType = "welcome" | "settings" | "molview";
+export type TabType = "welcome" | "settings" | "molview" | "renderResult";
 
 /**
  * Metadata for a single editor tab.
@@ -83,6 +86,12 @@ export interface TabData {
    * Present only for tabs with `type === "molview"`.
    */
   viewId?: number;
+
+  /**
+   * Completed render data.
+   * Present only for tabs with `type === "renderResult"`.
+   */
+  renderResult?: RenderResult;
 }
 
 // ────────────────────────────────────────────────────────────

--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -3,7 +3,11 @@ import type { SceneBgColor, ViewCenterMark } from '../../../shared/ipcTypes';
 import type { FileOpenOptions } from '../../components/fopen-opt-dlgs/types';
 import { ObjTuple } from '../shared/ObjTuple';
 import { ObjProxy } from './ObjProxy';
-import { WorkerTransport, type StreamProgressListener } from './WorkerTransport';
+import {
+    WorkerTransport,
+    type StreamProgressListener,
+    type RenderProgressListener,
+} from './WorkerTransport';
 import { EventSlots } from './EventSlots';
 import { ObjectFactory } from './ObjectFactory';
 import * as lifecycleApi from './apis/lifecycleApi';
@@ -51,6 +55,9 @@ export class AsyncCueMol {
     subscribeBusy(cb: (busy: boolean) => void): () => void { return this._transport.subscribeBusy(cb); }
     subscribeStreamProgress(cb: StreamProgressListener): () => void {
         return this._transport.subscribeStreamProgress(cb);
+    }
+    subscribeRenderProgress(cb: RenderProgressListener): () => void {
+        return this._transport.subscribeRenderProgress(cb);
     }
     invokeWorker(method: string, ...args: any[]): Promise<any[]> {
         return this._transport.invokeWorker(method, ...args);

--- a/tritium/react-gui/src/renderer/worker/client/WorkerTransport.ts
+++ b/tritium/react-gui/src/renderer/worker/client/WorkerTransport.ts
@@ -9,6 +9,8 @@ import type {
     ServiceKey,
     ServiceResult,
 } from '../shared/WorkerCalls';
+import type { RenderUpdate } from '../shared/renderTypes';
+import { RENDER_PROGRESS_CHANNEL } from '../shared/renderTypes';
 
 const log = console;
 
@@ -19,6 +21,8 @@ function makeMethodSeq(method: string, seqno: number): string {
 export type EventNotifyArgs = [number, string, number, number, number, string];
 
 export type StreamProgressListener = (reqId: string, bytes: number) => void;
+
+export type RenderProgressListener = (update: RenderUpdate) => void;
 
 export interface WorkerTransportOptions {
     onEventNotify: (args: EventNotifyArgs) => void;
@@ -33,6 +37,7 @@ export class WorkerTransport {
     private _busyListeners: Set<(busy: boolean) => void> = new Set();
     private _onEventNotify: (args: EventNotifyArgs) => void;
     private _streamProgressListeners: Set<StreamProgressListener> = new Set();
+    private _renderProgressListeners: Set<RenderProgressListener> = new Set();
 
     constructor(opts: WorkerTransportOptions) {
         this._onEventNotify = opts.onEventNotify;
@@ -62,6 +67,15 @@ export class WorkerTransport {
                 return;
             }
 
+            if (method === RENDER_PROGRESS_CHANNEL) {
+                // event.data shape: ['render-progress', RenderUpdate]
+                const [update] = event.data.slice(1) as [RenderUpdate];
+                for (const cb of this._renderProgressListeners) {
+                    try { cb(update); } catch (e) { log.warn('render-progress listener:', e); }
+                }
+                return;
+            }
+
             const method_seq = makeMethodSeq(method, seqno);
             if (method_seq in this._worker_onmessage_dict) {
                 this._worker_onmessage_dict[method_seq].apply(this, args);
@@ -75,6 +89,11 @@ export class WorkerTransport {
     subscribeStreamProgress(cb: StreamProgressListener): () => void {
         this._streamProgressListeners.add(cb);
         return () => { this._streamProgressListeners.delete(cb); };
+    }
+
+    subscribeRenderProgress(cb: RenderProgressListener): () => void {
+        this._renderProgressListeners.add(cb);
+        return () => { this._renderProgressListeners.delete(cb); };
     }
 
     isReady(): boolean { return this._ready; }

--- a/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
+++ b/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
@@ -122,6 +122,14 @@ export class WorkerService {
     }
 
     /**
+     * Push a message to the renderer on an out-of-band channel (no reply).
+     * Used by long-running services (e.g. render jobs) to stream updates.
+     */
+    pushMessage(channel: string, ...args: unknown[]): void {
+        this._postMessage([channel, ...args]);
+    }
+
+    /**
      * Wrap a TypedArray as a ByteArray that shares memory (zero-copy).
      * Used by streaming services to feed binary chunks into C++ readers.
      */

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
@@ -2,9 +2,11 @@
  * @file worker/server/services/renderBackends/PovrayBackend.ts
  * @description POV-Ray rendering backend (ports `uxp_gui` povrender.js).
  *
- * Phase 4 renders a single layer: the scene is exported to one `.pov`/`.inc`
- * pair and rendered by one POV-Ray process. Post-render alpha blending
- * (multi-layer + blendpng) is deferred to phase 5.
+ * The scene is exported to one `.pov`/`.inc` pair. When the exporter
+ * reports a post-blend table (semi-transparent objects), the scene is
+ * rendered as several layers and `blendpng` composites them; otherwise a
+ * single layer is rendered. `blendpng` always runs as the finalize step
+ * (it also stamps the output DPI), matching povrender.js.
  */
 
 import * as os from "os";
@@ -28,10 +30,11 @@ function expandHome(p: string): string {
   return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
 }
 
-// Bundled-binary locations. App-bundle packaging is deferred; phase 5 makes
-// these configurable via the SettingsPane.
+// Bundled-binary locations. App-bundle packaging is deferred; phase 5b
+// makes these configurable via the SettingsPane.
 const POV_EXE = expandHome("~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/bin/povray");
 const POV_INC = expandHome("~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/include");
+const BLENDPNG_EXE = expandHome("~/tmp/proj64_deplibs/cuemol2/bin/blendpng");
 
 /** Map a radiosity preset label to POV-Ray's `_radiosity` code (-1 = off). */
 const RADIOSITY_LABELS = [
@@ -51,6 +54,90 @@ function stereoCode(mode: string): number {
 }
 
 const RENDERED_RE = /Rendered \d+ of \d+ pixels \((\d+)%\)/;
+
+/** One render layer: extra POV-Ray declares plus the layer's alpha. */
+interface RenderLayer {
+  optArgs: string[];
+  alpha: number;
+}
+
+/**
+ * Derive render layers from the exporter's blend table. An empty table
+ * yields a single layer; otherwise layer 0 hides every overlay object and
+ * each subsequent layer shows only its own objects (mirrors povrender.js).
+ */
+function computeLayers(blendTable: Record<string, string>): RenderLayer[] {
+  const keys = Object.keys(blendTable);
+  if (keys.length === 0) return [{ optArgs: [], alpha: 1.0 }];
+
+  const allNames = new Set<string>();
+  for (const k of keys) {
+    for (const n of blendTable[k].split(",")) if (n) allNames.add(n);
+  }
+  const layers: RenderLayer[] = [
+    // Layer 0 (background): hide every overlay object.
+    { optArgs: [...allNames].map((n) => `Declare=_show${n}=0`), alpha: 1.0 },
+  ];
+  for (const k of keys) {
+    const shown = new Set(blendTable[k].split(",").filter(Boolean));
+    layers.push({
+      optArgs: [...allNames]
+        .filter((n) => !shown.has(n))
+        .map((n) => `Declare=_show${n}=0`),
+      alpha: parseFloat(`0.${k}`),
+    });
+  }
+  return layers;
+}
+
+/** Build the POV-Ray argument string for one layer. */
+function buildPovArgs(
+  exported: ExportedScene,
+  snapshot: RenderSettingsSnapshot,
+  outPng: string,
+  optArgs: string[],
+): string {
+  const common = snapshot.commonProps;
+  const pov = snapshot.backendProps;
+  const perspective = strVal(common, "projection", "perspective") === "perspective";
+
+  const args: string[] = [
+    `"Input_File_Name='${exported.inputPath}'"`,
+    `"Output_File_Name='${outPng}'"`,
+    `"Library_Path='${POV_INC}'"`,
+    `"Library_Path='${exported.workDir}'"`,
+    `Declare=_stereo=${stereoCode(strVal(common, "stereoMode", "none"))}`,
+    `Declare=_iod=${numVal(common, "stereoDepth", 0.03)}`,
+    `Declare=_perspective=${perspective ? 1 : 0}`,
+    `Declare=_shadow=${boolVal(pov, "shadow", false) ? 1 : 0}`,
+    `Declare=_light_inten=${numVal(pov, "lightIntensity", 1.3)}`,
+    `Declare=_flash_frac=${numVal(pov, "flashFraction", 0.6)}`,
+    `Declare=_amb_frac=${numVal(pov, "ambientFraction", 0)}`,
+    "File_Gamma=1",
+    "-D",
+    `+WT${numVal(common, "numThreads", 2)}`,
+    `+W${numVal(common, "width", 640)}`,
+    `+H${numVal(common, "height", 480)}`,
+    "+FN8",
+    "Quality=11",
+    "Antialias=On",
+    "Antialias_Depth=3",
+    "Antialias_Threshold=0.1",
+    "Jitter=Off",
+    "+V",
+  ];
+
+  const spread = numVal(pov, "lightSpread", 1);
+  if (spread > 1) args.push(`Declare=_light_spread=${spread}`);
+  if (boolVal(common, "transparentBg", false)) {
+    args.push("+UA");
+    args.push("Declare=_transpbg=1");
+  }
+  const radio = radiosityCode(strVal(pov, "radiosityMode", "Disable"));
+  if (radio >= 0) args.push(`Declare=_radiosity=${radio}`);
+
+  return [...args, ...optArgs].join(" ");
+}
 
 export const povrayBackend: RenderBackend = {
   id: "povray",
@@ -83,56 +170,50 @@ export const povrayBackend: RenderBackend = {
     exporter.setPath(povPath);
     exporter.setSubPath("inc", incPath);
     exporter.write();
+    const blendTableJson = exporter.blendTable;
     exporter.detach();
 
-    return { inputPath: povPath, workDir };
+    let blendTable: Record<string, string> = {};
+    if (blendTableJson) {
+      try {
+        blendTable = JSON.parse(blendTableJson) as Record<string, string>;
+      } catch {
+        blendTable = {};
+      }
+    }
+    return { inputPath: povPath, workDir, blendTable };
   },
 
   buildTasks(
     exported: ExportedScene,
     snapshot: RenderSettingsSnapshot,
   ): RenderTaskSpec[] {
-    const common = snapshot.commonProps;
-    const pov = snapshot.backendProps;
-    const outPng = this.outputImagePath(exported);
-    const perspective = strVal(common, "projection", "perspective") === "perspective";
+    const layers = computeLayers(exported.blendTable);
+    const layerPaths = layers.map((_, i) =>
+      path.join(exported.workDir, `render-layer${i}.png`),
+    );
 
-    const args: string[] = [
-      `"Input_File_Name='${exported.inputPath}'"`,
-      `"Output_File_Name='${outPng}'"`,
-      `"Library_Path='${POV_INC}'"`,
-      `"Library_Path='${exported.workDir}'"`,
-      `Declare=_stereo=${stereoCode(strVal(common, "stereoMode", "none"))}`,
-      `Declare=_iod=${numVal(common, "stereoDepth", 0.03)}`,
-      `Declare=_perspective=${perspective ? 1 : 0}`,
-      `Declare=_shadow=${boolVal(pov, "shadow", false) ? 1 : 0}`,
-      `Declare=_light_inten=${numVal(pov, "lightIntensity", 1.3)}`,
-      `Declare=_flash_frac=${numVal(pov, "flashFraction", 0.6)}`,
-      `Declare=_amb_frac=${numVal(pov, "ambientFraction", 0)}`,
-      "File_Gamma=1",
-      "-D",
-      `+WT${numVal(common, "numThreads", 2)}`,
-      `+W${numVal(common, "width", 640)}`,
-      `+H${numVal(common, "height", 480)}`,
-      "+FN8",
-      "Quality=11",
-      "Antialias=On",
-      "Antialias_Depth=3",
-      "Antialias_Threshold=0.1",
-      "Jitter=Off",
-      "+V",
-    ];
+    // One POV-Ray task per layer (run in parallel).
+    const tasks: RenderTaskSpec[] = layers.map((layer, i) => ({
+      exe: POV_EXE,
+      args: buildPovArgs(exported, snapshot, layerPaths[i], layer.optArgs),
+      kind: "render",
+    }));
 
-    const spread = numVal(pov, "lightSpread", 1);
-    if (spread > 1) args.push(`Declare=_light_spread=${spread}`);
-    if (boolVal(common, "transparentBg", false)) {
-      args.push("+UA");
-      args.push("Declare=_transpbg=1");
+    // blendpng finalize task: composite layers, stamp DPI.
+    const blendArgs: string[] = [layerPaths[0]];
+    for (let i = 1; i < layers.length; i++) {
+      blendArgs.push(layerPaths[i]);
+      blendArgs.push(String(layers[i].alpha));
     }
-    const radio = radiosityCode(strVal(pov, "radiosityMode", "Disable"));
-    if (radio >= 0) args.push(`Declare=_radiosity=${radio}`);
-
-    return [{ exe: POV_EXE, args: args.join(" "), waitFor: "" }];
+    blendArgs.push(this.outputImagePath(exported));
+    blendArgs.push(String(numVal(snapshot.commonProps, "dpi", 600)));
+    tasks.push({
+      exe: BLENDPNG_EXE,
+      args: blendArgs.join(" "),
+      kind: "finalize",
+    });
+    return tasks;
   },
 
   parseProgress(stdout: string): number | null {

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
@@ -16,6 +16,7 @@ import type { Scene } from "@cuemol/core/src/wrappers/Scene";
 import type { PovSceneExporter } from "@cuemol/core/src/wrappers/PovSceneExporter";
 import type { WorkerContext } from "../../types/WorkerContext";
 import type { RenderSettingsSnapshot } from "../../../../data/renderResult";
+import type { RenderBinaries } from "../../../shared/renderTypes";
 import {
   type RenderBackend,
   type ExportedScene,
@@ -29,12 +30,6 @@ import {
 function expandHome(p: string): string {
   return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
 }
-
-// Bundled-binary locations. App-bundle packaging is deferred; phase 5b
-// makes these configurable via the SettingsPane.
-const POV_EXE = expandHome("~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/bin/povray");
-const POV_INC = expandHome("~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/include");
-const BLENDPNG_EXE = expandHome("~/tmp/proj64_deplibs/cuemol2/bin/blendpng");
 
 /** Map a radiosity preset label to POV-Ray's `_radiosity` code (-1 = off). */
 const RADIOSITY_LABELS = [
@@ -96,6 +91,7 @@ function buildPovArgs(
   snapshot: RenderSettingsSnapshot,
   outPng: string,
   optArgs: string[],
+  povInc: string,
 ): string {
   const common = snapshot.commonProps;
   const pov = snapshot.backendProps;
@@ -104,7 +100,7 @@ function buildPovArgs(
   const args: string[] = [
     `"Input_File_Name='${exported.inputPath}'"`,
     `"Output_File_Name='${outPng}'"`,
-    `"Library_Path='${POV_INC}'"`,
+    `"Library_Path='${povInc}'"`,
     `"Library_Path='${exported.workDir}'"`,
     `Declare=_stereo=${stereoCode(strVal(common, "stereoMode", "none"))}`,
     `Declare=_iod=${numVal(common, "stereoDepth", 0.03)}`,
@@ -187,7 +183,12 @@ export const povrayBackend: RenderBackend = {
   buildTasks(
     exported: ExportedScene,
     snapshot: RenderSettingsSnapshot,
+    binaries: RenderBinaries,
   ): RenderTaskSpec[] {
+    const povExe = expandHome(binaries.povrayExe);
+    const povInc = expandHome(binaries.povrayInc);
+    const blendpngExe = expandHome(binaries.blendpng);
+
     const layers = computeLayers(exported.blendTable);
     const layerPaths = layers.map((_, i) =>
       path.join(exported.workDir, `render-layer${i}.png`),
@@ -195,8 +196,8 @@ export const povrayBackend: RenderBackend = {
 
     // One POV-Ray task per layer (run in parallel).
     const tasks: RenderTaskSpec[] = layers.map((layer, i) => ({
-      exe: POV_EXE,
-      args: buildPovArgs(exported, snapshot, layerPaths[i], layer.optArgs),
+      exe: povExe,
+      args: buildPovArgs(exported, snapshot, layerPaths[i], layer.optArgs, povInc),
       kind: "render",
     }));
 
@@ -209,7 +210,7 @@ export const povrayBackend: RenderBackend = {
     blendArgs.push(this.outputImagePath(exported));
     blendArgs.push(String(numVal(snapshot.commonProps, "dpi", 600)));
     tasks.push({
-      exe: BLENDPNG_EXE,
+      exe: blendpngExe,
       args: blendArgs.join(" "),
       kind: "finalize",
     });

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
@@ -1,0 +1,146 @@
+/**
+ * @file worker/server/services/renderBackends/PovrayBackend.ts
+ * @description POV-Ray rendering backend (ports `uxp_gui` povrender.js).
+ *
+ * Phase 4 renders a single layer: the scene is exported to one `.pov`/`.inc`
+ * pair and rendered by one POV-Ray process. Post-render alpha blending
+ * (multi-layer + blendpng) is deferred to phase 5.
+ */
+
+import * as os from "os";
+import * as path from "path";
+
+import type { Scene } from "@cuemol/core/src/wrappers/Scene";
+import type { PovSceneExporter } from "@cuemol/core/src/wrappers/PovSceneExporter";
+import type { WorkerContext } from "../../types/WorkerContext";
+import type { RenderSettingsSnapshot } from "../../../../data/renderResult";
+import {
+  type RenderBackend,
+  type ExportedScene,
+  type RenderTaskSpec,
+  numVal,
+  strVal,
+  boolVal,
+} from "./RenderBackend";
+
+/** Expand a leading `~` to the user's home directory. */
+function expandHome(p: string): string {
+  return p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
+}
+
+// Bundled-binary locations. App-bundle packaging is deferred; phase 5 makes
+// these configurable via the SettingsPane.
+const POV_EXE = expandHome("~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/bin/povray");
+const POV_INC = expandHome("~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/include");
+
+/** Map a radiosity preset label to POV-Ray's `_radiosity` code (-1 = off). */
+const RADIOSITY_LABELS = [
+  "Disable", "Default", "Debug", "Fast", "Normal", "2-Bounce", "Final",
+  "Outdoor LQ", "Outdoor HQ", "Outdoor Light", "Indoor LQ", "Indoor HQ",
+];
+function radiosityCode(label: string): number {
+  const idx = RADIOSITY_LABELS.indexOf(label);
+  return idx <= 0 ? -1 : idx - 1;
+}
+
+/** Map a stereo-mode label to POV-Ray's `_stereo` code. */
+function stereoCode(mode: string): number {
+  if (mode === "left") return -1;
+  if (mode === "right") return 1;
+  return 0;
+}
+
+const RENDERED_RE = /Rendered \d+ of \d+ pixels \((\d+)%\)/;
+
+export const povrayBackend: RenderBackend = {
+  id: "povray",
+
+  exportScene(
+    ctx: WorkerContext,
+    scene: Scene,
+    snapshot: RenderSettingsSnapshot,
+    workDir: string,
+  ): ExportedScene {
+    const exporter = ctx.strMgr.createHandler("pov", 2) as PovSceneExporter;
+    if (!exporter) throw new Error("cannot create POV-Ray exporter");
+
+    // Mirror uxp_gui povrender.js exactly: set only these properties and
+    // leave creaseLimit / edgeRise at their C++ defaults.
+    const common = snapshot.commonProps;
+    exporter.perspective = strVal(common, "projection", "perspective") === "perspective";
+    exporter.useClipZ = boolVal(common, "clipPlane", true);
+    exporter.usePostBlend = boolVal(common, "postBlend", true);
+    exporter.showEdgeLines = boolVal(common, "edgeLines", true);
+    exporter.usePixImgs = false;
+    exporter.makeRelIncPath = false;
+    exporter.camera = "__current";
+    exporter.width = numVal(common, "width", 640);
+    exporter.height = numVal(common, "height", 480);
+
+    const povPath = path.join(workDir, "render.pov");
+    const incPath = path.join(workDir, "render.inc");
+    exporter.attach(scene);
+    exporter.setPath(povPath);
+    exporter.setSubPath("inc", incPath);
+    exporter.write();
+    exporter.detach();
+
+    return { inputPath: povPath, workDir };
+  },
+
+  buildTasks(
+    exported: ExportedScene,
+    snapshot: RenderSettingsSnapshot,
+  ): RenderTaskSpec[] {
+    const common = snapshot.commonProps;
+    const pov = snapshot.backendProps;
+    const outPng = this.outputImagePath(exported);
+    const perspective = strVal(common, "projection", "perspective") === "perspective";
+
+    const args: string[] = [
+      `"Input_File_Name='${exported.inputPath}'"`,
+      `"Output_File_Name='${outPng}'"`,
+      `"Library_Path='${POV_INC}'"`,
+      `"Library_Path='${exported.workDir}'"`,
+      `Declare=_stereo=${stereoCode(strVal(common, "stereoMode", "none"))}`,
+      `Declare=_iod=${numVal(common, "stereoDepth", 0.03)}`,
+      `Declare=_perspective=${perspective ? 1 : 0}`,
+      `Declare=_shadow=${boolVal(pov, "shadow", false) ? 1 : 0}`,
+      `Declare=_light_inten=${numVal(pov, "lightIntensity", 1.3)}`,
+      `Declare=_flash_frac=${numVal(pov, "flashFraction", 0.6)}`,
+      `Declare=_amb_frac=${numVal(pov, "ambientFraction", 0)}`,
+      "File_Gamma=1",
+      "-D",
+      `+WT${numVal(common, "numThreads", 2)}`,
+      `+W${numVal(common, "width", 640)}`,
+      `+H${numVal(common, "height", 480)}`,
+      "+FN8",
+      "Quality=11",
+      "Antialias=On",
+      "Antialias_Depth=3",
+      "Antialias_Threshold=0.1",
+      "Jitter=Off",
+      "+V",
+    ];
+
+    const spread = numVal(pov, "lightSpread", 1);
+    if (spread > 1) args.push(`Declare=_light_spread=${spread}`);
+    if (boolVal(common, "transparentBg", false)) {
+      args.push("+UA");
+      args.push("Declare=_transpbg=1");
+    }
+    const radio = radiosityCode(strVal(pov, "radiosityMode", "Disable"));
+    if (radio >= 0) args.push(`Declare=_radiosity=${radio}`);
+
+    return [{ exe: POV_EXE, args: args.join(" "), waitFor: "" }];
+  },
+
+  parseProgress(stdout: string): number | null {
+    const m = RENDERED_RE.exec(stdout);
+    return m ? parseInt(m[1], 10) : null;
+  },
+
+  outputImagePath(exported: ExportedScene): string {
+    return path.join(exported.workDir, "render.png");
+  },
+};

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/RenderBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/RenderBackend.ts
@@ -12,6 +12,7 @@ import type { Scene } from "@cuemol/core/src/wrappers/Scene";
 import type { WorkerContext } from "../../types/WorkerContext";
 import type { PropDef } from "../../../../data/rendererProperties";
 import type { RenderSettingsSnapshot } from "../../../../data/renderResult";
+import type { RenderBinaries } from "../../../shared/renderTypes";
 
 /** Paths produced by a backend's `exportScene`. */
 export interface ExportedScene {
@@ -55,6 +56,7 @@ export interface RenderBackend {
   buildTasks(
     exported: ExportedScene,
     snapshot: RenderSettingsSnapshot,
+    binaries: RenderBinaries,
   ): RenderTaskSpec[];
   /** Extract a 0..100 progress percentage from a stdout chunk (null = none). */
   parseProgress(stdout: string): number | null;

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/RenderBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/RenderBackend.ts
@@ -19,6 +19,11 @@ export interface ExportedScene {
   inputPath: string;
   /** Working directory for all intermediate files. */
   workDir: string;
+  /**
+   * Post-blend layer table parsed from the exporter (alpha-key → comma-
+   * separated object names). Empty when the scene needs no layering.
+   */
+  blendTable: Record<string, string>;
 }
 
 /** One external-process task for `ProcessManager.queueTask`. */
@@ -27,8 +32,12 @@ export interface RenderTaskSpec {
   exe: string;
   /** Single argument string. */
   args: string;
-  /** Space-separated dependency task ids ("" = run immediately). */
-  waitFor: string;
+  /**
+   * `render` tasks run first (in parallel) and drive the progress
+   * percentage; `finalize` tasks (e.g. blendpng) are queued only after all
+   * render tasks finish and are reported as the "blending" phase.
+   */
+  kind: "render" | "finalize";
 }
 
 /** A pluggable rendering backend. */

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/RenderBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/RenderBackend.ts
@@ -1,0 +1,74 @@
+/**
+ * @file worker/server/services/renderBackends/RenderBackend.ts
+ * @description Backend-agnostic rendering interface.
+ *
+ * A `RenderBackend` knows how to write its own input files for a scene and
+ * how to build the external-process tasks that produce the image. The
+ * render-job service drives any backend through this interface, so adding
+ * a backend needs no change to the job pipeline.
+ */
+
+import type { Scene } from "@cuemol/core/src/wrappers/Scene";
+import type { WorkerContext } from "../../types/WorkerContext";
+import type { PropDef } from "../../../../data/rendererProperties";
+import type { RenderSettingsSnapshot } from "../../../../data/renderResult";
+
+/** Paths produced by a backend's `exportScene`. */
+export interface ExportedScene {
+  /** Input file the render process consumes. */
+  inputPath: string;
+  /** Working directory for all intermediate files. */
+  workDir: string;
+}
+
+/** One external-process task for `ProcessManager.queueTask`. */
+export interface RenderTaskSpec {
+  /** Executable path. */
+  exe: string;
+  /** Single argument string. */
+  args: string;
+  /** Space-separated dependency task ids ("" = run immediately). */
+  waitFor: string;
+}
+
+/** A pluggable rendering backend. */
+export interface RenderBackend {
+  /** Stable backend id (matches `RenderBackendId`). */
+  id: string;
+  /** Write the backend input files for `scene`; returns their paths. */
+  exportScene(
+    ctx: WorkerContext,
+    scene: Scene,
+    snapshot: RenderSettingsSnapshot,
+    workDir: string,
+  ): ExportedScene;
+  /** Build the process tasks that render `exported`. */
+  buildTasks(
+    exported: ExportedScene,
+    snapshot: RenderSettingsSnapshot,
+  ): RenderTaskSpec[];
+  /** Extract a 0..100 progress percentage from a stdout chunk (null = none). */
+  parseProgress(stdout: string): number | null;
+  /** Final output image path, read once all tasks complete. */
+  outputImagePath(exported: ExportedScene): string;
+}
+
+// ── PropDef value readers ────────────────────────────────────
+
+/** Read a numeric setting value by key. */
+export function numVal(props: PropDef[], key: string, fallback: number): number {
+  const v = props.find((p) => p.key === key)?.value;
+  return typeof v === "number" ? v : fallback;
+}
+
+/** Read a string setting value by key. */
+export function strVal(props: PropDef[], key: string, fallback: string): string {
+  const v = props.find((p) => p.key === key)?.value;
+  return typeof v === "string" ? v : fallback;
+}
+
+/** Read a boolean setting value by key. */
+export function boolVal(props: PropDef[], key: string, fallback: boolean): boolean {
+  const v = props.find((p) => p.key === key)?.value;
+  return typeof v === "boolean" ? v : fallback;
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/index.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @file worker/server/services/renderBackends/index.ts
+ * @description Registry of worker-side rendering backends.
+ *
+ * Adding a backend: implement `RenderBackend` and add it here.
+ */
+
+import type { RenderBackend } from "./RenderBackend";
+import { povrayBackend } from "./PovrayBackend";
+
+export type { RenderBackend } from "./RenderBackend";
+
+const BACKENDS: Record<string, RenderBackend> = {
+  [povrayBackend.id]: povrayBackend,
+};
+
+/** Look up a backend by id; null when the id is unknown. */
+export function getRenderBackend(id: string): RenderBackend | null {
+  return BACKENDS[id] ?? null;
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
@@ -246,7 +246,7 @@ function renderStart(ctx: WorkerContext, args: RenderStartArgs): RenderStartResu
   try {
     const exported = backend.exportScene(ctx, scene, args.snapshot, workDir);
     outputPath = backend.outputImagePath(exported);
-    const tasks = backend.buildTasks(exported, args.snapshot);
+    const tasks = backend.buildTasks(exported, args.snapshot, args.binaries);
     renderSpecs = tasks.filter((t) => t.kind === "render");
     finalizeSpecs = tasks.filter((t) => t.kind === "finalize");
     if (renderSpecs.length === 0) throw new Error("backend produced no render tasks");

--- a/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
@@ -1,0 +1,251 @@
+/**
+ * @file worker/server/services/renderJob.service.ts
+ * @description Worker-side render pipeline.
+ *
+ * `renderStart` exports the scene via the selected backend, queues the
+ * render process(es) on the C++ `ProcessManager`, and starts a polling
+ * timer that pushes `render-progress` updates to the renderer. `renderCancel`
+ * stops a running job. All file I/O uses Node `fs` (the worker runs with
+ * `nodeIntegrationInWorker: true`).
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import type { ProcessManager } from "@cuemol/core/src/wrappers/ProcessManager";
+import type { Scene } from "@cuemol/core/src/wrappers/Scene";
+import type { WorkerContext } from "../types/WorkerContext";
+import type {
+  RenderStartArgs,
+  RenderStartResult,
+  RenderCancelArgs,
+  RenderCancelResult,
+  RenderUpdate,
+} from "../../shared/renderTypes";
+import { RENDER_PROGRESS_CHANNEL } from "../../shared/renderTypes";
+import { getRenderBackend, type RenderBackend } from "./renderBackends";
+import { numVal } from "./renderBackends/RenderBackend";
+
+/** Poll interval for process status / stdout. */
+const POLL_MS = 700;
+
+/** ProcessManager task states. */
+const TASK_QUEUED = 0;
+const TASK_RUNNING = 1;
+
+/** State of one in-flight render job. */
+interface RenderJobEntry {
+  jobId: string;
+  workDir: string;
+  /** Queued task ids; an id is set to -1 once its task has ended. */
+  taskIds: number[];
+  outputPath: string;
+  startedAt: number;
+  timer: ReturnType<typeof setInterval> | null;
+  lastProgress: number;
+  cancelled: boolean;
+  /** Whether the working-dir path has been reported to the render log. */
+  announcedDir: boolean;
+}
+
+const jobs = new Map<string, RenderJobEntry>();
+
+/** Push a render update to the renderer. */
+function emit(ctx: WorkerContext, update: RenderUpdate): void {
+  ctx.svc.pushMessage(RENDER_PROGRESS_CHANNEL, update);
+}
+
+/** Remove a working directory, ignoring errors. */
+function cleanupDir(dir: string): void {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+function stopTimer(entry: RenderJobEntry): void {
+  if (entry.timer !== null) {
+    clearInterval(entry.timer);
+    entry.timer = null;
+  }
+}
+
+/** Read the finished image, emit completion, and clean up. */
+function finishJob(
+  ctx: WorkerContext,
+  entry: RenderJobEntry,
+  args: RenderStartArgs,
+): void {
+  stopTimer(entry);
+  jobs.delete(entry.jobId);
+  // Phase 4 keeps the working dir (render.pov / .inc / .png) for inspection;
+  // phase 5 re-enables success cleanup.
+  try {
+    const buf = fs.readFileSync(entry.outputPath);
+    emit(ctx, {
+      type: "complete",
+      jobId: entry.jobId,
+      imageDataUrl: `data:image/png;base64,${buf.toString("base64")}`,
+      width: numVal(args.snapshot.commonProps, "width", 0),
+      height: numVal(args.snapshot.commonProps, "height", 0),
+      elapsedSec: (Date.now() - entry.startedAt) / 1000,
+    });
+  } catch (e) {
+    emit(ctx, {
+      type: "error",
+      jobId: entry.jobId,
+      error: `Output image not produced: ${String(e)}`,
+    });
+  }
+}
+
+/** One poll tick: check process status, push progress, finish when done. */
+function pollJob(
+  ctx: WorkerContext,
+  backend: RenderBackend,
+  entry: RenderJobEntry,
+  args: RenderStartArgs,
+): void {
+  if (entry.cancelled) return;
+  const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+
+  let allDone = true;
+  let progress = entry.lastProgress;
+  let logChunk = "";
+  for (let i = 0; i < entry.taskIds.length; i++) {
+    const tid = entry.taskIds[i];
+    if (tid < 0) continue;
+    const status = pm.getTaskStatus(tid);
+    const out = pm.getResultOutput(tid);
+    if (out) {
+      const p = backend.parseProgress(out);
+      if (p !== null) progress = Math.max(progress, p);
+      else logChunk += out;
+    }
+    if (status === TASK_QUEUED || status === TASK_RUNNING) {
+      allDone = false;
+    } else {
+      entry.taskIds[i] = -1;
+    }
+  }
+  entry.lastProgress = progress;
+
+  // Report the working-dir path once so the .pov/.inc can be inspected.
+  if (!entry.announcedDir) {
+    logChunk = `Working dir: ${entry.workDir}\n${logChunk}`;
+    entry.announcedDir = true;
+  }
+
+  if (!allDone) {
+    emit(ctx, {
+      type: "progress",
+      jobId: entry.jobId,
+      progress,
+      phase: "running",
+      logChunk: logChunk || undefined,
+    });
+    return;
+  }
+  finishJob(ctx, entry, args);
+}
+
+/** Start a render job. */
+function renderStart(ctx: WorkerContext, args: RenderStartArgs): RenderStartResult {
+  const scene = ctx.sceMgr.getScene(args.sceneId) as Scene | null;
+  if (!scene) return { ok: false, jobId: "", error: "Scene not found" };
+
+  const backend = getRenderBackend(args.snapshot.backend);
+  if (!backend) {
+    return { ok: false, jobId: "", error: `Unknown backend: ${args.snapshot.backend}` };
+  }
+
+  // Capture the active view into the "__current" camera the exporter uses.
+  if (args.viewId !== undefined) {
+    const s = scene as unknown as {
+      saveViewToCam?: (viewId: number, camName: string) => boolean;
+    };
+    try {
+      s.saveViewToCam?.(args.viewId, "__current");
+    } catch {
+      /* fall back to the scene's default camera */
+    }
+  }
+
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "cuemol-render-"));
+  emit(ctx, {
+    type: "progress",
+    jobId: "pending",
+    progress: 0,
+    phase: "exporting",
+  });
+
+  let outputPath: string;
+  let taskIds: number[];
+  try {
+    const exported = backend.exportScene(ctx, scene, args.snapshot, workDir);
+    outputPath = backend.outputImagePath(exported);
+    const tasks = backend.buildTasks(exported, args.snapshot);
+    const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+    taskIds = [];
+    for (const t of tasks) {
+      const tid = pm.queueTask(t.exe, t.args, t.waitFor);
+      if (tid < 0) throw new Error("ProcessManager could not queue the render task");
+      taskIds.push(tid);
+    }
+  } catch (e) {
+    cleanupDir(workDir);
+    return { ok: false, jobId: "", error: String(e) };
+  }
+
+  const jobId = `render-${Date.now()}`;
+  const entry: RenderJobEntry = {
+    jobId,
+    workDir,
+    taskIds,
+    outputPath,
+    startedAt: Date.now(),
+    timer: null,
+    lastProgress: 0,
+    cancelled: false,
+    announcedDir: false,
+  };
+  jobs.set(jobId, entry);
+  entry.timer = setInterval(() => {
+    try {
+      pollJob(ctx, backend, entry, args);
+    } catch (e) {
+      stopTimer(entry);
+      jobs.delete(jobId);
+      emit(ctx, { type: "error", jobId, error: String(e) });
+      cleanupDir(entry.workDir);
+    }
+  }, POLL_MS);
+
+  return { ok: true, jobId };
+}
+
+/** Cancel a running render job. */
+function renderCancel(ctx: WorkerContext, args: RenderCancelArgs): RenderCancelResult {
+  const entry = jobs.get(args.jobId);
+  if (!entry) return { ok: false };
+  entry.cancelled = true;
+  stopTimer(entry);
+  jobs.delete(entry.jobId);
+
+  const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+  for (const tid of entry.taskIds) {
+    if (tid >= 0) {
+      try {
+        pm.kill(tid);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  cleanupDir(entry.workDir);
+  return { ok: true };
+}
+
+export const services = { renderStart, renderCancel };

--- a/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
@@ -7,6 +7,15 @@
  * timer that pushes `render-progress` updates to the renderer. `renderCancel`
  * stops a running job. All file I/O uses Node `fs` (the worker runs with
  * `nodeIntegrationInWorker: true`).
+ *
+ * ## Queue ordering
+ *
+ * `ProcessManager` only advances its queue when `queueTask` is called (its
+ * idle-task pump is not driven inside the worker). So instead of queuing the
+ * blendpng finalize task up-front with a dependency, the pipeline runs in
+ * two phases: all render tasks are queued first, and the finalize task is
+ * queued by the poll loop once every render task has finished — that
+ * `queueTask` call is what starts it.
  */
 
 import * as fs from "fs";
@@ -25,7 +34,7 @@ import type {
 } from "../../shared/renderTypes";
 import { RENDER_PROGRESS_CHANNEL } from "../../shared/renderTypes";
 import { getRenderBackend, type RenderBackend } from "./renderBackends";
-import { numVal } from "./renderBackends/RenderBackend";
+import { numVal, type RenderTaskSpec } from "./renderBackends/RenderBackend";
 
 /** Poll interval for process status / stdout. */
 const POLL_MS = 700;
@@ -34,19 +43,27 @@ const POLL_MS = 700;
 const TASK_QUEUED = 0;
 const TASK_RUNNING = 1;
 
+/** Phase of a render job. */
+type JobPhase = "render" | "finalize";
+
 /** State of one in-flight render job. */
 interface RenderJobEntry {
   jobId: string;
   workDir: string;
-  /** Queued task ids; an id is set to -1 once its task has ended. */
-  taskIds: number[];
   outputPath: string;
   startedAt: number;
   timer: ReturnType<typeof setInterval> | null;
-  lastProgress: number;
   cancelled: boolean;
   /** Whether the working-dir path has been reported to the render log. */
   announcedDir: boolean;
+  /** Current phase. */
+  phase: JobPhase;
+  /** Finalize task specs, queued once render tasks finish. */
+  finalizeSpecs: RenderTaskSpec[];
+  /** Task ids of the current phase; an id is set to -1 once its task ends. */
+  taskIds: number[];
+  /** Per-task progress 0..100, parallel to `taskIds`. */
+  taskProgress: number[];
 }
 
 const jobs = new Map<string, RenderJobEntry>();
@@ -72,7 +89,7 @@ function stopTimer(entry: RenderJobEntry): void {
   }
 }
 
-/** Read the finished image, emit completion, and clean up. */
+/** Read the finished image and emit completion (or an error). */
 function finishJob(
   ctx: WorkerContext,
   entry: RenderJobEntry,
@@ -80,8 +97,7 @@ function finishJob(
 ): void {
   stopTimer(entry);
   jobs.delete(entry.jobId);
-  // Phase 4 keeps the working dir (render.pov / .inc / .png) for inspection;
-  // phase 5 re-enables success cleanup.
+  // Phase 5 keeps the working dir (render.pov / .inc / .png) for inspection.
   try {
     const buf = fs.readFileSync(entry.outputPath);
     emit(ctx, {
@@ -101,7 +117,42 @@ function finishJob(
   }
 }
 
-/** One poll tick: check process status, push progress, finish when done. */
+/** Poll the current phase's tasks; returns the accumulated stdout log. */
+function pollTasks(
+  ctx: WorkerContext,
+  backend: RenderBackend,
+  entry: RenderJobEntry,
+): { allDone: boolean; logChunk: string } {
+  const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+  let allDone = true;
+  let logChunk = "";
+  for (let i = 0; i < entry.taskIds.length; i++) {
+    const tid = entry.taskIds[i];
+    if (tid < 0) continue;
+    const status = pm.getTaskStatus(tid);
+    // getResultOutput also moves an ended task out of its slot.
+    const out = pm.getResultOutput(tid);
+    if (out) {
+      const p = backend.parseProgress(out);
+      if (p !== null) entry.taskProgress[i] = Math.max(entry.taskProgress[i], p);
+      else logChunk += out;
+    }
+    if (status === TASK_QUEUED || status === TASK_RUNNING) {
+      allDone = false;
+    } else {
+      entry.taskProgress[i] = 100;
+      entry.taskIds[i] = -1;
+    }
+  }
+  return { allDone, logChunk };
+}
+
+/** Mean of an array (0 when empty). */
+function mean(xs: number[]): number {
+  return xs.length ? Math.round(xs.reduce((s, x) => s + x, 0) / xs.length) : 0;
+}
+
+/** One poll tick. */
 function pollJob(
   ctx: WorkerContext,
   backend: RenderBackend,
@@ -109,46 +160,59 @@ function pollJob(
   args: RenderStartArgs,
 ): void {
   if (entry.cancelled) return;
-  const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+  const { allDone, logChunk: rawLog } = pollTasks(ctx, backend, entry);
 
-  let allDone = true;
-  let progress = entry.lastProgress;
-  let logChunk = "";
-  for (let i = 0; i < entry.taskIds.length; i++) {
-    const tid = entry.taskIds[i];
-    if (tid < 0) continue;
-    const status = pm.getTaskStatus(tid);
-    const out = pm.getResultOutput(tid);
-    if (out) {
-      const p = backend.parseProgress(out);
-      if (p !== null) progress = Math.max(progress, p);
-      else logChunk += out;
-    }
-    if (status === TASK_QUEUED || status === TASK_RUNNING) {
-      allDone = false;
-    } else {
-      entry.taskIds[i] = -1;
-    }
-  }
-  entry.lastProgress = progress;
-
-  // Report the working-dir path once so the .pov/.inc can be inspected.
+  let logChunk = rawLog;
   if (!entry.announcedDir) {
     logChunk = `Working dir: ${entry.workDir}\n${logChunk}`;
     entry.announcedDir = true;
   }
 
-  if (!allDone) {
+  if (entry.phase === "render") {
+    if (!allDone) {
+      emit(ctx, {
+        type: "progress",
+        jobId: entry.jobId,
+        progress: mean(entry.taskProgress),
+        phase: "running",
+        logChunk: logChunk || undefined,
+      });
+      return;
+    }
+    // All render tasks finished — queue the finalize task(s) now. The
+    // queueTask call is what advances the ProcessManager queue.
     emit(ctx, {
       type: "progress",
       jobId: entry.jobId,
-      progress,
-      phase: "running",
+      progress: 100,
+      phase: "blending",
       logChunk: logChunk || undefined,
     });
+    if (entry.finalizeSpecs.length === 0) {
+      finishJob(ctx, entry, args);
+      return;
+    }
+    const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+    const finIds: number[] = [];
+    for (const t of entry.finalizeSpecs) {
+      const tid = pm.queueTask(t.exe, t.args, "");
+      if (tid >= 0) finIds.push(tid);
+    }
+    entry.phase = "finalize";
+    entry.taskIds = finIds;
+    entry.taskProgress = finIds.map(() => 0);
     return;
   }
-  finishJob(ctx, entry, args);
+
+  // Finalize phase.
+  emit(ctx, {
+    type: "progress",
+    jobId: entry.jobId,
+    progress: 100,
+    phase: "blending",
+    logChunk: logChunk || undefined,
+  });
+  if (allDone) finishJob(ctx, entry, args);
 }
 
 /** Start a render job. */
@@ -174,24 +238,33 @@ function renderStart(ctx: WorkerContext, args: RenderStartArgs): RenderStartResu
   }
 
   const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "cuemol-render-"));
-  emit(ctx, {
-    type: "progress",
-    jobId: "pending",
-    progress: 0,
-    phase: "exporting",
-  });
 
   let outputPath: string;
+  let renderSpecs: RenderTaskSpec[];
+  let finalizeSpecs: RenderTaskSpec[];
   let taskIds: number[];
   try {
     const exported = backend.exportScene(ctx, scene, args.snapshot, workDir);
     outputPath = backend.outputImagePath(exported);
     const tasks = backend.buildTasks(exported, args.snapshot);
+    renderSpecs = tasks.filter((t) => t.kind === "render");
+    finalizeSpecs = tasks.filter((t) => t.kind === "finalize");
+    if (renderSpecs.length === 0) throw new Error("backend produced no render tasks");
+
+    // Fail early with a clear message if a binary is missing.
+    for (const exe of new Set(tasks.map((t) => t.exe))) {
+      if (!fs.existsSync(exe)) throw new Error(`Executable not found: ${exe}`);
+    }
+
     const pm = ctx.svc.getService("ProcessManager") as ProcessManager;
+    // Give every render layer a slot so none waits in the (un-pumped) queue.
+    if (renderSpecs.length > pm.getSlotSize()) {
+      pm.setSlotSize(renderSpecs.length);
+    }
     taskIds = [];
-    for (const t of tasks) {
-      const tid = pm.queueTask(t.exe, t.args, t.waitFor);
-      if (tid < 0) throw new Error("ProcessManager could not queue the render task");
+    for (const t of renderSpecs) {
+      const tid = pm.queueTask(t.exe, t.args, "");
+      if (tid < 0) throw new Error("ProcessManager could not queue a render task");
       taskIds.push(tid);
     }
   } catch (e) {
@@ -203,13 +276,15 @@ function renderStart(ctx: WorkerContext, args: RenderStartArgs): RenderStartResu
   const entry: RenderJobEntry = {
     jobId,
     workDir,
-    taskIds,
     outputPath,
     startedAt: Date.now(),
     timer: null,
-    lastProgress: 0,
     cancelled: false,
     announcedDir: false,
+    phase: "render",
+    finalizeSpecs,
+    taskIds,
+    taskProgress: taskIds.map(() => 0),
   };
   jobs.set(jobId, entry);
   entry.timer = setInterval(() => {
@@ -219,7 +294,6 @@ function renderStart(ctx: WorkerContext, args: RenderStartArgs): RenderStartResu
       stopTimer(entry);
       jobs.delete(jobId);
       emit(ctx, { type: "error", jobId, error: String(e) });
-      cleanupDir(entry.workDir);
     }
   }, POLL_MS);
 

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -21,6 +21,12 @@
  */
 
 import type { ObjTuple } from './ObjTuple'
+import type {
+  RenderStartArgs,
+  RenderStartResult,
+  RenderCancelArgs,
+  RenderCancelResult,
+} from './renderTypes'
 
 import type { AppInfoResult } from '../server/services/appInfo.service'
 import type { CreateNewSceneAndViewArgs, CreateNewSceneAndViewResult } from '../server/services/createNewSceneAndView.service'
@@ -276,6 +282,8 @@ export interface ServiceMap {
   streamLoadFromUrl:          { args: StreamLoadFromUrlArgs;           result: StreamLoadFromUrlResult }
   streamLoadDensityMap:       { args: StreamLoadDensityMapArgs;        result: StreamLoadDensityMapResult }
   cancelStreamLoad:           { args: CancelStreamLoadArgs;            result: CancelStreamLoadResult }
+  renderStart:                { args: RenderStartArgs;                 result: RenderStartResult }
+  renderCancel:               { args: RenderCancelArgs;                result: RenderCancelResult }
   proposeNewTabNames:         { args: ProposeNewTabNamesArgs;          result: ProposeNewTabNamesResult }
   proposeUniqName:            { args: ProposeUniqNameArgs;             result: ProposeUniqNameResult }
   redo:                       { args: RedoArgs;                        result: { ok: boolean } }

--- a/tritium/react-gui/src/renderer/worker/shared/renderTypes.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/renderTypes.ts
@@ -1,0 +1,63 @@
+/**
+ * @file worker/shared/renderTypes.ts
+ * @description Types shared by both threads for the render pipeline:
+ * the `renderStart` / `renderCancel` service contracts and the
+ * worker → renderer `render-progress` push payload.
+ */
+
+import type { RenderSettingsSnapshot } from "../../data/renderResult";
+
+/** Push-channel name for worker → renderer render updates. */
+export const RENDER_PROGRESS_CHANNEL = "render-progress";
+
+/** Arguments for the `renderStart` worker service. */
+export interface RenderStartArgs {
+  sceneId: number;
+  /** Active view id, captured into the "__current" camera before export. */
+  viewId?: number;
+  /** Frozen settings used for this render. */
+  snapshot: RenderSettingsSnapshot;
+}
+
+export interface RenderStartResult {
+  ok: boolean;
+  jobId: string;
+  error?: string;
+}
+
+export interface RenderCancelArgs {
+  jobId: string;
+}
+
+export interface RenderCancelResult {
+  ok: boolean;
+}
+
+/** Coarse phase of a running render. */
+export type RenderUpdatePhase = "exporting" | "running" | "blending";
+
+/**
+ * Worker → renderer push payload (channel `render-progress`).
+ * One discriminated union covers progress, completion and failure.
+ */
+export type RenderUpdate =
+  | {
+      type: "progress";
+      jobId: string;
+      progress: number; // 0..100
+      phase: RenderUpdatePhase;
+      logChunk?: string;
+    }
+  | {
+      type: "complete";
+      jobId: string;
+      imageDataUrl: string;
+      width: number;
+      height: number;
+      elapsedSec: number;
+    }
+  | {
+      type: "error";
+      jobId: string;
+      error: string;
+    };

--- a/tritium/react-gui/src/renderer/worker/shared/renderTypes.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/renderTypes.ts
@@ -10,6 +10,26 @@ import type { RenderSettingsSnapshot } from "../../data/renderResult";
 /** Push-channel name for worker → renderer render updates. */
 export const RENDER_PROGRESS_CHANNEL = "render-progress";
 
+/**
+ * Paths to the external binaries the render pipeline drives. Configured in
+ * the SettingsPane and persisted; a leading `~` is expanded by the worker.
+ */
+export interface RenderBinaries {
+  /** POV-Ray executable. */
+  povrayExe: string;
+  /** POV-Ray standard include directory. */
+  povrayInc: string;
+  /** blendpng layer-compositing executable. */
+  blendpng: string;
+}
+
+/** Default binary locations (app-bundle packaging is a later concern). */
+export const DEFAULT_RENDER_BINARIES: RenderBinaries = {
+  povrayExe: "~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/bin/povray",
+  povrayInc: "~/tmp/proj64_deplibs/cuemol2_bundle_apps/povray/include",
+  blendpng: "~/tmp/proj64_deplibs/cuemol2/bin/blendpng",
+};
+
 /** Arguments for the `renderStart` worker service. */
 export interface RenderStartArgs {
   sceneId: number;
@@ -17,6 +37,8 @@ export interface RenderStartArgs {
   viewId?: number;
   /** Frozen settings used for this render. */
   snapshot: RenderSettingsSnapshot;
+  /** External binary paths to use. */
+  binaries: RenderBinaries;
 }
 
 export interface RenderStartResult {

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -15,6 +15,7 @@ export const IPC = {
   DIALOG_CAMERA_OPEN: 'dialog:cameraOpen',
   DIALOG_CAMERA_SAVE: 'dialog:cameraSave',
   DIALOG_OBJECT_SAVE: 'dialog:objectSave',
+  DIALOG_PICK_PATH:   'dialog:pickPath',
   FILE_EXISTS:        'file:exists',
   FILE_BACKUP_RENAME: 'file:backupRename',
   LAYOUT_LOAD:    'layout:load',

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -48,6 +48,8 @@ export interface InvokeChannels {
                                 defaultFilterIndex?: number
                               };
                               res: { canceled: boolean; filePath: string; filterIndex: number } }
+  [IPC.DIALOG_PICK_PATH]:  { req: { title: string; directory?: boolean };
+                             res: { canceled: boolean; filePath: string } }
   [IPC.FILE_EXISTS]:       { req: { path: string };      res: { exists: boolean } }
   [IPC.FILE_BACKUP_RENAME]:{ req: { path: string };
                              res: { ok: boolean; backed: boolean; error?: string } }

--- a/tritium/react-gui/src/shared/ipcTypes.ts
+++ b/tritium/react-gui/src/shared/ipcTypes.ts
@@ -41,6 +41,12 @@ export interface UiState {
   sidebarActiveView?: string
   selectionMolId?: string
   theme?: 'dark' | 'light'
+  /** POV-Ray executable path (Rendering settings). */
+  povrayExe?: string
+  /** POV-Ray include directory path (Rendering settings). */
+  povrayInc?: string
+  /** blendpng executable path (Rendering settings). */
+  blendpng?: string
 }
 
 // ── File dialog ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Introduce a fifth inspector target kind, renderSettings, that opens a mock render-settings editor in the Inspector panel.

- InspectorTarget becomes a discriminated union (node | renderSettings)
- RenderSettingsEditor: backend selector plus Image/Camera/Quality/Output accordions, driven by a backend descriptor registry (RENDER_BACKENDS)
- Extract PropGroupedEditor from PropertiesTab for reuse
- Toolbar Render button dispatches the UiRenderSettings command
- Inspector header shows a target-category badge
- Recenter the compact select caret icon so it stays inside the border

Phase 1 is mock-only: no rendering is performed yet. Also includes the overall rendering UI implementation plan.