### PR TITLE
Wire ObjReader options into file-open dialog via reader-based load

### DIFF
--- a/tritium/react-gui/src/main/handlers/fileDialogs.ts
+++ b/tritium/react-gui/src/main/handlers/fileDialogs.ts
@@ -136,12 +136,14 @@ export async function handleCameraSaveDialog(
  */
 export async function handlePickPathDialog(
   mainWindow: BrowserWindow,
-  payload: { title: string; directory?: boolean },
+  payload: { title: string; directory?: boolean; filters?: { name: string; extensions: string[] }[] },
 ): Promise<{ canceled: boolean; filePath: string }> {
   const result = await withMenuBlocked('native', () =>
     dialog.showOpenDialog(mainWindow, {
       title: payload.title,
       properties: [payload.directory ? 'openDirectory' : 'openFile'],
+      // Filters only apply to file mode; ignored by the OS for directories.
+      ...(payload.filters && !payload.directory ? { filters: payload.filters } : {}),
     }),
   )
   if (result.canceled || result.filePaths.length === 0) {

--- a/tritium/react-gui/src/renderer/__test__/applyReaderOptions.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/applyReaderOptions.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Contract tests for applyReaderOptions (worker helper).
+ *
+ * Pins the UXP-derived mapping from the file-open dialog's format options
+ * onto concrete reader properties (uxp_gui/.../fopen-*opt-page ondlgok):
+ *   - pdb / mmcif: per-property names, including the mmcif divergence
+ *     (build2ndry -> loadsecstr = !build2ndry, no loadsegid).
+ *   - mtzmap / ccp4map: column + numeric props.
+ *   - msms: vertex_file (skipped when empty).
+ *   - namdcoor: setSubPath('topo', psf) method, not a property.
+ *   - unknown / mismatched nickname: no-op.
+ *
+ * The reader is a plain object whose property writes are observable; a
+ * mismatch between the resolved nickname and format.kind must touch nothing.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { ObjReader } from '@cuemol/core/src/wrappers/ObjReader'
+import type { FormatOptions } from '../components/fopen-opt-dlgs/types'
+import { applyReaderOptions } from '../worker/server/services/helpers/applyReaderOptions'
+
+function makeReader() {
+    const setSubPath = vi.fn()
+    const reader = { setSubPath } as Record<string, unknown> & { setSubPath: typeof setSubPath }
+    return { reader, setSubPath }
+}
+
+const pdbFmt: FormatOptions = {
+    kind: 'pdb',
+    options: {
+        loadModel: true, loadAnisou: true, loadAltConf: false,
+        loadSegid: true, build2ndry: false, autoTopology: true,
+    },
+}
+
+describe('applyReaderOptions', () => {
+    it('pdb: maps every option to its reader property name', () => {
+        const { reader } = makeReader()
+        applyReaderOptions(reader as unknown as ObjReader, 'pdb', pdbFmt)
+        expect(reader).toMatchObject({
+            loadmodel: true,
+            loadanisou: true,
+            loadaltconf: false,
+            loadsegid: true,
+            build2ndry: false,
+            autoTopoGen: true,
+        })
+    })
+
+    it('mmcif: build2ndry inverts to loadsecstr and loadsegid is NOT wired', () => {
+        const { reader } = makeReader()
+        const fmt: FormatOptions = {
+            kind: 'mmcif',
+            options: {
+                loadModel: true, loadAnisou: false, loadAltConf: true,
+                loadSegid: true, build2ndry: true, autoTopology: false,
+            },
+        }
+        applyReaderOptions(reader as unknown as ObjReader, 'mmcif', fmt)
+        expect(reader).toMatchObject({
+            loadmodel: true,
+            loadanisou: false,
+            loadaltconf: true,
+            autoTopoGen: false,
+            loadsecstr: false,  // = !build2ndry
+        })
+        expect('loadsegid' in reader).toBe(false)
+        expect('build2ndry' in reader).toBe(false)
+    })
+
+    it('mtzmap: maps columns, resolution and grid (phase on, weight off)', () => {
+        const { reader } = makeReader()
+        const fmt: FormatOptions = {
+            kind: 'mtz',
+            options: {
+                columnF: 'FWT', columnPhi: 'PHWT', phaseEnabled: true,
+                columnW: 'FOM', weightEnabled: false,
+                resolutionLimit: 2.5, gridSpacing: 0.25,
+            },
+        }
+        applyReaderOptions(reader as unknown as ObjReader, 'mtzmap', fmt)
+        expect(reader).toMatchObject({
+            clmn_F: 'FWT', clmn_PHI: 'PHWT',
+            clmn_WT: '',  // weight disabled -> empty
+            resolution: 2.5, gridsize: 0.25,
+        })
+    })
+
+    it('mtzmap: phase disabled -> clmn_PHI empty; weight enabled -> clmn_WT set', () => {
+        const { reader } = makeReader()
+        const fmt: FormatOptions = {
+            kind: 'mtz',
+            options: {
+                columnF: 'FP', columnPhi: 'PHIM', phaseEnabled: false,
+                columnW: 'FOMM', weightEnabled: true,
+                resolutionLimit: 0, gridSpacing: 0.333333,
+            },
+        }
+        applyReaderOptions(reader as unknown as ObjReader, 'mtzmap', fmt)
+        expect(reader).toMatchObject({
+            clmn_F: 'FP', clmn_PHI: '', clmn_WT: 'FOMM',
+        })
+    })
+
+    it('ccp4map: maps normalize + truncate enable/value pairs', () => {
+        const { reader } = makeReader()
+        const fmt: FormatOptions = {
+            kind: 'ccp4map',
+            options: {
+                normalize: true,
+                truncateMinEnabled: true, truncateMin: -4,
+                truncateMaxEnabled: false, truncateMax: 6,
+            },
+        }
+        applyReaderOptions(reader as unknown as ObjReader, 'ccp4map', fmt)
+        expect(reader).toMatchObject({
+            normalize: true,
+            truncate_min: true, min: -4,
+            truncate_max: false, max: 6,
+        })
+    })
+
+    it('msms: sets vertex_file when present', () => {
+        const { reader } = makeReader()
+        const fmt: FormatOptions = { kind: 'msms', options: { vertFilePath: '/data/x.vert' } }
+        applyReaderOptions(reader as unknown as ObjReader, 'msms', fmt)
+        expect(reader.vertex_file).toBe('/data/x.vert')
+    })
+
+    it('msms: skips vertex_file when empty', () => {
+        const { reader } = makeReader()
+        const fmt: FormatOptions = { kind: 'msms', options: { vertFilePath: '' } }
+        applyReaderOptions(reader as unknown as ObjReader, 'msms', fmt)
+        expect('vertex_file' in reader).toBe(false)
+    })
+
+    it('namdcoor: wires PSF via setSubPath("topo", path)', () => {
+        const { reader, setSubPath } = makeReader()
+        const fmt: FormatOptions = { kind: 'namdcoor', options: { psfFilePath: '/data/x.psf' } }
+        applyReaderOptions(reader as unknown as ObjReader, 'namdcoor', fmt)
+        expect(setSubPath).toHaveBeenCalledWith('topo', '/data/x.psf')
+    })
+
+    it('namdcoor: skips setSubPath when psf path empty', () => {
+        const { reader, setSubPath } = makeReader()
+        const fmt: FormatOptions = { kind: 'namdcoor', options: { psfFilePath: '' } }
+        applyReaderOptions(reader as unknown as ObjReader, 'namdcoor', fmt)
+        expect(setSubPath).not.toHaveBeenCalled()
+    })
+
+    it('amberprm: wires coord via setSubPath("coord", path)', () => {
+        const { reader, setSubPath } = makeReader()
+        const fmt: FormatOptions = { kind: 'amberprm', options: { coordFilePath: '/data/x.rst7' } }
+        applyReaderOptions(reader as unknown as ObjReader, 'amberprm', fmt)
+        expect(setSubPath).toHaveBeenCalledWith('coord', '/data/x.rst7')
+    })
+
+    it('amberprm: skips setSubPath when coord path empty (topology-only)', () => {
+        const { reader, setSubPath } = makeReader()
+        const fmt: FormatOptions = { kind: 'amberprm', options: { coordFilePath: '' } }
+        applyReaderOptions(reader as unknown as ObjReader, 'amberprm', fmt)
+        expect(setSubPath).not.toHaveBeenCalled()
+    })
+
+    it('unknown format: no-op', () => {
+        const { reader } = makeReader()
+        applyReaderOptions(reader as unknown as ObjReader, 'pdb', { kind: 'unknown', options: {} })
+        // Only the setSubPath stub should remain; no option property written.
+        expect(Object.keys(reader)).toEqual(['setSubPath'])
+    })
+
+    it('nickname / format.kind mismatch: no-op (safe)', () => {
+        const { reader } = makeReader()
+        // resolved reader is mtzmap but the dialog carried pdb options.
+        applyReaderOptions(reader as unknown as ObjReader, 'mtzmap', pdbFmt)
+        expect(Object.keys(reader)).toEqual(['setSubPath'])
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
@@ -148,6 +148,7 @@ describe('Modal dialog: backdrop click + close button are disabled', () => {
         sceneId: 0,
         rendererTypes: ['*default'],
         objType: '',
+        readerName: 'pdb',
         onConfirm: () => {},
         onCancel: () => {},
       }),

--- a/tritium/react-gui/src/renderer/__test__/editServiceTxnWrap.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/editServiceTxnWrap.test.ts
@@ -19,6 +19,7 @@ import { services as loadSceneServices } from '../worker/server/services/loadSce
 const { loadObject } = loadObjectServices
 const { loadScene } = loadSceneServices
 
+const OBJREADER_CATEGORY = 0
 const SCEREADER_CATEGORY = 3
 
 function makeCtx(opts: {
@@ -29,21 +30,16 @@ function makeCtx(opts: {
 
     const mockMol = { name: '', getClassName: () => 'MolCoord' }
 
-    // loadObject path: LoadObjectCommand mock. `run()` either records
-    // a success or throws (used by the rollback test). `result_object`
-    // returns mockMol after a successful run.
-    const cmdRunFn = opts.objreaderReadFn ?? (() => calls.push('cmd.run'))
-    const loadObjCmd: Record<string, unknown> = {
-        setTargetScene: vi.fn(() => calls.push('setTargetScene')),
-        run: vi.fn(cmdRunFn),
+    // loadObject path: reader-based load (no LoadObjectCommand). createHandler
+    // returns this objReader for the 'pdb' nickname; read() either records a
+    // success or throws (used by the rollback test).
+    const objReader = {
+        setPath: vi.fn(),
+        createDefaultObj: vi.fn(() => mockMol),
+        attach: vi.fn(),
+        read: vi.fn(opts.objreaderReadFn ?? (() => calls.push('reader.read'))),
+        detach: vi.fn(),
     }
-    let fp = '', ff = '', on = ''
-    let cf = false
-    Object.defineProperty(loadObjCmd, 'file_path', { get() { return fp }, set(v: string) { fp = v } })
-    Object.defineProperty(loadObjCmd, 'file_format', { get() { return ff }, set(v: string) { ff = v } })
-    Object.defineProperty(loadObjCmd, 'object_name', { get() { return on }, set(v: string) { on = v } })
-    Object.defineProperty(loadObjCmd, 'content_first', { get() { return cf }, set(v: boolean) { cf = v } })
-    Object.defineProperty(loadObjCmd, 'result_object', { get() { return mockMol } })
 
     // loadScene path: still the direct-API SceneXMLReader call.
     const sceReader = {
@@ -63,28 +59,26 @@ function makeCtx(opts: {
         rollbackUndoTxn: vi.fn(() => calls.push('rollback')),
     }
 
-    const sceInfo = JSON.stringify([
+    // Reader info: a pdb objreader and the qsc scene reader, so pickReaderName
+    // (ext-first) resolves /test.pdb -> 'pdb' and /test.qsc -> 'qsc_xml'.
+    const info = JSON.stringify([
+        { name: 'pdb', fext: '*.pdb', category: OBJREADER_CATEGORY },
         { name: 'qsc_xml', fext: '*.qsc', category: SCEREADER_CATEGORY },
     ])
 
     const ctx = {
         sceMgr: { getScene: vi.fn(() => mockScene) },
-        cmdMgr: {
-            getCmd: vi.fn((name: string) => {
-                if (name === 'load_object') return loadObjCmd
-                throw new Error(`cmd path not used: ${name}`)
-            }),
-        },
         strMgr: {
-            getInfoJSON2: vi.fn(() => sceInfo),
+            getInfoJSON2: vi.fn(() => info),
             createHandler: vi.fn((name: string, cat: number) => {
+                if (cat === OBJREADER_CATEGORY && name === 'pdb') return objReader
                 if (cat === SCEREADER_CATEGORY && name === 'qsc_xml') return sceReader
                 return null
             }),
         },
     } as unknown as WorkerContext
 
-    return { calls, ctx, mockScene, loadObjCmd, sceReader }
+    return { calls, ctx, mockScene, objReader, sceReader }
 }
 
 describe('loadObject service — undo txn wrapping', () => {

--- a/tritium/react-gui/src/renderer/__test__/fileOpenOptionDialog.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/fileOpenOptionDialog.test.tsx
@@ -81,6 +81,7 @@ function mount(props: Partial<React.ComponentProps<typeof FileOpenOptionDialog>>
             sceneId: 7,
             rendererTypes: ['simple', 'ribbon', 'cartoon'],
             objType: 'MolCoord',
+            readerName: 'pdb',
             onConfirm: (o: FileOpenOptions) => { captured = o },
             onCancel: () => { canceled = true },
             ...props,

--- a/tritium/react-gui/src/renderer/__test__/getCompatibleRendererNamesService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/getCompatibleRendererNamesService.test.ts
@@ -71,6 +71,7 @@ describe('getCompatibleRendererNames — explicit readerName branch', () => {
         expect(result).toEqual({
             types: ['simple', 'cartoon', 'tube', 'ribbon'],
             objType: 'MolCoord',
+            readerName: 'mmcif',
         })
     })
 
@@ -84,7 +85,7 @@ describe('getCompatibleRendererNames — explicit readerName branch', () => {
             filePath: '1mbn.cif',
             readerName: 'mmcif',
         })
-        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord' })
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord', readerName: 'mmcif' })
     })
 
     it('returns empty objType when tmpObj.getClassName() is undefined', () => {
@@ -97,7 +98,7 @@ describe('getCompatibleRendererNames — explicit readerName branch', () => {
             filePath: '1mbn.cif',
             readerName: 'mmcif',
         })
-        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: '' })
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: '', readerName: 'mmcif' })
     })
 })
 
@@ -115,7 +116,7 @@ describe('getCompatibleRendererNames — extension fallback branch', () => {
         const result = getCompatibleRendererNames(env.ctx, { filePath: '/x/foo.pdb' })
         expect(env.getInfoJSON2).toHaveBeenCalled()
         expect(env.createHandler).toHaveBeenCalledWith('pdb', 0)
-        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord' })
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord', readerName: 'pdb' })
     })
 
     it('returns empty types and empty objType when no reader matches the extension', () => {
@@ -124,7 +125,7 @@ describe('getCompatibleRendererNames — extension fallback branch', () => {
             info: [{ name: 'pdb', fext: '*.pdb', category: 0 }],
         })
         const result = getCompatibleRendererNames(env.ctx, { filePath: '/x/unknown.xyz' })
-        expect(result).toEqual({ types: [], objType: '' })
+        expect(result).toEqual({ types: [], objType: '', readerName: '' })
     })
 
     it('respects category filter (only OBJECT_READER, category=0)', () => {
@@ -138,7 +139,7 @@ describe('getCompatibleRendererNames — extension fallback branch', () => {
         })
         const result = getCompatibleRendererNames(env.ctx, { filePath: '1mbn.cif' })
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord' })
+        expect(result).toEqual({ types: ['simple', 'cartoon'], objType: 'MolCoord', readerName: 'mmcif' })
     })
 })
 
@@ -173,7 +174,7 @@ describe('getCompatibleRendererNames — .cif ambiguity (regression)', () => {
         const result = getCompatibleRendererNames(env.ctx, { filePath: '1mbn.cif' })
         expect(env.searchReaderByContent).toHaveBeenCalledWith('1mbn.cif', 'mmcifmap,mmcif', 0, false, 65536)
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord' })
+        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord', readerName: 'mmcif' })
     })
 
     // When the sniffer returns empty (e.g. header too short, both readers
@@ -188,7 +189,7 @@ describe('getCompatibleRendererNames — .cif ambiguity (regression)', () => {
         } as never)
         const result = getCompatibleRendererNames(env.ctx, { filePath: '1mbn.cif' })
         expect(env.createHandler).toHaveBeenCalledWith('mmcifmap', 0)
-        expect(result).toEqual({ types: ['contour', 'isosurf'], objType: 'DensityMap' })
+        expect(result).toEqual({ types: ['contour', 'isosurf'], objType: 'DensityMap', readerName: 'mmcifmap' })
     })
 
     // Content-first mode: the extension is ignored entirely; the sniffer
@@ -206,7 +207,7 @@ describe('getCompatibleRendererNames — .cif ambiguity (regression)', () => {
         })
         expect(env.searchReaderByContent).toHaveBeenCalledWith('1mbn.cif', '', 0, false, 65536)
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord' })
+        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord', readerName: 'mmcif' })
     })
 
     it('with readerName="mmcif": explicit override skips the lookup entirely', () => {
@@ -217,6 +218,6 @@ describe('getCompatibleRendererNames — .cif ambiguity (regression)', () => {
         })
         expect(env.searchReaderByContent).not.toHaveBeenCalled()
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
-        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord' })
+        expect(result).toEqual({ types: ['simple', 'cartoon', 'tube', 'ribbon'], objType: 'MolCoord', readerName: 'mmcif' })
     })
 })

--- a/tritium/react-gui/src/renderer/__test__/getMtzColumnInfoService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/getMtzColumnInfoService.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for getMtzColumnInfo (worker service).
+ *
+ * Pins the UXP onInit contract: create the 'mtzmap' reader, setPath, call
+ * getColumnInfoJSON(), keep only F/P/W columns, and read min_res / max_res /
+ * resolution off the reader (populated as a side effect of the header parse).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { WorkerContext } from '../worker/server/types/WorkerContext'
+
+import { services } from '../worker/server/services/getMtzColumnInfo.service'
+const { getMtzColumnInfo } = services
+
+function makeCtx(opts: {
+    json?: string
+    createNull?: boolean
+    getColumnThrows?: boolean
+} = {}) {
+    const reader = {
+        setPath: vi.fn(),
+        getColumnInfoJSON: vi.fn(() => {
+            if (opts.getColumnThrows) throw new Error('bad mtz')
+            return opts.json ?? '[]'
+        }),
+        min_res: 50.0,
+        max_res: 1.8,
+        resolution: 1.8,
+    }
+    const createHandler = vi.fn(() => (opts.createNull ? null : reader))
+    const ctx = { strMgr: { createHandler } } as unknown as WorkerContext
+    return { ctx, reader, createHandler }
+}
+
+describe('getMtzColumnInfo service', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('creates mtzmap reader, sets path, returns F/P/W columns + resolution range', () => {
+        const json = JSON.stringify([
+            { nid: 0, name: 'H', type: 'H' },
+            { nid: 3, name: 'FWT', type: 'F' },
+            { nid: 4, name: 'PHWT', type: 'P' },
+            { nid: 5, name: 'FOM', type: 'W' },
+        ])
+        const { ctx, reader, createHandler } = makeCtx({ json })
+        const result = getMtzColumnInfo(ctx, { filePath: '/data/x.mtz' })
+
+        expect(createHandler).toHaveBeenCalledWith('mtzmap', 0)
+        expect(reader.setPath).toHaveBeenCalledWith('/data/x.mtz')
+        expect(result.ok).toBe(true)
+        // H/index columns are filtered out.
+        expect(result.columns).toEqual([
+            { name: 'FWT', type: 'F' },
+            { name: 'PHWT', type: 'P' },
+            { name: 'FOM', type: 'W' },
+        ])
+        expect(result).toMatchObject({ minRes: 50.0, maxRes: 1.8, resolution: 1.8 })
+    })
+
+    it('returns ok:false when createHandler fails', () => {
+        const { ctx } = makeCtx({ createNull: true })
+        expect(getMtzColumnInfo(ctx, { filePath: '/data/x.mtz' })).toMatchObject({ ok: false, columns: [] })
+    })
+
+    it('returns ok:false when getColumnInfoJSON throws', () => {
+        const { ctx } = makeCtx({ getColumnThrows: true })
+        expect(getMtzColumnInfo(ctx, { filePath: '/data/x.mtz' })).toMatchObject({ ok: false, columns: [] })
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/loadObjectService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/loadObjectService.test.ts
@@ -1,110 +1,80 @@
 /**
  * Degrade-detection tests for `loadObject` (worker service).
  *
- * Pins the new LoadObjectCommand-based contract:
+ * Pins the reader-based load contract (replaces the old LoadObjectCommand
+ * path), mirroring UXP fileOpenHelper1 (uxp_gui/.../fileopen.js):
  *
- *   - `ctx.cmdMgr.getCmd('load_object')` is the entry point.
- *   - The scene is handed to the command via the `setTargetScene()`
- *     METHOD, not the `target_scene` PROPERTY setter (the latter routes
- *     through setPropHelper -> setupParentData, which clobbers the
- *     scene's parent linkage and breaks nested undo records).
- *   - `file_path`, `file_format` (empty -> guess), `object_name`, and
- *     `content_first` are assigned via property setters (these are safe
- *     because LScrObjBase::setupParentData is a no-op for non-object
- *     property values).
- *   - `cmd.run()` is invoked and `cmd.result_object` is read back as
- *     the freshly created object.
- *   - `setupRenderer(ctx, mol, options.renderer)` runs after a
- *     successful load.
- *
- * The new contract delegates *all* reader-picking, .gz transparent
- * decompression, default-name fallback, and scene.addObject() into the
- * C++ command body, so this test no longer pins step-by-step calls on
- * the reader or the scene.
+ *   - pickReaderName(ctx, path, contentFirst) resolves the reader nickname.
+ *     '' (no match) -> ok:false, no scene mutation.
+ *   - ctx.strMgr.createHandler(nickname, 0) creates the reader.
+ *   - reader.setPath(path); '.gz' -> reader.compress = 'gzip'.
+ *   - applyReaderOptions(reader, nickname, format) wires format options
+ *     BEFORE read() (the whole point of dropping LoadObjectCommand).
+ *   - inside the undo txn: createDefaultObj -> attach -> read -> detach ->
+ *     name -> scene.addObject -> setupRenderer.
+ *   - read() throwing rolls back the undo txn (no commit).
  */
-
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { WorkerContext } from '../worker/server/types/WorkerContext'
 
 vi.mock('../worker/server/services/setupRenderer.service', () => ({
     setupRenderer: vi.fn(),
 }))
+vi.mock('../worker/server/services/helpers/pickReaderName', () => ({
+    pickReaderName: vi.fn(() => 'pdb'),
+    OBJREADER_CATEGORY: 0,
+}))
+vi.mock('../worker/server/services/helpers/applyReaderOptions', () => ({
+    applyReaderOptions: vi.fn(),
+}))
 
 import { services } from '../worker/server/services/loadObject.service'
 import { setupRenderer } from '../worker/server/services/setupRenderer.service'
+import { pickReaderName } from '../worker/server/services/helpers/pickReaderName'
+import { applyReaderOptions } from '../worker/server/services/helpers/applyReaderOptions'
 
 const { loadObject } = services
 
-function makeFixture(opts: {
-    runThrows?: boolean
-    resultObjectNull?: boolean
-    cmdMissing?: boolean
-} = {}) {
+function makeFixture(opts: { readThrows?: boolean } = {}) {
     const calls: string[] = []
 
-    const mol: Record<string, unknown> = {
-        getClassName: () => 'MolCoord',
+    const obj: Record<string, unknown> = { __obj: true }
+    Object.defineProperty(obj, 'name', {
+        set(v: string) { calls.push(`name=${v}`) },
+        configurable: true,
+    })
+
+    let compress = ''
+    const reader: Record<string, unknown> = {
+        setPath: vi.fn((p: string) => calls.push(`setPath=${p}`)),
+        createDefaultObj: vi.fn(() => { calls.push('createDefaultObj'); return obj }),
+        attach: vi.fn(() => calls.push('attach')),
+        read: vi.fn(() => {
+            calls.push('read')
+            if (opts.readThrows) throw new Error('parse fail')
+        }),
+        detach: vi.fn(() => calls.push('detach')),
     }
-
-    // Track which writes hit the command -- accessors record into `calls`.
-    let filePath = ''
-    let fileFormat = ''
-    let objectName = ''
-    let contentFirst = false
-    let maxSniffBytes = 0
-
-    const setTargetScene = vi.fn((s: unknown) => calls.push(`setTargetScene(${s ? 'scene' : 'null'})`))
-    const run = vi.fn(() => {
-        calls.push('run')
-        if (opts.runThrows) throw new Error('parse fail')
-    })
-
-    const cmd: Record<string, unknown> = {
-        setTargetScene,
-        run,
-    }
-    Object.defineProperty(cmd, 'file_path', {
-        get() { return filePath },
-        set(v: string) { filePath = v; calls.push(`file_path=${v}`) },
-    })
-    Object.defineProperty(cmd, 'file_format', {
-        get() { return fileFormat },
-        set(v: string) { fileFormat = v; calls.push(`file_format=${v}`) },
-    })
-    Object.defineProperty(cmd, 'object_name', {
-        get() { return objectName },
-        set(v: string) { objectName = v; calls.push(`object_name=${v}`) },
-    })
-    Object.defineProperty(cmd, 'content_first', {
-        get() { return contentFirst },
-        set(v: boolean) { contentFirst = v; calls.push(`content_first=${v}`) },
-    })
-    Object.defineProperty(cmd, 'max_sniff_bytes', {
-        get() { return maxSniffBytes },
-        set(v: number) { maxSniffBytes = v; calls.push(`max_sniff_bytes=${v}`) },
-    })
-    Object.defineProperty(cmd, 'result_object', {
-        get() {
-            calls.push('result_object')
-            return opts.resultObjectNull ? null : mol
-        },
+    Object.defineProperty(reader, 'compress', {
+        get() { return compress },
+        set(v: string) { compress = v; calls.push(`compress=${v}`) },
     })
 
     const scene = {
         startUndoTxn: vi.fn((label: string) => calls.push(`start:${label}`)),
         commitUndoTxn: vi.fn(() => calls.push('commit')),
         rollbackUndoTxn: vi.fn(() => calls.push('rollback')),
+        addObject: vi.fn(() => calls.push('addObject')),
     }
 
-    const getCmd = vi.fn(() => (opts.cmdMissing ? null : cmd))
+    const createHandler = vi.fn(() => reader)
 
     const ctx = {
         sceMgr: { getScene: vi.fn(() => scene) },
-        cmdMgr: { getCmd },
-        strMgr: {},
+        strMgr: { createHandler },
     } as unknown as WorkerContext
 
-    return { ctx, scene, cmd, mol, calls, getCmd, setTargetScene, run }
+    return { ctx, scene, reader, obj, calls, createHandler }
 }
 
 const baseRendererOpts = {
@@ -116,147 +86,112 @@ const baseRendererOpts = {
     centerView: false,
 }
 
-describe('loadObject.service — LoadObjectCommand path', () => {
+const unknownFormat = { kind: 'unknown', options: {} } as const
+
+describe('loadObject.service — reader-based path', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        ;(pickReaderName as ReturnType<typeof vi.fn>).mockReturnValue('pdb')
     })
 
-    it('happy path: setTargetScene method, then file_path / file_format / object_name / content_first / max_sniff_bytes / run / result_object / setupRenderer', () => {
-        const { ctx, calls, mol } = makeFixture()
+    it('happy path: setPath -> applyReaderOptions -> createDefaultObj/attach/read/detach -> name -> addObject -> setupRenderer (in txn)', () => {
+        const { ctx, calls, obj, createHandler } = makeFixture()
         const result = loadObject(ctx, {
             filePath: '/data/1ubq.pdb',
             sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
+            options: { format: unknownFormat, renderer: baseRendererOpts } as any,
             contentFirst: false,
         })
         expect(result).toEqual({ ok: true })
+        expect(createHandler).toHaveBeenCalledWith('pdb', 0)
         expect(calls).toEqual([
+            'setPath=/data/1ubq.pdb',
             'start:Open file',
-            'setTargetScene(scene)',
-            'file_path=/data/1ubq.pdb',
-            'file_format=',
-            'object_name=',
-            'content_first=false',
-            'max_sniff_bytes=65536',
-            'run',
-            'result_object',
+            'createDefaultObj',
+            'attach',
+            'read',
+            'detach',
+            'name=1ubq',          // objectName empty -> file stem
+            'addObject',
             'commit',
         ])
-        expect(setupRenderer).toHaveBeenCalledWith(ctx, mol, baseRendererOpts)
+        expect(applyReaderOptions).toHaveBeenCalledWith(expect.anything(), 'pdb', unknownFormat)
+        expect(setupRenderer).toHaveBeenCalledWith(ctx, obj, baseRendererOpts)
     })
 
-    it('content-first flag propagates to cmd.content_first', () => {
+    it('.gz path: sets reader.compress = "gzip"', () => {
         const { ctx, calls } = makeFixture()
         loadObject(ctx, {
-            filePath: '/data/file.cif',
+            filePath: '/data/1ubq.pdb.gz',
             sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
-            contentFirst: true,
-        })
-        expect(calls).toContain('content_first=true')
-    })
-
-    it('maxSniffBytes > 0 propagates to cmd.max_sniff_bytes', () => {
-        const { ctx, calls } = makeFixture()
-        loadObject(ctx, {
-            filePath: '/data/file.cif',
-            sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
-            contentFirst: false,
-            maxSniffBytes: 4096,
-        })
-        expect(calls).toContain('max_sniff_bytes=4096')
-    })
-
-    // The service always sets a cap. When the caller omits maxSniffBytes
-    // (or passes 0), the worker-side DEFAULT_SNIFF_CAP (64 KB) is applied
-    // so pathological inputs can't stall the sniff loop. Pins the
-    // contract: the cap is the source-of-truth ceiling, not the reader's
-    // own peek window.
-    it('maxSniffBytes 0 / undefined falls back to DEFAULT_SNIFF_CAP (65536)', () => {
-        const { ctx, calls } = makeFixture()
-        loadObject(ctx, {
-            filePath: '/data/file.cif',
-            sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
+            options: { format: unknownFormat, renderer: baseRendererOpts } as any,
             contentFirst: false,
         })
-        expect(calls).toContain('max_sniff_bytes=65536')
+        expect(calls).toContain('compress=gzip')
     })
 
-    it('options.renderer.objectName flows into cmd.object_name', () => {
+    it('non-.gz path: does NOT set compress', () => {
+        const { ctx, calls } = makeFixture()
+        loadObject(ctx, {
+            filePath: '/data/1ubq.pdb',
+            sceneId: 1,
+            options: { format: unknownFormat, renderer: baseRendererOpts } as any,
+            contentFirst: false,
+        })
+        expect(calls).not.toContain('compress=gzip')
+    })
+
+    it('objectName from renderer options overrides the file stem', () => {
         const { ctx, calls } = makeFixture()
         loadObject(ctx, {
             filePath: '/data/1ubq.pdb',
             sceneId: 1,
             options: {
-                format: { kind: 'unknown' },
+                format: unknownFormat,
                 renderer: { ...baseRendererOpts, objectName: 'myMol' },
             } as any,
             contentFirst: false,
         })
-        expect(calls).toContain('object_name=myMol')
+        expect(calls).toContain('name=myMol')
+        expect(calls).not.toContain('name=1ubq')
     })
 
-    it('scene is attached via setTargetScene METHOD (no `target_scene =` assignment exposed)', () => {
-        const { ctx, setTargetScene, cmd } = makeFixture()
+    it('contentFirst flag is forwarded to pickReaderName', () => {
+        const { ctx } = makeFixture()
         loadObject(ctx, {
-            filePath: '/data/1ubq.pdb',
+            filePath: '/data/file',
             sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
-            contentFirst: false,
+            options: { format: unknownFormat, renderer: baseRendererOpts } as any,
+            contentFirst: true,
         })
-        expect(setTargetScene).toHaveBeenCalledTimes(1)
-        // The command must NOT expose target_scene as a writable accessor
-        // here. (Production wrapper does, but on the property-setter path;
-        // we ensure the service does not touch it.)
-        expect(Object.prototype.hasOwnProperty.call(cmd, 'target_scene')).toBe(false)
+        expect(pickReaderName).toHaveBeenCalledWith(ctx, '/data/file', true, undefined)
     })
 
-    it('cmd.file_format is left empty so guessFileFormat() picks the reader', () => {
-        const { ctx, calls } = makeFixture()
-        loadObject(ctx, {
-            filePath: '/data/1ubq.pdb',
-            sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
-            contentFirst: false,
-        })
-        expect(calls).toContain('file_format=')
-    })
-
-    it('returns ok:false when getCmd("load_object") returns null', () => {
-        const { ctx } = makeFixture({ cmdMissing: true })
+    it('returns ok:false when no reader matches (pickReaderName -> "")', () => {
+        const { ctx, createHandler } = makeFixture()
+        ;(pickReaderName as ReturnType<typeof vi.fn>).mockReturnValue('')
         const result = loadObject(ctx, {
-            filePath: '/data/1ubq.pdb',
+            filePath: '/data/mystery',
             sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
+            options: { format: unknownFormat, renderer: baseRendererOpts } as any,
             contentFirst: false,
         })
         expect(result).toEqual({ ok: false })
+        expect(createHandler).not.toHaveBeenCalled()
         expect(setupRenderer).not.toHaveBeenCalled()
     })
 
-    it('returns ok:false when result_object is null', () => {
-        const { ctx } = makeFixture({ resultObjectNull: true })
-        const result = loadObject(ctx, {
-            filePath: '/data/1ubq.pdb',
-            sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
-            contentFirst: false,
-        })
-        expect(result).toEqual({ ok: false })
-        expect(setupRenderer).not.toHaveBeenCalled()
-    })
-
-    it('cmd.run() throwing propagates and rolls back the undo txn', () => {
-        const { ctx, calls } = makeFixture({ runThrows: true })
+    it('read() throwing propagates and rolls back the undo txn', () => {
+        const { ctx, calls } = makeFixture({ readThrows: true })
         expect(() => loadObject(ctx, {
             filePath: '/data/1ubq.pdb',
             sceneId: 1,
-            options: { format: { kind: 'unknown' }, renderer: baseRendererOpts } as any,
+            options: { format: unknownFormat, renderer: baseRendererOpts } as any,
             contentFirst: false,
         })).toThrow('parse fail')
         expect(calls).toContain('rollback')
         expect(calls).not.toContain('commit')
+        expect(calls).not.toContain('addObject')
+        expect(setupRenderer).not.toHaveBeenCalled()
     })
 })

--- a/tritium/react-gui/src/renderer/__test__/mtzColumns.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/mtzColumns.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for computeMtzDefaults (default MTZ column selection).
+ *
+ * Pins the UXP selectDefaultColumns conventions: PHENIX, REFMAC5, SIGMAA,
+ * RESOLVE, DM patterns plus the first-column fallback and the phase/weight
+ * checkbox defaults.
+ */
+import { describe, it, expect } from 'vitest'
+import { computeMtzDefaults } from '../components/fopen-opt-dlgs/mtzColumns'
+import type { MtzColumn } from '../worker/server/services/getMtzColumnInfo.service'
+
+const col = (name: string, type: string): MtzColumn => ({ name, type })
+
+describe('computeMtzDefaults', () => {
+    it('PHENIX: picks 2FOFCWT / PH2FOFCWT, phase on, weight off', () => {
+        const cols = [col('2FOFCWT', 'F'), col('PH2FOFCWT', 'P'), col('FOFCWT', 'F')]
+        expect(computeMtzDefaults(cols)).toEqual({
+            columnF: '2FOFCWT', columnPhi: 'PH2FOFCWT', columnW: '',
+            phaseEnabled: true, weightEnabled: false,
+        })
+    })
+
+    it('REFMAC5: picks FWT / PHWT', () => {
+        const cols = [col('FWT', 'F'), col('PHWT', 'P')]
+        expect(computeMtzDefaults(cols)).toMatchObject({ columnF: 'FWT', columnPhi: 'PHWT' })
+    })
+
+    it('SIGMAA: FWT / PHIC when PHWT absent', () => {
+        const cols = [col('FWT', 'F'), col('PHIC', 'P')]
+        expect(computeMtzDefaults(cols)).toMatchObject({ columnF: 'FWT', columnPhi: 'PHIC' })
+    })
+
+    it('RESOLVE: FP / PHIM / FOMM with weight enabled', () => {
+        const cols = [col('FP', 'F'), col('PHIM', 'P'), col('FOMM', 'W')]
+        expect(computeMtzDefaults(cols)).toEqual({
+            columnF: 'FP', columnPhi: 'PHIM', columnW: 'FOMM',
+            phaseEnabled: true, weightEnabled: true,
+        })
+    })
+
+    it('DM: FDM / PHIDM / FOMDM with weight enabled', () => {
+        const cols = [col('FDM', 'F'), col('PHIDM', 'P'), col('FOMDM', 'W')]
+        expect(computeMtzDefaults(cols)).toEqual({
+            columnF: 'FDM', columnPhi: 'PHIDM', columnW: 'FOMDM',
+            phaseEnabled: true, weightEnabled: true,
+        })
+    })
+
+    it('no known pattern: falls back to first column of each type', () => {
+        const cols = [col('MYF', 'F'), col('MYP', 'P'), col('MYW', 'W')]
+        expect(computeMtzDefaults(cols)).toEqual({
+            columnF: 'MYF', columnPhi: 'MYP', columnW: 'MYW',
+            phaseEnabled: true, weightEnabled: false,
+        })
+    })
+
+    it('no phase columns: phaseEnabled false, columnPhi empty', () => {
+        const cols = [col('MYF', 'F')]
+        expect(computeMtzDefaults(cols)).toEqual({
+            columnF: 'MYF', columnPhi: '', columnW: '',
+            phaseEnabled: false, weightEnabled: false,
+        })
+    })
+
+    it('empty column list: all empty, both checkboxes off', () => {
+        expect(computeMtzDefaults([])).toEqual({
+            columnF: '', columnPhi: '', columnW: '',
+            phaseEnabled: false, weightEnabled: false,
+        })
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/namdcoorPsfPath.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/namdcoorPsfPath.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the NAMD coordinate option dialog's PSF path helpers:
+ *   - deriveDefaultPsfPath: coord path -> .psf path (UXP splitFileName + .psf).
+ *   - psfPathHistory: localStorage-backed last-used path round-trip.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { deriveDefaultPsfPath } from '../components/fopen-opt-dlgs/types'
+import { getLastPsfPath, setLastPsfPath, STORAGE_KEY } from '../components/fopen-opt-dlgs/psfPathHistory'
+import {
+    getLastCoordPath,
+    setLastCoordPath,
+    STORAGE_KEY as COORD_STORAGE_KEY,
+} from '../components/fopen-opt-dlgs/coordPathHistory'
+
+describe('deriveDefaultPsfPath', () => {
+    it('replaces a .coor extension with .psf', () => {
+        expect(deriveDefaultPsfPath('/data/run.coor')).toBe('/data/run.psf')
+    })
+
+    it('replaces any final extension with .psf', () => {
+        expect(deriveDefaultPsfPath('/data/run.namdbin')).toBe('/data/run.psf')
+    })
+
+    it('appends .psf when there is no extension', () => {
+        expect(deriveDefaultPsfPath('/data/run')).toBe('/data/run.psf')
+    })
+
+    it('only strips the final extension, not dots in the directory', () => {
+        expect(deriveDefaultPsfPath('/data.v2/run.coor')).toBe('/data.v2/run.psf')
+    })
+
+    it('returns empty string for empty input', () => {
+        expect(deriveDefaultPsfPath('')).toBe('')
+    })
+})
+
+describe('psfPathHistory', () => {
+    beforeEach(() => {
+        localStorage.removeItem(STORAGE_KEY)
+    })
+
+    it('returns undefined when nothing stored', () => {
+        expect(getLastPsfPath()).toBeUndefined()
+    })
+
+    it('round-trips a stored path', () => {
+        setLastPsfPath('/data/run.psf')
+        expect(getLastPsfPath()).toBe('/data/run.psf')
+    })
+
+    it('ignores an empty set', () => {
+        setLastPsfPath('')
+        expect(getLastPsfPath()).toBeUndefined()
+    })
+})
+
+describe('coordPathHistory (AMBER)', () => {
+    beforeEach(() => {
+        localStorage.removeItem(COORD_STORAGE_KEY)
+    })
+
+    it('returns undefined when nothing stored', () => {
+        expect(getLastCoordPath()).toBeUndefined()
+    })
+
+    it('round-trips a stored coord path', () => {
+        setLastCoordPath('/data/system.rst7')
+        expect(getLastCoordPath()).toBe('/data/system.rst7')
+    })
+
+    it('ignores an empty set', () => {
+        setLastCoordPath('')
+        expect(getLastCoordPath()).toBeUndefined()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/streamLoadFromUrlService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/streamLoadFromUrlService.test.ts
@@ -20,9 +20,13 @@ vi.mock('../worker/server/services/setupRenderer.service', () => ({
 vi.mock('../worker/server/services/withUndoTxn', () => ({
     withUndoTxn: vi.fn((_scene: unknown, _label: string, fn: () => unknown) => fn()),
 }))
+vi.mock('../worker/server/services/helpers/applyReaderOptions', () => ({
+    applyReaderOptions: vi.fn(),
+}))
 
 import { services } from '../worker/server/services/streamLoadFromUrl.service'
 import { setupRenderer } from '../worker/server/services/setupRenderer.service'
+import { applyReaderOptions } from '../worker/server/services/helpers/applyReaderOptions'
 
 const { streamLoadFromUrl, cancelStreamLoad } = services
 
@@ -133,6 +137,10 @@ describe('streamLoadFromUrl service', () => {
         })
 
         expect(env.createHandler).toHaveBeenCalledWith('mmcif', 0)
+        // Format options are wired onto the reader before streaming.
+        expect(applyReaderOptions).toHaveBeenCalledWith(
+            env.reader, 'mmcif', expect.objectContaining({ kind: 'mmcif' }),
+        )
         expect(env.loadObjectAsync).toHaveBeenCalledWith(env.reader)
         expect(env.supplyDataAsync).toHaveBeenCalledTimes(2)
         expect(env.supplyDataAsync.mock.calls[0]).toEqual([42, expect.objectContaining({ len: 4 }), 4])

--- a/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
@@ -78,7 +78,7 @@ export function useSceneCommands({
                     // reader, otherwise (e.g.) the dialog offers density-map
                     // renderers for a coordinate CIF and the subsequent load
                     // crashes when the chosen renderer is applied to a MolCoord.
-                    const { types, objType } = await cm.getCompatibleRendererNames(
+                    const { types, objType, readerName } = await cm.getCompatibleRendererNames(
                         data.path, undefined, data.contentFirst,
                     )
                     // Empty types means the C++ side could not identify a
@@ -98,6 +98,7 @@ export function useSceneCommands({
                         sceneId: info.scene_uid,
                         rendererTypes: types,
                         objType,
+                        readerName,
                     })
                     if (options === null) return
                     await cm.loadObject(data.path, info.scene_uid, options, data.contentFirst)
@@ -161,6 +162,7 @@ export function useSceneCommands({
                             sceneId: info.scene_uid,
                             rendererTypes,
                             objType,
+                            readerName,
                         })
                         if (options !== null) {
                             tasks.push(() => streamWithProgress(

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialog.tsx
@@ -25,22 +25,28 @@ import { useCueMol } from '../../hooks/useCueMol';
 import {
   type FileOpenOptions,
   type FormatOptions,
-  detectFormatKind,
+  formatKindForReader,
   buildDefaultFormatOptions,
   isFormatOptionsModified,
   isMolFormat,
+  deriveDefaultPsfPath,
 } from './types';
 import { useRendererOptions } from './useRendererOptions';
+import { computeMtzDefaults } from './mtzColumns';
+import { getLastPsfPath, setLastPsfPath } from './psfPathHistory';
+import { getLastCoordPath, setLastCoordPath } from './coordPathHistory';
+import type { GetMtzColumnInfoResult } from '../../worker/server/services/getMtzColumnInfo.service';
 
 import { PdbOptionsPane } from './panes/PdbOptionsPane';
 import { MtzOptionsPane } from './panes/MtzOptionsPane';
 import { Ccp4MapOptionsPane } from './panes/Ccp4MapOptionsPane';
 import { MsmsOptionsPane } from './panes/MsmsOptionsPane';
 import { NamdCoorOptionsPane } from './panes/NamdCoorOptionsPane';
+import { AmberPrmtopOptionsPane } from './panes/AmberPrmtopOptionsPane';
 import { RendererOptionsPane } from './panes/RendererOptionsPane';
 import { pushHistory } from '../widgets/MolSelList';
 
-import type { PdbOptions, MtzOptions, Ccp4MapOptions, MsmsOptions, NamdCoorOptions } from './types';
+import type { PdbOptions, MtzOptions, Ccp4MapOptions, MsmsOptions, NamdCoorOptions, AmberPrmtopOptions } from './types';
 
 // ---- helpers ----
 
@@ -52,6 +58,7 @@ function formatLabel(kind: string): string {
     case 'ccp4map': return 'CCP4/MRC Map';
     case 'msms': return 'MSMS Surface';
     case 'namdcoor': return 'NAMD Coordinate';
+    case 'amberprm': return 'AMBER prmtop';
     default: return '';
   }
 }
@@ -77,6 +84,12 @@ export interface FileOpenOptionDialogProps {
    * string disables history get/set (a safe no-op).
    */
   objType: string;
+  /**
+   * Reader nickname cuemol/core resolved for this file (e.g. 'pdb',
+   * 'mtzmap'). The single source of truth for which format-specific option
+   * pane to show -- never re-derived from the extension on the TS side.
+   */
+  readerName: string;
   onConfirm: (options: FileOpenOptions) => void;
   onCancel: () => void;
 }
@@ -89,12 +102,13 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
   sceneId,
   rendererTypes,
   objType,
+  readerName,
   onConfirm,
   onCancel,
 }) => {
   const { theme } = useTheme();
   const { cm } = useCueMol();
-  const formatKind = detectFormatKind(filePath);
+  const formatKind = formatKindForReader(readerName);
   const formatName = formatLabel(formatKind);
   const hasFormatOptions = formatKind !== 'unknown';
 
@@ -118,16 +132,22 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
   // Stale-response guard for the object-name proposeUniqName fetch.
   const objNameSeqRef = useRef(0);
 
+  // MTZ column info read from the file header (null until loaded / non-MTZ).
+  const [mtzColumnInfo, setMtzColumnInfo] = useState<GetMtzColumnInfoResult | null>(null);
+  const mtzSeqRef = useRef(0);
+
   // Reset format state when a new file is shown (filePath changes between
   // opens). Renderer-options reset is handled by the shared hook on the
   // dialog's visibility transition.
   const [lastFilePath, setLastFilePath] = useState(filePath);
   if (filePath !== lastFilePath) {
     setLastFilePath(filePath);
-    setFormatOptions(buildDefaultFormatOptions(detectFormatKind(filePath)));
+    setFormatOptions(buildDefaultFormatOptions(formatKind));
     setIsFormatExpanded(false);
-    // Discard any in-flight object-name response for the previous file.
+    setMtzColumnInfo(null);
+    // Discard any in-flight responses for the previous file.
     objNameSeqRef.current += 1;
+    mtzSeqRef.current += 1;
   }
 
   // Effect: resolve a scene-wide unique object name when the dialog opens or
@@ -151,11 +171,74 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
     })();
   }, [cm, visible, filePath, sceneId]);
 
+  // Effect: when an MTZ file is shown, read its column labels + resolution
+  // range and seed the dialog's default column selections (UXP onInit +
+  // selectDefaultColumns). Runs once per file/scene open.
+  useEffect(() => {
+    if (!visible || !cm || formatKind !== 'mtz') return;
+    const seq = ++mtzSeqRef.current;
+    (async () => {
+      const info = await cm.getMtzColumnInfo(filePath);
+      if (seq !== mtzSeqRef.current) return; // stale
+      setMtzColumnInfo(info);
+      if (!info.ok) return;
+      const defs = computeMtzDefaults(info.columns);
+      setFormatOptions({
+        kind: 'mtz',
+        options: {
+          ...defs,
+          // Round to 1 decimal place to match UXP's decimalplaces="1" widget.
+          resolutionLimit: Math.round(info.resolution * 10) / 10,
+          gridSpacing: 0.25,
+        },
+      });
+    })();
+  }, [cm, visible, filePath, formatKind]);
+
+  // Effect: when a NAMD coordinate file is shown, seed the PSF topology path
+  // from history (last-used) or, failing that, the coordinate path with a
+  // `.psf` extension (UXP fopen-namdcooropt onInit). Only seeds while the
+  // path is still empty so it never clobbers a user edit.
+  useEffect(() => {
+    if (!visible || formatKind !== 'namdcoor') return;
+    const seeded = getLastPsfPath() ?? deriveDefaultPsfPath(filePath);
+    if (!seeded) return;
+    setFormatOptions((prev) =>
+      prev.kind === 'namdcoor' && prev.options.psfFilePath === ''
+        ? { kind: 'namdcoor', options: { psfFilePath: seeded } }
+        : prev,
+    );
+  }, [visible, filePath, formatKind]);
+
+  // Effect: when an AMBER prmtop file is shown, seed the coordinate path from
+  // history (last-used). Unlike NAMD's required PSF, the coord sub-stream is
+  // optional and its extension (rst7 / inpcrd / restrt) is ambiguous, so there
+  // is no path-derivation fallback -- an empty path means topology-only.
+  useEffect(() => {
+    if (!visible || formatKind !== 'amberprm') return;
+    const seeded = getLastCoordPath();
+    if (!seeded) return;
+    setFormatOptions((prev) =>
+      prev.kind === 'amberprm' && prev.options.coordFilePath === ''
+        ? { kind: 'amberprm', options: { coordFilePath: seeded } }
+        : prev,
+    );
+  }, [visible, filePath, formatKind]);
+
   const handleConfirm = useCallback(() => {
     if (rendererOptions.selectionEnabled && rendererOptions.selection) {
       pushHistory(rendererOptions.selection);
     }
     commitHistory();
+    // Remember the chosen PSF path for the next NAMD coordinate load (UXP
+    // pref "cuemol2.ui.histories.namdcoor.psfpath").
+    if (formatOptions.kind === 'namdcoor' && formatOptions.options.psfFilePath) {
+      setLastPsfPath(formatOptions.options.psfFilePath);
+    }
+    // Remember the chosen AMBER coordinate path for the next prmtop load.
+    if (formatOptions.kind === 'amberprm' && formatOptions.options.coordFilePath) {
+      setLastCoordPath(formatOptions.options.coordFilePath);
+    }
     onConfirm({ format: formatOptions, renderer: rendererOptions });
   }, [onConfirm, formatOptions, rendererOptions, commitHistory]);
 
@@ -229,6 +312,7 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
                   <MtzOptionsPane
                     options={formatOptions.options}
                     onChange={(opts: MtzOptions) => setFormatOptions({ kind: 'mtz', options: opts })}
+                    columnInfo={mtzColumnInfo}
                   />
                 )}
                 {formatKind === 'ccp4map' && formatOptions.kind === 'ccp4map' && (
@@ -247,6 +331,12 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
                   <NamdCoorOptionsPane
                     options={formatOptions.options}
                     onChange={(opts: NamdCoorOptions) => setFormatOptions({ kind: 'namdcoor', options: opts })}
+                  />
+                )}
+                {formatKind === 'amberprm' && formatOptions.kind === 'amberprm' && (
+                  <AmberPrmtopOptionsPane
+                    options={formatOptions.options}
+                    onChange={(opts: AmberPrmtopOptions) => setFormatOptions({ kind: 'amberprm', options: opts })}
                   />
                 )}
               </div>

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialogProvider.tsx
@@ -16,6 +16,11 @@ export interface FileOpenOptionDialogArgs {
    * Empty string is treated as "no history" (safe no-op).
    */
   objType?: string
+  /**
+   * Reader nickname cuemol/core resolved for the file (e.g. 'pdb', 'mtzmap').
+   * Drives which format-specific option pane is shown.
+   */
+  readerName?: string
 }
 
 export const {
@@ -30,6 +35,7 @@ export const {
       sceneId={args?.sceneId ?? 0}
       rendererTypes={args?.rendererTypes ?? []}
       objType={args?.objType ?? ''}
+      readerName={args?.readerName ?? ''}
       onConfirm={(options) => resolve(options)}
       onCancel={() => resolve(null)}
     />

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/coordPathHistory.ts
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/coordPathHistory.ts
@@ -1,0 +1,28 @@
+/**
+ * @file coordPathHistory.ts
+ * @description localStorage-backed "last used AMBER coordinate path" for the
+ * AMBER prmtop file-open dialog. Analogous to psfPathHistory (NAMD), so
+ * reopening the dialog defaults to the most recently chosen inpcrd / rst7 /
+ * restrt file.
+ *
+ * Reads are defensive: a missing / corrupt / non-string payload returns
+ * `undefined` rather than throwing.
+ */
+
+import { loadJSON, saveJSON } from '../../utils/localStorageJSON';
+
+export const STORAGE_KEY = 'cuemol.fopenOptions.amberCoordPath';
+
+function asString(raw: unknown): string | null {
+    return typeof raw === 'string' ? raw : null;
+}
+
+export function getLastCoordPath(): string | undefined {
+    const v = loadJSON<string | null>(STORAGE_KEY, asString, null);
+    return v && v.length > 0 ? v : undefined;
+}
+
+export function setLastCoordPath(path: string): void {
+    if (!path) return;
+    saveJSON(STORAGE_KEY, path);
+}

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/mtzColumns.ts
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/mtzColumns.ts
@@ -1,0 +1,69 @@
+/**
+ * @file fopen-opt-dlgs/mtzColumns.ts
+ * @description Default amplitude / phase / weight column selection for an MTZ
+ * file, ported from the UXP fopen-mtzopt-page selectDefaultColumns() logic
+ * (uxp_gui/cuemol2/base/content/fopen-mtzopt-page.js). Recognises the common
+ * refinement-program column conventions and falls back to the first column of
+ * each type otherwise.
+ */
+import type { MtzColumn } from '../../worker/server/services/getMtzColumnInfo.service';
+import type { MtzOptions } from './types';
+
+export type MtzColumnDefaults = Pick<
+  MtzOptions,
+  'columnF' | 'columnPhi' | 'columnW' | 'phaseEnabled' | 'weightEnabled'
+>;
+
+/**
+ * Pick default column selections from an MTZ column list.
+ *
+ * @param columns - F / P / W columns reported by the worker.
+ * @returns Default selections and phase/weight checkbox states.
+ *
+ * @remarks
+ * - Phase is enabled by default when any P column exists; Weight only for the
+ *   RESOLVE / DM conventions (which carry an explicit FOM column).
+ * - Pattern order matches UXP: PHENIX, REFMAC5, SIGMAA, RESOLVE, DM.
+ */
+export function computeMtzDefaults(columns: MtzColumn[]): MtzColumnDefaults {
+  const fcols = columns.filter((c) => c.type === 'F').map((c) => c.name);
+  const pcols = columns.filter((c) => c.type === 'P').map((c) => c.name);
+  const wcols = columns.filter((c) => c.type === 'W').map((c) => c.name);
+  const has = (name: string, type: string) =>
+    columns.some((c) => c.name === name && c.type === type);
+
+  // Defaults: first column of each type; phase on when available, weight off.
+  let columnF = fcols[0] ?? '';
+  let columnPhi = pcols[0] ?? '';
+  let columnW = wcols[0] ?? '';
+  const phaseEnabled = pcols.length > 0;
+  let weightEnabled = false;
+
+  if (has('2FOFCWT', 'F') && has('PH2FOFCWT', 'P')) {
+    // PHENIX.REFINE
+    columnF = '2FOFCWT';
+    columnPhi = 'PH2FOFCWT';
+  } else if (has('FWT', 'F') && has('PHWT', 'P')) {
+    // REFMAC5
+    columnF = 'FWT';
+    columnPhi = 'PHWT';
+  } else if (has('FWT', 'F') && has('PHIC', 'P')) {
+    // SIGMAA
+    columnF = 'FWT';
+    columnPhi = 'PHIC';
+  } else if (has('FP', 'F') && has('PHIM', 'P') && has('FOMM', 'W')) {
+    // RESOLVE
+    columnF = 'FP';
+    columnPhi = 'PHIM';
+    columnW = 'FOMM';
+    weightEnabled = true;
+  } else if (has('FDM', 'F') && has('PHIDM', 'P') && has('FOMDM', 'W')) {
+    // DM
+    columnF = 'FDM';
+    columnPhi = 'PHIDM';
+    columnW = 'FOMDM';
+    weightEnabled = true;
+  }
+
+  return { columnF, columnPhi, columnW, phaseEnabled, weightEnabled };
+}

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/AmberPrmtopOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/AmberPrmtopOptionsPane.tsx
@@ -1,0 +1,59 @@
+/**
+ * @file panes/AmberPrmtopOptionsPane.tsx
+ * @description Option pane for AMBER prmtop topology files. Analogous to the
+ * NAMD coordinate pane: the prmtop is the main stream (topology) and an
+ * optional coordinate file (inpcrd / rst7 / restrt) is attached as the
+ * reader's "coord" sub-stream. A "Change..." button opens a native file
+ * picker filtered to those extensions. Leaving the path empty performs a
+ * topology-only load (atoms at default positions).
+ */
+
+import React, { useCallback } from 'react';
+import { InputGroup, FormGroup, Button, ControlGroup } from '@blueprintjs/core';
+import type { AmberPrmtopOptions } from '../types';
+import { IPC } from '../../../../shared/ipcChannels';
+
+interface AmberPrmtopOptionsPaneProps {
+  options: AmberPrmtopOptions;
+  onChange: (updated: AmberPrmtopOptions) => void;
+}
+
+export const AmberPrmtopOptionsPane: React.FC<AmberPrmtopOptionsPaneProps> = ({ options, onChange }) => {
+  const handleBrowse = useCallback(async () => {
+    try {
+      const res = await window.electronAPI?.invoke(IPC.DIALOG_PICK_PATH, {
+        title: 'Select AMBER coordinate file',
+        filters: [
+          { name: 'AMBER coordinates', extensions: ['rst7', 'inpcrd', 'restrt'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      });
+      if (res && !res.canceled && res.filePath) onChange({ coordFilePath: res.filePath });
+    } catch {
+      /* dialog unavailable (e.g. Vite dev server) -- ignore */
+    }
+  }, [onChange]);
+
+  return (
+    <div className="fod-section">
+      <div className="fod-section-title">Coordinates</div>
+      <FormGroup
+        label="Coordinate file (inpcrd / rst7)"
+        labelFor="amber-coord"
+        helperText="Optional. Leave empty to load topology only (atoms at zero)."
+        className="fod-form-group"
+      >
+        <ControlGroup fill>
+          <InputGroup
+            id="amber-coord"
+            placeholder="/path/to/system.rst7"
+            value={options.coordFilePath}
+            onChange={(e) => onChange({ coordFilePath: e.target.value })}
+            fill
+          />
+          <Button text="Change..." onClick={handleBrowse} />
+        </ControlGroup>
+      </FormGroup>
+    </div>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/Ccp4MapOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/Ccp4MapOptionsPane.tsx
@@ -29,21 +29,35 @@ export const Ccp4MapOptionsPane: React.FC<Ccp4MapOptionsPaneProps> = ({ options,
       />
       <Divider />
       <div className="fod-section-title">Truncation (sigma)</div>
+      <Switch
+        label="Truncate minimum"
+        checked={options.truncateMinEnabled}
+        onChange={(e) => onChange({ ...options, truncateMinEnabled: e.target.checked })}
+        className="fod-switch"
+      />
       <FormGroup label="Minimum" labelFor="ccp4-min" className="fod-form-group">
         <NumericInput
           id="ccp4-min"
           value={options.truncateMin}
           onValueChange={setNum('truncateMin')}
+          disabled={!options.truncateMinEnabled}
           stepSize={0.5}
           minorStepSize={0.1}
           fill
         />
       </FormGroup>
+      <Switch
+        label="Truncate maximum"
+        checked={options.truncateMaxEnabled}
+        onChange={(e) => onChange({ ...options, truncateMaxEnabled: e.target.checked })}
+        className="fod-switch"
+      />
       <FormGroup label="Maximum" labelFor="ccp4-max" className="fod-form-group">
         <NumericInput
           id="ccp4-max"
           value={options.truncateMax}
           onValueChange={setNum('truncateMax')}
+          disabled={!options.truncateMaxEnabled}
           stepSize={0.5}
           minorStepSize={0.1}
           fill

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/MtzOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/MtzOptionsPane.tsx
@@ -1,79 +1,141 @@
 /**
  * @file panes/MtzOptionsPane.tsx
- * @description Option pane for MTZ reflection data files.
+ * @description Option pane for MTZ reflection data files. Mirrors the UXP
+ * fopen-mtzopt-page: amplitude / phase / weight columns are chosen from
+ * dropdowns populated by the actual column labels in the file, phase and
+ * weight are each gated by a checkbox (disabled when the file has no column
+ * of that type), and resolution / grid spacing follow the UXP controls.
  */
 
 import React from 'react';
-import { InputGroup, NumericInput, FormGroup } from '@blueprintjs/core';
+import { Checkbox, HTMLSelect, NumericInput, FormGroup } from '@blueprintjs/core';
 import type { MtzOptions } from '../types';
+import type { GetMtzColumnInfoResult } from '../../../worker/server/services/getMtzColumnInfo.service';
 
 interface MtzOptionsPaneProps {
   options: MtzOptions;
   onChange: (updated: MtzOptions) => void;
+  /** Column info read from the file; null while the header is being read. */
+  columnInfo: GetMtzColumnInfoResult | null;
 }
 
-export const MtzOptionsPane: React.FC<MtzOptionsPaneProps> = ({ options, onChange }) => {
-  const setStr = (key: keyof Pick<MtzOptions, 'columnF' | 'columnPhi' | 'columnW'>) =>
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange({ ...options, [key]: e.target.value });
-    };
+// UXP grid-spacing presets (fopen-mtzopt-page.xul).
+const GRID_PRESETS = [
+  { label: 'Fine (0.25)', value: 0.25 },
+  { label: 'Coarse (0.33)', value: 0.333333 },
+];
 
-  const setNum = (key: keyof Pick<MtzOptions, 'resolutionLimit' | 'gridSpacing'>) =>
-    (val: number) => {
-      if (!isNaN(val)) onChange({ ...options, [key]: val });
-    };
+// UXP's resolution textbox uses decimalplaces="1" / increment="0.1", so every
+// shown value and bound is rounded to a single decimal place. Match that here
+// rather than exposing the reader's raw shell limit (e.g. 1.69923983).
+function round1(x: number): number {
+  return Math.round(x * 10) / 10;
+}
+
+export const MtzOptionsPane: React.FC<MtzOptionsPaneProps> = ({ options, onChange, columnInfo }) => {
+  if (!columnInfo || !columnInfo.ok) {
+    return (
+      <div className="fod-section">
+        <div className="fod-section-title">Column Selection</div>
+        <div className="fod-hint">Reading MTZ header...</div>
+      </div>
+    );
+  }
+
+  const fCols = columnInfo.columns.filter((c) => c.type === 'F').map((c) => c.name);
+  const pCols = columnInfo.columns.filter((c) => c.type === 'P').map((c) => c.name);
+  const wCols = columnInfo.columns.filter((c) => c.type === 'W').map((c) => c.name);
+
+  const hasF = fCols.length > 0;
+  const hasP = pCols.length > 0;
+  const hasW = wCols.length > 0;
+
+  // Resolution textbox range mirrors UXP: min = highest-resolution shell
+  // (maxRes, the smaller number), max = lowest-resolution shell (minRes).
+  // Rounded to 1 decimal place like UXP's decimalplaces="1" widget.
+  const resoMin = round1(columnInfo.maxRes);
+  const resoMax = round1(columnInfo.minRes);
+
+  const renderColumnSelect = (
+    id: string,
+    cols: string[],
+    value: string,
+    disabled: boolean,
+    onSelect: (v: string) => void,
+  ) => (
+    <HTMLSelect
+      id={id}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onSelect(e.currentTarget.value)}
+      fill
+    >
+      {cols.length === 0 && <option value="">(none)</option>}
+      {cols.map((name) => (
+        <option key={name} value={name}>{name}</option>
+      ))}
+    </HTMLSelect>
+  );
 
   return (
     <div className="fod-section">
       <div className="fod-section-title">Column Selection</div>
+
       <FormGroup label="Amplitude (F)" labelFor="mtz-col-f" className="fod-form-group">
-        <InputGroup
-          id="mtz-col-f"
-          placeholder="e.g. 2FOFCWT"
-          value={options.columnF}
-          onChange={setStr('columnF')}
-        />
+        {renderColumnSelect('mtz-col-f', fCols, options.columnF, !hasF, (v) =>
+          onChange({ ...options, columnF: v }),
+        )}
       </FormGroup>
-      <FormGroup label="Phase (PHI)" labelFor="mtz-col-phi" className="fod-form-group">
-        <InputGroup
-          id="mtz-col-phi"
-          placeholder="e.g. PH2FOFCWT"
-          value={options.columnPhi}
-          onChange={setStr('columnPhi')}
+
+      <FormGroup className="fod-form-group">
+        <Checkbox
+          label="Phase"
+          checked={options.phaseEnabled && hasP}
+          disabled={!hasP}
+          onChange={(e) => onChange({ ...options, phaseEnabled: e.currentTarget.checked })}
         />
+        {renderColumnSelect('mtz-col-phi', pCols, options.columnPhi, !hasP || !options.phaseEnabled, (v) =>
+          onChange({ ...options, columnPhi: v }),
+        )}
       </FormGroup>
-      <FormGroup label="Weight (WT)" labelFor="mtz-col-w" className="fod-form-group">
-        <InputGroup
-          id="mtz-col-w"
-          placeholder="e.g. FOM"
-          value={options.columnW}
-          onChange={setStr('columnW')}
+
+      <FormGroup className="fod-form-group">
+        <Checkbox
+          label="Weight"
+          checked={options.weightEnabled && hasW}
+          disabled={!hasW}
+          onChange={(e) => onChange({ ...options, weightEnabled: e.currentTarget.checked })}
         />
+        {renderColumnSelect('mtz-col-w', wCols, options.columnW, !hasW || !options.weightEnabled, (v) =>
+          onChange({ ...options, columnW: v }),
+        )}
       </FormGroup>
+
       <div className="fod-section-title" style={{ marginTop: 12 }}>Map Parameters</div>
-      <FormGroup label="Resolution limit (A)" labelFor="mtz-reso" className="fod-form-group">
+      <FormGroup label="Max resolution (A)" labelFor="mtz-reso" className="fod-form-group">
         <NumericInput
           id="mtz-reso"
-          placeholder="0 = no limit"
           value={options.resolutionLimit}
-          onValueChange={setNum('resolutionLimit')}
-          min={0}
+          onValueChange={(val) => { if (!isNaN(val)) onChange({ ...options, resolutionLimit: round1(val) }); }}
+          min={resoMin > 0 ? resoMin : undefined}
+          max={resoMax > 0 ? resoMax : undefined}
           stepSize={0.1}
-          minorStepSize={0.01}
+          minorStepSize={null}
+          majorStepSize={null}
           fill
         />
       </FormGroup>
       <FormGroup label="Grid spacing (A)" labelFor="mtz-grid" className="fod-form-group">
-        <NumericInput
+        <HTMLSelect
           id="mtz-grid"
           value={options.gridSpacing}
-          onValueChange={setNum('gridSpacing')}
-          min={0.1}
-          max={1.0}
-          stepSize={0.01}
-          minorStepSize={0.001}
+          onChange={(e) => onChange({ ...options, gridSpacing: parseFloat(e.currentTarget.value) })}
           fill
-        />
+        >
+          {GRID_PRESETS.map((p) => (
+            <option key={p.label} value={p.value}>{p.label}</option>
+          ))}
+        </HTMLSelect>
       </FormGroup>
     </div>
   );

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/NamdCoorOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/NamdCoorOptionsPane.tsx
@@ -1,32 +1,58 @@
 /**
  * @file panes/NamdCoorOptionsPane.tsx
- * @description Option pane for NAMD binary coordinate files.
+ * @description Option pane for NAMD binary coordinate files. Mirrors the UXP
+ * fopen-namdcooropt page: a PSF topology path text box plus a "Change..."
+ * button that opens a native file picker filtered to *.psf. The default path
+ * (last-used history, else the coordinate path with a .psf extension) is
+ * seeded by FileOpenOptionDialog.
  */
 
-import React from 'react';
-import { InputGroup, FormGroup } from '@blueprintjs/core';
+import React, { useCallback } from 'react';
+import { InputGroup, FormGroup, Button, ControlGroup } from '@blueprintjs/core';
 import type { NamdCoorOptions } from '../types';
+import { IPC } from '../../../../shared/ipcChannels';
 
 interface NamdCoorOptionsPaneProps {
   options: NamdCoorOptions;
   onChange: (updated: NamdCoorOptions) => void;
 }
 
-export const NamdCoorOptionsPane: React.FC<NamdCoorOptionsPaneProps> = ({ options, onChange }) => (
-  <div className="fod-section">
-    <div className="fod-section-title">Topology</div>
-    <FormGroup
-      label="PSF topology file path"
-      labelFor="namd-psf"
-      helperText="Required to assign atom types and connectivity"
-      className="fod-form-group"
-    >
-      <InputGroup
-        id="namd-psf"
-        placeholder="/path/to/topology.psf"
-        value={options.psfFilePath}
-        onChange={(e) => onChange({ psfFilePath: e.target.value })}
-      />
-    </FormGroup>
-  </div>
-);
+export const NamdCoorOptionsPane: React.FC<NamdCoorOptionsPaneProps> = ({ options, onChange }) => {
+  const handleBrowse = useCallback(async () => {
+    try {
+      const res = await window.electronAPI?.invoke(IPC.DIALOG_PICK_PATH, {
+        title: 'Select PSF file',
+        filters: [
+          { name: 'PSF file', extensions: ['psf'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      });
+      if (res && !res.canceled && res.filePath) onChange({ psfFilePath: res.filePath });
+    } catch {
+      /* dialog unavailable (e.g. Vite dev server) -- ignore */
+    }
+  }, [onChange]);
+
+  return (
+    <div className="fod-section">
+      <div className="fod-section-title">Topology</div>
+      <FormGroup
+        label="PSF topology file"
+        labelFor="namd-psf"
+        helperText="Required to assign atom types and connectivity"
+        className="fod-form-group"
+      >
+        <ControlGroup fill>
+          <InputGroup
+            id="namd-psf"
+            placeholder="/path/to/topology.psf"
+            value={options.psfFilePath}
+            onChange={(e) => onChange({ psfFilePath: e.target.value })}
+            fill
+          />
+          <Button text="Change..." onClick={handleBrowse} />
+        </ControlGroup>
+      </FormGroup>
+    </div>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/psfPathHistory.ts
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/psfPathHistory.ts
@@ -1,0 +1,28 @@
+/**
+ * @file psfPathHistory.ts
+ * @description localStorage-backed "last used PSF topology path" for the NAMD
+ * coordinate file-open dialog. Mirrors UXP semantics of
+ *   pref.get/set("cuemol2.ui.histories.namdcoor.psfpath")
+ * so reopening the dialog defaults to the most recently chosen PSF file.
+ *
+ * Reads are defensive: a missing / corrupt / non-string payload returns
+ * `undefined` rather than throwing.
+ */
+
+import { loadJSON, saveJSON } from '../../utils/localStorageJSON';
+
+export const STORAGE_KEY = 'cuemol.fopenOptions.namdcoorPsfPath';
+
+function asString(raw: unknown): string | null {
+    return typeof raw === 'string' ? raw : null;
+}
+
+export function getLastPsfPath(): string | undefined {
+    const v = loadJSON<string | null>(STORAGE_KEY, asString, null);
+    return v && v.length > 0 ? v : undefined;
+}
+
+export function setLastPsfPath(path: string): void {
+    if (!path) return;
+    saveJSON(STORAGE_KEY, path);
+}

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/types.ts
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/types.ts
@@ -5,7 +5,7 @@
 
 // ---- Format kind ----
 
-export type FormatKind = 'pdb' | 'mmcif' | 'mtz' | 'ccp4map' | 'msms' | 'namdcoor' | 'unknown';
+export type FormatKind = 'pdb' | 'mmcif' | 'mtz' | 'ccp4map' | 'msms' | 'namdcoor' | 'amberprm' | 'unknown';
 
 // ---- Per-format option types ----
 
@@ -21,14 +21,20 @@ export interface PdbOptions {
 export interface MtzOptions {
   columnF: string;
   columnPhi: string;
+  /** Whether the phase column is used (UXP "Phase" checkbox). */
+  phaseEnabled: boolean;
   columnW: string;
+  /** Whether the weight column is used (UXP "Weight" checkbox). */
+  weightEnabled: boolean;
   resolutionLimit: number;
   gridSpacing: number;
 }
 
 export interface Ccp4MapOptions {
   normalize: boolean;
+  truncateMinEnabled: boolean;
   truncateMin: number;
+  truncateMaxEnabled: boolean;
   truncateMax: number;
 }
 
@@ -38,6 +44,14 @@ export interface MsmsOptions {
 
 export interface NamdCoorOptions {
   psfFilePath: string;
+}
+
+export interface AmberPrmtopOptions {
+  /**
+   * Optional AMBER coordinate file (inpcrd / rst7 / restrt) attached as the
+   * reader's "coord" sub-stream. Empty -> topology-only load (atoms at zero).
+   */
+  coordFilePath: string;
 }
 
 export interface RendererOptions {
@@ -57,6 +71,7 @@ export type FormatOptions =
   | { kind: 'ccp4map'; options: Ccp4MapOptions }
   | { kind: 'msms'; options: MsmsOptions }
   | { kind: 'namdcoor'; options: NamdCoorOptions }
+  | { kind: 'amberprm'; options: AmberPrmtopOptions }
   | { kind: 'unknown'; options: Record<string, never> };
 
 export interface FileOpenOptions {
@@ -66,29 +81,29 @@ export interface FileOpenOptions {
 
 // ---- Format detection ----
 
-export function detectFormatKind(filePath: string): FormatKind {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-  switch (ext) {
-    case 'pdb':
-    case 'ent':
-      return 'pdb';
-    case 'cif':
-    case 'mmcif':
-      return 'mmcif';
-    case 'mtz':
-      return 'mtz';
-    case 'ccp4':
-    case 'map':
-    case 'mrc':
-      return 'ccp4map';
-    case 'face':
-      return 'msms';
-    case 'crd':
-    case 'namdbin':
-      return 'namdcoor';
-    default:
-      return 'unknown';
-  }
+// Maps a cuemol/core reader nickname (the single source of truth for file
+// type, resolved C++-side by StreamManager) to the dialog's option-pane kind.
+// This mirrors UXP `selectShowTab(reader_name, "<nickname>")`: the pane is
+// keyed on the resolved reader, never on an ad-hoc extension parse. Reader
+// nicknames come from each ObjReader's getName() (PDBFileReader -> "pdb",
+// MTZ2MapReader -> "mtzmap", etc.).
+const READER_NICK_TO_KIND: Record<string, FormatKind> = {
+  pdb: 'pdb',
+  mmcif: 'mmcif',
+  mtzmap: 'mtz',
+  ccp4map: 'ccp4map',
+  msms: 'msms',
+  namdcoor: 'namdcoor',
+  amberprm: 'amberprm',
+};
+
+/**
+ * Resolve which format-specific option pane to show from the reader nickname
+ * that cuemol/core picked for the file. Returns 'unknown' (no pane) for any
+ * reader without dialog options.
+ */
+export function formatKindForReader(readerName: string): FormatKind {
+  return READER_NICK_TO_KIND[readerName] ?? 'unknown';
 }
 
 // ---- Default values ----
@@ -105,19 +120,29 @@ export function getDefaultPdbOptions(): PdbOptions {
 }
 
 export function getDefaultMtzOptions(): MtzOptions {
+  // Placeholders; the real defaults (column selections + resolution) are
+  // filled in by FileOpenOptionDialog once the worker reads the MTZ header.
+  // Grid spacing defaults to the UXP "Fine" preset (0.25).
   return {
     columnF: '',
     columnPhi: '',
+    phaseEnabled: true,
     columnW: '',
+    weightEnabled: false,
     resolutionLimit: 0,
-    gridSpacing: 0.33,
+    gridSpacing: 0.25,
   };
 }
 
 export function getDefaultCcp4MapOptions(): Ccp4MapOptions {
+  // Truncation disabled by default, matching the CCP4MapReader defaults
+  // (truncate_min / truncate_max false). The sigma values are retained as
+  // editable defaults so enabling a toggle uses a sensible clamp.
   return {
     normalize: true,
+    truncateMinEnabled: false,
     truncateMin: -5.0,
+    truncateMaxEnabled: false,
     truncateMax: 5.0,
   };
 }
@@ -128,6 +153,22 @@ export function getDefaultMsmsOptions(): MsmsOptions {
 
 export function getDefaultNamdCoorOptions(): NamdCoorOptions {
   return { psfFilePath: '' };
+}
+
+export function getDefaultAmberPrmtopOptions(): AmberPrmtopOptions {
+  // Coord sub-stream is optional; default empty (topology-only). The dialog
+  // seeds the last-used coord path from history when available.
+  return { coordFilePath: '' };
+}
+
+/**
+ * Default PSF topology path for a NAMD coordinate file: the coordinate path
+ * with its final extension replaced by `.psf`. Mirrors UXP fopen-namdcooropt
+ * (`util.splitFileName(path, "*.coor") + ".psf"`).
+ */
+export function deriveDefaultPsfPath(coorPath: string): string {
+  if (!coorPath) return '';
+  return coorPath.replace(/\.[^.\\/]+$/, '') + '.psf';
 }
 
 export function getDefaultRendererOptions(filePath: string, defaultRendType?: string): RendererOptions {
@@ -185,8 +226,9 @@ export function isFormatOptionsModified(options: FormatOptions): boolean {
       return (
         o.columnF !== d.columnF ||
         o.columnPhi !== d.columnPhi ||
+        o.phaseEnabled !== d.phaseEnabled ||
         o.columnW !== d.columnW ||
-        o.resolutionLimit !== d.resolutionLimit ||
+        o.weightEnabled !== d.weightEnabled ||
         o.gridSpacing !== d.gridSpacing
       );
     }
@@ -195,7 +237,9 @@ export function isFormatOptionsModified(options: FormatOptions): boolean {
       const o = options.options;
       return (
         o.normalize !== d.normalize ||
+        o.truncateMinEnabled !== d.truncateMinEnabled ||
         o.truncateMin !== d.truncateMin ||
+        o.truncateMaxEnabled !== d.truncateMaxEnabled ||
         o.truncateMax !== d.truncateMax
       );
     }
@@ -203,6 +247,8 @@ export function isFormatOptionsModified(options: FormatOptions): boolean {
       return options.options.vertFilePath !== '';
     case 'namdcoor':
       return options.options.psfFilePath !== '';
+    case 'amberprm':
+      return options.options.coordFilePath !== '';
     default:
       return false;
   }
@@ -222,6 +268,8 @@ export function buildDefaultFormatOptions(kind: FormatKind): FormatOptions {
       return { kind: 'msms', options: getDefaultMsmsOptions() };
     case 'namdcoor':
       return { kind: 'namdcoor', options: getDefaultNamdCoorOptions() };
+    case 'amberprm':
+      return { kind: 'amberprm', options: getDefaultAmberPrmtopOptions() };
     default:
       return { kind: 'unknown', options: {} };
   }

--- a/tritium/react-gui/src/renderer/styles/_file-open-dialog.css
+++ b/tritium/react-gui/src/renderer/styles/_file-open-dialog.css
@@ -65,6 +65,12 @@
   margin-bottom: var(--space-4);
 }
 
+/* Inline hint / placeholder text (e.g. "Reading MTZ header...") */
+.fod-hint {
+  font-size: var(--fs-lg);
+  color: var(--text-secondary);
+}
+
 /* Switch rows */
 .fod-switch {
   margin-bottom: var(--space-2);

--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -29,6 +29,7 @@ import * as editApi from './apis/editApi';
 import * as sceneViewApi from './apis/sceneViewApi';
 import type { ProposeUniqNameArgs, ProposeUniqNameResult } from '../server/services/proposeUniqName.service';
 import type { GetCompatibleRendererNamesResult } from '../server/services/getCompatibleRendererNames.service';
+import type { GetMtzColumnInfoResult } from '../server/services/getMtzColumnInfo.service';
 import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../server/services/createViewInScene.service';
 import type { ProposeNewTabNamesArgs, ProposeNewTabNamesResult } from '../server/services/proposeNewTabNames.service';
 import type { GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service';
@@ -263,6 +264,11 @@ export class AsyncCueMol {
     /** Ask which renderer types are compatible with `filePath`. */
     getCompatibleRendererNames(filePath: string, readerName?: string, contentFirst = false): Promise<GetCompatibleRendererNamesResult> {
         return fileApi.getCompatibleRendererNames(this._transport, filePath, readerName, contentFirst);
+    }
+
+    /** Read MTZ column labels + resolution range for the file-open dialog. */
+    getMtzColumnInfo(filePath: string): Promise<GetMtzColumnInfoResult> {
+        return fileApi.getMtzColumnInfo(this._transport, filePath);
     }
 
     /** Fetch open-dialog filters for the given file-category id. */

--- a/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
@@ -11,6 +11,7 @@ import { WorkerTransport } from '../WorkerTransport';
 import type { ElectronFileFilter } from '../../../../shared/ipcTypes';
 import type { FileOpenOptions } from '../../../components/fopen-opt-dlgs/types';
 import type { GetCompatibleRendererNamesResult } from '../../server/services/getCompatibleRendererNames.service';
+import type { GetMtzColumnInfoResult } from '../../server/services/getMtzColumnInfo.service';
 
 const log = console;
 
@@ -39,7 +40,27 @@ export async function getCompatibleRendererNames(
         });
     } catch (e) {
         log.warn('getCompatibleRendererNames failed:', e);
-        return { types: [], objType: '' };
+        return { types: [], objType: '', readerName: '' };
+    }
+}
+
+/**
+ * Read an MTZ file's column labels + resolution range to populate the
+ * file-open dialog's amplitude / phase / weight dropdowns.
+ *
+ * @param transport - Worker transport.
+ * @param filePath - Absolute path of the MTZ file.
+ * @returns Column list and resolution range; `ok:false` (empty) on failure.
+ * @remarks Calls `getMtzColumnInfo` worker service.
+ */
+export async function getMtzColumnInfo(
+    transport: WorkerTransport, filePath: string,
+): Promise<GetMtzColumnInfoResult> {
+    try {
+        return await transport.invokeService('getMtzColumnInfo', { filePath });
+    } catch (e) {
+        log.warn('getMtzColumnInfo failed:', e);
+        return { ok: false, columns: [], minRes: 0, maxRes: 0, resolution: 0 };
     }
 }
 

--- a/tritium/react-gui/src/renderer/worker/server/services/getCompatibleRendererNames.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/getCompatibleRendererNames.service.ts
@@ -1,11 +1,10 @@
 // Runs in Web Worker thread. Wrappers are sync (no await on C++ wrappers).
 import type { WorkerContext } from '../types/WorkerContext';
 import type { ObjReader } from '@cuemol/core/src/wrappers/ObjReader';
-import { DEFAULT_SNIFF_CAP } from '../../shared/sniffConfig';
+import { pickReaderName, OBJREADER_CATEGORY } from './helpers/pickReaderName';
 
 const log = console;
 const RENDERER_TEST_TYPES = new Set(['ms2test', 'symm']);
-const OBJREADER_CATEGORY = 0;
 
 export interface GetCompatibleRendererNamesArgs {
     filePath: string;
@@ -38,49 +37,17 @@ export interface GetCompatibleRendererNamesResult {
      * FileOpenOptionDialog. Empty string when not available.
      */
     objType: string;
+    /**
+     * The reader nickname C++ resolved for this file (e.g. 'pdb', 'mtzmap').
+     * This is the single source of truth for which reader will load the file,
+     * and the dialog uses it to pick the format-specific option pane (mirrors
+     * UXP `selectShowTab(reader_name, ...)`). Empty string when no reader
+     * matched.
+     */
+    readerName: string;
 }
 
-const EMPTY_RESULT: GetCompatibleRendererNamesResult = { types: [], objType: '' };
-
-/**
- * Pick the reader nickname for `filePath`. Mirrors the C++
- * LoadObjectCommand::guessFileFormat() so this lookup and the actual
- * load resolve to the same reader.
- */
-function pickReaderName(
-    ctx: WorkerContext,
-    filePath: string,
-    contentFirst: boolean,
-): string {
-    if (contentFirst) {
-        // Pure content-first: every registered reader's canHandleContent
-        // runs; the first YES wins. Returns '' when nothing claims it.
-        // maxBytes=0 means unbounded -- readers scan their stream until
-        // a verdict or EOF. The UI layer doesn't need a cap for the
-        // disambiguation step (real files break out within a few KB).
-        return ctx.strMgr.searchReaderByContent(filePath, '', OBJREADER_CATEGORY, false, DEFAULT_SNIFF_CAP);
-    }
-
-    // Ext-first: collect every reader whose fext claims this extension.
-    const infoJson = ctx.strMgr.getInfoJSON2();
-    const info: Array<{ name: string; fext: string; category: number }> = JSON.parse(infoJson);
-    const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-    const candidates = info
-        .filter(
-            (e) =>
-                e.category === OBJREADER_CATEGORY &&
-                e.fext.split(';').map((s) => s.trim().replace(/^\*\./, '').toLowerCase()).includes(ext),
-        )
-        .map((e) => e.name);
-
-    if (candidates.length === 0) return '';
-    if (candidates.length === 1) return candidates[0];
-
-    // Multiple readers share this extension. Disambiguate by content.
-    const csv = candidates.join(',');
-    const hit = ctx.strMgr.searchReaderByContent(filePath, csv, OBJREADER_CATEGORY, false, DEFAULT_SNIFF_CAP);
-    return hit || candidates[0];
-}
+const EMPTY_RESULT: GetCompatibleRendererNamesResult = { types: [], objType: '', readerName: '' };
 
 function getCompatibleRendererNames(
     ctx: WorkerContext,
@@ -100,14 +67,14 @@ function getCompatibleRendererNames(
     const objType = (tmpObj as any).getClassName?.() ?? '';
 
     const rendTypesStr = tmpObj.searchCompatibleRendererNames();
-    if (!rendTypesStr) return { types: [], objType };
+    if (!rendTypesStr) return { types: [], objType, readerName };
 
     const types = rendTypesStr
         .split(',')
         .map((s: string) => s.trim())
         .filter((s: string) => s.length > 0 && s.charAt(0) !== '*' && !RENDERER_TEST_TYPES.has(s));
 
-    return { types, objType };
+    return { types, objType, readerName };
 }
 
 export const services = { getCompatibleRendererNames };

--- a/tritium/react-gui/src/renderer/worker/server/services/getMtzColumnInfo.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/getMtzColumnInfo.service.ts
@@ -1,0 +1,76 @@
+/**
+ * @file worker/server/services/getMtzColumnInfo.service.ts
+ * @description Read an MTZ file's column labels and resolution range so the
+ * file-open dialog can populate amplitude / phase / weight dropdowns. Mirrors
+ * the UXP fopen-mtzopt-page onInit path, which calls
+ * `reader.getColumnInfoJSON()` and reads `min_res` / `max_res` / `resolution`
+ * off a reader that has only parsed the MTZ header.
+ *
+ * Runs in the Web Worker thread (sync C++ wrappers, no await). Read-only --
+ * the reader only parses the header/footer (no scene mutation), so this is
+ * NOT wrapped in an undo txn.
+ */
+import type { WorkerContext } from '../types/WorkerContext';
+import type { MTZ2MapReader } from '@cuemol/core/src/wrappers/MTZ2MapReader';
+import { OBJREADER_CATEGORY } from './helpers/pickReaderName';
+
+const log = console;
+
+/** A single MTZ column relevant to map synthesis (F=amplitude, P=phase, W=weight). */
+export interface MtzColumn {
+    name: string;
+    /** MTZ column-type char: 'F' (amplitude), 'P' (phase), 'W' (weight). */
+    type: string;
+}
+
+export interface GetMtzColumnInfoArgs {
+    filePath: string;
+}
+
+export interface GetMtzColumnInfoResult {
+    ok: boolean;
+    /** F / P / W columns only (the types the dialog offers). */
+    columns: MtzColumn[];
+    /** Lowest-resolution shell in Angstrom (the larger number). */
+    minRes: number;
+    /** Highest-resolution shell in Angstrom (the smaller number). */
+    maxRes: number;
+    /** Reader's default resolution limit (== maxRes until overridden). */
+    resolution: number;
+}
+
+const EMPTY: GetMtzColumnInfoResult = { ok: false, columns: [], minRes: 0, maxRes: 0, resolution: 0 };
+
+const RELEVANT_TYPES = new Set(['F', 'P', 'W']);
+
+function getMtzColumnInfo(ctx: WorkerContext, args: GetMtzColumnInfoArgs): GetMtzColumnInfoResult {
+    const reader = ctx.strMgr.createHandler('mtzmap', OBJREADER_CATEGORY) as unknown as MTZ2MapReader | null;
+    if (!reader) {
+        log.warn('[worker] getMtzColumnInfo: createHandler("mtzmap") failed');
+        return EMPTY;
+    }
+
+    try {
+        reader.setPath(args.filePath);
+        // Parses the MTZ header/footer; also populates min_res / max_res /
+        // resolution as a side effect (UXP relies on the same ordering).
+        const json = reader.getColumnInfoJSON();
+        const raw = JSON.parse(json) as Array<{ name: string; type: string }>;
+        const columns = raw
+            .filter((c) => RELEVANT_TYPES.has(c.type))
+            .map((c) => ({ name: c.name, type: c.type }));
+
+        return {
+            ok: true,
+            columns,
+            minRes: reader.min_res,
+            maxRes: reader.max_res,
+            resolution: reader.resolution,
+        };
+    } catch (e) {
+        log.warn('[worker] getMtzColumnInfo failed:', e);
+        return EMPTY;
+    }
+}
+
+export const services = { getMtzColumnInfo };

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/applyReaderOptions.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/applyReaderOptions.ts
@@ -1,0 +1,120 @@
+/**
+ * @file worker/server/services/helpers/applyReaderOptions.ts
+ * @description Apply the file-open dialog's format-specific options onto a
+ * freshly created ObjReader, before read(). This is the worker-side
+ * equivalent of the UXP `fopen-*opt-page` `ondlgok` handlers
+ * (uxp_gui/cuemol2/base/content/fopen-{pdb,mmcif,mtz,ccp4map,msms,namdcoor}opt-page),
+ * which assign dialog values directly onto reader properties.
+ *
+ * Runs in the Web Worker thread (sync C++ wrappers, no await).
+ *
+ * @remarks Reader properties live on concrete reader subclasses (PDBFileReader,
+ * MTZ2MapReader, ...) and are not present on the generated `ObjReader` TS type,
+ * so each assignment casts through `unknown` per the CLAUDE.md duck-typing rule.
+ * The mapping is keyed on the resolved reader `nickname` (not the dialog's
+ * extension-guessed `format.kind`) so it stays correct if the two diverge; the
+ * `format.kind` guard makes a mismatch a safe no-op.
+ */
+import type { ObjReader } from '@cuemol/core/src/wrappers/ObjReader';
+import type { FormatOptions } from '../../../../components/fopen-opt-dlgs/types';
+
+// Narrow the reader to an indexable bag so subclass properties / setSubPath
+// can be assigned without the generated type complaining.
+type ReaderBag = Record<string, unknown> & {
+    setSubPath?: (key: string, path: string) => void;
+};
+
+/**
+ * Apply `format` onto `reader` according to the resolved reader `nickname`.
+ * No-op when `format.kind` is 'unknown' or does not correspond to `nickname`.
+ *
+ * @param reader - the reader handler created by StreamManager.createHandler
+ * @param nickname - resolved reader nickname (pdb / mmcif / mtzmap / ...)
+ * @param format - the dialog's format-specific options (discriminated union)
+ */
+export function applyReaderOptions(
+    reader: ObjReader,
+    nickname: string,
+    format: FormatOptions,
+): void {
+    const r = reader as unknown as ReaderBag;
+
+    switch (nickname) {
+        case 'pdb': {
+            if (format.kind !== 'pdb') return;
+            const o = format.options;
+            r.loadmodel = o.loadModel;
+            r.loadanisou = o.loadAnisou;
+            r.loadaltconf = o.loadAltConf;
+            r.loadsegid = o.loadSegid;
+            r.build2ndry = o.build2ndry;
+            r.autoTopoGen = o.autoTopology;
+            return;
+        }
+        case 'mmcif': {
+            if (format.kind !== 'mmcif') return;
+            const o = format.options;
+            r.loadmodel = o.loadModel;
+            r.loadanisou = o.loadAnisou;
+            r.loadaltconf = o.loadAltConf;
+            r.autoTopoGen = o.autoTopology;
+            // mmcif reader has `loadsecstr` (load 2ndry from file) instead of
+            // `build2ndry` (recompute), and no `loadsegid`. UXP wires
+            // loadsecstr = !calc_2ndry, so build2ndry (recompute) inverts.
+            r.loadsecstr = !o.build2ndry;
+            return;
+        }
+        case 'mtzmap': {
+            if (format.kind !== 'mtz') return;
+            const o = format.options;
+            r.clmn_F = o.columnF;
+            // UXP gates phase / weight on their checkbox; unchecked -> empty
+            // string, which the reader treats as "unset".
+            r.clmn_PHI = o.phaseEnabled ? o.columnPhi : '';
+            r.clmn_WT = o.weightEnabled ? o.columnW : '';
+            r.resolution = o.resolutionLimit;
+            r.gridsize = o.gridSpacing;
+            return;
+        }
+        case 'ccp4map': {
+            if (format.kind !== 'ccp4map') return;
+            const o = format.options;
+            r.normalize = o.normalize;
+            r.truncate_min = o.truncateMinEnabled;
+            r.min = o.truncateMin;
+            r.truncate_max = o.truncateMaxEnabled;
+            r.max = o.truncateMax;
+            return;
+        }
+        case 'msms': {
+            if (format.kind !== 'msms') return;
+            const o = format.options;
+            if (o.vertFilePath) r.vertex_file = o.vertFilePath;
+            return;
+        }
+        case 'namdcoor': {
+            if (format.kind !== 'namdcoor') return;
+            const o = format.options;
+            // PSF topology is a sub-stream keyed 'topo' (NAMDCoorReader
+            // createInStream("topo")); UXP wires it via setSubPath.
+            if (o.psfFilePath && typeof r.setSubPath === 'function') {
+                r.setSubPath('topo', o.psfFilePath);
+            }
+            return;
+        }
+        case 'amberprm': {
+            if (format.kind !== 'amberprm') return;
+            const o = format.options;
+            // AMBER coordinates (inpcrd / rst7 / restrt) are an optional
+            // sub-stream keyed 'coord' (AmberPrmtopReader createInStream("coord")).
+            // Empty -> topology-only load.
+            if (o.coordFilePath && typeof r.setSubPath === 'function') {
+                r.setSubPath('coord', o.coordFilePath);
+            }
+            return;
+        }
+        default:
+            // Unknown / option-less format: nothing to wire.
+            return;
+    }
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts
@@ -1,0 +1,62 @@
+/**
+ * @file worker/server/services/helpers/pickReaderName.ts
+ * @description Resolve the reader nickname for a file path. Mirrors the C++
+ * LoadObjectCommand::guessFileFormat() so the dialog's renderer-type preview
+ * (getCompatibleRendererNames) and the actual load (loadObject) resolve to
+ * the same reader.
+ *
+ * Runs in the Web Worker thread (sync C++ wrappers, no await).
+ */
+import type { WorkerContext } from '../../types/WorkerContext';
+import { DEFAULT_SNIFF_CAP } from '../../../shared/sniffConfig';
+
+export const OBJREADER_CATEGORY = 0;
+
+/**
+ * Pick the reader nickname for `filePath`.
+ *
+ * @param ctx - worker context (uses ctx.strMgr)
+ * @param filePath - path of the file to load
+ * @param contentFirst - when true, ignore the extension and pick the reader
+ *   purely by content-sniffing every registered reader; when false, the
+ *   extension narrows the candidate set first and content sniff only
+ *   disambiguates when several readers share the extension.
+ * @param maxSniffBytes - upper bound on bytes each reader's canHandleContent
+ *   may consume during sniff. Defaults to DEFAULT_SNIFF_CAP.
+ * @returns the resolved reader nickname, or '' when none matches.
+ */
+export function pickReaderName(
+    ctx: WorkerContext,
+    filePath: string,
+    contentFirst: boolean,
+    maxSniffBytes: number = DEFAULT_SNIFF_CAP,
+): string {
+    const cap = maxSniffBytes > 0 ? maxSniffBytes : DEFAULT_SNIFF_CAP;
+    if (contentFirst) {
+        // Pure content-first: every registered reader's canHandleContent
+        // runs; the first YES wins. Returns '' when nothing claims it.
+        // The cap bounds each candidate's stream scan so pathological
+        // inputs can't stall the sniff loop.
+        return ctx.strMgr.searchReaderByContent(filePath, '', OBJREADER_CATEGORY, false, cap);
+    }
+
+    // Ext-first: collect every reader whose fext claims this extension.
+    const infoJson = ctx.strMgr.getInfoJSON2();
+    const info: Array<{ name: string; fext: string; category: number }> = JSON.parse(infoJson);
+    const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+    const candidates = info
+        .filter(
+            (e) =>
+                e.category === OBJREADER_CATEGORY &&
+                e.fext.split(';').map((s) => s.trim().replace(/^\*\./, '').toLowerCase()).includes(ext),
+        )
+        .map((e) => e.name);
+
+    if (candidates.length === 0) return '';
+    if (candidates.length === 1) return candidates[0];
+
+    // Multiple readers share this extension. Disambiguate by content.
+    const csv = candidates.join(',');
+    const hit = ctx.strMgr.searchReaderByContent(filePath, csv, OBJREADER_CATEGORY, false, cap);
+    return hit || candidates[0];
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/loadObject.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/loadObject.service.ts
@@ -1,29 +1,32 @@
 // Runs in Web Worker thread. Wrappers are sync (no await on C++ wrappers).
 //
-// Routes object-file loads through `qsys::LoadObjectCommand`, mirroring
-// UXP / CLI semantics:
+// Loads an object file directly through a StreamManager reader, mirroring
+// the UXP fileOpenHelper1 flow (uxp_gui/cuemol2/base/content/fileopen.js):
 //
-//   1. cmd.setTargetScene(scene)  -- method, NOT the auto-generated
-//      `target_scene` property setter. Property setters route through
-//      LScrObjBase::setPropHelper -> setupParentData which clobbers the
-//      scene's m_thisname / m_rootuid and breaks nested undo records.
-//   2. file_path / file_format / object_name / content_first are string /
-//      boolean properties, which are no-ops in setupParentData and safe.
-//   3. cmd.run() picks the reader via guessFileFormat(catID, content_first),
-//      reads the file, names the new object, and calls scene.addObject().
-//   4. cmd.result_object is a readonly getter -- getter paths never call
-//      setupParentData, so it is safe to read back.
+//   1. pickReaderName() resolves the reader nickname the same way the C++
+//      LoadObjectCommand::guessFileFormat() does (and the same way the
+//      dialog's renderer-type preview did), so this load and the preview
+//      agree on which reader runs.
+//   2. createHandler() + setPath() + (.gz) compress mirror UXP's reader
+//      setup.
+//   3. applyReaderOptions() wires the dialog's format-specific options
+//      (loadModel, build2ndry, clmn_F, normalize, vertex_file, psf, ...)
+//      onto the reader BEFORE read(). LoadObjectCommand had no interface
+//      for this, which is why these options were previously dropped.
+//   4. createDefaultObj / attach / read / detach / name / addObject runs
+//      inside the undo txn so a parse failure rolls back cleanly.
 //
 // Renderer-side setup (selection / colorscheme / render-style) stays
-// outside the command path and runs via setupRenderer().
+// outside the reader path and runs via setupRenderer().
 import type { WorkerContext } from '../types/WorkerContext';
-import type { LoadObjectCommand } from '@cuemol/core/src/wrappers/LoadObjectCommand';
-import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
+import type { ObjReader } from '@cuemol/core/src/wrappers/ObjReader';
+import type { Object as CObject } from '@cuemol/core/src/wrappers/Object';
 import type { Scene } from '@cuemol/core/src/wrappers/Scene';
 import type { FileOpenOptions } from '../../../components/fopen-opt-dlgs/types';
 import { setupRenderer } from './setupRenderer.service';
 import { withUndoTxn } from './withUndoTxn';
-import { DEFAULT_SNIFF_CAP } from '../../shared/sniffConfig';
+import { pickReaderName, OBJREADER_CATEGORY } from './helpers/pickReaderName';
+import { applyReaderOptions } from './helpers/applyReaderOptions';
 
 const log = console;
 
@@ -32,70 +35,76 @@ export interface LoadObjectArgs {
     sceneId: number;
     options: FileOpenOptions;
     /**
-     * When true, ignore the file extension and have C++ side pick the
-     * reader purely by content-sniffing every registered reader. When
-     * false (default), the extension narrows the candidate set first.
+     * When true, ignore the file extension and pick the reader purely by
+     * content-sniffing every registered reader. When false (default), the
+     * extension narrows the candidate set first.
      */
     contentFirst: boolean;
     /**
-     * Optional byte cap forwarded to LoadObjectCommand.max_sniff_bytes.
-     * 0 / undefined leaves the C++ side at its default (unbounded -- the
-     * streaming sniffer reads each candidate's stream until it returns a
-     * verdict or hits EOF). Scripts that want to bound sniff against
-     * pathological / very large inputs can pass a positive value here.
+     * Optional byte cap forwarded to pickReaderName's content-sniff. 0 /
+     * undefined falls back to DEFAULT_SNIFF_CAP. Lets scripts bound sniff
+     * against pathological / very large inputs.
      */
     maxSniffBytes?: number;
 }
 
+/**
+ * Default object name: the file's basename with its final extension removed.
+ * Mirrors C++ LoadObjectCommand::createDefaultObjName (path stem).
+ */
+function fileStem(filePath: string): string {
+    const base = filePath.split(/[\\/]/).pop() ?? filePath;
+    return base.replace(/\.[^.]+$/, '');
+}
+
 function loadObject(ctx: WorkerContext, args: LoadObjectArgs): { ok: boolean } {
     log.info(`[worker] loading object file: ${args.filePath} (contentFirst=${args.contentFirst})`);
+
+    const nickname = pickReaderName(ctx, args.filePath, args.contentFirst, args.maxSniffBytes);
+    if (!nickname) {
+        log.warn(`[worker] loadObject: no reader matched ${args.filePath}`);
+        return { ok: false };
+    }
+
+    const reader = ctx.strMgr.createHandler(nickname, OBJREADER_CATEGORY) as unknown as ObjReader | null;
+    if (!reader) {
+        log.warn(`[worker] loadObject: createHandler failed for "${nickname}"`);
+        return { ok: false };
+    }
+
+    reader.setPath(args.filePath);
+    // Transparent gzip, mirroring UXP fileopen.js (reader.compress = "gzip").
+    // compress is enum-typed in the wrapper but accepts strings at runtime.
+    if (args.filePath.toLowerCase().endsWith('.gz')) {
+        (reader as unknown as { compress: string }).compress = 'gzip';
+    }
+    // Wire the dialog's format-specific reader options before read().
+    applyReaderOptions(reader, nickname, args.options.format);
+
     const scene = ctx.sceMgr.getScene(args.sceneId) as Scene;
 
     return withUndoTxn(scene, 'Open file', () => {
-        const cmd = ctx.cmdMgr.getCmd('load_object') as unknown as LoadObjectCommand | null;
-        if (!cmd) {
-            log.warn('[worker] loadObject: load_object command not registered');
-            return { ok: false };
-        }
-
-        // Method-based scene setter avoids the parent-linkage corruption
-        // the auto-generated `target_scene` property setter would cause.
-        cmd.setTargetScene(scene);
-        cmd.file_path = args.filePath;
-        // Empty file_format hands picking back to guessFileFormat().
-        cmd.file_format = '';
-        cmd.object_name = args.options.renderer.objectName ?? '';
-        // Enum properties cross the wrapper as their string ID, but
-        // boolean properties go through as plain booleans.
-        cmd.content_first = args.contentFirst;
-        // Always apply a sniff cap. Defaults to the worker-side
-        // DEFAULT_SNIFF_CAP (64 KB) so pathological inputs can't stall
-        // the sniff loop; callers may override per-request when a real
-        // file genuinely needs more.
-        cmd.max_sniff_bytes = args.maxSniffBytes && args.maxSniffBytes > 0
-            ? args.maxSniffBytes
-            : DEFAULT_SNIFF_CAP;
-
-        if (args.options.format.kind !== 'unknown') {
-            log.info(
-                `[worker] loadObject: format=${args.options.format.kind} options dropped (not wired to C++)`,
-            );
-        }
-
+        let obj: CObject | null = null;
         try {
-            cmd.run();
+            obj = reader.createDefaultObj() as unknown as CObject;
+            reader.attach(obj);
+            reader.read();
+            reader.detach();
         } catch (e) {
-            log.warn('[worker] loadObject: cmd.run() failed:', e);
+            log.warn('[worker] loadObject: reader.read() failed:', e);
             throw e;  // bubble up so withUndoTxn rolls back
         }
 
-        const mol = cmd.result_object as unknown as MolCoord | null;
-        if (!mol) {
-            log.warn('[worker] loadObject: result_object is null');
+        if (!obj) {
+            log.warn('[worker] loadObject: createDefaultObj returned null');
             return { ok: false };
         }
 
-        setupRenderer(ctx, mol, args.options.renderer);
+        (obj as unknown as { name: string }).name =
+            args.options.renderer.objectName || fileStem(args.filePath);
+        (scene as unknown as { addObject: (o: CObject) => void }).addObject(obj);
+
+        setupRenderer(ctx, obj, args.options.renderer);
         return { ok: true };
     });
 }

--- a/tritium/react-gui/src/renderer/worker/server/services/streamLoadFromUrl.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/streamLoadFromUrl.service.ts
@@ -9,6 +9,7 @@ import type { FileOpenOptions } from '../../../components/fopen-opt-dlgs/types';
 import { setupRenderer } from './setupRenderer.service';
 import { withUndoTxn } from './withUndoTxn';
 import { streamFetchToReader, cancelStream } from './helpers/streamFetchToReader';
+import { applyReaderOptions } from './helpers/applyReaderOptions';
 
 const log = console;
 
@@ -44,6 +45,10 @@ async function streamLoadFromUrl(
     if (!reader) {
         throw new Error(`createHandler failed for reader "${args.readerName}"`);
     }
+
+    // Wire the dialog's format-specific reader options before streaming, the
+    // same way the local file-open path does (readerName is the nickname).
+    applyReaderOptions(reader, args.readerName, args.options.format);
 
     const { obj, canceled } = await streamFetchToReader(ctx, {
         reqId: args.reqId,

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -32,6 +32,7 @@ import type { AppInfoResult } from '../server/services/appInfo.service'
 import type { CreateNewSceneAndViewArgs, CreateNewSceneAndViewResult } from '../server/services/createNewSceneAndView.service'
 import type { CreateViewInSceneArgs, CreateViewInSceneResult } from '../server/services/createViewInScene.service'
 import type { GetCompatibleRendererNamesArgs, GetCompatibleRendererNamesResult } from '../server/services/getCompatibleRendererNames.service'
+import type { GetMtzColumnInfoArgs, GetMtzColumnInfoResult } from '../server/services/getMtzColumnInfo.service'
 import type { GetOpenFiltersArgs } from '../server/services/getOpenFilters.service'
 import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service'
 import type { GetSelDefsArgs, GetSelDefsResult } from '../server/services/getSelDefs.service'
@@ -345,6 +346,7 @@ export interface ServiceMap {
   createNewSceneAndView:      { args: CreateNewSceneAndViewArgs;       result: CreateNewSceneAndViewResult }
   createViewInScene:          { args: CreateViewInSceneArgs;           result: CreateViewInSceneResult }
   getCompatibleRendererNames: { args: GetCompatibleRendererNamesArgs;  result: GetCompatibleRendererNamesResult }
+  getMtzColumnInfo:           { args: GetMtzColumnInfoArgs;            result: GetMtzColumnInfoResult }
   getOpenFilters:             { args: GetOpenFiltersArgs;              result: ElectronFileFilter[] }
   getSceneCloseInfo:          { args: GetSceneCloseInfoArgs;           result: GetSceneCloseInfoResult }
   getSelDefs:                 { args: GetSelDefsArgs;                  result: GetSelDefsResult }

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -49,7 +49,9 @@ export interface InvokeChannels {
                                 defaultFilterIndex?: number
                               };
                               res: { canceled: boolean; filePath: string; filterIndex: number } }
-  [IPC.DIALOG_PICK_PATH]:  { req: { title: string; directory?: boolean };
+  [IPC.DIALOG_PICK_PATH]:  { req: { title: string; directory?: boolean;
+                                     /** Optional open-dialog file filters (file mode only). */
+                                     filters?: { name: string; extensions: string[] }[] };
                              res: { canceled: boolean; filePath: string } }
   [IPC.SAVE_TEXT_AS]:      { req: {
                                 defaultName: string


### PR DESCRIPTION
Replace LoadObjectCommand in the object file-open path with a direct StreamManager reader-based load so reader options collected by the file-open option dialog are actually applied to cuemol/core. The LoadObjectCommand had no interface to set reader options, so all format-specific options (PDB/mmCIF/MTZ/CCP4/MSMS/NAMD) were silently dropped in the worker layer.

Core changes:
- loadObject.service: pickReaderName -> createHandler -> setPath ->
  applyReaderOptions -> createDefaultObj/attach/read/detach -> name ->
  addObject -> setupRenderer, inside the undo txn (mirrors UXP fileopen).
- helpers/pickReaderName: extracted from getCompatibleRendererNames so the load and the dialog preview resolve the same reader.
- helpers/applyReaderOptions: maps dialog FormatOptions onto reader properties per nickname, matching the UXP fopen-*opt-page wiring (incl. mmcif loadsecstr = !build2ndry, namd/amber setSubPath).
- streamLoadFromUrl: wire format options for the Get PDB path too.

Format pane selection now uses the cuemol/core reader nickname (getCompatibleRendererNames returns readerName) instead of an ad-hoc TS-side extension parser, removing a behavior-mismatch source.

Dialog improvements (UXP parity):
- MTZ: amplitude/phase/weight column dropdowns populated from the file via getMtzColumnInfo, phase/weight checkboxes with disable logic, default-column conventions, resolution range, grid presets.
- CCP4: add truncate min/max enable toggles.
- NAMD: PSF path picker (Change...) + default/derived path + history.
- AMBER prmtop: coordinate sub-stream pane (rst7/inpcrd) + picker + history (coord is optional -> no path derivation).
- Extend DIALOG_PICK_PATH with optional file filters.