### PR TITLE
Add color picker widget (UXP colpicker port) to react-gui

### DIFF
--- a/docs/migration/adr/ADR-0020-color-picker-widget.md
+++ b/docs/migration/adr/ADR-0020-color-picker-widget.md
@@ -1,0 +1,80 @@
+# ADR-0020: Color picker widget — popover-panel port of UXP colpicker
+
+- Status: accepted (ColorPane decks wired; Paint table + Inspector deferred)
+- Date: 2026-05-29
+- Mapping rows: [`widget.colpicker`](../mapping/custom_widgets.md#widgetcolpicker), [`widget.colorslider`](../mapping/custom_widgets.md#widgetcolorslider), [`menu.color`](../mapping/menus.md#menucolor)
+
+## Context
+
+UXP implemented colour selection as a composite XBL widget (`colpicker.js` +
+`colorSlider.xml` + `color-menu.xul`), embedded as `<mycolpicker>` in 17 XUL
+files. The widget is a text box + caret menu (RGB / HSB / Named colors /
+Palette / Use mol color); each mode opens a floating panel. Tritium's
+ColorPane decks previously used a plain text input with a hardcoded
+`NAMED_COLORS` preview map, so only `#hex` / `rgb()` strings previewed
+correctly -- named colours and `hsb()` did not, and there was no mode-based
+editing.
+
+A first port reproduced UXP literally (caret menu -> second floating panel),
+but the two-step popover flow was awkward, so the widget was reworked to a
+single popover with an inline mode switch (see Decision).
+
+## Decision
+
+Ship a reusable React widget `ColorPicker`
+(`react-gui/src/renderer/components/widgets/colorpicker/`): swatch +
+`InputGroup` + caret. The caret opens a SINGLE Blueprint `Popover` whose top
+row is a segmented `ButtonGroup` mode switch (RGB / HSB / Named / Palette /
+Mol) and whose body shows the active mode's panel. RGB and HSB stay separate
+modes (not merged). "Mol" has no editable params, so selecting it applies
+`$molcol` immediately and shows a short note. Panels: `RgbHsbPanel` (three
+gradient `ColorSlider`s + `NumericInput` spinners), `NamedListPanel` (scene +
+global named colours), `PalettePanel` (UXP `buildPaletteBox` tile grid).
+Colour resolution, the named-colour list, and the out-of-gamut check are
+delegated to a new worker service `colorPicker.service.ts` (`compileColor` /
+`getNamedColors`) so previews match the C++ StyleManager exactly; HSB<->RGB
+maths and gradient/hsb-string formatting are pure local helpers in
+`colorMath.ts` (no per-drag IPC).
+
+The widget is controlled via `value` / `onChange(value, completed)`;
+`completed=false` during slider drags and `true` on commit (panel close,
+named/palette pick, text-box blur, mol-color pick). ColorPane consumes it
+through a `ColorPickerContext` + thin `PaneColorPicker` adapter that forwards
+only completed edits to the existing deck `onCommit`, so undo behaviour is
+unchanged. Visual styling modernises the UXP look using design tokens
+(`_colorpicker.css`); the legacy resizer handle, XUL listbox, and old spinner
+chrome are not reproduced.
+
+## Consequences
+
+- Accurate previews everywhere the widget is used; named/HSB/tuple colours
+  now render their true colour, and out-of-gamut colours show an amber
+  warning swatch that clamps to the device colour on click.
+- HSB editing keeps a separate working triple inside `RgbHsbPanel` (like
+  UXP's `mHSBValue`) so dragging hue through a grey does not lose the hue to
+  an RGB round-trip.
+- Live slider edits update the widget's own swatch but are NOT pushed to the
+  3D view until the gesture completes (commit-on-release), matching the prior
+  blur-commit behaviour and avoiding undo-step spam. True live 3D preview is
+  future work.
+- Scope is the Solid / CPK / Bfac / Elepot decks. The Paint table cell (a
+  distinct td-background layout) and the Inspector `ColorEditor` (native
+  `<input type=color>`) are not yet migrated; `NAMED_COLORS` /
+  `resolveColorPreview` remain only for the Paint table.
+
+## Notes
+
+- Widget: `react-gui/src/renderer/components/widgets/colorpicker/ColorPicker.tsx`
+  (+ `ColorSlider`, `RgbHsbPanel`, `NamedListPanel`, `PalettePanel`,
+  `colorMath.ts`); styles in `react-gui/src/renderer/styles/_colorpicker.css`.
+- Worker service: `react-gui/src/renderer/worker/server/services/colorPicker.service.ts`;
+  `ServiceMap` rows `compileColor` / `getNamedColors` in
+  `worker/shared/WorkerCalls.ts`.
+- Integration: `components/panes/ColorPane.tsx` (`ColorPickerContext`,
+  `PaneColorPicker`, `SolidDeck`, `ColorField`, `ColorSwatchInline`).
+- UXP parity references: `uxp_gui/cuemol2/base/content/colpicker.js`,
+  `colorSlider.xml`, `color-menu.xul`; colour maths from
+  `uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/util.js`
+  (`convHSB2RGB` / `convRGB2HSB` / `packToHTMLColor`).
+- Tests: `__test__/colorMath.test.ts`, `__test__/colorPickerService.test.ts`,
+  `__test__/ColorPicker.test.tsx`.

--- a/docs/migration/adr/_index.md
+++ b/docs/migration/adr/_index.md
@@ -48,3 +48,4 @@ Architecture Decision Records for the UXP → tritium migration.
 | [ADR-0017](ADR-0017-povray-rendering-ui.md) | POV-Ray rendering UI — Inspector settings, BottomPanel tab, Render Result tab, worker pipeline | accepted (single-frame; animation deferred) | 2026-05-18 | `dialog.tool.render-pov` |
 | [ADR-0018](ADR-0018-molstruct-panel.md) | MolStruct panel — lazy load, multi-select, deferred virtualization | accepted (tree perf deferred) | 2026-05-24 | `panel.molstruct` |
 | [ADR-0019](ADR-0019-seq-panel-selection-latency.md) | Sequence panel — residual selection-commit latency (future work) | proposed (future work) | 2026-05-24 | `panel.btmpanel-holder.seq` |
+| [ADR-0020](ADR-0020-color-picker-widget.md) | Color picker widget — popover-panel port of UXP colpicker | accepted (ColorPane decks wired; Paint table + Inspector deferred) | 2026-05-29 | `widget.colpicker`, `widget.colorslider`, `menu.color` |

--- a/docs/migration/mapping/_index.md
+++ b/docs/migration/mapping/_index.md
@@ -7,7 +7,7 @@
 - Updated: 2026-05-24 (`panel.btmpanel-holder.seq` Phase 2: drag range select + shift+click range extend with green tracking rect; pointer flow + setPointerCapture)
 - Updated: 2026-05-24 (`panel.btmpanel-holder` split into `.log` / `.seq`; `.seq` Phase 1 wip: Canvas grid + click toggle + Center ctx menu)
 - Updated: 2026-05-24 (`panel.selection` Command tab done: molecule selector + multi-line text + History MRU shared with `MolSelList` via `applyMolSelString`; E2E verified)
-- Updated: 2026-05-24 (`panel.molstruct` Phase 1+2: live tree, lazy load, Select / Center / Zoom — ADR-0018)
+- Updated: 2026-05-29 (`widget.colpicker` / `widget.colorslider` / `menu.color`: color picker widget — ADR-0020)
 - Source files: `docs/migration/mapping/*.md` (excluding this file)
 - Option-specification UX: see [`../option-ux-guidelines.md`](../option-ux-guidelines.md)
   for routing dialog migrations to modal / panel / drawer / popover patterns
@@ -19,15 +19,15 @@
 | Category | File | Total | done | wip | review | todo | frozen |
 |----------|------|------:|-----:|----:|-------:|-----:|-------:|
 | Panel | [panels.md](panels.md) | 27 | 4 | 17 | 1 | 5 | 0 |
-| Menu | [menus.md](menus.md) | 4 | 1 | 2 | 0 | 1 | 0 |
+| Menu | [menus.md](menus.md) | 4 | 2 | 2 | 0 | 0 | 0 |
 | Toolbar | [toolbars.md](toolbars.md) | 2 | 0 | 1 | 0 | 1 | 0 |
 | Dialog\_property | [prop\_dlgs.md](prop_dlgs.md) | 13 | 0 | 0 | 0 | 13 | 0 |
 | Dialog\_other | [other\_dlgs.md](other_dlgs.md) | 18 | 0 | 3 | 0 | 15 | 0 |
 | Dialog\_tool | [tool\_dlgs.md](tool_dlgs.md) | 21 | 1 | 0 | 0 | 20 | 0 |
-| Custom Widget | [custom\_widgets.md](custom_widgets.md) | 13 | 0 | 1 | 0 | 12 | 0 |
+| Custom Widget | [custom\_widgets.md](custom_widgets.md) | 13 | 1 | 2 | 0 | 10 | 0 |
 | Overlay | [overlay.md](overlay.md) | 28 | 0 | 1 | 0 | 27 | 0 |
 | Other | [other.md](other.md) | 4 | 0 | 1 | 0 | 3 | 0 |
-| **Total** | | **130** | **6** | **26** | **1** | **97** | **0** |
+| **Total** | | **130** | **8** | **27** | **1** | **94** | **0** |
 
 > frozen = `blocked` status in mapping files
 
@@ -74,6 +74,7 @@
 | [`dialog.about`](other_dlgs.md#dialogabout) | `AboutDialog` / `useDialog` | GRE info・userAgent は省略 |
 | [`other.cuemol2`](other.md#othercuemol2) | `App` / `ContentArea` / `TabBar` / `ConfirmCloseTabDialog` / `useQuitHandler` | Main window layout done; close-tab confirmation dialog (UXP `closeTabImpl`) implemented; UXP `onCloseEvent` quit chain wired (cmd-Q walks all tabs via `before-quit` → `APP_QUIT_REQUEST` → `APP_QUIT_PROCEED`) |
 | [`widget.molsellist`](custom_widgets.md) | `MolSelList` (`components/widgets/MolSelList/`) | First consumer wired in `RendererOptionsPane` (file-open dialog); editable `InputGroup` + chevron-only `HTMLSelect` (OS-native dropdown listbox with `<optgroup>` Preset / History / Scene / Global); history via `localStorage`; worker services `getSelDefs` / `validateSelection` added |
+| [`widget.colpicker`](custom_widgets.md) | `ColorPicker` (`components/widgets/colorpicker/`) / `colorPicker.service` | UXP colpicker port (ADR-0020): swatch + text box + caret opening a single popover with a segmented mode switch (RGB / HSB / Named / Palette / Mol) + out-of-gamut warning; `compileColor` / `getNamedColors` worker services. Wired into ColorPane Solid/CPK/Bfac/Elepot decks; Paint table cell + Inspector ColorEditor still pending |
 | [`panel.workspace.tree`](panels.md#panelworkspacetree) | `ScenePane` (tree) / `useSceneTree` / `useSceneTreeController` / `sceneTreeDnd` / `InlineRenameInput` / `sceneTree.service` / `reorderSceneNode.service` | Live tree + visibility toggle + selection (single + multi via Cmd/Ctrl+click) + event-driven auto-refresh + drag-drop reorder (worker + in-app DnD OK; ADR-0001) + F2 inline rename; pending: Shift+range select |
 | [`panel.workspace.ctxmenu.multi`](panels.md#panelworkspacectxmenumulti) | `useSceneContextMenu` / `main/sceneContextMenu` (multi) / `bulkSceneNodeOps.service` | Right-clicking a multi-selected row opens a multi-only menu: Show / Hide / Delete via `bulkSetNodeVisible` / `bulkDeleteNode` (single undo txn per batch); worker + in-app multi-select OK; pending: Copy (clipboard is single-item) |
 | [`panel.workspace.toolbar`](panels.md#panelworkspacetoolbar) | `ScenePane` (toolbar) / `useSceneTreeController` / `sceneOps.service` / `createRendererOnObject.service` / `getNewRendererOptions.service` | Focus / Delete / Property / Add wired (Add shares the New Renderer flow with the ctxmenu); property dialog still a read-only stub |

--- a/docs/migration/mapping/custom_widgets.md
+++ b/docs/migration/mapping/custom_widgets.md
@@ -20,8 +20,8 @@ Status values:
 |----|-------|---------|--------|----|-----|-------|
 | [`widget.wheelbtn`](../uxp-inventory/custom_widgets.md#widgetwheelbtn) | | | todo | | | |
 | [`widget.numslider`](../uxp-inventory/custom_widgets.md#widgetnumslider) | | | todo | | | |
-| [`widget.colorslider`](../uxp-inventory/custom_widgets.md#widgetcolorslider) | | | todo | | | |
-| [`widget.colpicker`](../uxp-inventory/custom_widgets.md#widgetcolpicker) | | | todo | | | |
+| [`widget.colorslider`](../uxp-inventory/custom_widgets.md#widgetcolorslider) | `components/widgets/colorpicker/ColorSlider.tsx` | direct | done | | [ADR-0020](../adr/ADR-0020-color-picker-widget.md) | Gradient-track range slider; linear + hue gradients via CSS. Used by `RgbHsbPanel`. |
+| [`widget.colpicker`](../uxp-inventory/custom_widgets.md#widgetcolpicker) | `components/widgets/colorpicker/ColorPicker.tsx` | direct | wip | | [ADR-0020](../adr/ADR-0020-color-picker-widget.md) | Single popover + segmented mode switch (RGB/HSB/Named/Palette/Mol) + out-of-gamut warning; `compileColor`/`getNamedColors` worker services. Wired into ColorPane Solid/CPK/Bfac/Elepot decks; Paint table cell + Inspector ColorEditor still pending. |
 | [`widget.mainview`](../uxp-inventory/custom_widgets.md#widgetmainview) | | | todo | | | |
 | [`widget.molsellist`](../uxp-inventory/custom_widgets.md#widgetmolsellist) | `components/widgets/MolSelList/MolSelList.tsx` | direct | wip | | | First consumer: `RendererOptionsPane` (file-open dialog). Editable `InputGroup` + chevron-only `HTMLSelect` (CSS-shrunk to ~30 px, hidden empty sentinel option keeps the display blank — no "Pick…" text). Click chevron → OS-native dropdown listbox with `<optgroup>` Preset / History / Scene / Global, sidesteps Dialog flip/overflow. History via `localStorage`. Worker services `getSelDefs` (StyleManager scene+global named-sel defs) / `validateSelection` added. |
 | [`widget.paintpanel`](../uxp-inventory/custom_widgets.md#widgetpaintpanel) | | | todo | | | |

--- a/docs/migration/mapping/menus.md
+++ b/docs/migration/mapping/menus.md
@@ -18,7 +18,7 @@ Status values:
 
 | ID | React | Mapping | Status | PR | ADR | Notes |
 |----|-------|---------|--------|----|-----|-------|
-| [`menu.color`](../uxp-inventory/menus.md#menucolor) | | | todo | | | Color picker popup; deferred pending color picker UI design |
+| [`menu.color`](../uxp-inventory/menus.md#menucolor) | `components/widgets/colorpicker/PalettePanel.tsx` | merged | done | | [ADR-0020](../adr/ADR-0020-color-picker-widget.md) | UXP color-menu presets merged into the color picker Palette panel (grayscale + 7 hue rows x 7 sat/bri variations). |
 | [`menu.cuemol2`](../uxp-inventory/menus.md#menucuemol2) | `menuTemplate` / `MenuBar` / `useMenuDispatch` | split | wip | | | Full 9-group menu structure added (File/Edit/Rendering/Scene/View/Tools/Window/Help); per-item implementation status is tracked below; `MenuBar` (React) is suppressed on macOS -- native Electron menu only |
 | [`menu.cuemol2-macos`](../uxp-inventory/menus.md#menucuemol2-macos) | `main/menu.ts` (`macOnlyGroups`) | direct | wip | | | macOS App menu added; per-item implementation status is tracked below |
 | [`menu.cuemol2-scripts`](../uxp-inventory/menus.md#menucuemol2-scripts) | — | dropped | done | | | XUL script loader overlay; Electron app handles module loading natively — no migration needed |
@@ -29,7 +29,7 @@ Completion counts treat `wired` and `native` as complete. `stub` means the menu 
 
 | Scope | Complete | Stub / todo | Completion | Notes |
 |-------|---------:|------------:|-----------:|-------|
-| `menu.color` | 0 | 1 | 0% | Not migrated or itemized in Tritium yet |
+| `menu.color` | 1 | 0 | 100% | Presets merged into the color picker Palette panel (see ADR-0020) |
 | `menu.cuemol2` | 25 | 30 | 45% | Main menubar structure exists; 55 item-level migration points tracked (1 dropped counted as complete) |
 | `menu.cuemol2-macos` | 6 | 1 | 86% | OS-native items complete; Preferences is stubbed |
 | `menu.cuemol2-scripts` | 1 | 0 | 100% | Dropped intentionally because Electron module loading replaces the XUL script overlay |

--- a/tritium/react-gui/src/renderer/__test__/ColorPicker.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/ColorPicker.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { act } from 'react'
+import { mountTree, flushPromises } from './helpers/testHarness'
+
+void React
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+    )!.set!
+    setter.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+/**
+ * Degrade-detection tests for the ColorPicker widget wire contract.
+ *
+ * Pins:
+ *   - on mount the canonical value is resolved through the `compileColor`
+ *     service and the text box shows it
+ *   - a valid text-box edit commits via `onChange(value, /*completed=*\/ true)`
+ *   - an invalid edit (StyleManager rejects -> ok:false) does NOT commit and
+ *     reverts the draft
+ *   - the caret opens one popover whose segmented switch defaults to the
+ *     RGB slider panel, and choosing the Palette segment swaps the body
+ *
+ * Theme is mocked (the widget reads it only for the Blueprint dark portal
+ * class); the worker `cm` is a stub whose `invokeService` returns canned
+ * compileColor / getNamedColors results.
+ */
+
+vi.mock('../contexts/ThemeContext', () => ({
+    useTheme: () => ({ theme: 'dark' }),
+}))
+
+import { ColorPicker } from '../components/widgets/colorpicker/ColorPicker'
+
+interface CmStub {
+    invokeService: ReturnType<typeof vi.fn>
+}
+
+function makeCm(compileOk = true): CmStub {
+    return {
+        invokeService: vi.fn((name: string) => {
+            if (name === 'compileColor') {
+                return Promise.resolve(
+                    compileOk
+                        ? { ok: true, r: 0, g: 0, b: 255, hex: '#0000ff', className: 'Color', inGamut: true }
+                        : { ok: false },
+                )
+            }
+            return Promise.resolve({ scene: [], global: [] })
+        }),
+    }
+}
+
+describe('ColorPicker', () => {
+    it('resolves the value via compileColor on mount', async () => {
+        const cm = makeCm()
+        const { container, unmount } = mountTree(
+            <ColorPicker value="#0000FF" sceneId={3} cm={cm as never} onChange={vi.fn()} />,
+        )
+        await act(async () => {
+            await flushPromises()
+        })
+        expect(cm.invokeService).toHaveBeenCalledWith('compileColor', {
+            colorStr: '#0000FF',
+            sceneId: 3,
+        })
+        const input = container.querySelector('input.bp5-input') as HTMLInputElement
+        expect(input.value).toBe('#0000FF')
+        unmount()
+    })
+
+    it('commits a valid text edit with completed=true', async () => {
+        const cm = makeCm(true)
+        const onChange = vi.fn()
+        const { container, unmount } = mountTree(
+            <ColorPicker value="#0000FF" sceneId={0} cm={cm as never} onChange={onChange} />,
+        )
+        await act(async () => {
+            await flushPromises()
+        })
+        const input = container.querySelector('input.bp5-input') as HTMLInputElement
+        await act(async () => {
+            setInputValue(input, 'red')
+        })
+        await act(async () => {
+            input.dispatchEvent(new Event('focusout', { bubbles: true }))
+            await flushPromises()
+        })
+        expect(onChange).toHaveBeenCalledWith('red', true)
+        unmount()
+    })
+
+    it('does not commit an invalid text edit and reverts the draft', async () => {
+        const cm = makeCm(false)
+        const onChange = vi.fn()
+        const { container, unmount } = mountTree(
+            <ColorPicker value="#0000FF" sceneId={0} cm={cm as never} onChange={onChange} />,
+        )
+        await act(async () => {
+            await flushPromises()
+        })
+        const input = container.querySelector('input.bp5-input') as HTMLInputElement
+        await act(async () => {
+            setInputValue(input, 'garbage')
+        })
+        await act(async () => {
+            input.dispatchEvent(new Event('focusout', { bubbles: true }))
+            await flushPromises()
+        })
+        expect(onChange).not.toHaveBeenCalled()
+        expect(input.value).toBe('#0000FF')
+        unmount()
+    })
+
+    it('opens one popover defaulting to RGB sliders, and swaps body on segment switch', async () => {
+        const cm = makeCm()
+        const { container, unmount } = mountTree(
+            <ColorPicker value="#0000FF" sceneId={0} cm={cm as never} onChange={vi.fn()} />,
+        )
+        await act(async () => {
+            await flushPromises()
+        })
+        // Open the popover (caret button).
+        const caret = container.querySelector('button.bp5-button') as HTMLButtonElement
+        await act(async () => {
+            caret.click()
+            await flushPromises()
+        })
+        // Default mode renders the RGB slider panel.
+        expect(document.querySelector('.cp-slider-panel')).toBeTruthy()
+        // The segmented switch offers all modes; clicking Palette swaps the body.
+        const paletteSeg = Array.from(
+            document.querySelectorAll('.cp-modebar button'),
+        ).find((el) => el.textContent === 'Palette') as HTMLElement
+        expect(paletteSeg).toBeTruthy()
+        await act(async () => {
+            paletteSeg.click()
+            await flushPromises()
+        })
+        expect(document.querySelector('.cp-slider-panel')).toBeNull()
+        expect(document.querySelector('.cp-palette')).toBeTruthy()
+        unmount()
+    })
+
+    it('applies $molcol immediately when the Mol segment is chosen', async () => {
+        const cm = makeCm()
+        const onChange = vi.fn()
+        const { container, unmount } = mountTree(
+            <ColorPicker value="#0000FF" sceneId={0} cm={cm as never} onChange={onChange} />,
+        )
+        await act(async () => {
+            await flushPromises()
+        })
+        const caret = container.querySelector('button.bp5-button') as HTMLButtonElement
+        await act(async () => {
+            caret.click()
+            await flushPromises()
+        })
+        const molSeg = Array.from(document.querySelectorAll('.cp-modebar button')).find(
+            (el) => el.textContent === 'Mol',
+        ) as HTMLElement
+        await act(async () => {
+            molSeg.click()
+            await flushPromises()
+        })
+        expect(onChange).toHaveBeenCalledWith('$molcol', true)
+        unmount()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/colorMath.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/colorMath.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Degrade-detection tests for the colour-picker maths (`colorMath.ts`).
+ *
+ * Pins the UXP-ported HSB<->RGB conversions and hex packing at the colour
+ * boundaries the picker relies on (primary hues, greyscale, black/white).
+ * These are pure functions; if a refactor changes the rounding or the hue
+ * sextant logic the slider gradients and palette tiles drift, and these
+ * assertions catch it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { hsbToRgb, rgbToHsb, packToHex, packToHsbString } from '../components/widgets/colorpicker/colorMath'
+
+describe('hsbToRgb', () => {
+    it('maps primary hues at full sat/bri', () => {
+        expect(hsbToRgb([0, 100, 100])).toEqual([255, 0, 0]) // red
+        expect(hsbToRgb([120, 100, 100])).toEqual([0, 255, 0]) // green
+        expect(hsbToRgb([240, 100, 100])).toEqual([0, 0, 255]) // blue
+        expect(hsbToRgb([60, 100, 100])).toEqual([255, 255, 0]) // yellow
+    })
+
+    it('produces greyscale when saturation is 0', () => {
+        expect(hsbToRgb([0, 0, 100])).toEqual([255, 255, 255])
+        expect(hsbToRgb([0, 0, 0])).toEqual([0, 0, 0])
+    })
+
+    it('wraps hue modulo 360', () => {
+        expect(hsbToRgb([360, 100, 100])).toEqual(hsbToRgb([0, 100, 100]))
+    })
+})
+
+describe('rgbToHsb', () => {
+    it('inverts the primary hues', () => {
+        expect(rgbToHsb([255, 0, 0])).toEqual([0, 100, 100])
+        expect(rgbToHsb([0, 255, 0])).toEqual([120, 100, 100])
+        expect(rgbToHsb([0, 0, 255])).toEqual([240, 100, 100])
+    })
+
+    it('reports zero saturation for greys', () => {
+        expect(rgbToHsb([128, 128, 128])).toEqual([0, 0, 50])
+        expect(rgbToHsb([0, 0, 0])).toEqual([0, 0, 0])
+    })
+})
+
+describe('packToHex', () => {
+    it('zero-pads each channel', () => {
+        expect(packToHex([0, 0, 0])).toBe('#000000')
+        expect(packToHex([255, 255, 255])).toBe('#ffffff')
+        expect(packToHex([0, 0, 255])).toBe('#0000ff')
+    })
+
+    it('clamps out-of-range channels', () => {
+        expect(packToHex([300, -5, 128])).toBe('#ff0080')
+    })
+})
+
+describe('packToHsbString', () => {
+    it('formats saturation/brightness as 0-1 fractions (UXP convention)', () => {
+        expect(packToHsbString([240, 100, 50])).toBe('hsb(240,1,0.5)')
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/colorPickerService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/colorPickerService.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Degrade-detection tests for the `colorPicker` worker service.
+ *
+ * Pins the StyleManager contract the colour picker depends on:
+ *   - compileColor routes the string + scope to `styleMgr.compileColor`
+ *     and surfaces RGB / className / gamut info
+ *   - an in-gamut colour reports inGamut=true with no device RGB
+ *   - an out-of-gamut colour decodes the device code into devR/G/B
+ *   - getNamedColors merges scene-scoped then global definitions, each
+ *     resolved via `styleMgr.getColor`
+ *   - a colour string the StyleManager rejects yields { ok: false }
+ *
+ * The service runs in the worker thread where wrappers are synchronous, so
+ * the StyleManager is mocked as a plain object.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { WorkerContext } from '../worker/server/types/WorkerContext'
+import { services } from '../worker/server/services/colorPicker.service'
+
+function makeColorObj(
+    r: number,
+    g: number,
+    b: number,
+    opts: { className?: string; inGamut?: boolean; devCode?: number } = {},
+) {
+    return {
+        r: () => r,
+        g: () => g,
+        b: () => b,
+        getClassName: () => opts.className ?? 'Color',
+        isInGamut: () => opts.inGamut ?? true,
+        getDevCode: () => opts.devCode ?? 0,
+    }
+}
+
+function makeCtx(styleMgr: Record<string, unknown>): WorkerContext {
+    return { styleMgr } as unknown as WorkerContext
+}
+
+describe('colorPicker.compileColor', () => {
+    it('resolves RGB, hex and className for an in-gamut colour', () => {
+        const compileColor = vi.fn(() => makeColorObj(0, 0, 255, { className: 'NamedColor' }))
+        const ctx = makeCtx({ compileColor })
+
+        const res = services.compileColor(ctx, { colorStr: 'blue', sceneId: 7 })
+
+        expect(compileColor).toHaveBeenCalledWith('blue', 7)
+        expect(res).toMatchObject({
+            ok: true,
+            r: 0,
+            g: 0,
+            b: 255,
+            hex: '#0000ff',
+            className: 'NamedColor',
+            inGamut: true,
+        })
+        expect(res.devR).toBeUndefined()
+    })
+
+    it('decodes device RGB when the colour is out of gamut', () => {
+        const devCode = (0x11 << 16) | (0x22 << 8) | 0x33
+        const compileColor = vi.fn(() =>
+            makeColorObj(255, 0, 0, { inGamut: false, devCode }),
+        )
+        const ctx = makeCtx({ compileColor })
+
+        const res = services.compileColor(ctx, { colorStr: '#ff0000', sceneId: 0 })
+
+        expect(res.inGamut).toBe(false)
+        expect(res.devR).toBe(0x11)
+        expect(res.devG).toBe(0x22)
+        expect(res.devB).toBe(0x33)
+    })
+
+    it('returns ok:false when the StyleManager rejects the string', () => {
+        const compileColor = vi.fn(() => {
+            throw new Error('bad color')
+        })
+        const ctx = makeCtx({ compileColor })
+
+        expect(services.compileColor(ctx, { colorStr: 'nope', sceneId: 0 })).toEqual({
+            ok: false,
+        })
+    })
+})
+
+describe('colorPicker.getNamedColors', () => {
+    it('merges scene then global defs, each resolved via getColor', () => {
+        const getColorDefsJSON = vi.fn((sceneId: number) =>
+            sceneId === 5 ? JSON.stringify(['scenered']) : JSON.stringify(['aqua']),
+        )
+        const getColor = vi.fn((name: string) =>
+            name === 'scenered' ? makeColorObj(255, 0, 0) : makeColorObj(0, 255, 255),
+        )
+        const ctx = makeCtx({ getColorDefsJSON, getColor })
+
+        const res = services.getNamedColors(ctx, { sceneId: 5 })
+
+        expect(getColorDefsJSON).toHaveBeenCalledWith(5)
+        expect(getColorDefsJSON).toHaveBeenCalledWith(0)
+        expect(res.scene).toEqual([{ name: 'scenered', r: 255, g: 0, b: 0, hex: '#ff0000' }])
+        expect(res.global).toEqual([{ name: 'aqua', r: 0, g: 255, b: 255, hex: '#00ffff' }])
+    })
+
+    it('skips the scene scope when sceneId is 0', () => {
+        const getColorDefsJSON = vi.fn(() => JSON.stringify(['aqua']))
+        const getColor = vi.fn(() => makeColorObj(0, 255, 255))
+        const ctx = makeCtx({ getColorDefsJSON, getColor })
+
+        const res = services.getNamedColors(ctx, { sceneId: 0 })
+
+        expect(res.scene).toEqual([])
+        expect(getColorDefsJSON).not.toHaveBeenCalledWith(5)
+    })
+})

--- a/tritium/react-gui/src/renderer/app.css
+++ b/tritium/react-gui/src/renderer/app.css
@@ -8,6 +8,7 @@
 @import "./styles/_activity-bar.css";
 @import "./styles/_side-panel.css";
 @import "./styles/_color-panel.css";
+@import "./styles/_colorpicker.css";
 @import "./styles/_inspector-panel.css";
 @import "./styles/_inspector-generic-tab.css";
 @import "./styles/_config-pane.css";

--- a/tritium/react-gui/src/renderer/components/panes/ColorPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/ColorPane.tsx
@@ -26,7 +26,7 @@
  * This pane is one of the components within the ExplorerView.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import {
     Button,
     ButtonGroup,
@@ -51,6 +51,7 @@ import type {
     PaintEntryDto,
     RainbowParams,
 } from '../../worker/server/services/rendererColoring.service'
+import { ColorPicker } from '../widgets/colorpicker/ColorPicker'
 import { usePaintCapableRenderers } from '../../hooks/usePaintCapableRenderers'
 import { useRendererColoringState } from '../../hooks/useRendererColoringState'
 import { useElePotMapObjects } from '../../hooks/useElePotMapObjects'
@@ -88,6 +89,44 @@ const resolveColorPreview = (color: string): string => {
         return trimmed
     // Unknown format (e.g. "(255,128,0,255)" tuple) -- let the browser try.
     return trimmed
+}
+
+// ────────────────────────────────────────────────────────────
+// Colour-picker context
+//
+// The deck colour editors are nested several components deep; rather than
+// thread `cm` / `sceneId` through every deck, ColorPane publishes them via
+// a context that `PaneColorPicker` consumes. `PaneColorPicker` adapts the
+// reusable ColorPicker widget to the deck `onCommit(value)` convention by
+// forwarding only completed edits.
+// ────────────────────────────────────────────────────────────
+
+interface ColorPickerCtx {
+    cm: AsyncCueMol | null
+    sceneId: number | undefined
+}
+
+const ColorPickerContext = createContext<ColorPickerCtx>({ cm: null, sceneId: undefined })
+
+interface PaneColorPickerProps {
+    value: string
+    onCommit: (value: string) => void
+    className?: string
+}
+
+const PaneColorPicker: React.FC<PaneColorPickerProps> = ({ value, onCommit, className }) => {
+    const { cm, sceneId } = useContext(ColorPickerContext)
+    return (
+        <ColorPicker
+            value={value}
+            cm={cm}
+            sceneId={sceneId}
+            className={className}
+            onChange={(v, completed) => {
+                if (completed && v !== value) onCommit(v)
+            }}
+        />
+    )
 }
 
 // ────────────────────────────────────────────────────────────
@@ -412,40 +451,17 @@ interface SolidDeckProps {
     onCommit: (color: string) => void
 }
 
-const SolidDeck: React.FC<SolidDeckProps> = ({ className, defaultColor, onCommit }) => {
-    const [draft, setDraft] = useState(defaultColor)
-    useEffect(() => setDraft(defaultColor), [defaultColor])
-
-    const commit = useCallback(() => {
-        if (draft === defaultColor) return
-        onCommit(draft)
-    }, [draft, defaultColor, onCommit])
-
-    return (
-        <div className="color-solid-deck">
-            <div className="color-section-label">
-                {className === '' ? 'Solid coloring' : className}
-            </div>
-            <div className="color-solid-row">
-                <label className="color-solid-label">Default color</label>
-                <div
-                    className="color-solid-swatch"
-                    style={{ backgroundColor: resolveColorPreview(draft) }}
-                />
-                <input
-                    className="color-inline-input color-value-input color-solid-input"
-                    value={draft}
-                    onChange={(e) => setDraft(e.target.value)}
-                    onBlur={commit}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter') e.currentTarget.blur()
-                    }}
-                    spellCheck={false}
-                />
-            </div>
+const SolidDeck: React.FC<SolidDeckProps> = ({ className, defaultColor, onCommit }) => (
+    <div className="color-solid-deck">
+        <div className="color-section-label">
+            {className === '' ? 'Solid coloring' : className}
         </div>
-    )
-}
+        <div className="color-solid-row">
+            <label className="color-solid-label">Default color</label>
+            <PaneColorPicker value={defaultColor} onCommit={onCommit} />
+        </div>
+    </div>
+)
 
 interface DeferredDeckProps {
     className: string
@@ -473,32 +489,12 @@ interface ColorFieldProps {
     onCommit: (next: string) => void
 }
 
-const ColorField: React.FC<ColorFieldProps> = ({ label, value, onCommit }) => {
-    const [draft, setDraft] = useState(value)
-    useEffect(() => setDraft(value), [value])
-    const commit = () => {
-        if (draft !== value) onCommit(draft)
-    }
-    return (
-        <div className="color-field-row">
-            <label className="color-field-label">{label}</label>
-            <div
-                className="color-solid-swatch"
-                style={{ backgroundColor: resolveColorPreview(draft) }}
-            />
-            <input
-                className="color-inline-input color-value-input color-field-input"
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onBlur={commit}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter') e.currentTarget.blur()
-                }}
-                spellCheck={false}
-            />
-        </div>
-    )
-}
+const ColorField: React.FC<ColorFieldProps> = ({ label, value, onCommit }) => (
+    <div className="color-field-row">
+        <label className="color-field-label">{label}</label>
+        <PaneColorPicker value={value} onCommit={onCommit} />
+    </div>
+)
 
 interface CpkDeckProps {
     colors: CpkColors
@@ -800,27 +796,9 @@ const NumberFieldInline: React.FC<{
 const ColorSwatchInline: React.FC<{
     value: string
     onCommit: (next: string) => void
-}> = ({ value, onCommit }) => {
-    const [draft, setDraft] = useState(value)
-    useEffect(() => setDraft(value), [value])
-    const commit = () => { if (draft !== value) onCommit(draft) }
-    return (
-        <>
-            <div
-                className="color-solid-swatch"
-                style={{ backgroundColor: resolveColorPreview(draft) }}
-            />
-            <input
-                className="color-inline-input color-value-input color-field-input"
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onBlur={commit}
-                onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur() }}
-                spellCheck={false}
-            />
-        </>
-    )
-}
+}> = ({ value, onCommit }) => (
+    <PaneColorPicker value={value} onCommit={onCommit} />
+)
 
 // ────────────────────────────────────────────────────────────
 // Main component
@@ -1130,6 +1108,7 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
     const dropdownDisabled = target === null
 
     return (
+        <ColorPickerContext.Provider value={{ cm, sceneId }}>
         <div className="sp-pane">
             <SectionHeader
                 title="Color"
@@ -1191,5 +1170,6 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
                 </div>
             )}
         </div>
+        </ColorPickerContext.Provider>
     )
 }

--- a/tritium/react-gui/src/renderer/components/widgets/colorpicker/ColorPicker.tsx
+++ b/tritium/react-gui/src/renderer/components/widgets/colorpicker/ColorPicker.tsx
@@ -1,0 +1,279 @@
+/**
+ * @file renderer/components/widgets/colorpicker/ColorPicker.tsx
+ * @description Reusable colour-picker widget (UXP `colpicker.js` port).
+ *
+ * Layout: a swatch + text box + caret. The caret opens a single popover
+ * whose top row is a segmented mode switch (RGB / HSB / Named / Palette /
+ * Mol); the body below shows the active mode's panel. This replaces UXP's
+ * two-step caret-menu-then-floating-panel flow with one popover so mode
+ * switching stays in place. "Mol" applies `$molcol` immediately (it has no
+ * editable params).
+ *
+ * The widget is controlled -- the parent owns the canonical colour string
+ * via `value` / `onChange`. `onChange(value, completed)` fires with
+ * `completed=false` during live slider drags and `true` on commit (popover
+ * close, palette/named pick, text-box blur, mol-color pick), letting callers
+ * debounce undo steps.
+ *
+ * Colour resolution (string -> RGB), the named-colour list, and the
+ * out-of-gamut check are delegated to the `compileColor` / `getNamedColors`
+ * worker services so previews match the C++ StyleManager exactly.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Button, ButtonGroup, InputGroup, Popover, Tooltip } from '@blueprintjs/core'
+import { useTheme } from '../../../contexts/ThemeContext'
+import type { AsyncCueMol } from '../../../worker/client/AsyncCueMol'
+import type { CompileColorResult } from '../../../worker/server/services/colorPicker.service'
+import { packToHex, type Rgb } from './colorMath'
+import { RgbHsbPanel } from './RgbHsbPanel'
+import { NamedListPanel } from './NamedListPanel'
+import { PalettePanel } from './PalettePanel'
+
+const MOL_COLOR = '$molcol'
+
+type Mode = 'rgb' | 'hsb' | 'named' | 'palette' | 'mol'
+
+const MODE_SEGMENTS: Array<{ mode: Mode; label: string }> = [
+    { mode: 'rgb', label: 'RGB' },
+    { mode: 'hsb', label: 'HSB' },
+    { mode: 'named', label: 'Named' },
+    { mode: 'palette', label: 'Palette' },
+    { mode: 'mol', label: 'Mol' },
+]
+
+interface ColorPickerProps {
+    /** Canonical CueMol colour string (e.g. "#0000FF", "red", "$molcol"). */
+    value: string
+    sceneId: number | undefined
+    cm: AsyncCueMol | null
+    /** completed=false during a live drag, true on commit. */
+    onChange: (value: string, completed: boolean) => void
+    disabled?: boolean
+    className?: string
+}
+
+/**
+ * Colour-picker widget: swatch + text box + single popover with a segmented
+ * mode switch over the RGB / HSB / Named / Palette panels.
+ */
+export const ColorPicker: React.FC<ColorPickerProps> = ({
+    value,
+    sceneId,
+    cm,
+    onChange,
+    disabled,
+    className,
+}) => {
+    const { theme } = useTheme()
+    const portalClassName = theme === 'dark' ? 'bp5-dark' : ''
+
+    const [draft, setDraft] = useState(value)
+    const [resolved, setResolved] = useState<CompileColorResult | null>(null)
+    const [liveRgb, setLiveRgb] = useState<Rgb | null>(null)
+    const [open, setOpen] = useState(false)
+    const [mode, setMode] = useState<Mode>(value === MOL_COLOR ? 'mol' : 'rgb')
+
+    // Latest live value, so the popover-close commit reports the final colour.
+    const liveValueRef = useRef(value)
+
+    // Resolve the authoritative colour whenever the parent value changes.
+    useEffect(() => {
+        setDraft(value)
+        liveValueRef.current = value
+        let cancelled = false
+        if (!cm) {
+            setResolved(null)
+            setLiveRgb(null)
+            return
+        }
+        ;(async () => {
+            const res = await cm.invokeService('compileColor', {
+                colorStr: value,
+                sceneId: sceneId ?? 0,
+            })
+            if (cancelled) return
+            setResolved(res)
+            setLiveRgb(res.ok && res.r !== undefined ? [res.r, res.g!, res.b!] : null)
+        })()
+        return () => {
+            cancelled = true
+        }
+    }, [value, sceneId, cm])
+
+    const isMol = value === MOL_COLOR
+    const swatchColor = liveRgb ? packToHex(liveRgb) : 'transparent'
+
+    // --- Live panel edits (sliders) ---
+    const handlePanelChange = useCallback(
+        (colorStr: string, rgb: Rgb, completed: boolean) => {
+            liveValueRef.current = colorStr
+            setDraft(colorStr)
+            setLiveRgb(rgb)
+            onChange(colorStr, completed)
+        },
+        [onChange],
+    )
+
+    // --- Named / palette pick (immediate commit, popover stays open) ---
+    const handlePick = useCallback(
+        (colorStr: string) => {
+            liveValueRef.current = colorStr
+            setDraft(colorStr)
+            onChange(colorStr, true)
+        },
+        [onChange],
+    )
+
+    // --- Text box commit ---
+    const commitText = useCallback(async () => {
+        if (draft === value) return
+        if (!cm) {
+            onChange(draft, true)
+            return
+        }
+        const res = await cm.invokeService('compileColor', {
+            colorStr: draft,
+            sceneId: sceneId ?? 0,
+        })
+        if (res.ok) {
+            onChange(draft, true)
+        } else {
+            // Invalid input -- revert to the last valid value.
+            setDraft(value)
+        }
+    }, [draft, value, cm, sceneId, onChange])
+
+    // --- Mode segment switch ---
+    const selectMode = (next: Mode) => {
+        setMode(next)
+        if (next === 'mol') {
+            // "Mol" has no editable params -- apply $molcol immediately.
+            liveValueRef.current = MOL_COLOR
+            setDraft(MOL_COLOR)
+            onChange(MOL_COLOR, true)
+        }
+    }
+
+    // Commit the live colour when the popover closes (UXP onPopupHiding).
+    const handleClose = () => {
+        setOpen(false)
+        if (liveValueRef.current !== value) {
+            onChange(liveValueRef.current, true)
+        }
+    }
+
+    const panelBody = (() => {
+        switch (mode) {
+            case 'rgb':
+            case 'hsb':
+                return (
+                    <RgbHsbPanel
+                        mode={mode}
+                        initialRgb={liveRgb ?? [0, 0, 0]}
+                        onChange={handlePanelChange}
+                    />
+                )
+            case 'named':
+                return (
+                    <NamedListPanel
+                        cm={cm}
+                        sceneId={sceneId}
+                        selectedName={
+                            resolved?.className === 'NamedColor' ? value : undefined
+                        }
+                        onSelect={handlePick}
+                    />
+                )
+            case 'palette':
+                return <PalettePanel onSelect={handlePick} />
+            case 'mol':
+                return (
+                    <div className="cp-mol-note">
+                        Uses the parent molecule&apos;s colour (<code>$molcol</code>).
+                    </div>
+                )
+        }
+    })()
+
+    const popoverContent = (
+        <div className="cp-panel">
+            <ButtonGroup className="cp-modebar" fill>
+                {MODE_SEGMENTS.map((seg) => (
+                    <Button
+                        key={seg.mode}
+                        small
+                        text={seg.label}
+                        active={mode === seg.mode}
+                        onClick={() => selectMode(seg.mode)}
+                    />
+                ))}
+            </ButtonGroup>
+            <div className="cp-panel-body">{panelBody}</div>
+        </div>
+    )
+
+    return (
+        <Popover
+            isOpen={open}
+            onClose={handleClose}
+            placement="bottom-start"
+            portalClassName={portalClassName}
+            content={popoverContent}
+            renderTarget={({ isOpen: _o, ref, ...targetProps }) => (
+                <div
+                    {...targetProps}
+                    ref={ref}
+                    className={'cp-widget' + (className ? ' ' + className : '')}
+                >
+                    {resolved && resolved.inGamut === false ? (
+                        <Tooltip content="Out of gamut -- click to clamp" compact>
+                            <button
+                                type="button"
+                                className="cp-swatch cp-swatch--warn"
+                                style={{ background: swatchColor }}
+                                disabled={disabled}
+                                onClick={() => {
+                                    if (resolved.devR !== undefined) {
+                                        handlePick(
+                                            packToHex([
+                                                resolved.devR,
+                                                resolved.devG!,
+                                                resolved.devB!,
+                                            ]),
+                                        )
+                                    }
+                                }}
+                            />
+                        </Tooltip>
+                    ) : (
+                        <span
+                            className={'cp-swatch' + (isMol ? ' cp-swatch--mol' : '')}
+                            style={{ background: swatchColor }}
+                        />
+                    )}
+                    <InputGroup
+                        small
+                        fill
+                        className="cp-textbox"
+                        value={draft}
+                        disabled={disabled}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onBlur={() => void commitText()}
+                        onKeyDown={(e) => {
+                            if (e.key === 'Enter') e.currentTarget.blur()
+                        }}
+                        spellCheck={false}
+                    />
+                    <Button
+                        small
+                        minimal
+                        rightIcon="caret-down"
+                        disabled={disabled}
+                        onClick={() => (open ? handleClose() : setOpen(true))}
+                    />
+                </div>
+            )}
+        />
+    )
+}

--- a/tritium/react-gui/src/renderer/components/widgets/colorpicker/ColorSlider.tsx
+++ b/tritium/react-gui/src/renderer/components/widgets/colorpicker/ColorSlider.tsx
@@ -1,0 +1,65 @@
+/**
+ * @file renderer/components/widgets/colorpicker/ColorSlider.tsx
+ * @description Single-channel colour slider with a gradient track.
+ *
+ * Ports the UXP `colorSlider.xml` binding: a horizontal slider whose track
+ * shows the colour gradient for one channel (e.g. red 0-255, or the hue
+ * rainbow). Live drag emits `completed=false`; releasing the thumb (pointer
+ * up / key up / blur) emits `completed=true`, matching UXP's split between
+ * the `change` and `dragStateChange` events so the renderer commits an undo
+ * step only once per gesture.
+ */
+
+import React, { useRef } from 'react'
+
+interface ColorSliderProps {
+    min: number
+    max: number
+    value: number
+    /** CSS background applied to the track (linear-gradient string). */
+    gradient: string
+    /** `completed` is false during a drag, true when the gesture ends. */
+    onChange: (value: number, completed: boolean) => void
+    disabled?: boolean
+}
+
+/**
+ * Gradient-backed range slider for one colour component.
+ */
+export const ColorSlider: React.FC<ColorSliderProps> = ({
+    min,
+    max,
+    value,
+    gradient,
+    onChange,
+    disabled,
+}) => {
+    // Tracks the latest value so the end-of-gesture (completed) event reports
+    // the final position without waiting for a re-render.
+    const latest = useRef(value)
+    latest.current = value
+
+    const commit = () => onChange(latest.current, true)
+
+    return (
+        <div className="cp-slider">
+            <div className="cp-slider-track" style={{ background: gradient }} />
+            <input
+                type="range"
+                className="cp-slider-input"
+                min={min}
+                max={max}
+                value={value}
+                disabled={disabled}
+                onChange={(e) => {
+                    const v = Number(e.target.value)
+                    latest.current = v
+                    onChange(v, false)
+                }}
+                onPointerUp={commit}
+                onKeyUp={commit}
+                onBlur={commit}
+            />
+        </div>
+    )
+}

--- a/tritium/react-gui/src/renderer/components/widgets/colorpicker/NamedListPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/widgets/colorpicker/NamedListPanel.tsx
@@ -1,0 +1,81 @@
+/**
+ * @file renderer/components/widgets/colorpicker/NamedListPanel.tsx
+ * @description Named-colour list for the colour picker popover.
+ *
+ * Ports UXP `setupNamedList` / `appendColorList`: scene-scoped colour
+ * definitions followed by the global ones, each shown as a swatch + name.
+ * Selecting a row commits the colour by its name. Colours are fetched once
+ * per open via the `getNamedColors` worker service.
+ */
+
+import React, { useEffect, useState } from 'react'
+import { Spinner } from '@blueprintjs/core'
+import type { AsyncCueMol } from '../../../worker/client/AsyncCueMol'
+import type { NamedColorEntry } from '../../../worker/server/services/colorPicker.service'
+
+interface NamedListPanelProps {
+    cm: AsyncCueMol | null
+    sceneId: number | undefined
+    /** Currently selected name (for highlight), if the colour is named. */
+    selectedName?: string
+    /** Commit a named colour. */
+    onSelect: (name: string) => void
+}
+
+/**
+ * Scrollable list of scene + global named colours.
+ */
+export const NamedListPanel: React.FC<NamedListPanelProps> = ({
+    cm,
+    sceneId,
+    selectedName,
+    onSelect,
+}) => {
+    const [entries, setEntries] = useState<NamedColorEntry[] | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        if (!cm) {
+            setEntries([])
+            return
+        }
+        ;(async () => {
+            const res = await cm.invokeService('getNamedColors', {
+                sceneId: sceneId ?? 0,
+            })
+            if (cancelled) return
+            // Scene definitions first (UXP order), then global.
+            setEntries([...res.scene, ...res.global])
+        })()
+        return () => {
+            cancelled = true
+        }
+    }, [cm, sceneId])
+
+    if (entries === null) {
+        return (
+            <div className="cp-named-loading">
+                <Spinner size={20} />
+            </div>
+        )
+    }
+
+    return (
+        <div className="cp-named-list">
+            {entries.map((e) => (
+                <button
+                    type="button"
+                    key={e.name}
+                    className={
+                        'cp-named-row' +
+                        (e.name === selectedName ? ' cp-named-row--selected' : '')
+                    }
+                    onClick={() => onSelect(e.name)}
+                >
+                    <span className="cp-named-swatch" style={{ background: e.hex }} />
+                    <span className="cp-named-name">{e.name}</span>
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/tritium/react-gui/src/renderer/components/widgets/colorpicker/PalettePanel.tsx
+++ b/tritium/react-gui/src/renderer/components/widgets/colorpicker/PalettePanel.tsx
@@ -1,0 +1,85 @@
+/**
+ * @file renderer/components/widgets/colorpicker/PalettePanel.tsx
+ * @description Preset colour palette grid for the colour picker popover.
+ *
+ * Ports UXP `buildPaletteBox` / `appendPaletteRow` (colpicker.js): a
+ * grayscale row plus seven hue rows, each with seven saturation/brightness
+ * variations. Cells are computed locally with `colorMath`; clicking a cell
+ * commits its `#rrggbb` value.
+ */
+
+import React from 'react'
+import { hsbToRgb, packToHex } from './colorMath'
+
+interface PalettePanelProps {
+    onSelect: (hex: string) => void
+}
+
+interface Cell {
+    hex: string
+    tip: string
+}
+
+// UXP grayscale entry (white -> black).
+const GRAYSCALE: Cell[] = [
+    { hex: '#ffffff', tip: 'White' },
+    { hex: packToHex([191, 191, 191]), tip: '75% Gray' },
+    { hex: packToHex([128, 128, 128]), tip: '50% Gray' },
+    { hex: packToHex([64, 64, 64]), tip: '25% Gray' },
+    { hex: '#000000', tip: 'Black' },
+]
+
+// UXP hue rows: [hue, label].
+const HUES: Array<[number, string]> = [
+    [0, 'Red'],
+    [30, 'Orange'],
+    [60, 'Yellow'],
+    [120, 'Green'],
+    [180, 'Cyan'],
+    [240, 'Blue'],
+    [300, 'Purple'],
+]
+
+// UXP saturation/brightness variations per hue.
+const VARIATIONS: Array<[number, number]> = [
+    [25, 100],
+    [50, 100],
+    [75, 100],
+    [100, 100],
+    [100, 75],
+    [100, 50],
+    [100, 25],
+]
+
+function hueRow(hue: number, label: string): Cell[] {
+    return VARIATIONS.map(([sat, bri]) => {
+        let tip = label
+        if (sat !== 100) tip += `, sat=${sat}%`
+        if (bri !== 100) tip += `, bri=${bri}%`
+        return { hex: packToHex(hsbToRgb([hue, sat, bri])), tip }
+    })
+}
+
+const ROWS: Cell[][] = [GRAYSCALE, ...HUES.map(([h, l]) => hueRow(h, l))]
+
+/**
+ * Preset colour tile grid.
+ */
+export const PalettePanel: React.FC<PalettePanelProps> = ({ onSelect }) => (
+    <div className="cp-palette">
+        {ROWS.map((row, ri) => (
+            <div className="cp-palette-row" key={ri}>
+                {row.map((cell, ci) => (
+                    <button
+                        type="button"
+                        key={ci}
+                        className="cp-palette-cell"
+                        style={{ background: cell.hex }}
+                        title={cell.tip}
+                        onClick={() => onSelect(cell.hex)}
+                    />
+                ))}
+            </div>
+        ))}
+    </div>
+)

--- a/tritium/react-gui/src/renderer/components/widgets/colorpicker/RgbHsbPanel.tsx
+++ b/tritium/react-gui/src/renderer/components/widgets/colorpicker/RgbHsbPanel.tsx
@@ -1,0 +1,150 @@
+/**
+ * @file renderer/components/widgets/colorpicker/RgbHsbPanel.tsx
+ * @description RGB / HSB slider panel for the colour picker popover.
+ *
+ * Ports the UXP slider deck (`colpicker.js` setupRGB / setupHSB +
+ * colorSlider): three labelled rows, each a gradient `ColorSlider` plus a
+ * `NumericInput` spinner. The panel owns its working colour as RGB (RGB
+ * mode) or HSB (HSB mode) -- like UXP's separate `mHSBValue` -- so dragging
+ * a hue slider through a grey does not lose the hue to a round-trip. It is
+ * seeded once from `initialRgb` when the popover content mounts; edits are
+ * computed locally with `colorMath` (no IPC) and reported upward with both
+ * the colour string and the resolved RGB (for instant swatch preview).
+ */
+
+import React, { useState } from 'react'
+import { NumericInput } from '@blueprintjs/core'
+import { ColorSlider } from './ColorSlider'
+import { hsbToRgb, packToHex, packToHsbString, rgbToHsb, type Hsb, type Rgb } from './colorMath'
+
+export type SliderMode = 'rgb' | 'hsb'
+
+interface RgbHsbPanelProps {
+    mode: SliderMode
+    /** Colour to seed the panel with (resolved RGB 0-255). */
+    initialRgb: Rgb
+    /**
+     * Reports an edit: the CueMol colour string, its resolved RGB, and
+     * whether the gesture has completed (false during a slider drag).
+     */
+    onChange: (colorStr: string, rgb: Rgb, completed: boolean) => void
+}
+
+interface RowSpec {
+    label: string
+    min: number
+    max: number
+    value: number
+    gradient: string
+}
+
+function rgbRows(rgb: Rgb): RowSpec[] {
+    const [r, g, b] = rgb
+    return [
+        {
+            label: 'R',
+            min: 0,
+            max: 255,
+            value: r,
+            gradient: `linear-gradient(to right, ${packToHex([0, g, b])}, ${packToHex([255, g, b])})`,
+        },
+        {
+            label: 'G',
+            min: 0,
+            max: 255,
+            value: g,
+            gradient: `linear-gradient(to right, ${packToHex([r, 0, b])}, ${packToHex([r, 255, b])})`,
+        },
+        {
+            label: 'B',
+            min: 0,
+            max: 255,
+            value: b,
+            gradient: `linear-gradient(to right, ${packToHex([r, g, 0])}, ${packToHex([r, g, 255])})`,
+        },
+    ]
+}
+
+function hsbRows(hsb: Hsb): RowSpec[] {
+    const [h, s, v] = hsb
+    const hueStops = [0, 60, 120, 180, 240, 300, 360]
+        .map((deg) => packToHex(hsbToRgb([deg, s, v])))
+        .join(', ')
+    return [
+        {
+            label: 'H',
+            min: 0,
+            max: 360,
+            value: h,
+            gradient: `linear-gradient(to right, ${hueStops})`,
+        },
+        {
+            label: 'S',
+            min: 0,
+            max: 100,
+            value: s,
+            gradient: `linear-gradient(to right, ${packToHex(hsbToRgb([h, 0, v]))}, ${packToHex(hsbToRgb([h, 100, v]))})`,
+        },
+        {
+            label: 'B',
+            min: 0,
+            max: 100,
+            value: v,
+            gradient: `linear-gradient(to right, ${packToHex(hsbToRgb([h, s, 0]))}, ${packToHex(hsbToRgb([h, s, 100]))})`,
+        },
+    ]
+}
+
+/**
+ * RGB/HSB slider panel: three gradient sliders + numeric spinners.
+ */
+export const RgbHsbPanel: React.FC<RgbHsbPanelProps> = ({ mode, initialRgb, onChange }) => {
+    // Working colour in the mode's native space, seeded once on mount.
+    const [rgb, setRgb] = useState<Rgb>(initialRgb)
+    const [hsb, setHsb] = useState<Hsb>(() => rgbToHsb(initialRgb))
+
+    const rows = mode === 'rgb' ? rgbRows(rgb) : hsbRows(hsb)
+
+    const edit = (index: number, next: number, completed: boolean) => {
+        if (mode === 'rgb') {
+            const out: Rgb = [...rgb]
+            out[index] = next
+            setRgb(out)
+            onChange(packToHex(out), out, completed)
+        } else {
+            const out: Hsb = [...hsb]
+            out[index] = next
+            setHsb(out)
+            const outRgb = hsbToRgb(out)
+            onChange(packToHsbString(out), outRgb, completed)
+        }
+    }
+
+    return (
+        <div className="cp-slider-panel">
+            {rows.map((row, i) => (
+                <div className="cp-slider-row" key={row.label}>
+                    <span className="cp-slider-label">{row.label}</span>
+                    <ColorSlider
+                        min={row.min}
+                        max={row.max}
+                        value={row.value}
+                        gradient={row.gradient}
+                        onChange={(v, completed) => edit(i, v, completed)}
+                    />
+                    <NumericInput
+                        className="cp-slider-spinner"
+                        min={row.min}
+                        max={row.max}
+                        value={row.value}
+                        clampValueOnBlur
+                        onValueChange={(v) => {
+                            if (Number.isNaN(v)) return
+                            edit(i, Math.max(row.min, Math.min(row.max, v)), true)
+                        }}
+                    />
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/tritium/react-gui/src/renderer/components/widgets/colorpicker/colorMath.ts
+++ b/tritium/react-gui/src/renderer/components/widgets/colorpicker/colorMath.ts
@@ -1,0 +1,119 @@
+/**
+ * @file renderer/components/widgets/colorpicker/colorMath.ts
+ * @description Pure colour-space helpers for the colour picker widget.
+ *
+ * Ported from the UXP `cuemol2ui-lib/util.js` (`convHSB2RGB`,
+ * `convRGB2HSB`, `packToHTMLColor`). Kept dependency-free so slider
+ * gradients and HSB text formatting can be computed locally without an
+ * IPC round-trip to the C++ StyleManager.
+ *
+ * Conventions match UXP: RGB components are integers 0-255; HSB is
+ * hue 0-360, saturation 0-100, brightness 0-100.
+ */
+
+export type Rgb = [number, number, number]
+export type Hsb = [number, number, number]
+
+/**
+ * Convert an HSB triple to RGB.
+ *
+ * @param hsb - [hue 0-360, saturation 0-100, brightness 0-100]
+ * @returns [r, g, b] integers 0-255
+ */
+export function hsbToRgb(hsb: Hsb): Rgb {
+    let h = hsb[0]
+    let s = hsb[1]
+    let v = hsb[2]
+
+    h = ((h % 360) + 360) % 360
+    s /= 100
+    v /= 100
+    h /= 60
+
+    const i = Math.floor(h)
+    const f = h - i
+    const p = v * (1 - s)
+    const q = v * (1 - s * f)
+    const t = v * (1 - s * (1 - f))
+
+    let r = 0
+    let g = 0
+    let b = 0
+    if (i === 0) {
+        r = v
+        g = t
+        b = p
+    } else if (i === 1) {
+        r = q
+        g = v
+        b = p
+    } else if (i === 2) {
+        r = p
+        g = v
+        b = t
+    } else if (i === 3) {
+        r = p
+        g = q
+        b = v
+    } else if (i === 4) {
+        r = t
+        g = p
+        b = v
+    } else {
+        r = v
+        g = p
+        b = q
+    }
+
+    return [Math.floor(r * 255), Math.floor(g * 255), Math.floor(b * 255)]
+}
+
+/**
+ * Convert an RGB triple to HSB.
+ *
+ * @param rgb - [r, g, b] integers 0-255
+ * @returns [hue 0-360, saturation 0-100, brightness 0-100]
+ */
+export function rgbToHsb(rgb: Rgb): Hsb {
+    const red = rgb[0] / 255
+    const grn = rgb[1] / 255
+    const blu = rgb[2] / 255
+
+    const x = Math.min(red, grn, blu)
+    const val = Math.max(red, grn, blu)
+
+    if (x === val) {
+        return [0, 0, Math.floor(val * 100)]
+    }
+
+    const f = red === x ? grn - blu : grn === x ? blu - red : red - grn
+    const i = red === x ? 3 : grn === x ? 5 : 1
+    const hue = (Math.floor((i - f / (val - x)) * 60) + 360) % 360
+    const sat = Math.floor(((val - x) / val) * 100)
+
+    return [hue, sat, Math.floor(val * 100)]
+}
+
+/**
+ * Pack an RGB triple into a CSS `#rrggbb` hex string.
+ *
+ * @param rgb - [r, g, b] integers 0-255
+ * @returns lower-case `#rrggbb`
+ */
+export function packToHex(rgb: Rgb): string {
+    const hex = (v: number): string => {
+        const clamped = Math.max(0, Math.min(255, Math.round(v)))
+        return (clamped < 16 ? '0' : '') + clamped.toString(16)
+    }
+    return '#' + hex(rgb[0]) + hex(rgb[1]) + hex(rgb[2])
+}
+
+/**
+ * Format an HSB triple as the CueMol `hsb(h,s,b)` colour string, matching
+ * UXP `updateMain` (saturation/brightness expressed as 0-1 fractions).
+ *
+ * @param hsb - [hue 0-360, saturation 0-100, brightness 0-100]
+ */
+export function packToHsbString(hsb: Hsb): string {
+    return `hsb(${hsb[0]},${hsb[1] / 100},${hsb[2] / 100})`
+}

--- a/tritium/react-gui/src/renderer/styles/_color-panel.css
+++ b/tritium/react-gui/src/renderer/styles/_color-panel.css
@@ -233,7 +233,10 @@
 }
 
 .color-field-label {
-  min-width: 78px;
+  /* Sized to the longest CPK element label ("Phosphorus") so element rows
+     stay column-aligned; trimmed from 78px to reduce the gap before the
+     colour picker swatch for shorter labels. */
+  min-width: 64px;
   font-size: var(--fs-base);
   color: var(--text-primary);
   flex-shrink: 0;

--- a/tritium/react-gui/src/renderer/styles/_colorpicker.css
+++ b/tritium/react-gui/src/renderer/styles/_colorpicker.css
@@ -1,0 +1,252 @@
+/* ─── Colour picker widget (UXP colpicker.js port) ─── */
+
+.cp-widget {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+}
+
+.cp-swatch {
+  width: var(--ctrl-h-md);
+  height: var(--ctrl-h-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+  padding: 0;
+}
+
+button.cp-swatch {
+  cursor: pointer;
+}
+
+/* Out-of-gamut warning: amber ring + clickable to clamp. */
+.cp-swatch--warn {
+  border-color: var(--accent-yellow);
+  box-shadow: 0 0 0 1px var(--accent-yellow);
+}
+
+/* "Use mol color" indicator: dashed border over the swatch background. */
+.cp-swatch--mol {
+  border-style: dashed;
+  border-color: var(--accent);
+}
+
+.cp-textbox {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ─── Popover panel shell ─── */
+
+.cp-panel {
+  box-sizing: border-box;
+  width: 240px;
+  padding: var(--space-3);
+  background: var(--bg-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Segmented mode switch (RGB / HSB / Named / Palette / Mol). */
+.cp-modebar {
+  flex-shrink: 0;
+}
+
+.cp-panel-body {
+  display: flex;
+  flex-direction: column;
+}
+
+/* "Mol" mode note (no editable params). */
+.cp-mol-note {
+  font-size: var(--fs-base);
+  color: var(--text-secondary);
+  line-height: var(--lh-normal);
+  padding: var(--space-3) var(--space-2);
+}
+
+.cp-mol-note code {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+/* ─── RGB / HSB slider panel ─── */
+
+.cp-slider-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.cp-slider-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.cp-slider-label {
+  width: var(--space-5);
+  font-size: var(--fs-base);
+  color: var(--text-primary);
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.cp-slider {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  height: var(--ctrl-h-md);
+  display: flex;
+  align-items: center;
+}
+
+.cp-slider-track {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.cp-slider-input {
+  position: relative;
+  width: 100%;
+  margin: 0;
+  background: transparent;
+  -webkit-appearance: none;
+  appearance: none;
+  height: var(--ctrl-h-md);
+  cursor: pointer;
+}
+
+.cp-slider-input::-webkit-slider-runnable-track {
+  background: transparent;
+  height: var(--ctrl-h-md);
+}
+
+.cp-slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 18px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--text-secondary);
+  box-shadow: 0 1px 2px var(--slider-handle-shadow);
+}
+
+.cp-slider-input:focus {
+  outline: none;
+}
+
+.cp-slider-input:focus::-webkit-slider-thumb {
+  border-color: var(--accent);
+}
+
+.cp-slider-spinner {
+  flex: 0 0 64px;
+  width: 64px;
+  /* min-width:auto (the flex default) would keep the NumericInput at its
+     min-content width and blow out the panel; pin it to 0 so width holds. */
+  min-width: 0;
+}
+
+/* Keep the NumericInput compact so it never blows out the panel width. */
+.cp-slider-spinner .bp5-input-group {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.cp-slider-spinner .bp5-input {
+  width: 100%;
+  min-width: 0;
+  padding-right: var(--space-2);
+}
+
+/* ─── Named colour list panel ─── */
+
+.cp-named-list {
+  width: 100%;
+  max-height: 280px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.cp-named-loading {
+  width: 100%;
+  padding: var(--space-5);
+  display: flex;
+  justify-content: center;
+}
+
+.cp-named-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  border-radius: var(--radius-sm);
+}
+
+.cp-named-row:hover {
+  background: var(--bg-hover);
+}
+
+.cp-named-row--selected {
+  background: var(--bg-active);
+}
+
+.cp-named-swatch {
+  width: var(--icon-lg);
+  height: var(--icon-lg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.cp-named-name {
+  font-size: var(--fs-lg);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Palette panel ─── */
+
+.cp-palette {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* Seven equal columns so hue rows fill the panel width and columns align;
+   the grayscale row (5 cells) leaves its last two columns empty. */
+.cp-palette-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: var(--space-1);
+}
+
+.cp-palette-cell {
+  width: 100%;
+  height: var(--ctrl-h-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0;
+  cursor: pointer;
+}
+
+.cp-palette-cell:hover {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/colorPicker.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/colorPicker.service.ts
@@ -1,0 +1,151 @@
+// Runs in Web Worker thread. Wrappers are sync (no await on C++ wrappers).
+//
+// Backs the colour-picker widget (ports UXP `colpicker.js` StyleManager
+// usage): compiling colour strings to RGB + gamut info, and listing the
+// named colours defined for a scene plus the global scope.
+import type { AbstractColor } from '@cuemol/core/src/wrappers/AbstractColor';
+import type { WorkerContext } from '../types/WorkerContext';
+
+// --- compileColor ---
+
+export interface CompileColorArgs {
+    /** CueMol colour string: "#RRGGBB", "rgb(...)", "hsb(...)", a named
+     *  colour, or "$molcol". */
+    colorStr: string;
+    /** Scene scope for named-colour / device-profile resolution (0 = global). */
+    sceneId: number;
+}
+
+export interface CompileColorResult {
+    ok: boolean;
+    /** Resolved RGB (0-255). Absent when ok === false. */
+    r?: number;
+    g?: number;
+    b?: number;
+    /** Lower-case "#rrggbb" of the resolved colour. */
+    hex?: string;
+    /** C++ wrapper class name; "NamedColor" identifies a named colour. */
+    className?: string;
+    /** False when the colour falls outside the scene's proofing gamut. */
+    inGamut?: boolean;
+    /** Device-gamut-clamped RGB (only meaningful when inGamut === false). */
+    devR?: number;
+    devG?: number;
+    devB?: number;
+}
+
+function packHex(r: number, g: number, b: number): string {
+    const h = (v: number): string => (v < 16 ? '0' : '') + (v & 0xff).toString(16);
+    return '#' + h(r) + h(g) + h(b);
+}
+
+/**
+ * Compile a colour string via the C++ StyleManager and report its RGB,
+ * class name, and proofing-gamut status.
+ *
+ * Mirrors UXP `ColorPicker.updateColorBox` (colpicker.js): the gamut check
+ * and device-colour read are folded into a single worker call so the
+ * renderer never chains multiple IPC round-trips per colour edit.
+ */
+function compileColor(ctx: WorkerContext, args: CompileColorArgs): CompileColorResult {
+    const sceneId = args.sceneId || 0;
+    let color: AbstractColor;
+    try {
+        color = ctx.styleMgr.compileColor(args.colorStr, sceneId);
+    } catch {
+        return { ok: false };
+    }
+
+    const r = color.r();
+    const g = color.g();
+    const b = color.b();
+    let className: string | undefined;
+    try {
+        className = color.getClassName();
+    } catch {
+        className = undefined;
+    }
+
+    const result: CompileColorResult = {
+        ok: true,
+        r,
+        g,
+        b,
+        hex: packHex(r, g, b),
+        className,
+        inGamut: true,
+    };
+
+    // Gamut / device-colour check is only meaningful under colour proofing.
+    // Treat any failure (method missing, proofing off) as "in gamut".
+    try {
+        if (!color.isInGamut(sceneId)) {
+            const devcc = color.getDevCode(sceneId);
+            result.inGamut = false;
+            result.devR = (devcc >> 16) & 0xff;
+            result.devG = (devcc >> 8) & 0xff;
+            result.devB = devcc & 0xff;
+        }
+    } catch {
+        result.inGamut = true;
+    }
+
+    return result;
+}
+
+// --- getNamedColors ---
+
+export interface GetNamedColorsArgs {
+    sceneId: number;
+}
+
+export interface NamedColorEntry {
+    name: string;
+    r: number;
+    g: number;
+    b: number;
+    hex: string;
+}
+
+export interface GetNamedColorsResult {
+    /** Scene-scoped colour definitions (empty when sceneId is 0). */
+    scene: NamedColorEntry[];
+    /** Global colour definitions. */
+    global: NamedColorEntry[];
+}
+
+function resolveDefs(ctx: WorkerContext, sceneId: number): NamedColorEntry[] {
+    let names: string[];
+    try {
+        names = JSON.parse(ctx.styleMgr.getColorDefsJSON(sceneId));
+    } catch {
+        return [];
+    }
+    const out: NamedColorEntry[] = [];
+    for (const name of names) {
+        try {
+            const color = ctx.styleMgr.getColor(name, sceneId);
+            const r = color.r();
+            const g = color.g();
+            const b = color.b();
+            out.push({ name, r, g, b, hex: packHex(r, g, b) });
+        } catch {
+            // Skip undefined / un-resolvable entries (UXP swallows these too).
+        }
+    }
+    return out;
+}
+
+/**
+ * List named colours for the scene scope and the global scope, each with
+ * resolved RGB previews. Mirrors UXP `setupNamedList` / `appendColorList`.
+ */
+function getNamedColors(ctx: WorkerContext, args: GetNamedColorsArgs): GetNamedColorsResult {
+    const sceneId = args.sceneId || 0;
+    return {
+        scene: sceneId !== 0 ? resolveDefs(ctx, sceneId) : [],
+        global: resolveDefs(ctx, 0),
+    };
+}
+
+export const services = { compileColor, getNamedColors };

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -77,6 +77,12 @@ import type {
   SceneColorProofingResult,
 } from '../server/services/sceneBgColor.service'
 import type {
+  CompileColorArgs,
+  CompileColorResult,
+  GetNamedColorsArgs,
+  GetNamedColorsResult,
+} from '../server/services/colorPicker.service'
+import type {
   GetSceneTreeArgs,
   GetSceneTreeResult,
   SetNodeVisibleArgs,
@@ -368,6 +374,8 @@ export interface ServiceMap {
   setSceneBgColor:            { args: SetSceneBgColorArgs;             result: SceneBgColorResult }
   getSceneColorProofing:      { args: SceneColorProofingArgs;          result: SceneColorProofingResult }
   toggleSceneColorProofing:   { args: SceneColorProofingArgs;          result: SceneColorProofingResult }
+  compileColor:               { args: CompileColorArgs;                result: CompileColorResult }
+  getNamedColors:             { args: GetNamedColorsArgs;              result: GetNamedColorsResult }
   getSceneTree:               { args: GetSceneTreeArgs;                result: GetSceneTreeResult }
   setNodeVisible:             { args: SetNodeVisibleArgs;              result: SetNodeVisibleResult }
   focusOnNode:                { args: FocusOnNodeArgs;                 result: FocusOnNodeResult }


### PR DESCRIPTION
Port the legacy UXP color picker (colpicker.js / colorSlider.xml / color-menu.xul) to tritium/react-gui as a reusable widget and wire it into the ColorPane Solid/CPK/Bfac/Elepot decks.

- ColorPicker widget: swatch + text box + caret opening a single popover with a segmented mode switch (RGB / HSB / Named / Palette / Mol). RGB/HSB are gradient sliders + numeric spinners; Named lists scene + global colours; Palette is the UXP preset tile grid; Mol applies $molcol. Out-of-gamut colours show a warning swatch that clamps on click.
- colorPicker worker service (compileColor / getNamedColors) resolves colours via the C++ StyleManager so previews are exact; HSB<->RGB maths are pure local helpers (no per-drag IPC).
- ColorPane decks consume the widget via a ColorPickerContext adapter; short element-label column trimmed (78px -> 64px).
- Tests for colorMath, the worker service, and the widget wire contract.
- Docs: ADR-0020 + mapping rows (widget.colpicker / widget.colorslider / menu.color).