### PR TITLE
Add JSDoc to worker/client/ files (14 files)

### DIFF
--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -1,3 +1,14 @@
+/**
+ * @file renderer/worker/client/AsyncCueMol.ts
+ * @description Renderer-thread facade over `WorkerTransport` + `ObjectFactory`
+ * + `EventSlots`. Exposes one async method per worker entry point used by
+ * the renderer.
+ *
+ * All public methods are `async` (each call is one IPC round-trip). To
+ * avoid chained `await` overhead, prefer writing a worker service that
+ * does the work in one round-trip rather than calling many methods here
+ * in sequence.
+ */
 import { BaseWrapper } from '@cuemol/core/src/BaseWrapper';
 import type { SceneBgColor, ViewCenterMark } from '../../../shared/ipcTypes';
 import type { FileOpenOptions } from '../../components/fopen-opt-dlgs/types';
@@ -36,11 +47,16 @@ import type {
 
 const log = console;
 
+/**
+ * Renderer-thread facade. One instance per renderer process; constructed
+ * via `createCueMol()` in `client/index.ts`.
+ */
 export class AsyncCueMol {
     private _transport: WorkerTransport;
     private _slots: EventSlots;
     private _factory: ObjectFactory;
 
+    /** Construct the transport, slot table, and object factory. */
     constructor() {
         this._slots = new EventSlots();
         this._transport = new WorkerTransport({
@@ -49,49 +65,112 @@ export class AsyncCueMol {
         this._factory = new ObjectFactory(this._transport, this);
     }
 
-    // -------- Transport facade (preserves test surface + ObjProxy contract)
+    // --- Transport facade (preserves test surface + ObjProxy contract) ---
+
+    /** Whether the worker has been launched and not yet terminated. */
     isReady(): boolean { return this._transport.isReady(); }
+
+    /** Whether at least one tracked call is currently in flight. */
     isBusy(): boolean { return this._transport.isBusy(); }
+
+    /** Subscribe to busy-state edges. Returns an unsubscribe function. */
     subscribeBusy(cb: (busy: boolean) => void): () => void { return this._transport.subscribeBusy(cb); }
+
+    /** Subscribe to `stream-progress` push messages. */
     subscribeStreamProgress(cb: StreamProgressListener): () => void {
         return this._transport.subscribeStreamProgress(cb);
     }
+
+    /** Subscribe to `render-progress` push messages from `renderJob`. */
     subscribeRenderProgress(cb: RenderProgressListener): () => void {
         return this._transport.subscribeRenderProgress(cb);
     }
+
+    /** Low-level raw worker call. Prefer the typed helpers below. */
     invokeWorker(method: string, ...args: any[]): Promise<any[]> {
         return this._transport.invokeWorker(method, ...args);
     }
+
+    /**
+     * Low-level raw worker call carrying a `Transferable`.
+     *
+     * @remarks Used only by `bindCanvas` to transfer the
+     *   `OffscreenCanvas`; not tracked by the busy counter.
+     */
     invokeWorkerWithTransfer(method: string, transfer: any, ...args: any[]): Promise<any[]> {
         return this._transport.invokeWorkerWithTransfer(method, transfer, ...args);
     }
+
+    /** Call a worker service (`ServiceMap` entry). */
     invokeService<K extends ServiceKey>(name: K, args: ServiceArgs<K>): Promise<ServiceResult<K>> {
         return this._transport.invokeService(name, args);
     }
+
+    /** Call a worker variadic method (`MethodMap` entry). */
     invokeMethodTyped<K extends MethodKey>(name: K, ...args: MethodArgs<K>): Promise<MethodResult<K>> {
         return this._transport.invokeMethod(name, ...args);
     }
+
+    /** Call a worker RPC handler (`RpcMap` entry -- used by `ObjProxy`). */
     invokeRpc<K extends RpcKey>(name: K, ...args: RpcArgs<K>): Promise<RpcResult<K>> {
         return this._transport.invokeRpc(name, ...args);
     }
+
+    /** Fire-and-forget `postMessage`. */
     postMessage(method: string, seq: number, args: any[], xfer: any = null): void {
         this._transport.postMessage(method, seq, args, xfer);
     }
+
+    /** Allocate the next call sequence number. */
     getSeqNo(): number { return this._transport.getSeqNo(); }
+
+    /** Register a one-shot reply handler keyed by `method.seqno`. */
     addListener(method: string, seqno: number, handler: any): void {
         this._transport.addListener(method, seqno, handler);
     }
 
-    // -------- Factory facade (preserves BaseWrapper._utils contract)
+    // --- Factory facade (preserves BaseWrapper._utils contract) ---
+
+    /** Construct a `BaseWrapper` for an already-resolved `ObjProxy`. */
     createWrapperImpl(obj: ObjProxy): BaseWrapper { return this._factory.createWrapperImpl(obj); }
+
+    /** Resolve a Promise of `ObjProxy` and wrap the result. */
     createWrapper(prom: Promise<ObjProxy>): Promise<BaseWrapper | null> { return this._factory.createWrapper(prom); }
+
+    /** Return the `ObjTuple` underlying a proxy. */
     getWrapped(obj: ObjProxy): ObjTuple { return this._factory.getWrapped(obj); }
+
+    /** Create a new C++ object of `className` on the worker side. */
     createObj(className: string): Promise<BaseWrapper | null> { return this._factory.createObj(className); }
+
+    /** Look up a registered singleton service (`StyleManager`, ...). */
     getService(className: string): Promise<BaseWrapper | null> { return this._factory.getService(className); }
+
+    /** Check whether `className` is registered with the C++ class registry. */
     hasClass(className: string): Promise<boolean | null> { return this._factory.hasClass(className); }
+
+    /** Return a JSON document listing every class known to the registry. */
     getAllClassNamesJSON(): Promise<string | null> { return this._factory.getAllClassNamesJSON(); }
 
-    // -------- Event subscription
+    // --- Event subscription ---
+
+    /**
+     * Register a worker-side event listener and remember the slot id.
+     *
+     * @param aCatStr - Category string (`'log'` for log events, `''` for
+     *   source-uid match).
+     * @param aSrcType - Source-type bitmask (OR-combine `SEM_*` constants).
+     * @param aEvtType - Event-type filter (`SEM_ANY` for any).
+     * @param aSrcID - Source uid scope (`scene.uid`, or `SEM_ANY` for
+     *   global).
+     * @param aObs - Observer: function `(args) => void` or object with
+     *   `notify(args)`.
+     * @returns The slot id; pass to {@link removeEventListener} for
+     *   cleanup.
+     * @remarks Forgetting cleanup leaks listeners across scene switches
+     *   and causes ghost handlers to fire on stale state. See "CueMol
+     *   event framework" in `tritium/CLAUDE.md`.
+     */
     async addEventListener(
         aCatStr: string, aSrcType: number, aEvtType: number, aSrcID: number, aObs: any,
     ): Promise<number> {
@@ -102,94 +181,179 @@ export class AsyncCueMol {
         this._slots.register(slot_id, aObs);
         return slot_id;
     }
+
+    /**
+     * Remove a previously-registered event listener.
+     *
+     * @param nID - Slot id returned by {@link addEventListener}.
+     */
     async removeEventListener(nID: number): Promise<void> {
         await this._transport.invokeWorker('removeEventListener', nID);
         this._slots.unregister(nID);
         log.info("EventManager, unload slot: " + nID);
     }
+
+    /**
+     * Dispatch an `event-notify` payload received from the worker.
+     *
+     * @remarks Wired internally by the constructor; not normally called
+     *   from outside.
+     */
     eventNotify(
         slot: number, category: string, srcCat: number, evtType: number, srcUID: number, evtStr: string,
     ): any {
         return this._slots.notify(slot, category, srcCat, evtType, srcUID, evtStr);
     }
 
-    // -------- Lifecycle
+    // --- Lifecycle ---
+
+    /** Boot the worker-side CueMol runtime by loading `sysconfig.xml`. */
     initCueMol(sysConfigPath?: string): Promise<void> { return lifecycleApi.initCueMol(this._transport, sysConfigPath); }
+
+    /** Apply a user style sheet to the running scene manager. */
     loadUserStyle(userStylePath?: string): Promise<boolean> { return lifecycleApi.loadUserStyle(this._transport, userStylePath); }
+
+    /** Switch the renderer's view-input style (mouse-button bindings). */
     setViewInputConfigStyle(styleName: string): Promise<boolean> { return lifecycleApi.setViewInputConfigStyle(this._transport, styleName); }
+
+    /** Shut down the worker and terminate the underlying handle. */
     terminateWorker(): Promise<void> { return lifecycleApi.terminateWorker(this._transport); }
+
+    /** Fetch app `{ version, build }` metadata from the worker. */
     getAppInfo(): Promise<{ version: string; build: string }> { return lifecycleApi.getAppInfo(this._transport); }
 
-    // -------- View lifecycle
+    // --- View lifecycle ---
+
+    /**
+     * Transfer canvas control to the worker and bind it to a view.
+     *
+     * @remarks One-shot per canvas element: `transferControlToOffscreen()`
+     *   may be called only once. Use {@link addView} for additional view
+     *   tabs on the already-bound canvas.
+     */
     bindCanvas(canvas: any, view_id: number, dpr: number): Promise<any[]> { return viewApi.bindCanvas(this._transport, canvas, view_id, dpr); }
+
+    /** Attach a new view to the already-bound OffscreenCanvas. */
     addView(view_id: number, dpr: number): Promise<boolean> { return viewApi.addView(this._transport, view_id, dpr); }
+
+    /** Make `view_id` the currently rendered view. */
     activateView(view_id: number): Promise<void> { return viewApi.activateView(this._transport, view_id); }
+
+    /** Stop the view loop and remove the view from `bound_views`. */
     removeView(view_id: number): Promise<void> { return viewApi.removeView(this._transport, view_id); }
+
+    /** Notify the worker that a view's canvas was resized. */
     resized(view_id: number, w: number, h: number, dpr: number): void { viewApi.resized(this._transport, view_id, w, h, dpr); }
 
-    // -------- Input events (fire-and-forget)
+    // --- Input events (fire-and-forget) ---
+
+    /** Forward a mouse event to the worker. */
     onMouseEvent(view_id: number, method: string, event: any): void { inputApi.onMouseEvent(this._transport, view_id, method, event); }
+
+    /** Forward a wheel event to the worker. */
     onWheelEvent(view_id: number, event: any): void { inputApi.onWheelEvent(this._transport, view_id, event); }
+
+    /** Forward a trackpad gesture to the worker. */
     onGestureEvent(view_id: number, axisID: number, delta: number, event?: any): void {
         inputApi.onGestureEvent(this._transport, view_id, axisID, delta, event);
     }
 
-    // -------- File operations
+    // --- File operations ---
+
+    /** Ask which renderer types are compatible with `filePath`. */
     getCompatibleRendererNames(filePath: string, readerName?: string): Promise<GetCompatibleRendererNamesResult> {
         return fileApi.getCompatibleRendererNames(this._transport, filePath, readerName);
     }
+
+    /** Fetch open-dialog filters for the given file-category id. */
     getOpenFilters(catId: number): Promise<ElectronFileFilter[]> { return fileApi.getOpenFilters(this._transport, catId); }
+
+    /** Create a new scene + default view on the worker side. */
     createNewSceneAndView(dpr: number, name?: string, bindView?: boolean): Promise<{ scene_uid: number; view_uid: number; scene_name: string; view_name: string } | null> {
         return fileApi.createNewSceneAndView(this._transport, dpr, name, bindView);
     }
+
+    /** Load a QSC scene file into an existing scene. */
     loadScene(filePath: string, scene_id: number): Promise<boolean> { return fileApi.loadScene(this._transport, filePath, scene_id); }
+
+    /** Load an object (PDB / map / mesh / ...) into a scene. */
     loadObject(filePath: string, scene_id: number, options: FileOpenOptions): Promise<boolean> {
         return fileApi.loadObject(this._transport, filePath, scene_id, options);
     }
 
-    // -------- Edit
+    // --- Edit ---
+
+    /** Undo the last transaction on a scene. */
     undo(scene_id: number, depth = 0): Promise<boolean> { return editApi.undo(this._transport, scene_id, depth); }
+
+    /** Redo the most recently undone transaction. */
     redo(scene_id: number, depth = 0): Promise<boolean> { return editApi.redo(this._transport, scene_id, depth); }
 
-    // -------- Scene / View settings
+    // --- Scene / View settings ---
+
+    /** Read the projection mode (perspective vs orthographic) of a view. */
     getViewProjection(viewId: number): Promise<{ ok: boolean; perspective: boolean } | null> {
         return sceneViewApi.getViewProjection(this._transport, viewId);
     }
+
+    /** Change the projection mode of a view. */
     setViewProjection(viewId: number, perspective: boolean): Promise<{ ok: boolean; perspective: boolean } | null> {
         return sceneViewApi.setViewProjection(this._transport, viewId, perspective);
     }
+
+    /** Read the view-center mark display style. */
     getViewCenterMark(viewId: number): Promise<{ ok: boolean; centerMark: ViewCenterMark } | null> {
         return sceneViewApi.getViewCenterMark(this._transport, viewId);
     }
+
+    /** Change the view-center mark display style. */
     setViewCenterMark(viewId: number, centerMark: ViewCenterMark): Promise<{ ok: boolean; centerMark: ViewCenterMark } | null> {
         return sceneViewApi.setViewCenterMark(this._transport, viewId, centerMark);
     }
+
+    /** Read the background color of a scene. */
     getSceneBgColor(sceneId: number): Promise<{ ok: boolean; bgColor: SceneBgColor } | null> {
         return sceneViewApi.getSceneBgColor(this._transport, sceneId);
     }
+
+    /** Set the background color of a scene to a preset name. */
     setSceneBgColor(sceneId: number, colorName: 'white' | 'black'): Promise<{ ok: boolean; bgColor: SceneBgColor } | null> {
         return sceneViewApi.setSceneBgColor(this._transport, sceneId, colorName);
     }
+
+    /** Propose a unique name in a given namespace (scene / object / ...). */
     proposeUniqName(args: ProposeUniqNameArgs): Promise<ProposeUniqNameResult | null> {
         return sceneViewApi.proposeUniqName(this._transport, args);
     }
+
+    /** Create an additional view inside an existing scene (multi-view). */
     createViewInScene(args: CreateViewInSceneArgs): Promise<CreateViewInSceneResult | null> {
         return sceneViewApi.createViewInScene(this._transport, args);
     }
+
+    /** Compute default names for a new-tab dialog. */
     proposeNewTabNames(args: ProposeNewTabNamesArgs): Promise<ProposeNewTabNamesResult | null> {
         return sceneViewApi.proposeNewTabNames(this._transport, args);
     }
+
+    /** Ask whether closing a view requires a save-changes prompt. */
     getSceneCloseInfo(viewId: number): Promise<GetSceneCloseInfoResult | null> {
         return sceneViewApi.getSceneCloseInfo(this._transport, { viewId });
     }
 
-    // -------- Navigation tools
+    // --- Navigation tools ---
+
+    /** Hit-test the cursor at `(x, y)` in `viewId`. */
     naviHitTest(args: { viewId: number; x: number; y: number }): Promise<{ hit: boolean; raw?: any } | null> {
         return naviApi.naviHitTest(this._transport, args);
     }
+
+    /** Atom-pick click handler; updates the status-bar message. */
     naviClickAtom(args: { viewId: number; x: number; y: number }): Promise<{ handled: boolean; statusMessage?: string; hitres?: any } | null> {
         return naviApi.naviClickAtom(this._transport, args);
     }
+
+    /** Residue-selection click handler (toggle / extend). */
     naviResidSel(args: {
         viewId: number; x: number; y: number;
         mode: 'toggle' | 'extend';
@@ -197,33 +361,49 @@ export class AsyncCueMol {
     }): Promise<{ handled: boolean; objId?: number; atomId?: number } | null> {
         return naviApi.naviResidSel(this._transport, args);
     }
+
+    /** Move the view center to the world coord at `(x, y, z)`. */
     naviCenterAt(args: { viewId: number; x: number; y: number; z: number }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCenterAt(this._transport, args);
     }
+
+    /** Move the view center to a symmetry mate of an atom. */
     naviCenterAtSymm(args: {
         viewId: number; objId: number; rendId: number; atomId: number; symmId: number;
     }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCenterAtSymm(this._transport, args);
     }
+
+    /** Context-menu "select" -- replaces the selection on the object. */
     naviCtxSelect(args: {
         viewId: number; objId: number; atomId: number; mode: 'atom' | 'residue' | 'chain' | 'mol';
     }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCtxSelect(this._transport, args);
     }
+
+    /** Context-menu "add to selection" -- adds without replacing. */
     naviCtxAddSelect(args: {
         viewId: number; objId: number; atomId: number; mode: 'atom' | 'residue' | 'chain' | 'mol';
     }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCtxAddSelect(this._transport, args);
     }
+
+    /** Context-menu "unselect" -- clear the object's selection. */
     naviCtxUnselect(args: { viewId: number; objId: number }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCtxUnselect(this._transport, args);
     }
+
+    /** Context-menu "invert selection". */
     naviCtxInvertSel(args: { viewId: number; objId: number }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCtxInvertSel(this._transport, args);
     }
+
+    /** Context-menu "toggle side-chain selection". */
     naviCtxToggleSidechain(args: { viewId: number; objId: number }): Promise<{ ok: boolean } | null> {
         return naviApi.naviCtxToggleSidechain(this._transport, args);
     }
+
+    /** Context-menu "select within N angstroms". */
     naviCtxAround(args: {
         viewId: number; objId: number; distance: number; byres: boolean;
     }): Promise<{ ok: boolean } | null> {

--- a/tritium/react-gui/src/renderer/worker/client/EventSlots.ts
+++ b/tritium/react-gui/src/renderer/worker/client/EventSlots.ts
@@ -1,16 +1,53 @@
+/**
+ * @file renderer/worker/client/EventSlots.ts
+ * @description Renderer-side slot table for worker `event-notify` messages.
+ *
+ * `WorkerTransport` receives `event-notify` messages from the Web Worker
+ * (which mirror `qlib::ScrEventManager` callbacks) and dispatches each one
+ * into this table. Subscribers register against a numeric `slotId` returned
+ * by the worker when they call `addEventListener`.
+ */
 import type { EventNotifyArgs } from './WorkerTransport';
 
+/**
+ * Slot registry for renderer-side worker event listeners.
+ *
+ * @remarks One instance is owned by `AsyncCueMol`. Slot IDs are allocated
+ *   by the worker (`qlib::ScrEventManager`) and returned through
+ *   `addEventListener`, so the renderer side is purely a routing table.
+ */
 export class EventSlots {
     private _slot: { [key: string]: any } = {};
 
+    /**
+     * Register an observer for the given slot ID.
+     *
+     * @param slotId - Slot identifier returned by the worker's
+     *   `addEventListener` reply.
+     * @param observer - Either a function `(args) => void` or an object
+     *   with a `notify(args)` method.
+     */
     register(slotId: number, observer: any): void {
         this._slot[slotId.toString()] = observer;
     }
 
+    /**
+     * Forget the observer for the given slot ID.
+     *
+     * @param slotId - Slot identifier previously passed to `register`.
+     */
     unregister(slotId: number): void {
         delete this._slot[slotId.toString()];
     }
 
+    /**
+     * Dispatch a worker `event-notify` payload to the registered observer.
+     *
+     * @param args - Tuple `[slot, category, srcCat, evtType, srcUID, evtStr]`
+     *   forwarded from `WorkerTransport`. `evtStr` is the JSON-encoded
+     *   event-specific payload (`""` means an empty object).
+     * @returns Observer return value, or `null` if no observer is bound.
+     */
     notify(...args: EventNotifyArgs): any {
         const [slot, category, srcCat, evtType, srcUID, evtStr] = args;
         let json: string | null = null;

--- a/tritium/react-gui/src/renderer/worker/client/ObjProxy.ts
+++ b/tritium/react-gui/src/renderer/worker/client/ObjProxy.ts
@@ -1,27 +1,57 @@
+/**
+ * @file renderer/worker/client/ObjProxy.ts
+ * @description IPC proxy for a single C++ wrapper object living in the
+ * Web Worker. `BaseWrapper` (in renderer mode) holds an `ObjProxy` instead
+ * of the native object, and routes every property access / method call
+ * through `getProp` / `setProp` / `invokeMethod`. The worker side dispatches
+ * each call via the `RpcMap` table.
+ */
 import { ObjTuple, isObjTuple } from '../shared/ObjTuple';
 import type { AsyncCueMol } from './AsyncCueMol';
-// import { createLogger } from "../logger";
 
-// const log = createLogger(import.meta.url);
 const log = console;
 
+/**
+ * Renderer-side handle for a C++ wrapper object owned by the worker.
+ *
+ * @remarks Identity is captured by an `ObjTuple` (`{_obj_id, _class_name}`)
+ *   so that every IPC round-trip can address the same native object. When
+ *   a property read or method call returns another wrapper object, the
+ *   reply carries an `ObjTuple` which is auto-wrapped into a new
+ *   `ObjProxy` so the caller can chain further calls.
+ */
 export class ObjProxy {
     private _obj: ObjTuple;
     private _acm: AsyncCueMol;
 
+    /**
+     * @param objId - Worker-side object id (opaque string).
+     * @param className - C++ class name (used by `ObjectFactory` to choose
+     *   the wrapper class).
+     * @param worker - The `AsyncCueMol` used to send `invokeRpc` calls.
+     */
     constructor(objId: string, className: string, worker: AsyncCueMol) {
         this._obj = new ObjTuple(objId, className);
         this._acm = worker;
     }
 
+    /** Return the C++ class name captured at construction. */
     getClassName(): string {
         return this._obj.className;
     }
 
+    /** Return the underlying `ObjTuple` (used by `ObjectFactory.getWrapped`). */
     getObjTuple(): ObjTuple {
         return this._obj;
     }
 
+    /**
+     * Read a property on the worker-side wrapper.
+     *
+     * @param propName - Property name on the C++ class.
+     * @returns The property value. If the reply is an `ObjTuple`, it is
+     *   auto-wrapped into a new `ObjProxy`.
+     */
     async getProp(propName: string): Promise<unknown> {
         try {
             const result = await this._acm.invokeRpc('getProp', this._obj, propName);
@@ -37,6 +67,13 @@ export class ObjProxy {
         }
     }
 
+    /**
+     * Write a property on the worker-side wrapper.
+     *
+     * @param propName - Property name on the C++ class.
+     * @param value - New value. May be an `ObjProxy` / `ObjTuple` for
+     *   wrapper-typed properties (the worker side unwraps it).
+     */
     async setProp(propName: string, value: unknown): Promise<void> {
         try {
             await this._acm.invokeRpc('setProp', this._obj, propName, value);
@@ -47,6 +84,14 @@ export class ObjProxy {
         }
     }
 
+    /**
+     * Invoke a method on the worker-side wrapper.
+     *
+     * @param method - Method name on the C++ class.
+     * @param args - Arguments passed through to the worker.
+     * @returns The method return value. If the reply is an `ObjTuple`, it
+     *   is auto-wrapped into a new `ObjProxy`.
+     */
     async invokeMethod(method: string, ...args: unknown[]): Promise<unknown> {
         try {
             const result = await this._acm.invokeRpc('invokeMethod', method, this._obj, args);

--- a/tritium/react-gui/src/renderer/worker/client/ObjectFactory.ts
+++ b/tritium/react-gui/src/renderer/worker/client/ObjectFactory.ts
@@ -1,3 +1,12 @@
+/**
+ * @file renderer/worker/client/ObjectFactory.ts
+ * @description Constructs `BaseWrapper` instances from `ObjProxy` handles.
+ *
+ * Used by `AsyncCueMol` as a facade. Direct callers go through
+ * `createObj` / `getService`, which round-trip to the worker and wrap the
+ * returned id; `createWrapperImpl` is also called from `ObjProxy.getProp`
+ * / `invokeMethod` when a reply carries an `ObjTuple`.
+ */
 import { BaseWrapper } from '@cuemol/core/src/BaseWrapper';
 import { wrapper_map } from '@cuemol/core/src/wrappers/wrapper-loader';
 import type { AsyncCueMol } from './AsyncCueMol';
@@ -7,15 +16,32 @@ import { WorkerTransport } from './WorkerTransport';
 
 const log = console;
 
+/**
+ * Factory for renderer-side `BaseWrapper` instances backed by `ObjProxy`.
+ */
 export class ObjectFactory {
     private _transport: WorkerTransport;
     private _asyncCueMol: AsyncCueMol;
 
+    /**
+     * @param transport - Worker transport used for `createObj` /
+     *   `getService` / `hasClass` IPC calls.
+     * @param asyncCueMol - Parent facade, passed to each `ObjProxy` so it
+     *   can dispatch RPC calls.
+     */
     constructor(transport: WorkerTransport, asyncCueMol: AsyncCueMol) {
         this._transport = transport;
         this._asyncCueMol = asyncCueMol;
     }
 
+    /**
+     * Construct a `BaseWrapper` for an already-resolved `ObjProxy`.
+     *
+     * @param obj - The proxy whose class name selects the wrapper class.
+     * @returns A new wrapper instance.
+     * @remarks Synchronous variant -- use when you already hold the proxy.
+     *   For Promise inputs use {@link createWrapper}.
+     */
     createWrapperImpl(obj: ObjProxy): BaseWrapper {
         const className = obj.getClassName();
         const Klass = wrapper_map[className];
@@ -23,6 +49,13 @@ export class ObjectFactory {
         return wrapper;
     }
 
+    /**
+     * Resolve a Promise of `ObjProxy` and wrap the result.
+     *
+     * @param prom - Promise that resolves with a proxy or null/undefined.
+     * @returns The wrapper, or `null` when the proxy is missing or the
+     *   Promise rejects (errors are logged).
+     */
     async createWrapper(prom: Promise<ObjProxy>): Promise<BaseWrapper | null> {
         return prom.then((resolvedObj: any) => {
             if (resolvedObj === null || resolvedObj === undefined) return null;
@@ -33,10 +66,18 @@ export class ObjectFactory {
         });
     }
 
+    /** Return the `ObjTuple` underlying a proxy. */
     getWrapped(obj: ObjProxy): ObjTuple {
         return obj.getObjTuple();
     }
 
+    /**
+     * Create a new C++ object of `className` on the worker side and return
+     * a wrapper for it.
+     *
+     * @param className - Registered C++ class name.
+     * @returns The new wrapper, or `null` if creation fails.
+     */
     async createObj(className: string): Promise<BaseWrapper | null> {
         try {
             const result = await this._transport.invokeWorker('createObj', className);
@@ -53,6 +94,13 @@ export class ObjectFactory {
         return null;
     }
 
+    /**
+     * Look up a registered singleton service (e.g. `'StyleManager'`,
+     * `'StreamManager'`) and return a wrapper.
+     *
+     * @param className - Registered service class name.
+     * @returns The wrapper, or `null` if the service is unknown.
+     */
     async getService(className: string): Promise<BaseWrapper | null> {
         try {
             const result = await this._transport.invokeWorker('getService', className);
@@ -69,6 +117,13 @@ export class ObjectFactory {
         return null;
     }
 
+    /**
+     * Check whether a class name is registered with the C++ class
+     * registry.
+     *
+     * @param className - Class name to probe.
+     * @returns `true`/`false`, or `null` on transport failure.
+     */
     async hasClass(className: string): Promise<boolean | null> {
         try {
             const result = await this._transport.invokeWorker('hasClass', className);
@@ -83,6 +138,12 @@ export class ObjectFactory {
         return null;
     }
 
+    /**
+     * Return a JSON document listing every class known to the C++ class
+     * registry. Used to populate dev / introspection tools.
+     *
+     * @returns JSON string, or `null` on failure.
+     */
     async getAllClassNamesJSON(): Promise<string | null> {
         try {
             const result = await this._transport.invokeWorker('getAllClassNamesJSON');

--- a/tritium/react-gui/src/renderer/worker/client/WorkerTransport.ts
+++ b/tritium/react-gui/src/renderer/worker/client/WorkerTransport.ts
@@ -1,3 +1,13 @@
+/**
+ * @file renderer/worker/client/WorkerTransport.ts
+ * @description Renderer-side handle for the Web Worker process.
+ *
+ * Owns the `Worker` instance, allocates per-call sequence numbers, routes
+ * replies back to their callers, and exposes typed `invokeService<K>` /
+ * `invokeMethod<K>` / `invokeRpc<K>` helpers built on top of the low-level
+ * `invokeWorker` array-tail protocol. Also fans out `event-notify`,
+ * `stream-progress` and `render-progress` push messages to subscribers.
+ */
 import type {
     MethodArgs,
     MethodKey,
@@ -14,20 +24,38 @@ import { RENDER_PROGRESS_CHANNEL } from '../shared/renderTypes';
 
 const log = console;
 
+/** Build the per-call dispatch key from a method name and sequence number. */
 function makeMethodSeq(method: string, seqno: number): string {
     return method + '.' + seqno.toString();
 }
 
+/**
+ * Payload tuple for a worker `event-notify` push:
+ * `[slot, category, srcCat, evtType, srcUID, evtStr]`.
+ */
 export type EventNotifyArgs = [number, string, number, number, number, string];
 
+/**
+ * Listener for `stream-progress` push messages.
+ *
+ * @param reqId - Stream-request identifier issued by the worker.
+ * @param bytes - Cumulative bytes transferred so far.
+ */
 export type StreamProgressListener = (reqId: string, bytes: number) => void;
 
+/** Listener for `render-progress` push messages from `renderJob`. */
 export type RenderProgressListener = (update: RenderUpdate) => void;
 
+/** Construction options for {@link WorkerTransport}. */
 export interface WorkerTransportOptions {
+    /** Forwarder for `event-notify` payloads (typically routes to `EventSlots.notify`). */
     onEventNotify: (args: EventNotifyArgs) => void;
 }
 
+/**
+ * Web Worker transport. One instance per renderer process; owned by
+ * `AsyncCueMol`.
+ */
 export class WorkerTransport {
     private _ready: boolean = false;
     private _seqno: number = 0;
@@ -39,6 +67,13 @@ export class WorkerTransport {
     private _streamProgressListeners: Set<StreamProgressListener> = new Set();
     private _renderProgressListeners: Set<RenderProgressListener> = new Set();
 
+    /**
+     * Spawn the Web Worker (entry: `../server/worker_launcher.ts`) and
+     * install the `onmessage` dispatcher.
+     *
+     * @param opts - `onEventNotify` handler used for `event-notify` push
+     *   messages.
+     */
     constructor(opts: WorkerTransportOptions) {
         this._onEventNotify = opts.onEventNotify;
         log.info('launch worker...');
@@ -86,18 +121,38 @@ export class WorkerTransport {
         this._ready = true;
     }
 
+    /**
+     * Subscribe to `stream-progress` push messages.
+     *
+     * @returns An unsubscribe function.
+     */
     subscribeStreamProgress(cb: StreamProgressListener): () => void {
         this._streamProgressListeners.add(cb);
         return () => { this._streamProgressListeners.delete(cb); };
     }
 
+    /**
+     * Subscribe to `render-progress` push messages from `renderJob`.
+     *
+     * @returns An unsubscribe function.
+     */
     subscribeRenderProgress(cb: RenderProgressListener): () => void {
         this._renderProgressListeners.add(cb);
         return () => { this._renderProgressListeners.delete(cb); };
     }
 
+    /** Whether the worker has been launched and not yet terminated. */
     isReady(): boolean { return this._ready; }
 
+    /**
+     * Low-level send. Bypasses the busy counter; used by typed helpers and
+     * by fire-and-forget event forwarders.
+     *
+     * @param method - Worker-side handler name.
+     * @param seq - Sequence number from {@link getSeqNo}.
+     * @param args - Positional arguments forwarded to the worker.
+     * @param xfer - Optional `Transferable` (used by `bindCanvas`).
+     */
     postMessage(method: string, seq: number, args: any[], xfer: any = null): void {
         if (xfer === null)
             this._worker.postMessage([method, seq, ...args]);
@@ -105,41 +160,68 @@ export class WorkerTransport {
             this._worker.postMessage([method, seq, ...args], [xfer]);
     }
 
+    /** Allocate the next call sequence number. */
     getSeqNo(): number {
         this._seqno++;
         return this._seqno;
     }
 
+    /**
+     * Register a one-shot reply handler keyed by `method.seqno`. Consumed
+     * by `onmessage` when the worker replies, then deleted.
+     */
     addListener(method: string, seqno: number, handler: any): void {
         const method_seq = makeMethodSeq(method, seqno);
         this._worker_onmessage_dict[method_seq] = handler;
     }
 
+    /** Increment the pending-call counter, firing `busy=true` on rising edge. */
     private _incPending(): void {
         const wasBusy = this._pendingCount > 0;
         this._pendingCount++;
         if (!wasBusy) this._notifyBusyChange(true);
     }
 
+    /** Decrement the pending-call counter, firing `busy=false` at zero. */
     private _decPending(): void {
         if (this._pendingCount <= 0) return;
         this._pendingCount--;
         if (this._pendingCount === 0) this._notifyBusyChange(false);
     }
 
+    /** Fan-out helper invoked when the pending-call edge crosses zero. */
     private _notifyBusyChange(busy: boolean): void {
         for (const cb of this._busyListeners) {
             try { cb(busy); } catch (e) { log.warn('busy listener error:', e); }
         }
     }
 
+    /** Whether at least one tracked call is currently in flight. */
     isBusy(): boolean { return this._pendingCount > 0; }
 
+    /**
+     * Subscribe to busy-state edges.
+     *
+     * @param cb - Called with `true` when the first call goes pending and
+     *   `false` when the last call resolves.
+     * @returns An unsubscribe function.
+     */
     subscribeBusy(cb: (busy: boolean) => void): () => void {
         this._busyListeners.add(cb);
         return () => { this._busyListeners.delete(cb); };
     }
 
+    /**
+     * Raw worker call. Returns the worker reply as the `args` tail of the
+     * message; reject on a `result === false` reply.
+     *
+     * @param method - Worker-side handler name.
+     * @param args - Positional arguments.
+     * @returns The trailing args of the worker's reply message.
+     * @remarks Tracked by the busy counter. Prefer the typed helpers
+     *   ({@link invokeService}, {@link invokeMethod}, {@link invokeRpc})
+     *   for any new call site.
+     */
     async invokeWorker(method: string, ...args: any[]): Promise<any[]> {
         const cur_seq = this.getSeqNo();
         this._incPending();
@@ -157,6 +239,17 @@ export class WorkerTransport {
         return promise;
     }
 
+    /**
+     * Raw worker call carrying a `Transferable`. Used by `bindCanvas` to
+     * hand off an `OffscreenCanvas`.
+     *
+     * @param method - Worker-side handler name.
+     * @param transfer - The `Transferable` (passed in the `[transfer]`
+     *   list).
+     * @param args - Positional arguments.
+     * @returns The trailing args of the worker's reply.
+     * @remarks **Not** tracked by the busy counter (one-shot init only).
+     */
     async invokeWorkerWithTransfer(method: string, transfer: any, ...args: any[]): Promise<any[]> {
         const cur_seq = this.getSeqNo();
         const promise = new Promise<any[]>((resolve, reject) => {
@@ -169,27 +262,50 @@ export class WorkerTransport {
         return promise;
     }
 
-    // ───────────────────────────────────────────────────────────
-    // Typed call helpers (preferred over invokeWorker for new code).
-    // Each helper wraps invokeWorker's array-tail response into the
-    // single-value contract documented by the corresponding map.
-    // ───────────────────────────────────────────────────────────
+    // --- Typed call helpers ---
+    // Preferred over `invokeWorker` for new code. Each helper wraps the
+    // array-tail response into the single-value contract documented by
+    // the corresponding map in `worker/shared/WorkerCalls.ts`.
 
+    /**
+     * Call a worker service (`ServiceMap` entry).
+     *
+     * @param name - Service key (compile-checked against `ServiceMap`).
+     * @param args - Service request payload.
+     */
     async invokeService<K extends ServiceKey>(name: K, args: ServiceArgs<K>): Promise<ServiceResult<K>> {
         const result = await this.invokeWorker(name, args);
         return result[0] as ServiceResult<K>;
     }
 
+    /**
+     * Call a worker variadic method (`MethodMap` entry -- infrastructure /
+     * hot-path events such as `bindCanvas` or `mouseMove`).
+     *
+     * @param name - Method key.
+     * @param args - Variadic argument tuple.
+     */
     async invokeMethod<K extends MethodKey>(name: K, ...args: MethodArgs<K>): Promise<MethodResult<K>> {
         const result = await this.invokeWorker(name, ...args);
         return result[0] as MethodResult<K>;
     }
 
+    /**
+     * Call a worker RPC handler (`RpcMap` entry -- used by `ObjProxy` for
+     * `createObj`, `getProp`, `invokeMethod`, ...).
+     *
+     * @param name - RPC key.
+     * @param args - Variadic argument tuple.
+     */
     async invokeRpc<K extends RpcKey>(name: K, ...args: RpcArgs<K>): Promise<RpcResult<K>> {
         const result = await this.invokeWorker(name, ...args);
         return result[0] as RpcResult<K>;
     }
 
+    /**
+     * Terminate the underlying `Worker`. After this, `isReady()` returns
+     * false and no further calls may be made.
+     */
     terminate(): void {
         this._worker.terminate();
         this._ready = false;

--- a/tritium/react-gui/src/renderer/worker/client/apis/editApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/editApi.ts
@@ -1,6 +1,20 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeService.
+/**
+ * @file renderer/worker/client/apis/editApi.ts
+ * @description Renderer-thread thin wrappers for worker undo / redo
+ * services. Each call dispatches to the C++ `UndoManager` owned by the
+ * scene.
+ */
 import { WorkerTransport } from '../WorkerTransport';
 
+/**
+ * Undo the last transaction on a scene.
+ *
+ * @param transport - Worker transport.
+ * @param scene_id - Scene uid whose `UndoManager` is invoked.
+ * @param depth - Number of additional transactions to undo (0 = one).
+ * @returns `true` if at least one transaction was undone.
+ * @remarks Calls `undo` worker service.
+ */
 export async function undo(
     transport: WorkerTransport, scene_id: number, depth = 0,
 ): Promise<boolean> {
@@ -8,6 +22,15 @@ export async function undo(
     return result?.ok ?? false;
 }
 
+/**
+ * Redo the most recently undone transaction.
+ *
+ * @param transport - Worker transport.
+ * @param scene_id - Scene uid whose `UndoManager` is invoked.
+ * @param depth - Number of additional transactions to redo (0 = one).
+ * @returns `true` if at least one transaction was redone.
+ * @remarks Calls `redo` worker service.
+ */
 export async function redo(
     transport: WorkerTransport, scene_id: number, depth = 0,
 ): Promise<boolean> {

--- a/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
@@ -1,4 +1,12 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeService.
+/**
+ * @file renderer/worker/client/apis/fileApi.ts
+ * @description Renderer-thread thin wrappers for worker file-I/O services
+ * (renderer-compatibility probe, open-dialog filters, new scene+view,
+ * scene / object load).
+ *
+ * Each function returns a Promise resolved with the worker reply and logs
+ * a warning on failure.
+ */
 import { WorkerTransport } from '../WorkerTransport';
 import type { ElectronFileFilter } from '../../../../shared/ipcTypes';
 import type { FileOpenOptions } from '../../../components/fopen-opt-dlgs/types';
@@ -6,6 +14,18 @@ import type { GetCompatibleRendererNamesResult } from '../../server/services/get
 
 const log = console;
 
+/**
+ * Ask the worker which renderer types are compatible with the contents of
+ * `filePath`. Drives the "open file" renderer-picker dialog.
+ *
+ * @param transport - Worker transport.
+ * @param filePath - Absolute file path the user selected.
+ * @param readerName - Optional explicit reader to use instead of
+ *   auto-detection.
+ * @returns Object listing compatible renderer types and the detected
+ *   object type; empty fields on failure.
+ * @remarks Calls `getCompatibleRendererNames` worker service.
+ */
 export async function getCompatibleRendererNames(
     transport: WorkerTransport, filePath: string, readerName?: string,
 ): Promise<GetCompatibleRendererNamesResult> {
@@ -19,6 +39,15 @@ export async function getCompatibleRendererNames(
     }
 }
 
+/**
+ * Fetch the file-type filter list for an open-dialog category.
+ *
+ * @param transport - Worker transport.
+ * @param catId - File-category id (see C++ `FileCatTypes`).
+ * @returns `ElectronFileFilter[]` for the Electron dialog; empty on
+ *   failure.
+ * @remarks Calls `getOpenFilters` worker service.
+ */
 export async function getOpenFilters(
     transport: WorkerTransport, catId: number,
 ): Promise<ElectronFileFilter[]> {
@@ -30,6 +59,19 @@ export async function getOpenFilters(
     }
 }
 
+/**
+ * Create a new scene plus default view on the worker side.
+ *
+ * @param transport - Worker transport.
+ * @param dpr - Device pixel ratio for the new view.
+ * @param name - Optional scene name; the worker proposes a unique one if
+ *   omitted.
+ * @param bindView - When `true`, immediately bind the new view; defaults
+ *   to deferred binding so `MolViewPane` can call `bindCanvas` later.
+ * @returns `{ scene_uid, view_uid, scene_name, view_name }`, or `null` on
+ *   failure.
+ * @remarks Calls `createNewSceneAndView` worker service.
+ */
 export async function createNewSceneAndView(
     transport: WorkerTransport, dpr: number, name?: string, bindView?: boolean,
 ): Promise<{ scene_uid: number; view_uid: number; scene_name: string; view_name: string } | null> {
@@ -41,6 +83,15 @@ export async function createNewSceneAndView(
     }
 }
 
+/**
+ * Load a QSC scene file into an existing scene.
+ *
+ * @param transport - Worker transport.
+ * @param filePath - Absolute path to the `.qsc` file.
+ * @param scene_id - Target scene uid.
+ * @returns `true` on success (also `true` when reply lacks `ok`).
+ * @remarks Calls `loadScene` worker service.
+ */
 export async function loadScene(
     transport: WorkerTransport, filePath: string, scene_id: number,
 ): Promise<boolean> {
@@ -49,6 +100,17 @@ export async function loadScene(
     return result?.ok ?? true;
 }
 
+/**
+ * Load an object (PDB / map / mesh / ...) into a scene.
+ *
+ * @param transport - Worker transport.
+ * @param filePath - Absolute path to the file.
+ * @param scene_id - Target scene uid.
+ * @param options - File-type-specific open options collected from the
+ *   user (renderer type, builder name, ...).
+ * @returns `true` on success.
+ * @remarks Calls `loadObject` worker service.
+ */
 export async function loadObject(
     transport: WorkerTransport, filePath: string, scene_id: number, options: FileOpenOptions,
 ): Promise<boolean> {

--- a/tritium/react-gui/src/renderer/worker/client/apis/inputApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/inputApi.ts
@@ -1,6 +1,22 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeWorker.
+/**
+ * @file renderer/worker/client/apis/inputApi.ts
+ * @description Renderer-thread input-event forwarders. Each function picks
+ * the fields the worker actually consumes off a DOM event and fires it as
+ * a `postMessage` (no await; no reply).
+ */
 import { WorkerTransport } from '../WorkerTransport';
 
+/**
+ * Forward a mouse event (mousedown / mousemove / mouseup / etc.) to the
+ * worker.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - Target view uid.
+ * @param method - Worker-side handler name (e.g. `'mouseDown'`,
+ *   `'mouseMove'`).
+ * @param event - DOM `MouseEvent`. Only the fields needed by the worker
+ *   are serialised.
+ */
 export function onMouseEvent(
     transport: WorkerTransport, view_id: number, method: string, event: any,
 ): void {
@@ -12,6 +28,13 @@ export function onMouseEvent(
     transport.postMessage(method, cur_seq, [view_id, ev]);
 }
 
+/**
+ * Forward a wheel event to the worker.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - Target view uid.
+ * @param event - DOM `WheelEvent`.
+ */
 export function onWheelEvent(transport: WorkerTransport, view_id: number, event: any): void {
     const { offsetX, offsetY, screenX, screenY, deltaX, deltaY,
             ctrlKey, shiftKey, altKey } = event;
@@ -21,6 +44,16 @@ export function onWheelEvent(transport: WorkerTransport, view_id: number, event:
     transport.postMessage('wheel', cur_seq, [view_id, ev]);
 }
 
+/**
+ * Forward a trackpad gesture (pinch / rotate / pan) to the worker.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - Target view uid.
+ * @param axisID - Gesture axis (see `gestureAxes` in `worker/shared`).
+ * @param delta - Signed magnitude along `axisID`.
+ * @param event - Optional originating DOM event for modifier-key / coords;
+ *   defaults to zeroes when omitted.
+ */
 export function onGestureEvent(
     transport: WorkerTransport, view_id: number, axisID: number, delta: number, event?: any,
 ): void {

--- a/tritium/react-gui/src/renderer/worker/client/apis/lifecycleApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/lifecycleApi.ts
@@ -1,8 +1,21 @@
-// Runs in renderer thread. Calls cross to worker via transport.invoke{Service,Method}.
+/**
+ * @file renderer/worker/client/apis/lifecycleApi.ts
+ * @description Renderer-thread thin wrappers for worker lifecycle calls
+ * (init / user-style load / view-input style / terminate / app info).
+ * Each function returns a Promise resolved with the worker reply and
+ * swallows transport errors with a logged warning.
+ */
 import { WorkerTransport } from '../WorkerTransport';
 
 const log = console;
 
+/**
+ * Boot the worker-side CueMol runtime by loading `sysconfig.xml`.
+ *
+ * @param transport - Worker transport.
+ * @param sysConfigPath - Absolute path to `sysconfig.xml`. Defaults to the
+ *   worker-side baked-in path when omitted.
+ */
 export async function initCueMol(transport: WorkerTransport, sysConfigPath?: string): Promise<void> {
     log.info(`initCueMol sysConfigPath=<${sysConfigPath}>`);
     try {
@@ -13,6 +26,14 @@ export async function initCueMol(transport: WorkerTransport, sysConfigPath?: str
     }
 }
 
+/**
+ * Apply a user style sheet (XML) to the running scene manager.
+ *
+ * @param transport - Worker transport.
+ * @param userStylePath - Absolute path to the user style XML. May be
+ *   omitted to apply the built-in default.
+ * @returns `true` on success, `false` on transport failure.
+ */
 export async function loadUserStyle(transport: WorkerTransport, userStylePath?: string): Promise<boolean> {
     try {
         return await transport.invokeMethod('loadUserStyle', userStylePath);
@@ -22,6 +43,13 @@ export async function loadUserStyle(transport: WorkerTransport, userStylePath?: 
     }
 }
 
+/**
+ * Switch the renderer's view-input style (e.g. mouse-button bindings).
+ *
+ * @param transport - Worker transport.
+ * @param styleName - Registered input-style name.
+ * @returns `true` if accepted by the worker, `false` on failure.
+ */
 export async function setViewInputConfigStyle(transport: WorkerTransport, styleName: string): Promise<boolean> {
     try {
         return await transport.invokeMethod('setViewInputConfigStyle', styleName);
@@ -31,6 +59,12 @@ export async function setViewInputConfigStyle(transport: WorkerTransport, styleN
     }
 }
 
+/**
+ * Tell the worker to shut down and then terminate the underlying Web
+ * Worker handle.
+ *
+ * @param transport - Worker transport (terminated after the reply).
+ */
 export async function terminateWorker(transport: WorkerTransport): Promise<void> {
     try {
         await transport.invokeMethod('terminateWorker');
@@ -41,6 +75,12 @@ export async function terminateWorker(transport: WorkerTransport): Promise<void>
     }
 }
 
+/**
+ * Fetch the running app's version / build metadata from the worker.
+ *
+ * @param transport - Worker transport.
+ * @returns Object `{ version, build }`; both empty strings on failure.
+ */
 export async function getAppInfo(transport: WorkerTransport): Promise<{ version: string; build: string }> {
     try {
         return await transport.invokeService('appInfo', {});

--- a/tritium/react-gui/src/renderer/worker/client/apis/naviApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/naviApi.ts
@@ -1,19 +1,49 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeService.
+/**
+ * @file renderer/worker/client/apis/naviApi.ts
+ * @description Renderer-thread thin wrappers for the worker `naviTool`
+ * services. These drive the on-canvas picker / selection / center
+ * gestures exposed by the navigation toolbar and atom context menu.
+ *
+ * Coordinates `x` / `y` are in canvas-local CSS pixels; `viewId` selects
+ * the active view. Every call returns the worker reply or `null` on
+ * transport failure.
+ */
 import { WorkerTransport } from '../WorkerTransport';
 import type { NaviClickAtomResult, NaviHitTestResult, NaviResidSelResult } from '../../server/services/naviTool.service';
 
+/**
+ * Test whether the cursor at `(x, y)` hits anything renderable in the
+ * view. Returns the raw hit-test record for downstream tools.
+ *
+ * @param transport - Worker transport.
+ * @param args - `{ viewId, x, y }` canvas-local coordinates.
+ */
 export async function naviHitTest(
     transport: WorkerTransport, args: { viewId: number; x: number; y: number },
 ): Promise<NaviHitTestResult | null> {
     return await transport.invokeService('naviHitTest', args);
 }
 
+/**
+ * Handle an atom-pick click. Updates the status-bar message with the
+ * picked atom identification.
+ *
+ * @param transport - Worker transport.
+ * @param args - `{ viewId, x, y }` canvas-local coordinates.
+ */
 export async function naviClickAtom(
     transport: WorkerTransport, args: { viewId: number; x: number; y: number },
 ): Promise<NaviClickAtomResult | null> {
     return await transport.invokeService('naviClickAtom', args);
 }
 
+/**
+ * Toggle / extend the residue selection at the picked atom.
+ *
+ * @param transport - Worker transport.
+ * @param args - Pick coordinates plus `mode` (`'toggle'` adds/removes a
+ *   single residue, `'extend'` extends from `prevObjId` / `prevAtomId`).
+ */
 export async function naviResidSel(
     transport: WorkerTransport,
     args: {
@@ -25,12 +55,26 @@ export async function naviResidSel(
     return await transport.invokeService('naviResidSel', args);
 }
 
+/**
+ * Move the view center to the world coordinate at `(x, y, z)` under the
+ * cursor (z is the depth probed by hit-test).
+ *
+ * @param transport - Worker transport.
+ * @param args - View uid and world-space `(x, y, z)`.
+ */
 export async function naviCenterAt(
     transport: WorkerTransport, args: { viewId: number; x: number; y: number; z: number },
 ): Promise<{ ok: boolean } | null> {
     return await transport.invokeService('naviCenterAt', args);
 }
 
+/**
+ * Move the view center to a symmetry mate's image of an atom.
+ *
+ * @param transport - Worker transport.
+ * @param args - View uid, object / renderer / atom ids, and `symmId` (the
+ *   crystallographic symmetry index).
+ */
 export async function naviCenterAtSymm(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; rendId: number; atomId: number; symmId: number },
@@ -38,6 +82,14 @@ export async function naviCenterAtSymm(
     return await transport.invokeService('naviCenterAtSymm', args);
 }
 
+/**
+ * Atom context-menu "select" handler. Replaces the current selection on
+ * the object with atoms matching `mode`.
+ *
+ * @param transport - Worker transport.
+ * @param args - Picked atom plus selection granularity (`'atom'`,
+ *   `'residue'`, `'chain'`, `'mol'`).
+ */
 export async function naviCtxSelect(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; atomId: number; mode: 'atom' | 'residue' | 'chain' | 'mol' },
@@ -45,6 +97,13 @@ export async function naviCtxSelect(
     return await transport.invokeService('naviCtxSelect', args);
 }
 
+/**
+ * Atom context-menu "add to selection" handler. Adds atoms to the
+ * existing selection rather than replacing it.
+ *
+ * @param transport - Worker transport.
+ * @param args - Same shape as {@link naviCtxSelect}.
+ */
 export async function naviCtxAddSelect(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; atomId: number; mode: 'atom' | 'residue' | 'chain' | 'mol' },
@@ -52,24 +111,49 @@ export async function naviCtxAddSelect(
     return await transport.invokeService('naviCtxAddSelect', args);
 }
 
+/**
+ * Clear the selection on the picked object.
+ *
+ * @param transport - Worker transport.
+ * @param args - `{ viewId, objId }`.
+ */
 export async function naviCtxUnselect(
     transport: WorkerTransport, args: { viewId: number; objId: number },
 ): Promise<{ ok: boolean } | null> {
     return await transport.invokeService('naviCtxUnselect', args);
 }
 
+/**
+ * Invert the selection on the picked object.
+ *
+ * @param transport - Worker transport.
+ * @param args - `{ viewId, objId }`.
+ */
 export async function naviCtxInvertSel(
     transport: WorkerTransport, args: { viewId: number; objId: number },
 ): Promise<{ ok: boolean } | null> {
     return await transport.invokeService('naviCtxInvertSel', args);
 }
 
+/**
+ * Toggle the side-chain selection on the picked object.
+ *
+ * @param transport - Worker transport.
+ * @param args - `{ viewId, objId }`.
+ */
 export async function naviCtxToggleSidechain(
     transport: WorkerTransport, args: { viewId: number; objId: number },
 ): Promise<{ ok: boolean } | null> {
     return await transport.invokeService('naviCtxToggleSidechain', args);
 }
 
+/**
+ * "Select within N angstroms" context-menu handler.
+ *
+ * @param transport - Worker transport.
+ * @param args - Object uid, sphere radius `distance` in angstroms, and
+ *   `byres` (true = expand to whole residues).
+ */
 export async function naviCtxAround(
     transport: WorkerTransport,
     args: { viewId: number; objId: number; distance: number; byres: boolean },

--- a/tritium/react-gui/src/renderer/worker/client/apis/sceneViewApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/sceneViewApi.ts
@@ -1,4 +1,11 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeService.
+/**
+ * @file renderer/worker/client/apis/sceneViewApi.ts
+ * @description Renderer-thread thin wrappers for worker scene / view
+ * settings services (projection, center mark, background color, unique
+ * name proposal, multi-view, scene-close info).
+ *
+ * Each function returns the worker reply or `null` on transport failure.
+ */
 import type { ProposeUniqNameArgs, ProposeUniqNameResult } from '../../server/services/proposeUniqName.service';
 import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../../server/services/createViewInScene.service';
 import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../../server/services/proposeNewTabNames.service';
@@ -6,60 +13,138 @@ import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../../serve
 import { WorkerTransport } from '../WorkerTransport';
 import type { SceneBgColor, ViewCenterMark } from '../../../../shared/ipcTypes';
 
+/**
+ * Read the projection mode (perspective vs. orthographic) of a view.
+ *
+ * @param transport - Worker transport.
+ * @param viewId - Target view uid.
+ * @remarks Calls `getViewProjection` worker service.
+ */
 export async function getViewProjection(
     transport: WorkerTransport, viewId: number,
 ): Promise<{ ok: boolean; perspective: boolean } | null> {
     return await transport.invokeService('getViewProjection', { viewId });
 }
 
+/**
+ * Change the projection mode of a view.
+ *
+ * @param transport - Worker transport.
+ * @param viewId - Target view uid.
+ * @param perspective - `true` for perspective, `false` for orthographic.
+ * @remarks Calls `setViewProjection` worker service.
+ */
 export async function setViewProjection(
     transport: WorkerTransport, viewId: number, perspective: boolean,
 ): Promise<{ ok: boolean; perspective: boolean } | null> {
     return await transport.invokeService('setViewProjection', { viewId, perspective });
 }
 
+/**
+ * Read the view-center mark display style.
+ *
+ * @param transport - Worker transport.
+ * @param viewId - Target view uid.
+ * @remarks Calls `getViewCenterMark` worker service.
+ */
 export async function getViewCenterMark(
     transport: WorkerTransport, viewId: number,
 ): Promise<{ ok: boolean; centerMark: ViewCenterMark } | null> {
     return await transport.invokeService('getViewCenterMark', { viewId });
 }
 
+/**
+ * Change the view-center mark display style.
+ *
+ * @param transport - Worker transport.
+ * @param viewId - Target view uid.
+ * @param centerMark - Mark style enum.
+ * @remarks Calls `setViewCenterMark` worker service.
+ */
 export async function setViewCenterMark(
     transport: WorkerTransport, viewId: number, centerMark: ViewCenterMark,
 ): Promise<{ ok: boolean; centerMark: ViewCenterMark } | null> {
     return await transport.invokeService('setViewCenterMark', { viewId, centerMark });
 }
 
+/**
+ * Read the background color of a scene.
+ *
+ * @param transport - Worker transport.
+ * @param sceneId - Target scene uid.
+ * @remarks Calls `getSceneBgColor` worker service.
+ */
 export async function getSceneBgColor(
     transport: WorkerTransport, sceneId: number,
 ): Promise<{ ok: boolean; bgColor: SceneBgColor } | null> {
     return await transport.invokeService('getSceneBgColor', { sceneId });
 }
 
+/**
+ * Set the background color of a scene to one of the preset names.
+ *
+ * @param transport - Worker transport.
+ * @param sceneId - Target scene uid.
+ * @param colorName - `'white'` or `'black'`.
+ * @remarks Calls `setSceneBgColor` worker service.
+ */
 export async function setSceneBgColor(
     transport: WorkerTransport, sceneId: number, colorName: 'white' | 'black',
 ): Promise<{ ok: boolean; bgColor: SceneBgColor } | null> {
     return await transport.invokeService('setSceneBgColor', { sceneId, colorName });
 }
 
+/**
+ * Ask the worker to propose a unique name in a given namespace (scene,
+ * object, renderer, ...). Used by rename dialogs to seed an
+ * already-available default.
+ *
+ * @param transport - Worker transport.
+ * @param args - Namespace + base name.
+ * @remarks Calls `proposeUniqName` worker service.
+ */
 export async function proposeUniqName(
     transport: WorkerTransport, args: ProposeUniqNameArgs,
 ): Promise<ProposeUniqNameResult | null> {
     return await transport.invokeService('proposeUniqName', args);
 }
 
+/**
+ * Create an additional view inside an existing scene (for split / multi
+ * view).
+ *
+ * @param transport - Worker transport.
+ * @param args - Scene uid, requested name, and dpr.
+ * @remarks Calls `createViewInScene` worker service.
+ */
 export async function createViewInScene(
     transport: WorkerTransport, args: CreateViewInSceneArgs,
 ): Promise<CreateViewInSceneResult | null> {
     return await transport.invokeService('createViewInScene', args);
 }
 
+/**
+ * Compute default tab names for a new-tab dialog (scene name + view
+ * name).
+ *
+ * @param transport - Worker transport.
+ * @param args - Optional base hints.
+ * @remarks Calls `proposeNewTabNames` worker service.
+ */
 export async function proposeNewTabNames(
     transport: WorkerTransport, args: ProposeNewTabNamesArgs,
 ): Promise<ProposeNewTabNamesResult | null> {
     return await transport.invokeService('proposeNewTabNames', args);
 }
 
+/**
+ * Ask the worker whether closing a view requires a save-changes prompt
+ * (whether the scene is dirty, whether other views still reference it).
+ *
+ * @param transport - Worker transport.
+ * @param args - `{ viewId }`.
+ * @remarks Calls `getSceneCloseInfo` worker service.
+ */
 export async function getSceneCloseInfo(
     transport: WorkerTransport, args: GetSceneCloseInfoArgs,
 ): Promise<GetSceneCloseInfoResult | null> {

--- a/tritium/react-gui/src/renderer/worker/client/apis/viewApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/viewApi.ts
@@ -1,8 +1,31 @@
-// Runs in renderer thread. Calls cross to worker via transport.invokeMethod.
+/**
+ * @file renderer/worker/client/apis/viewApi.ts
+ * @description Renderer-thread thin wrappers for worker view-lifecycle
+ * calls (canvas bind, add / activate / remove view, resize).
+ *
+ * Each function returns a Promise resolved with the worker reply, except
+ * `resized` which is a fire-and-forget `postMessage`.
+ */
 import { WorkerTransport } from '../WorkerTransport';
 
 const log = console;
 
+/**
+ * Transfer an `HTMLCanvasElement`'s control to the worker and bind it as
+ * the rendering target for a view.
+ *
+ * @param transport - Worker transport.
+ * @param canvas - DOM canvas element.
+ * @param view_id - C++ view uid that owns the canvas.
+ * @param dpr - Device pixel ratio.
+ * @returns The worker reply (array tail of `invokeWorkerWithTransfer`).
+ *
+ * @remarks `canvas.transferControlToOffscreen()` may be called **only
+ *   once** per element; calling `bindCanvas` twice on the same canvas
+ *   throws `InvalidStateError`. After transfer the renderer thread can no
+ *   longer read pixels from the canvas. See "OffscreenCanvas / WebGL
+ *   lifecycle constraints" in `tritium/CLAUDE.md`.
+ */
 export async function bindCanvas(
     transport: WorkerTransport, canvas: any, view_id: number, dpr: number,
 ): Promise<any[]> {
@@ -12,6 +35,16 @@ export async function bindCanvas(
     );
 }
 
+/**
+ * Attach a new C++ view to the already-bound OffscreenCanvas.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - New view uid.
+ * @param dpr - Device pixel ratio.
+ * @returns `true` if the worker accepted the view, `false` on failure.
+ * @remarks Use this for additional scene tabs; `bindCanvas` is the
+ *   one-shot WebGL init.
+ */
 export async function addView(
     transport: WorkerTransport, view_id: number, dpr: number,
 ): Promise<boolean> {
@@ -23,14 +56,38 @@ export async function addView(
     }
 }
 
+/**
+ * Make the given view the currently rendered one.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - View uid to activate.
+ */
 export async function activateView(transport: WorkerTransport, view_id: number): Promise<void> {
     await transport.invokeMethod('activateView', view_id);
 }
 
+/**
+ * Stop the view loop and remove the view from the worker's `bound_views`.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - View uid to remove.
+ * @remarks The C++ `View` / `Scene` objects are not destroyed by this
+ *   call; only the renderer-side binding is released.
+ */
 export async function removeView(transport: WorkerTransport, view_id: number): Promise<void> {
     await transport.invokeMethod('removeView', view_id);
 }
 
+/**
+ * Notify the worker that a view's canvas was resized.
+ *
+ * @param transport - Worker transport.
+ * @param view_id - View uid.
+ * @param w - New width in CSS pixels.
+ * @param h - New height in CSS pixels.
+ * @param dpr - Device pixel ratio.
+ * @remarks Fire-and-forget; no reply is awaited.
+ */
 export function resized(
     transport: WorkerTransport, view_id: number, w: number, h: number, dpr: number,
 ): void {

--- a/tritium/react-gui/src/renderer/worker/client/asyncUtils.ts
+++ b/tritium/react-gui/src/renderer/worker/client/asyncUtils.ts
@@ -1,10 +1,24 @@
-// Bridge helper for sync-typed wrapper methods used in async (ObjProxy) mode.
-// Wrapper methods declare return type T, but at runtime the async path returns
-// Promise<T>. Use asAsync() to safely cast and await.
-//
-// Example:
-//   const json = await asAsync(strMgr.getInfoJSON2());
-//   await asAsync(reader.setPath(path));
+/**
+ * @file renderer/worker/client/asyncUtils.ts
+ * @description Bridge helper for sync-typed wrapper methods used in async
+ * (ObjProxy) mode. Wrapper methods declare return type `T`, but at runtime
+ * the renderer (async) path returns `Promise<T>`. `asAsync()` casts the
+ * value so the caller can `await` it without fighting the type system.
+ */
+
+/**
+ * Cast a sync-typed wrapper return value to its async (Promise) form.
+ *
+ * @param value - The value to cast (declared `T`, actually `Promise<T>` at
+ *   runtime under ObjProxy mode).
+ * @returns The same value typed as `Promise<Awaited<T>>`.
+ *
+ * @example
+ * ```ts
+ * const json = await asAsync(strMgr.getInfoJSON2());
+ * await asAsync(reader.setPath(path));
+ * ```
+ */
 export function asAsync<T>(value: T): Promise<Awaited<T>> {
   return value as unknown as Promise<Awaited<T>>;
 }

--- a/tritium/react-gui/src/renderer/worker/client/index.ts
+++ b/tritium/react-gui/src/renderer/worker/client/index.ts
@@ -1,16 +1,28 @@
+/**
+ * @file renderer/worker/client/index.ts
+ * @description Renderer-side singleton entry point for the worker bridge.
+ * Holds a single `AsyncCueMol` instance per renderer process and hands the
+ * same one back to every caller.
+ */
 import { AsyncCueMol } from './AsyncCueMol'
 import { createLogger } from "@/logger";
 
 const log = createLogger(import.meta.url);
 
-// Type for the Worker singleton wrapper
+/** Renderer-process-wide singleton wrapper around `AsyncCueMol`. */
 interface WorkerSingleton {
     value: AsyncCueMol | null;
 }
 
-// Singleton instance of CueMol
 const _worker: WorkerSingleton = { value: null };
 
+/**
+ * Return the renderer-process `AsyncCueMol` instance, creating it on first
+ * call. Subsequent calls return the existing instance when it is still
+ * ready, otherwise a fresh one is constructed.
+ *
+ * @returns The shared `AsyncCueMol` instance.
+ */
 export function createCueMol(): AsyncCueMol {
     if (_worker.value && _worker.value.isReady()) {
         log.info('cuemol already created');


### PR DESCRIPTION
Document every export in renderer-thread worker client surface: AsyncCueMol facade, WorkerTransport, ObjectFactory, ObjProxy, EventSlots, asyncUtils, the createCueMol singleton entry, and the seven thin api wrappers (lifecycle/view/input/file/edit/navi/sceneView).

Each file gets an @file header and JSDoc on every exported function, class, method, and type alias. @remarks call out side-effects and invariants where they matter (bindCanvas one-shot OffscreenCanvas transfer, addEventListener cleanup, invokeWorkerWithTransfer skipping the busy counter, ObjTuple auto-unwrap on getProp/invokeMethod).

Also clean up convention violations inside the same files: replace the non-ASCII box-drawing banner in WorkerTransport.ts with the "// --- ... ---" form, drop a stale commented-out import in ObjProxy.ts, and normalize em-dashes to "--".

Scope is intentionally limited to worker/client/ to keep this commit self-contained; worker/server/services/ and other directories still need similar coverage before the require-jsdoc ESLint rule can be turned on globally.