### PR TITLE
Add FBO render target abstraction and restore off-screen PNG export

### DIFF
--- a/src/gfx/CMakeLists.txt
+++ b/src/gfx/CMakeLists.txt
@@ -46,6 +46,7 @@ DrawAttrElems.hpp
 DrawElem.hpp
 AbstDrawElem.hpp
 VBORep.hpp
+RenderTarget.hpp
 GradientColor.hpp
 GpuPrim.hpp
 SphereGpuPrim.hpp

--- a/src/gfx/CMakeLists.txt
+++ b/src/gfx/CMakeLists.txt
@@ -27,6 +27,7 @@ CylinderGpuPrim.cpp
 TrigGpuPrim.cpp
 LineGpuPrim.cpp
 PixGpuPrim.cpp
+PostProcGpuPrim.cpp
 DisplayList.cpp
 ShaderObject.cpp
 )
@@ -52,6 +53,7 @@ CylinderGpuPrim.hpp
 TrigGpuPrim.hpp
 LineGpuPrim.hpp
 PixGpuPrim.hpp
+PostProcGpuPrim.hpp
 Hittest.hpp
 HittestContext.hpp
 LabelCacheImpl.hpp

--- a/src/gfx/DisplayContext.hpp
+++ b/src/gfx/DisplayContext.hpp
@@ -35,6 +35,7 @@ class ShaderObject;
 class PixGpuPrim;
 
 class BufTexRep;
+class RenderTarget;
 
 class GFX_API DisplayContext : public qlib::LObject
 {
@@ -510,6 +511,24 @@ public:
     /// Create a backend-specific PixRep for the given pixel buffer.
     /// Returns nullptr if this context does not support drawPixels.
     virtual PixRep *createPixRep(const PixelBuffer &pixbuf);
+
+    ///////////////////////////////
+    // Off-screen render target (FBO) support
+
+    /// Create a backend-specific off-screen render target of the given size
+    /// and attachment flags (see gfx::RTFlags). Returns nullptr if this
+    /// context does not support off-screen rendering (default).
+    virtual RenderTarget *createRenderTarget(int w, int h, int flags)
+    {
+        return nullptr;
+    }
+
+    /// Make the given render target the current draw target. Passing nullptr
+    /// restores the default framebuffer. Default is a no-op.
+    virtual void bindRenderTarget(RenderTarget *prt) {}
+
+    /// Restore the default framebuffer as the draw target. Default no-op.
+    virtual void bindDefaultFramebuffer() {}
 
     ///////////////////////////////
     // Buffer allocation

--- a/src/gfx/PostProcGpuPrim.cpp
+++ b/src/gfx/PostProcGpuPrim.cpp
@@ -1,0 +1,82 @@
+// -*-Mode: C++;-*-
+//
+// PostProcGpuPrim implementation
+//
+
+#include <common.h>
+
+#include "PostProcGpuPrim.hpp"
+#include "ShaderObject.hpp"
+#include "DisplayContext.hpp"
+#include "RenderTarget.hpp"
+
+#include <qlib/LTypes.hpp>
+
+using namespace gfx;
+
+bool PostProcGpuPrim::init(DisplayContext *pDC)
+{
+    if (m_pPO != nullptr) return true;
+
+    m_pPO = pDC->loadShaderObject("depthvis",
+                                  "%%CONFDIR%%/data/shaders/postproc_vert.glsl",
+                                  "%%CONFDIR%%/data/shaders/depthvis_frag.glsl");
+    if (m_pPO == nullptr) {
+        LOG_DPRINTLN("PostProcGpuPrim> ERROR: cannot load depthvis shader.");
+        return false;
+    }
+
+    alloc(pDC);
+    return true;
+}
+
+void PostProcGpuPrim::alloc(DisplayContext *pDC)
+{
+    MB_ASSERT(pDC != nullptr);
+
+    m_pDrawElem = MB_NEW TriArray();
+    TriArray &data = *m_pDrawElem;
+
+    data.setAttrSize(1);
+    data.setAttrInfo(0, ATTRLOC_VERTEX, 2, qlib::type_consts::QTC_FLOAT32,
+                     offsetof(Elem, x));
+
+    pDC->allocBuffer(data, 3, 0);
+    data.setDrawMode(AbstDrawElem::DRAW_TRIANGLES);
+
+    // Oversized triangle that covers the whole NDC viewport.
+    data.at(0) = {-1.0f, -1.0f};
+    data.at(1) = {3.0f, -1.0f};
+    data.at(2) = {-1.0f, 3.0f};
+}
+
+void PostProcGpuPrim::drawDepthVis(DisplayContext *pDC, RenderTarget *prt,
+                                   float vnear, float vfar)
+{
+    MB_ASSERT(m_pPO != nullptr);
+    MB_ASSERT(m_pDrawElem != nullptr);
+    if (prt == nullptr) return;
+
+    prt->bindDepthTex(RT_TU_DEPTH);
+
+    m_pPO->enable();
+    m_pPO->setUniform("u_depthTex", RT_TU_DEPTH);
+    m_pPO->setUniformF("u_near", vnear);
+    m_pPO->setUniformF("u_far", vfar);
+
+    pDC->drawElem(*m_pDrawElem);
+
+    m_pPO->disable();
+
+    prt->unbindTextures();
+}
+
+void PostProcGpuPrim::invalidate()
+{
+    if (m_pDrawElem != nullptr) {
+        delete m_pDrawElem;
+        m_pDrawElem = nullptr;
+    }
+    // m_pPO is owned by the shader-object cache (loadShaderObject); not deleted here.
+    m_pPO = nullptr;
+}

--- a/src/gfx/PostProcGpuPrim.hpp
+++ b/src/gfx/PostProcGpuPrim.hpp
@@ -1,0 +1,64 @@
+// -*-Mode: C++;-*-
+//
+// PostProcGpuPrim: fullscreen post-processing pass (depth visualization)
+//
+
+#pragma once
+
+#include "gfx.hpp"
+#include "GpuPrim.hpp"
+#include "DrawAttrArray.hpp"
+
+namespace gfx {
+
+class ShaderObject;
+class RenderTarget;
+
+/// Fullscreen post-processing primitive.
+///
+/// Draws a single screen-covering triangle. The current pass samples a
+/// RenderTarget's depth texture and writes a linearized grayscale
+/// visualization to the bound framebuffer. This is the reusable base shape for
+/// future screen-space effects (SSAO/GTAO), which swap the fragment shader.
+class GFX_API PostProcGpuPrim : public GpuPrim
+{
+private:
+    struct Elem
+    {
+        qfloat32 x, y;  // NDC vertex position
+    };
+
+    using TriArray = DrawAttrArray<Elem>;
+
+    // Must match layout(location=N) in postproc_vert.glsl.
+    static constexpr int ATTRLOC_VERTEX = 0;
+
+    ShaderObject *m_pPO = nullptr;
+    TriArray *m_pDrawElem = nullptr;
+
+public:
+    PostProcGpuPrim() = default;
+    ~PostProcGpuPrim() override
+    {
+        invalidate();
+    }
+
+    bool init(DisplayContext *pDC) override;
+    void draw(DisplayContext *pDC) override {}
+    void invalidate() override;
+    bool isValid() const override
+    {
+        return m_pPO != nullptr && m_pDrawElem != nullptr;
+    }
+
+    /// Sample prt's depth texture and draw a linearized grayscale fullscreen
+    /// image into the currently bound framebuffer. vnear/vfar are the camera
+    /// slab planes used to linearize the (perspective) depth.
+    void drawDepthVis(DisplayContext *pDC, RenderTarget *prt, float vnear,
+                      float vfar);
+
+private:
+    void alloc(DisplayContext *pDC);
+};
+
+}  // namespace gfx

--- a/src/gfx/RenderTarget.hpp
+++ b/src/gfx/RenderTarget.hpp
@@ -1,0 +1,73 @@
+// -*-Mode: C++;-*-
+//
+//  Off-screen render target (framebuffer object) abstraction
+//
+
+#pragma once
+
+#include "gfx.hpp"
+
+namespace gfx {
+
+/// Attachment configuration flags for RenderTarget (bitmask).
+enum RTFlags
+{
+    /// 8-bit RGBA color attachment 0.
+    RT_COLOR_RGBA8 = 0x01,
+    /// Sampleable depth texture attachment (DEPTH_COMPONENT24).
+    RT_DEPTH_TEX = 0x02,
+    /// MRT normal color attachment 1 (RGB16F). Reserved for future AO use.
+    RT_NORMAL_RGB16F = 0x08,
+};
+
+/// Conventional texture-unit assignments shared by post-processing passes.
+enum RTTexUnit
+{
+    RT_TU_COLOR = 0,
+    RT_TU_DEPTH = 1,
+    RT_TU_NORMAL = 2,
+    RT_TU_NOISE = 3,
+};
+
+/// Backend-independent off-screen render target (color + depth, optional
+/// MRT normal). Created via DisplayContext::createRenderTarget; the scene is
+/// rendered into it via bind()/unbind(), and its attachments are exposed to
+/// shaders as textures (bindDepthTex) or read back to the CPU (readColor).
+class GFX_API RenderTarget
+{
+public:
+    virtual ~RenderTarget() {}
+
+    /// Make this render target the current draw target and set the viewport
+    /// to its size. Saves the previous viewport for unbind().
+    virtual void bind() = 0;
+
+    /// Restore the default framebuffer and the previously saved viewport.
+    virtual void unbind() = 0;
+
+    /// Re-allocate all attachments to the given size. No-op if unchanged.
+    virtual void resize(int w, int h) = 0;
+
+    /// Bind color attachment idx as a sampler texture on the given texunit.
+    virtual void bindColorTex(int idx, int texUnit) = 0;
+
+    /// Bind the depth attachment as a sampler texture on the given texunit.
+    virtual void bindDepthTex(int texUnit) = 0;
+
+    /// Unbind sampler textures bound by bindColorTex / bindDepthTex.
+    virtual void unbindTextures() = 0;
+
+    /// Read back a sub-rectangle of color attachment idx into pbuf.
+    /// Coordinates are in framebuffer space (bottom-left origin). ncomp is 3
+    /// (RGB) or 4 (RGBA). pbuf must hold at least the platform row-aligned size.
+    virtual void readColor(int idx, int x, int y, int w, int h, int ncomp,
+                           void *pbuf) = 0;
+
+    /// True if an MRT normal attachment was allocated.
+    virtual bool hasNormal() const = 0;
+
+    virtual int getWidth() const = 0;
+    virtual int getHeight() const = 0;
+};
+
+}  // namespace gfx

--- a/src/gfx/RenderTarget.hpp
+++ b/src/gfx/RenderTarget.hpp
@@ -45,6 +45,11 @@ public:
     /// Restore the default framebuffer and the previously saved viewport.
     virtual void unbind() = 0;
 
+    /// Clear the color (RGBA) and depth buffers. Must be called while bound.
+    /// Unlike DisplayContext::clearBuffer, the alpha is explicit so off-screen
+    /// captures can produce a transparent background (a == 0).
+    virtual void clear(float r, float g, float b, float a) = 0;
+
     /// Re-allocate all attachments to the given size. No-op if unchanged.
     virtual void resize(int w, int h) = 0;
 

--- a/src/modules/rendering/ImgSceneExporter.cpp
+++ b/src/modules/rendering/ImgSceneExporter.cpp
@@ -60,19 +60,11 @@ void ImgSceneExporter::write()
   qlib::ensureNotNull(pCam.get());
   pImgView->setCamera(pCam);
 
-  // TEMPORARY: force depth-image capture on, bypassing the UXP dialog
-  // plumbing (chrome JS cache staleness). Revert to m_bUseDepth once the
-  // dialog wiring is confirmed.
-  const bool force_depth = true;
-
-  MB_DPRINTLN("ImgSceneExporter::write> useAlpha=%d, useDepth=%d (force_depth=%d)",
-              m_bUseAlpha, m_bUseDepth, force_depth);
-
   // Transparent background only when RGBA (alpha) output is requested.
   pImgView->setBgTransparent(m_bUseAlpha);
 
   // Capture a depth visualization instead of color when requested.
-  pImgView->setDepthMode(m_bUseDepth || force_depth);
+  pImgView->setDepthMode(m_bUseDepth);
 
   // Draw the scene
   pImgView->drawScene();

--- a/src/modules/rendering/ImgSceneExporter.cpp
+++ b/src/modules/rendering/ImgSceneExporter.cpp
@@ -60,6 +60,9 @@ void ImgSceneExporter::write()
   qlib::ensureNotNull(pCam.get());
   pImgView->setCamera(pCam);
 
+  MB_DPRINTLN("ImgSceneExporter::write> useAlpha=%d, useDepth=%d",
+              m_bUseAlpha, m_bUseDepth);
+
   // Transparent background only when RGBA (alpha) output is requested.
   pImgView->setBgTransparent(m_bUseAlpha);
 

--- a/src/modules/rendering/ImgSceneExporter.cpp
+++ b/src/modules/rendering/ImgSceneExporter.cpp
@@ -23,7 +23,7 @@ using qsys::ScenePtr;
 using qsys::CameraPtr;
 
 ImgSceneExporter::ImgSceneExporter()
-     : m_nWidth(500), m_nHeight(500), m_nIter(0), m_nAAOpt(0)
+     : m_nWidth(500), m_nHeight(500), m_nIter(0), m_nAAOpt(0), m_bUseDepth(false)
 {
 }
 
@@ -62,6 +62,9 @@ void ImgSceneExporter::write()
 
   // Transparent background only when RGBA (alpha) output is requested.
   pImgView->setBgTransparent(m_bUseAlpha);
+
+  // Capture a depth visualization instead of color when requested.
+  pImgView->setDepthMode(m_bUseDepth);
 
   // Draw the scene
   pImgView->drawScene();

--- a/src/modules/rendering/ImgSceneExporter.cpp
+++ b/src/modules/rendering/ImgSceneExporter.cpp
@@ -60,14 +60,19 @@ void ImgSceneExporter::write()
   qlib::ensureNotNull(pCam.get());
   pImgView->setCamera(pCam);
 
-  MB_DPRINTLN("ImgSceneExporter::write> useAlpha=%d, useDepth=%d",
-              m_bUseAlpha, m_bUseDepth);
+  // TEMPORARY: force depth-image capture on, bypassing the UXP dialog
+  // plumbing (chrome JS cache staleness). Revert to m_bUseDepth once the
+  // dialog wiring is confirmed.
+  const bool force_depth = true;
+
+  MB_DPRINTLN("ImgSceneExporter::write> useAlpha=%d, useDepth=%d (force_depth=%d)",
+              m_bUseAlpha, m_bUseDepth, force_depth);
 
   // Transparent background only when RGBA (alpha) output is requested.
   pImgView->setBgTransparent(m_bUseAlpha);
 
   // Capture a depth visualization instead of color when requested.
-  pImgView->setDepthMode(m_bUseDepth);
+  pImgView->setDepthMode(m_bUseDepth || force_depth);
 
   // Draw the scene
   pImgView->drawScene();

--- a/src/modules/rendering/ImgSceneExporter.cpp
+++ b/src/modules/rendering/ImgSceneExporter.cpp
@@ -60,6 +60,9 @@ void ImgSceneExporter::write()
   qlib::ensureNotNull(pCam.get());
   pImgView->setCamera(pCam);
 
+  // Transparent background only when RGBA (alpha) output is requested.
+  pImgView->setBgTransparent(m_bUseAlpha);
+
   // Draw the scene
   pImgView->drawScene();
 

--- a/src/modules/rendering/ImgSceneExporter.hpp
+++ b/src/modules/rendering/ImgSceneExporter.hpp
@@ -40,6 +40,9 @@ namespace render {
     /// Use RGBA pixel format
     bool m_bUseAlpha;
 
+    /// Export a depth visualization (grayscale) instead of the rendered color
+    bool m_bUseDepth;
+
     /// Antialiasing option
     int m_nAAOpt;
 
@@ -80,6 +83,9 @@ namespace render {
 
     bool getUseAlpha() const { return m_bUseAlpha; }
     void setUseAlpha(bool val) { m_bUseAlpha = val; }
+
+    bool getUseDepth() const { return m_bUseDepth; }
+    void setUseDepth(bool val) { m_bUseDepth = val; }
 
     int getWidth() const { return m_nWidth; }
     int getHeight() const { return m_nHeight; }

--- a/src/modules/rendering/ImgSceneExporter.qif
+++ b/src/modules/rendering/ImgSceneExporter.qif
@@ -31,6 +31,10 @@ runtime_class ImgSceneExporter extends SceneExporter
   property boolean alpha => redirect(getUseAlpha, setUseAlpha);
   default alpha = false;
 
+  /// Export a depth visualization (grayscale) instead of the rendered color
+  property boolean depth => redirect(getUseDepth, setUseDepth);
+  default depth = false;
+
   ////////////////////
   // Method definition
 

--- a/src/qsys/CMakeLists.txt
+++ b/src/qsys/CMakeLists.txt
@@ -48,6 +48,7 @@ RendGroup.cpp
 MultiGradient.cpp
 TTYView.cpp
 GUIView.cpp
+OffScreenView.cpp
 GUIDisplayContext.cpp
 QdfAbsWriter.cpp
 DrawObj.cpp
@@ -105,6 +106,7 @@ StreamManager.hpp
 SysConfig.hpp
 TTYView.hpp
 GUIView.hpp
+OffScreenView.hpp
 GUIDisplayContext.hpp
 TestRenderer.hpp
 UndoManager.hpp

--- a/src/qsys/GUIView.cpp
+++ b/src/qsys/GUIView.cpp
@@ -7,8 +7,10 @@
 
 #include <common.h>
 #include "GUIView.hpp"
+#include "OffScreenView.hpp"
 
 #include <gfx/HittestContext.hpp>
+#include <gfx/RenderTarget.hpp>
 #include <qlib/LPerfMeas.hpp>
 
 #include "CenterMarkDrawObj.hpp"
@@ -481,8 +483,18 @@ bool GUIView::hitTestImpl(gfx::DisplayContext *pdc, const Vector4D &parm, bool f
 
 qsys::View *GUIView::createOffScreenView(int w, int h, int aa_depth)
 {
-    // not implemented yet
-    return nullptr;
+    // aa_depth (multisample) is not supported yet.
+    DisplayContext *pdc = getDisplayContext();
+    if (pdc == nullptr) return nullptr;
+
+    auto *pView = MB_NEW OffScreenView(pdc, w, h,
+                                       gfx::RT_COLOR_RGBA8 | gfx::RT_DEPTH_TEX);
+    if (!pView->isValid()) {
+        // Off-screen rendering not supported by this display context.
+        delete pView;
+        return nullptr;
+    }
+    return pView;
 }
 
 void GUIView::readPixels(int x, int y, int width, int height, char *pbuf, int nbufsize,

--- a/src/qsys/OffScreenView.cpp
+++ b/src/qsys/OffScreenView.cpp
@@ -97,7 +97,6 @@ void OffScreenView::drawScene()
     // By default read-back samples the scene color attachment.
     m_pReadRT = m_pRT;
 
-    MB_DPRINTLN("OffScreenView::drawScene> depthMode=%d", m_bDepthMode);
     if (m_bDepthMode) {
         drawDepthVis(pdc);
     }
@@ -105,7 +104,6 @@ void OffScreenView::drawScene()
 
 void OffScreenView::drawDepthVis(gfx::DisplayContext *pdc)
 {
-    MB_DPRINTLN("OffScreenView::drawDepthVis> begin");
     // Render a fullscreen pass that samples the scene depth texture into a
     // separate color-only target (avoids a feedback loop on the depth texture)
     // and read that target back instead of the scene color.
@@ -126,7 +124,6 @@ void OffScreenView::drawDepthVis(gfx::DisplayContext *pdc)
                     (void *)m_pDepthVisRT, (void *)m_pPostProc);
         return;
     }
-    MB_DPRINTLN("OffScreenView::drawDepthVis> rendering depth pass");
 
     // Camera slab planes, matching setUpProjMat's near/far derivation.
     double dist = getViewDist();

--- a/src/qsys/OffScreenView.cpp
+++ b/src/qsys/OffScreenView.cpp
@@ -97,6 +97,7 @@ void OffScreenView::drawScene()
     // By default read-back samples the scene color attachment.
     m_pReadRT = m_pRT;
 
+    MB_DPRINTLN("OffScreenView::drawScene> depthMode=%d", m_bDepthMode);
     if (m_bDepthMode) {
         drawDepthVis(pdc);
     }
@@ -104,6 +105,7 @@ void OffScreenView::drawScene()
 
 void OffScreenView::drawDepthVis(gfx::DisplayContext *pdc)
 {
+    MB_DPRINTLN("OffScreenView::drawDepthVis> begin");
     // Render a fullscreen pass that samples the scene depth texture into a
     // separate color-only target (avoids a feedback loop on the depth texture)
     // and read that target back instead of the scene color.
@@ -119,9 +121,12 @@ void OffScreenView::drawDepthVis(gfx::DisplayContext *pdc)
         }
     }
     if (m_pDepthVisRT == nullptr || m_pPostProc == nullptr) {
-        MB_DPRINTLN("OffScreenView::drawDepthVis: depth pass unavailable");
+        MB_DPRINTLN("OffScreenView::drawDepthVis> depth pass unavailable "
+                    "(rt=%p, postproc=%p) -- falling back to color",
+                    (void *)m_pDepthVisRT, (void *)m_pPostProc);
         return;
     }
+    MB_DPRINTLN("OffScreenView::drawDepthVis> rendering depth pass");
 
     // Camera slab planes, matching setUpProjMat's near/far derivation.
     double dist = getViewDist();

--- a/src/qsys/OffScreenView.cpp
+++ b/src/qsys/OffScreenView.cpp
@@ -10,11 +10,19 @@
 
 #include <gfx/DisplayContext.hpp>
 #include <gfx/RenderTarget.hpp>
+#include <gfx/PostProcGpuPrim.hpp>
 
 namespace qsys {
 
 OffScreenView::OffScreenView(gfx::DisplayContext *pParentCtxt, int w, int h, int flags)
-    : super_t(), m_pParentCtxt(pParentCtxt), m_pRT(nullptr), m_bBgTransparent(false)
+    : super_t(),
+      m_pParentCtxt(pParentCtxt),
+      m_pRT(nullptr),
+      m_pDepthVisRT(nullptr),
+      m_pPostProc(nullptr),
+      m_pReadRT(nullptr),
+      m_bBgTransparent(false),
+      m_bDepthMode(false)
 {
     // Off-screen pixels map 1:1 to the requested size (no HiDPI scaling).
     unsetSclFac();
@@ -28,8 +36,20 @@ OffScreenView::OffScreenView(gfx::DisplayContext *pParentCtxt, int w, int h, int
 
 OffScreenView::~OffScreenView()
 {
+    if (m_pParentCtxt != nullptr &&
+        (m_pRT != nullptr || m_pDepthVisRT != nullptr || m_pPostProc != nullptr)) {
+        m_pParentCtxt->setCurrent();
+    }
+    if (m_pPostProc != nullptr) {
+        m_pPostProc->invalidate();
+        delete m_pPostProc;
+        m_pPostProc = nullptr;
+    }
+    if (m_pDepthVisRT != nullptr) {
+        delete m_pDepthVisRT;
+        m_pDepthVisRT = nullptr;
+    }
     if (m_pRT != nullptr) {
-        if (m_pParentCtxt != nullptr) m_pParentCtxt->setCurrent();
         delete m_pRT;
         m_pRT = nullptr;
     }
@@ -73,13 +93,57 @@ void OffScreenView::drawScene()
     pScene->display(pdc);
 
     m_pRT->unbind();
+
+    // By default read-back samples the scene color attachment.
+    m_pReadRT = m_pRT;
+
+    if (m_bDepthMode) {
+        drawDepthVis(pdc);
+    }
+}
+
+void OffScreenView::drawDepthVis(gfx::DisplayContext *pdc)
+{
+    // Render a fullscreen pass that samples the scene depth texture into a
+    // separate color-only target (avoids a feedback loop on the depth texture)
+    // and read that target back instead of the scene color.
+    if (m_pDepthVisRT == nullptr) {
+        m_pDepthVisRT = pdc->createRenderTarget(getWidth(), getHeight(),
+                                                gfx::RT_COLOR_RGBA8);
+    }
+    if (m_pPostProc == nullptr) {
+        m_pPostProc = MB_NEW gfx::PostProcGpuPrim();
+        if (!m_pPostProc->init(pdc)) {
+            delete m_pPostProc;
+            m_pPostProc = nullptr;
+        }
+    }
+    if (m_pDepthVisRT == nullptr || m_pPostProc == nullptr) {
+        MB_DPRINTLN("OffScreenView::drawDepthVis: depth pass unavailable");
+        return;
+    }
+
+    // Camera slab planes, matching setUpProjMat's near/far derivation.
+    double dist = getViewDist();
+    double slabdepth = getSlabDepth();
+    if (slabdepth <= 0.1) slabdepth = 0.1;
+    double slabnear = dist - slabdepth / 2.0;
+    if (slabnear < 0.1) slabnear = 0.1;
+    double slabfar = dist + slabdepth;
+
+    m_pDepthVisRT->bind();
+    m_pPostProc->drawDepthVis(pdc, m_pRT, float(slabnear), float(slabfar));
+    m_pDepthVisRT->unbind();
+
+    m_pReadRT = m_pDepthVisRT;
 }
 
 void OffScreenView::readPixels(int x, int y, int width, int height, char *pbuf,
                                int nbufsize, int ncomp)
 {
-    if (m_pRT == nullptr) return;
-    m_pRT->readColor(0, x, y, width, height, ncomp, pbuf);
+    gfx::RenderTarget *prt = (m_pReadRT != nullptr) ? m_pReadRT : m_pRT;
+    if (prt == nullptr) return;
+    prt->readColor(0, x, y, width, height, ncomp, pbuf);
 }
 
 }  // namespace qsys

--- a/src/qsys/OffScreenView.cpp
+++ b/src/qsys/OffScreenView.cpp
@@ -62,7 +62,13 @@ void OffScreenView::drawScene()
     setUpProjMat(getWidth(), getHeight());
     setUpModelMat(MM_NORMAL);
 
-    pdc->clearBuffer(pScene->getBgColor());
+    // Clear with a transparent background (alpha = 0) so an RGBA export yields
+    // a transparent backdrop. For RGB export the alpha is dropped on read-back,
+    // so the visible result is unchanged. (DisplayContext::clearBuffer would
+    // force alpha = 1, leaving the background opaque.)
+    gfx::ColorPtr bgcol = pScene->getBgColor();
+    m_pRT->clear(float(bgcol->fr()), float(bgcol->fg()), float(bgcol->fb()), 0.0f);
+
     pScene->display(pdc);
 
     m_pRT->unbind();

--- a/src/qsys/OffScreenView.cpp
+++ b/src/qsys/OffScreenView.cpp
@@ -14,7 +14,7 @@
 namespace qsys {
 
 OffScreenView::OffScreenView(gfx::DisplayContext *pParentCtxt, int w, int h, int flags)
-    : super_t(), m_pParentCtxt(pParentCtxt), m_pRT(nullptr)
+    : super_t(), m_pParentCtxt(pParentCtxt), m_pRT(nullptr), m_bBgTransparent(false)
 {
     // Off-screen pixels map 1:1 to the requested size (no HiDPI scaling).
     unsetSclFac();
@@ -62,12 +62,13 @@ void OffScreenView::drawScene()
     setUpProjMat(getWidth(), getHeight());
     setUpModelMat(MM_NORMAL);
 
-    // Clear with a transparent background (alpha = 0) so an RGBA export yields
-    // a transparent backdrop. For RGB export the alpha is dropped on read-back,
-    // so the visible result is unchanged. (DisplayContext::clearBuffer would
-    // force alpha = 1, leaving the background opaque.)
+    // Clear the background. When transparent capture is requested the alpha is
+    // 0 so an RGBA export yields a transparent backdrop; otherwise the opaque
+    // scene background color is used (alpha = 1). DisplayContext::clearBuffer
+    // cannot express this as it forces alpha = 1.
     gfx::ColorPtr bgcol = pScene->getBgColor();
-    m_pRT->clear(float(bgcol->fr()), float(bgcol->fg()), float(bgcol->fb()), 0.0f);
+    const float bg_a = m_bBgTransparent ? 0.0f : 1.0f;
+    m_pRT->clear(float(bgcol->fr()), float(bgcol->fg()), float(bgcol->fb()), bg_a);
 
     pScene->display(pdc);
 

--- a/src/qsys/OffScreenView.cpp
+++ b/src/qsys/OffScreenView.cpp
@@ -1,0 +1,78 @@
+// -*-Mode: C++;-*-
+//
+// OffScreenView: render into a framebuffer object for off-screen capture
+//
+
+#include <common.h>
+
+#include "OffScreenView.hpp"
+#include "Scene.hpp"
+
+#include <gfx/DisplayContext.hpp>
+#include <gfx/RenderTarget.hpp>
+
+namespace qsys {
+
+OffScreenView::OffScreenView(gfx::DisplayContext *pParentCtxt, int w, int h, int flags)
+    : super_t(), m_pParentCtxt(pParentCtxt), m_pRT(nullptr)
+{
+    // Off-screen pixels map 1:1 to the requested size (no HiDPI scaling).
+    unsetSclFac();
+    setViewSize(w, h);
+
+    if (m_pParentCtxt != nullptr) {
+        m_pParentCtxt->setCurrent();
+        m_pRT = m_pParentCtxt->createRenderTarget(w, h, flags);
+    }
+}
+
+OffScreenView::~OffScreenView()
+{
+    if (m_pRT != nullptr) {
+        if (m_pParentCtxt != nullptr) m_pParentCtxt->setCurrent();
+        delete m_pRT;
+        m_pRT = nullptr;
+    }
+}
+
+void OffScreenView::drawScene()
+{
+    if (m_pRT == nullptr) return;
+
+    ScenePtr pScene = getScene();
+    if (pScene.isnull()) {
+        MB_DPRINTLN("OffScreenView::drawScene: invalid scene %d", getSceneID());
+        return;
+    }
+
+    gfx::DisplayContext *pdc = m_pParentCtxt;
+
+    // NOTE: do NOT call safeSetCurrent() here -- it would re-target the shared
+    // display context to this view and force the scene renderers to allocate a
+    // fresh per-view VBO set. Keeping the parent's target view lets the export
+    // reuse the on-screen geometry buffers; only the matrices and the bound
+    // framebuffer differ.
+    if (!pdc->setCurrent()) return;
+
+    m_pRT->bind();
+
+    setFogColorImpl(pdc);
+    pdc->setLighting(false);
+
+    setUpProjMat(getWidth(), getHeight());
+    setUpModelMat(MM_NORMAL);
+
+    pdc->clearBuffer(pScene->getBgColor());
+    pScene->display(pdc);
+
+    m_pRT->unbind();
+}
+
+void OffScreenView::readPixels(int x, int y, int width, int height, char *pbuf,
+                               int nbufsize, int ncomp)
+{
+    if (m_pRT == nullptr) return;
+    m_pRT->readColor(0, x, y, width, height, ncomp, pbuf);
+}
+
+}  // namespace qsys

--- a/src/qsys/OffScreenView.hpp
+++ b/src/qsys/OffScreenView.hpp
@@ -1,0 +1,65 @@
+// -*-Mode: C++;-*-
+//
+// OffScreenView.hpp
+// View that renders into a framebuffer object for off-screen capture
+//
+
+#pragma once
+
+#include "qsys.hpp"
+#include "GUIView.hpp"
+
+namespace gfx {
+class DisplayContext;
+class RenderTarget;
+}  // namespace gfx
+
+namespace qsys {
+
+/// Off-screen view backed by a framebuffer object (gfx::RenderTarget).
+///
+/// Borrows the parent view's DisplayContext (and therefore its GL context)
+/// and redirects rendering into an FBO so the scene can be captured (e.g. for
+/// PNG export) and its color attachment read back to the CPU. Created by
+/// GUIView::createOffScreenView and used by render::ImgSceneExporter.
+class QSYS_API OffScreenView : public GUIView
+{
+    using super_t = GUIView;
+
+private:
+    /// Borrowed parent display context (NOT owned).
+    gfx::DisplayContext *m_pParentCtxt;
+
+    /// Owned off-screen render target.
+    gfx::RenderTarget *m_pRT;
+
+public:
+    /// Construct an off-screen view of (w,h) sharing pParentCtxt. Allocates
+    /// the render target with the given gfx::RTFlags; isValid() reports success.
+    OffScreenView(gfx::DisplayContext *pParentCtxt, int w, int h, int flags);
+    virtual ~OffScreenView();
+
+    /// True if the render target was allocated successfully.
+    bool isValid() const
+    {
+        return m_pRT != nullptr;
+    }
+
+    /// Return the borrowed parent display context.
+    virtual gfx::DisplayContext *getDisplayContext() override
+    {
+        return m_pParentCtxt;
+    }
+
+    /// No window to present to.
+    virtual void swapBuffers() override {}
+
+    /// Render the scene into the off-screen render target.
+    virtual void drawScene() override;
+
+    /// Read back a sub-rectangle of the color attachment (ncomp 3=RGB / 4=RGBA).
+    virtual void readPixels(int x, int y, int width, int height, char *pbuf,
+                            int nbufsize, int ncomp) override;
+};
+
+}  // namespace qsys

--- a/src/qsys/OffScreenView.hpp
+++ b/src/qsys/OffScreenView.hpp
@@ -12,6 +12,7 @@
 namespace gfx {
 class DisplayContext;
 class RenderTarget;
+class PostProcGpuPrim;
 }  // namespace gfx
 
 namespace qsys {
@@ -30,11 +31,23 @@ private:
     /// Borrowed parent display context (NOT owned).
     gfx::DisplayContext *m_pParentCtxt;
 
-    /// Owned off-screen render target.
+    /// Owned off-screen render target (scene color + depth).
     gfx::RenderTarget *m_pRT;
+
+    /// Owned color-only target for the depth visualization pass (depth mode).
+    gfx::RenderTarget *m_pDepthVisRT;
+
+    /// Owned fullscreen depth-visualization primitive (depth mode).
+    gfx::PostProcGpuPrim *m_pPostProc;
+
+    /// Target last rendered into; readPixels reads from this one.
+    gfx::RenderTarget *m_pReadRT;
 
     /// When true, clear the background transparent (alpha = 0).
     bool m_bBgTransparent;
+
+    /// When true, capture a depth visualization instead of the scene color.
+    bool m_bDepthMode;
 
 public:
     /// Construct an off-screen view of (w,h) sharing pParentCtxt. Allocates
@@ -63,12 +76,23 @@ public:
         m_bBgTransparent = b;
     }
 
+    /// Capture a depth visualization (grayscale) instead of the scene color.
+    virtual void setDepthMode(bool b) override
+    {
+        m_bDepthMode = b;
+    }
+
     /// Render the scene into the off-screen render target.
     virtual void drawScene() override;
 
     /// Read back a sub-rectangle of the color attachment (ncomp 3=RGB / 4=RGBA).
     virtual void readPixels(int x, int y, int width, int height, char *pbuf,
                             int nbufsize, int ncomp) override;
+
+private:
+    /// Run the fullscreen depth-visualization pass into m_pDepthVisRT and point
+    /// read-back at it. Called from drawScene when depth mode is enabled.
+    void drawDepthVis(gfx::DisplayContext *pdc);
 };
 
 }  // namespace qsys

--- a/src/qsys/OffScreenView.hpp
+++ b/src/qsys/OffScreenView.hpp
@@ -33,6 +33,9 @@ private:
     /// Owned off-screen render target.
     gfx::RenderTarget *m_pRT;
 
+    /// When true, clear the background transparent (alpha = 0).
+    bool m_bBgTransparent;
+
 public:
     /// Construct an off-screen view of (w,h) sharing pParentCtxt. Allocates
     /// the render target with the given gfx::RTFlags; isValid() reports success.
@@ -53,6 +56,12 @@ public:
 
     /// No window to present to.
     virtual void swapBuffers() override {}
+
+    /// Select transparent (alpha=0) vs opaque background-color clear.
+    virtual void setBgTransparent(bool b) override
+    {
+        m_bBgTransparent = b;
+    }
 
     /// Render the scene into the off-screen render target.
     virtual void drawScene() override;

--- a/src/qsys/View.hpp
+++ b/src/qsys/View.hpp
@@ -440,6 +440,11 @@ namespace qsys {
     /// Create a new off-screen view compatible with this view
     virtual View *createOffScreenView(int w, int h, int aa_depth);
 
+    /// Select the off-screen background: transparent (alpha = 0) when true,
+    /// the opaque scene background color (alpha = 1) when false. Default no-op
+    /// (on-screen views ignore it); honored by off-screen views.
+    virtual void setBgTransparent(bool b) {}
+
   private:
     
     /////////////////////////////////////////////////////////////

--- a/src/qsys/View.hpp
+++ b/src/qsys/View.hpp
@@ -445,6 +445,10 @@ namespace qsys {
     /// (on-screen views ignore it); honored by off-screen views.
     virtual void setBgTransparent(bool b) {}
 
+    /// When true, an off-screen view captures a depth visualization (grayscale)
+    /// instead of the rendered color. Default no-op; honored by off-screen views.
+    virtual void setDepthMode(bool b) {}
+
   private:
     
     /////////////////////////////////////////////////////////////

--- a/src/sysdep/CMakeLists.txt
+++ b/src/sysdep/CMakeLists.txt
@@ -84,6 +84,8 @@ SET(SHADER_SOURCES
   ogl_core/linew_vert.glsl
   ogl_core/linew2_vert.glsl
   ogl_core/linew_frag.glsl
+  ogl_core/postproc_vert.glsl
+  ogl_core/depthvis_frag.glsl
 )
 SET(SHADER_DEPS
   ogl_core/lighting_inc.glsl

--- a/src/sysdep/CMakeLists.txt
+++ b/src/sysdep/CMakeLists.txt
@@ -9,6 +9,7 @@ SET(SYSDEP_SRCS
   ogl_core/OcDisplayContext.cpp
   ogl_core/OcView.cpp
   ogl_core/OcBufferRep.cpp
+  ogl_core/OcRenderTarget.cpp
 )
 
 SET(SYSDEP_HDRS

--- a/src/sysdep/ogl_core/OcDisplayContext.cpp
+++ b/src/sysdep/ogl_core/OcDisplayContext.cpp
@@ -13,7 +13,9 @@
 #include <sysdep/OglProgramObject.hpp>
 
 #include <gfx/PixelBuffer.hpp>
+#include <gfx/RenderTarget.hpp>
 #include "OcBufTexRep.hpp"
+#include "OcRenderTarget.hpp"
 #include <gfx/SolidColor.hpp>
 #include <gfx/Mesh.hpp>
 #include <gfx/AbstDrawAttrs.hpp>
@@ -90,6 +92,29 @@ gfx::BufTexRep *OcDisplayContext::createBufTexRep()
     OcBufTexRep *p = MB_NEW OcBufTexRep();
     p->init(this);
     return p;
+}
+
+gfx::RenderTarget *OcDisplayContext::createRenderTarget(int w, int h, int flags)
+{
+    OcRenderTarget *p = MB_NEW OcRenderTarget();
+    if (!p->init(this, w, h, flags)) {
+        delete p;
+        return nullptr;
+    }
+    return p;
+}
+
+void OcDisplayContext::bindRenderTarget(gfx::RenderTarget *prt)
+{
+    if (prt != nullptr)
+        prt->bind();
+    else
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void OcDisplayContext::bindDefaultFramebuffer()
+{
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
 
 //////////

--- a/src/sysdep/ogl_core/OcDisplayContext.hpp
+++ b/src/sysdep/ogl_core/OcDisplayContext.hpp
@@ -14,6 +14,7 @@ class BufTexRep;
 class VBORep;
 class PixRep;
 class PixelBuffer;
+class RenderTarget;
 }  // namespace gfx
 
 namespace sysdep {
@@ -55,6 +56,12 @@ public:
     virtual gfx::VBORep *createVBORep(const gfx::AbstDrawAttrs &ada) override;
 
     virtual gfx::PixRep *createPixRep(const gfx::PixelBuffer &pixbuf) override;
+
+    virtual gfx::RenderTarget *createRenderTarget(int w, int h, int flags) override;
+
+    virtual void bindRenderTarget(gfx::RenderTarget *prt) override;
+
+    virtual void bindDefaultFramebuffer() override;
 };
 
 }  // namespace sysdep

--- a/src/sysdep/ogl_core/OcRenderTarget.cpp
+++ b/src/sysdep/ogl_core/OcRenderTarget.cpp
@@ -1,0 +1,199 @@
+// -*-Mode: C++;-*-
+//
+//  OpenGL off-screen render target (framebuffer object)
+//
+
+#include <common.h>
+
+#include "OcRenderTarget.hpp"
+#include "OglCommon.hpp"
+
+#include <gfx/DisplayContext.hpp>
+#include <qsys/SceneManager.hpp>
+#include <sysdep/OglError.hpp>
+
+namespace sysdep {
+
+OcRenderTarget::OcRenderTarget()
+    : m_nViewID(0),
+      m_nFBO(0),
+      m_nColorTex(0),
+      m_nDepthTex(0),
+      m_nNormalTex(0),
+      m_nWidth(0),
+      m_nHeight(0),
+      m_nFlags(0)
+{
+    m_savedVp[0] = m_savedVp[1] = m_savedVp[2] = m_savedVp[3] = 0;
+}
+
+bool OcRenderTarget::init(gfx::DisplayContext *pdc, int w, int h, int flags)
+{
+    m_nViewID = pdc->getViewID();
+    m_nWidth = w;
+    m_nHeight = h;
+    m_nFlags = flags;
+
+    GLuint fbo = 0;
+    glGenFramebuffers(1, &fbo);
+    m_nFBO = fbo;
+
+    GLuint tex = 0;
+    glGenTextures(1, &tex);
+    m_nColorTex = tex;
+
+    tex = 0;
+    glGenTextures(1, &tex);
+    m_nDepthTex = tex;
+
+    if (m_nFlags & gfx::RT_NORMAL_RGB16F) {
+        tex = 0;
+        glGenTextures(1, &tex);
+        m_nNormalTex = tex;
+    }
+    CHK_GLERROR("OcRenderTarget::init gen");
+
+    allocAttachments(w, h);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_nFBO);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           m_nColorTex, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                           m_nDepthTex, 0);
+
+    if (m_nNormalTex != 0) {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D,
+                               m_nNormalTex, 0);
+        GLenum bufs[2] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
+        glDrawBuffers(2, bufs);
+    } else {
+        GLenum bufs[1] = {GL_COLOR_ATTACHMENT0};
+        glDrawBuffers(1, bufs);
+    }
+    CHK_GLERROR("OcRenderTarget::init attach");
+
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    if (status != GL_FRAMEBUFFER_COMPLETE) {
+        LOG_DPRINTLN("OcRenderTarget> FBO incomplete: 0x%x (%dx%d)", status, w, h);
+        return false;
+    }
+
+    MB_DPRINTLN("OcRenderTarget::init view=%d fbo=%d color=%d depth=%d normal=%d (%dx%d) OK",
+                m_nViewID, m_nFBO, m_nColorTex, m_nDepthTex, m_nNormalTex, w, h);
+    return true;
+}
+
+void OcRenderTarget::allocAttachments(int w, int h)
+{
+    // Color attachment 0 (RGBA8)
+    glBindTexture(GL_TEXTURE_2D, m_nColorTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // Depth attachment (sampleable DEPTH_COMPONENT24)
+    glBindTexture(GL_TEXTURE_2D, m_nDepthTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, w, h, 0, GL_DEPTH_COMPONENT,
+                 GL_UNSIGNED_INT, nullptr);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // Optional MRT normal attachment 1 (RGB16F)
+    if (m_nNormalTex != 0) {
+        glBindTexture(GL_TEXTURE_2D, m_nNormalTex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, w, h, 0, GL_RGB, GL_FLOAT, nullptr);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+    CHK_GLERROR("OcRenderTarget::allocAttachments");
+}
+
+OcRenderTarget::~OcRenderTarget()
+{
+    if (m_nFBO == 0) return;
+
+    qsys::ViewPtr rvw = qsys::SceneManager::getViewS(m_nViewID);
+    if (rvw.isnull()) {
+        MB_DPRINTLN("OcRenderTarget> unknown parent view (%d), FBO cannot be deleted",
+                    m_nViewID);
+        return;
+    }
+    gfx::DisplayContext *pctxt = rvw->getDisplayContext();
+    if (pctxt == nullptr) {
+        MB_DPRINTLN("OcRenderTarget> view has no display context, FBO cannot be deleted");
+        return;
+    }
+    pctxt->setCurrent();
+
+    if (m_nColorTex != 0) glDeleteTextures(1, &m_nColorTex);
+    if (m_nDepthTex != 0) glDeleteTextures(1, &m_nDepthTex);
+    if (m_nNormalTex != 0) glDeleteTextures(1, &m_nNormalTex);
+    glDeleteFramebuffers(1, &m_nFBO);
+
+    MB_DPRINTLN("OcRenderTarget> fbo=%d deleted", m_nFBO);
+}
+
+void OcRenderTarget::bind()
+{
+    glGetIntegerv(GL_VIEWPORT, m_savedVp);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_nFBO);
+    glViewport(0, 0, m_nWidth, m_nHeight);
+    CHK_GLERROR("OcRenderTarget::bind");
+}
+
+void OcRenderTarget::unbind()
+{
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glViewport(m_savedVp[0], m_savedVp[1], m_savedVp[2], m_savedVp[3]);
+}
+
+void OcRenderTarget::resize(int w, int h)
+{
+    if (w == m_nWidth && h == m_nHeight) return;
+    m_nWidth = w;
+    m_nHeight = h;
+    allocAttachments(w, h);
+}
+
+void OcRenderTarget::bindColorTex(int idx, int texUnit)
+{
+    GLuint tex = (idx == 1 && m_nNormalTex != 0) ? m_nNormalTex : m_nColorTex;
+    glActiveTexture(GL_TEXTURE0 + texUnit);
+    glBindTexture(GL_TEXTURE_2D, tex);
+}
+
+void OcRenderTarget::bindDepthTex(int texUnit)
+{
+    glActiveTexture(GL_TEXTURE0 + texUnit);
+    glBindTexture(GL_TEXTURE_2D, m_nDepthTex);
+}
+
+void OcRenderTarget::unbindTextures()
+{
+    glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+void OcRenderTarget::readColor(int idx, int x, int y, int w, int h, int ncomp,
+                               void *pbuf)
+{
+    GLenum fmt = (ncomp == 4) ? GL_RGBA : GL_RGB;
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, m_nFBO);
+    glReadBuffer(GL_COLOR_ATTACHMENT0 + idx);
+    glReadPixels(x, y, w, h, fmt, GL_UNSIGNED_BYTE, pbuf);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    CHK_GLERROR("OcRenderTarget::readColor");
+}
+
+}  // namespace sysdep

--- a/src/sysdep/ogl_core/OcRenderTarget.cpp
+++ b/src/sysdep/ogl_core/OcRenderTarget.cpp
@@ -159,6 +159,12 @@ void OcRenderTarget::unbind()
     glViewport(m_savedVp[0], m_savedVp[1], m_savedVp[2], m_savedVp[3]);
 }
 
+void OcRenderTarget::clear(float r, float g, float b, float a)
+{
+    glClearColor(r, g, b, a);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+}
+
 void OcRenderTarget::resize(int w, int h)
 {
     if (w == m_nWidth && h == m_nHeight) return;

--- a/src/sysdep/ogl_core/OcRenderTarget.cpp
+++ b/src/sysdep/ogl_core/OcRenderTarget.cpp
@@ -42,9 +42,11 @@ bool OcRenderTarget::init(gfx::DisplayContext *pdc, int w, int h, int flags)
     glGenTextures(1, &tex);
     m_nColorTex = tex;
 
-    tex = 0;
-    glGenTextures(1, &tex);
-    m_nDepthTex = tex;
+    if (m_nFlags & gfx::RT_DEPTH_TEX) {
+        tex = 0;
+        glGenTextures(1, &tex);
+        m_nDepthTex = tex;
+    }
 
     if (m_nFlags & gfx::RT_NORMAL_RGB16F) {
         tex = 0;
@@ -59,8 +61,10 @@ bool OcRenderTarget::init(gfx::DisplayContext *pdc, int w, int h, int flags)
 
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                            m_nColorTex, 0);
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
-                           m_nDepthTex, 0);
+    if (m_nDepthTex != 0) {
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                               m_nDepthTex, 0);
+    }
 
     if (m_nNormalTex != 0) {
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D,
@@ -98,13 +102,15 @@ void OcRenderTarget::allocAttachments(int w, int h)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     // Depth attachment (sampleable DEPTH_COMPONENT24)
-    glBindTexture(GL_TEXTURE_2D, m_nDepthTex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, w, h, 0, GL_DEPTH_COMPONENT,
-                 GL_UNSIGNED_INT, nullptr);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    if (m_nDepthTex != 0) {
+        glBindTexture(GL_TEXTURE_2D, m_nDepthTex);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, w, h, 0,
+                     GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
 
     // Optional MRT normal attachment 1 (RGB16F)
     if (m_nNormalTex != 0) {

--- a/src/sysdep/ogl_core/OcRenderTarget.hpp
+++ b/src/sysdep/ogl_core/OcRenderTarget.hpp
@@ -1,0 +1,75 @@
+// -*-Mode: C++;-*-
+//
+//  OpenGL off-screen render target (framebuffer object)
+//
+
+#pragma once
+
+#include "sysdep.hpp"
+
+#include <gfx/RenderTarget.hpp>
+#include <qlib/LTypes.hpp>
+
+namespace gfx {
+class DisplayContext;
+}
+
+namespace sysdep {
+
+/// OpenGL (core profile) implementation of gfx::RenderTarget.
+/// Owns a framebuffer object with a color texture (RGBA8), a depth texture
+/// (DEPTH_COMPONENT24, sampleable) and an optional MRT normal texture (RGB16F).
+class OcRenderTarget : public gfx::RenderTarget
+{
+private:
+    /// Parent view ID (for context lookup at destruction).
+    qlib::uid_t m_nViewID;
+
+    quint32 m_nFBO;
+    quint32 m_nColorTex;
+    quint32 m_nDepthTex;
+    quint32 m_nNormalTex;
+
+    int m_nWidth;
+    int m_nHeight;
+    int m_nFlags;
+
+    /// Viewport saved by bind(), restored by unbind().
+    int m_savedVp[4];
+
+public:
+    OcRenderTarget();
+    virtual ~OcRenderTarget();
+
+    /// Allocate the FBO and attachments. Records the parent view ID for
+    /// cleanup. Returns false if the framebuffer is incomplete.
+    bool init(gfx::DisplayContext *pdc, int w, int h, int flags);
+
+    void bind() override;
+    void unbind() override;
+    void resize(int w, int h) override;
+    void bindColorTex(int idx, int texUnit) override;
+    void bindDepthTex(int texUnit) override;
+    void unbindTextures() override;
+    void readColor(int idx, int x, int y, int w, int h, int ncomp,
+                   void *pbuf) override;
+
+    bool hasNormal() const override
+    {
+        return (m_nFlags & gfx::RT_NORMAL_RGB16F) != 0;
+    }
+    int getWidth() const override
+    {
+        return m_nWidth;
+    }
+    int getHeight() const override
+    {
+        return m_nHeight;
+    }
+
+private:
+    /// (Re-)allocate attachment textures at the given size.
+    void allocAttachments(int w, int h);
+};
+
+}  // namespace sysdep

--- a/src/sysdep/ogl_core/OcRenderTarget.hpp
+++ b/src/sysdep/ogl_core/OcRenderTarget.hpp
@@ -47,6 +47,7 @@ public:
 
     void bind() override;
     void unbind() override;
+    void clear(float r, float g, float b, float a) override;
     void resize(int w, int h) override;
     void bindColorTex(int idx, int texUnit) override;
     void bindDepthTex(int texUnit) override;

--- a/src/sysdep/ogl_core/depthvis_frag.glsl
+++ b/src/sysdep/ogl_core/depthvis_frag.glsl
@@ -1,0 +1,22 @@
+// Depth visualization fragment shader.
+// Samples the off-screen depth texture and outputs a linearized grayscale
+// image (near = bright, far = dark). Assumes a perspective projection; for an
+// orthographic view the mapping is still monotonic.
+
+uniform sampler2D u_depthTex;
+uniform float u_near;
+uniform float u_far;
+
+in vec2 v_uv;
+
+out vec4 o_FragColor;
+
+void main()
+{
+    float d = texture(u_depthTex, v_uv).r;        // window depth [0,1]
+    float z_ndc = d * 2.0 - 1.0;                  // NDC depth [-1,1]
+    float denom = (u_far + u_near) - z_ndc * (u_far - u_near);
+    float lin = (2.0 * u_near * u_far) / denom;   // eye-space distance
+    float g = clamp((lin - u_near) / (u_far - u_near), 0.0, 1.0);
+    o_FragColor = vec4(vec3(1.0 - g), 1.0);
+}

--- a/src/sysdep/ogl_core/postproc_vert.glsl
+++ b/src/sysdep/ogl_core/postproc_vert.glsl
@@ -1,0 +1,13 @@
+// Fullscreen-triangle vertex shader for post-processing passes.
+// The vertex positions are already in normalized device coordinates; a single
+// oversized triangle (-1,-1)(3,-1)(-1,3) covers the whole viewport.
+
+layout(location = 0) in vec2 aVertex;
+
+out vec2 v_uv;
+
+void main()
+{
+    v_uv = aVertex * 0.5 + 0.5;
+    gl_Position = vec4(aVertex, 0.0, 1.0);
+}

--- a/tritium/core/CMakeLists.txt
+++ b/tritium/core/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(NODEJS_SRCS
     cxx_src/EcShaderObject.cpp
     cxx_src/EcBufferRep.cpp
     cxx_src/EcTexRep.cpp
+    cxx_src/EcRenderTarget.cpp
     cxx_src/EcTimerImpl.cpp
   )
 

--- a/tritium/core/cxx_src/EcRenderTarget.cpp
+++ b/tritium/core/cxx_src/EcRenderTarget.cpp
@@ -1,0 +1,230 @@
+// -*-Mode: C++;-*-
+//
+// React/WebGL off-screen render target (framebuffer object)
+//
+
+#include <common.h>
+
+#include "EcRenderTarget.hpp"
+#include "ElecView.hpp"
+
+#include <gfx/DisplayContext.hpp>
+#include <qsys/SceneManager.hpp>
+
+#include <cstring>
+
+namespace node_jsbr {
+
+EcRenderTarget::EcRenderTarget()
+    : m_nViewID(0), m_nWidth(0), m_nHeight(0), m_nFlags(0)
+{
+}
+
+ElecView *EcRenderTarget::getView() const
+{
+    qsys::ViewPtr rvw = qsys::SceneManager::getViewS(m_nViewID);
+    if (rvw.isnull()) return nullptr;
+    return dynamic_cast<ElecView *>(rvw.get());
+}
+
+bool EcRenderTarget::init(gfx::DisplayContext *pdc, int w, int h, int flags)
+{
+    auto pView = dynamic_cast<ElecView *>(pdc->getTargetView());
+    if (pView == nullptr) {
+        MB_THROW(qlib::RuntimeException, "target view is not set or not ElecView");
+        return false;
+    }
+    m_nViewID = pView->getUID();
+    m_fboName = qlib::LString::format("fbo_%p", this);
+    m_nWidth = w;
+    m_nHeight = h;
+    m_nFlags = flags;
+
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    auto method = peer.Get("createFramebuffer").As<Napi::Function>();
+    bool result = false;
+    try {
+        auto rval = method.Call(
+            peer, {Napi::String::New(env, m_fboName.c_str()),
+                   Napi::Number::New(env, w), Napi::Number::New(env, h),
+                   Napi::Number::New(env, flags)});
+        result = rval.As<Napi::Boolean>().Value();
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("createFramebuffer failed: %s", e.Message().c_str());
+        return false;
+    }
+    return result;
+}
+
+EcRenderTarget::~EcRenderTarget()
+{
+    auto pView = getView();
+    if (pView == nullptr) {
+        MB_DPRINTLN("EcRenderTarget> unknown parent view (%d), fbo %s not deleted",
+                    m_nViewID, m_fboName.c_str());
+        return;
+    }
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    try {
+        peer.Get("deleteFramebuffer")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::String::New(env, m_fboName.c_str())});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("deleteFramebuffer failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::bind()
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    try {
+        peer.Get("bindFramebuffer")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::String::New(env, m_fboName.c_str())});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("bindFramebuffer failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::unbind()
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    try {
+        peer.Get("bindDefaultFramebuffer").As<Napi::Function>().Call(peer, {});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("bindDefaultFramebuffer failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::clear(float r, float g, float b, float a)
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    try {
+        peer.Get("clearRenderTarget")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::Number::New(env, r), Napi::Number::New(env, g),
+                         Napi::Number::New(env, b), Napi::Number::New(env, a)});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("clearRenderTarget failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::resize(int w, int h)
+{
+    if (w == m_nWidth && h == m_nHeight) return;
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    try {
+        peer.Get("deleteFramebuffer")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::String::New(env, m_fboName.c_str())});
+        peer.Get("createFramebuffer")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::String::New(env, m_fboName.c_str()),
+                         Napi::Number::New(env, w), Napi::Number::New(env, h),
+                         Napi::Number::New(env, m_nFlags)});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("resize framebuffer failed: %s", e.Message().c_str());
+    }
+    m_nWidth = w;
+    m_nHeight = h;
+}
+
+void EcRenderTarget::bindColorTex(int idx, int texUnit)
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    try {
+        peer.Get("bindFBOTexture")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::String::New(env, m_fboName.c_str()),
+                         Napi::String::New(env, "color"),
+                         Napi::Number::New(env, texUnit)});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("bindFBOTexture(color) failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::bindDepthTex(int texUnit)
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+    try {
+        peer.Get("bindFBOTexture")
+            .As<Napi::Function>()
+            .Call(peer, {Napi::String::New(env, m_fboName.c_str()),
+                         Napi::String::New(env, "depth"),
+                         Napi::Number::New(env, texUnit)});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("bindFBOTexture(depth) failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::unbindTextures()
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    try {
+        peer.Get("unbindTexture").As<Napi::Function>().Call(peer, {});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("unbindTexture failed: %s", e.Message().c_str());
+    }
+}
+
+void EcRenderTarget::readColor(int idx, int x, int y, int w, int h, int ncomp,
+                               void *pbuf)
+{
+    auto pView = getView();
+    if (pView == nullptr) return;
+    auto peer = pView->getPeerObj();
+    auto env = peer.Env();
+
+    Napi::Value rval;
+    try {
+        rval = peer.Get("readPixels")
+                   .As<Napi::Function>()
+                   .Call(peer, {Napi::String::New(env, m_fboName.c_str()),
+                                Napi::Number::New(env, x), Napi::Number::New(env, y),
+                                Napi::Number::New(env, w), Napi::Number::New(env, h)});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("readPixels failed: %s", e.Message().c_str());
+        return;
+    }
+
+    if (!rval.IsTypedArray()) return;
+    Napi::Uint8Array arr = rval.As<Napi::Uint8Array>();
+    const uint8_t *src = arr.Data();
+    const size_t npix = static_cast<size_t>(w) * static_cast<size_t>(h);
+    if (arr.ByteLength() < npix * 4) return;
+
+    auto *dst = static_cast<uint8_t *>(pbuf);
+    if (ncomp == 4) {
+        memcpy(dst, src, npix * 4);
+    } else {
+        // RGB: drop the alpha channel.
+        for (size_t i = 0; i < npix; ++i) {
+            dst[i * 3 + 0] = src[i * 4 + 0];
+            dst[i * 3 + 1] = src[i * 4 + 1];
+            dst[i * 3 + 2] = src[i * 4 + 2];
+        }
+    }
+}
+
+}  // namespace node_jsbr

--- a/tritium/core/cxx_src/EcRenderTarget.hpp
+++ b/tritium/core/cxx_src/EcRenderTarget.hpp
@@ -1,0 +1,70 @@
+// -*-Mode: C++;-*-
+//
+// React/WebGL off-screen render target (framebuffer object)
+//
+
+#pragma once
+
+#include <napi.h>
+
+#include <gfx/RenderTarget.hpp>
+#include <qlib/LString.hpp>
+#include <qlib/LTypes.hpp>
+
+namespace gfx {
+class DisplayContext;
+}
+
+namespace node_jsbr {
+
+class ElecView;
+
+/// WebGL implementation of gfx::RenderTarget. Forwards all operations to the
+/// JS-side GfxManager peer (createFramebuffer / bindFramebuffer / readPixels
+/// ...). Mirrors the OpenGL OcRenderTarget so the portable off-screen view and
+/// image exporter work unchanged on the WebGL backend.
+class EcRenderTarget : public gfx::RenderTarget
+{
+private:
+    qlib::uid_t m_nViewID;
+    qlib::LString m_fboName;
+    int m_nWidth;
+    int m_nHeight;
+    int m_nFlags;
+
+public:
+    EcRenderTarget();
+    virtual ~EcRenderTarget();
+
+    /// Allocate the FBO via the peer. Returns false if creation failed.
+    bool init(gfx::DisplayContext *pdc, int w, int h, int flags);
+
+    void bind() override;
+    void unbind() override;
+    void clear(float r, float g, float b, float a) override;
+    void resize(int w, int h) override;
+    void bindColorTex(int idx, int texUnit) override;
+    void bindDepthTex(int texUnit) override;
+    void unbindTextures() override;
+    void readColor(int idx, int x, int y, int w, int h, int ncomp,
+                   void *pbuf) override;
+
+    bool hasNormal() const override
+    {
+        return (m_nFlags & gfx::RT_NORMAL_RGB16F) != 0;
+    }
+    int getWidth() const override
+    {
+        return m_nWidth;
+    }
+    int getHeight() const override
+    {
+        return m_nHeight;
+    }
+
+private:
+    /// Resolve the owning ElecView (and its peer) by view id. May be null.
+    ElecView *getView() const;
+};
+
+}  // namespace node_jsbr

--- a/tritium/core/cxx_src/ElecDisplayContext.cpp
+++ b/tritium/core/cxx_src/ElecDisplayContext.cpp
@@ -5,8 +5,10 @@
 #include "ElecView.hpp"
 #include "EcBufferRep.hpp"
 #include "EcTexRep.hpp"
+#include "EcRenderTarget.hpp"
 
 #include <gfx/AbstDrawAttrs.hpp>
+#include <gfx/RenderTarget.hpp>
 
 namespace node_jsbr {
 
@@ -130,6 +132,35 @@ gfx::PixRep *ElecDisplayContext::createPixRep(const gfx::PixelBuffer &pb)
     auto pRep = MB_NEW EcTexRep();
     pRep->create(this, pb);
     return pRep;
+}
+
+gfx::RenderTarget *ElecDisplayContext::createRenderTarget(int w, int h, int flags)
+{
+    auto *pRT = MB_NEW EcRenderTarget();
+    if (!pRT->init(this, w, h, flags)) {
+        delete pRT;
+        return nullptr;
+    }
+    return pRT;
+}
+
+void ElecDisplayContext::bindRenderTarget(gfx::RenderTarget *prt)
+{
+    if (prt != nullptr)
+        prt->bind();
+    else
+        bindDefaultFramebuffer();
+}
+
+void ElecDisplayContext::bindDefaultFramebuffer()
+{
+    if (!m_pView || !m_pView->isBound()) return;
+    auto peer = m_pView->getPeerObj();
+    try {
+        peer.Get("bindDefaultFramebuffer").As<Napi::Function>().Call(peer, {});
+    } catch (const Napi::Error &e) {
+        MB_DPRINTLN("bindDefaultFramebuffer> Error: %s", e.Message().c_str());
+    }
 }
 
 void ElecDisplayContext::allocBuffer(gfx::AbstDrawAttrs &ada, int nvert, int nind)

--- a/tritium/core/cxx_src/ElecDisplayContext.hpp
+++ b/tritium/core/cxx_src/ElecDisplayContext.hpp
@@ -4,6 +4,7 @@
 
 namespace gfx {
 class ShaderObject;
+class RenderTarget;
 }  // namespace gfx
 
 namespace node_jsbr {
@@ -51,6 +52,12 @@ public:
     virtual gfx::VBORep *createVBORep(const gfx::AbstDrawAttrs &ada) override;
 
     virtual gfx::PixRep *createPixRep(const gfx::PixelBuffer &pixbuf) override;
+
+    virtual gfx::RenderTarget *createRenderTarget(int w, int h, int flags) override;
+
+    virtual void bindRenderTarget(gfx::RenderTarget *prt) override;
+
+    virtual void bindDefaultFramebuffer() override;
 
     /// Allocate vertex/index buffers in V8 cage memory so the C++ side
     /// can write directly into them via qlib::Array::refer(), and the

--- a/tritium/react-gui/src/main/handlers/fileDialogs.ts
+++ b/tritium/react-gui/src/main/handlers/fileDialogs.ts
@@ -123,6 +123,26 @@ export async function handleCameraSaveDialog(
   }
 }
 
+export async function handleImageSaveDialog(
+  mainWindow: BrowserWindow,
+  defaultName: string,
+): Promise<{ canceled: boolean; filePath: string }> {
+  const result = await withMenuBlocked('native', () =>
+    dialog.showSaveDialog(mainWindow, {
+      title: 'Export Image As',
+      defaultPath: defaultName,
+      filters: [
+        { name: 'PNG image', extensions: ['png'] },
+        { name: 'All Files', extensions: ['*'] },
+      ],
+    }),
+  )
+  return {
+    canceled: result.canceled,
+    filePath: result.filePath ?? '',
+  }
+}
+
 // The filter list is built worker-side from
 // `StreamManager.findCompatibleWriterNamesForObj` × the writer category
 // of `StreamManager.getInfoJSON2`; the renderer forwards it here. We

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -36,6 +36,7 @@ import {
   handleStyleSaveDialog,
   handleCameraOpenDialog,
   handleCameraSaveDialog,
+  handleImageSaveDialog,
   handleObjectSaveDialog,
   handlePickPathDialog,
   handleSaveTextAsDialog,
@@ -185,6 +186,10 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
 
   handleInvoke(IPC.DIALOG_CAMERA_SAVE, async (_event, payload) =>
     handleCameraSaveDialog(mainWindow, payload.defaultName),
+  )
+
+  handleInvoke(IPC.DIALOG_IMAGE_SAVE, async (_event, payload) =>
+    handleImageSaveDialog(mainWindow, payload.defaultName),
   )
 
   handleInvoke(IPC.DIALOG_OBJECT_SAVE, async (_event, payload) =>

--- a/tritium/react-gui/src/renderer/commands/CommandMap.ts
+++ b/tritium/react-gui/src/renderer/commands/CommandMap.ts
@@ -35,6 +35,7 @@ export interface CommandMap {
   [CmdId.FileSaveAs]:          { args: void;            result: boolean }
   [CmdId.ObjectSaveAs]:        { args: void;            result: void }
   [CmdId.SaveCurrentView]:     { args: void;            result: void }
+  [CmdId.ExportImage]:         { args: void;            result: void }
   [CmdId.SceneReload]:         { args: void;            result: void }
 
   // Edit

--- a/tritium/react-gui/src/renderer/commands/ids.ts
+++ b/tritium/react-gui/src/renderer/commands/ids.ts
@@ -28,6 +28,7 @@ export const CmdId = {
   FileSaveAs:         'file.saveAs',         // no args
   ObjectSaveAs:       'object.saveAs',       // no args -- object (not scene) save
   SaveCurrentView:    'file.saveCurrentView', // no args
+  ExportImage:        'file.exportImage',    // no args -- render scene to PNG
   SceneReload:        'scene.reload',        // no args
 
   // Undo/redo

--- a/tritium/react-gui/src/renderer/commands/useFileCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useFileCommands.ts
@@ -86,6 +86,28 @@ export function useFileCommands({
         })
     })
 
+    // ExportImage — render the active scene off-screen to a PNG file (UXP
+    // `Export scene`). The C++ ImgSceneExporter renders through the WebGL FBO
+    // (gfx::RenderTarget) and reads the pixels back.
+    useRegisterCommand(CmdId.ExportImage, async () => {
+        if (!cm) return
+        const info = getActiveSceneInfo()
+        if (!info) return
+        const dlg = await window.electronAPI.invoke(IPC.DIALOG_IMAGE_SAVE, {
+            defaultName: 'image.png',
+        })
+        if (dlg.canceled || !dlg.filePath) return
+        await cm.invokeService('exportImage', {
+            sceneId: info.scene_uid,
+            viewId: info.view_id,
+            filePath: dlg.filePath,
+            width: 1024,
+            height: 768,
+            alpha: false,
+            depth: false,
+        })
+    })
+
     // SceneReload — UXP `onReloadScene`: re-read the scene from its source
     // file, confirming first when there are unsaved changes.
     useRegisterCommand(CmdId.SceneReload, async () => {

--- a/tritium/react-gui/src/renderer/hooks/useMenuDispatch.ts
+++ b/tritium/react-gui/src/renderer/hooks/useMenuDispatch.ts
@@ -94,6 +94,9 @@ export function useMenuDispatch(activeTab: string | null): {
         case 'menu:save-current-view':
           dispatch(CmdId.SaveCurrentView).catch(logErr('file.saveCurrentView:'))
           break
+        case 'menu:export-scene':
+          dispatch(CmdId.ExportImage).catch(logErr('file.exportImage:'))
+          break
         case 'menu:reload-scene':
           dispatch(CmdId.SceneReload).catch(logErr('scene.reload:'))
           break

--- a/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
@@ -103,6 +103,17 @@ export class GfxManager {
     // for textures
     private _tex_data: { [key: string]: WebGLTexture } = {};
 
+    // for off-screen render targets (framebuffer objects), keyed by name
+    private _fbo_data: {
+        [key: string]: {
+            fbo: WebGLFramebuffer;
+            colorTex: WebGLTexture;
+            depthTex: WebGLTexture | null;
+            w: number;
+            h: number;
+        };
+    } = {};
+
     private cuemol: any;
     private _sceMgr: any;
     private _canvas: any = null;
@@ -815,6 +826,132 @@ export class GfxManager {
         if (!(name in this._tex_data)) return false;
         gl.deleteTexture(this._tex_data[name]);
         delete this._tex_data[name];
+        return true;
+    }
+
+    //////////
+    // Off-screen render target (framebuffer object)
+    //
+    // Peer API for the C++ gfx::RenderTarget abstraction (EcRenderTarget),
+    // used by off-screen rendering / image export. Mirrors the OpenGL
+    // OcRenderTarget implementation. `flags` bit 0x02 (RT_DEPTH_TEX) requests a
+    // sampleable depth attachment.
+
+    /// API: create an FBO with an RGBA8 color texture and (optionally) a
+    /// sampleable DEPTH_COMPONENT24 depth texture. Returns false if incomplete.
+    createFramebuffer(name: string, width: number, height: number, flags: number): boolean {
+        const gl = this._context;
+        if (name in this._fbo_data) {
+            console.log(`createFramebuffer: ${name} already exists --> reuse`);
+            return true;
+        }
+
+        const fbo = gl.createFramebuffer()!;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+
+        // Color attachment 0 (RGBA8)
+        const colorTex = gl.createTexture()!;
+        gl.bindTexture(gl.TEXTURE_2D, colorTex);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0,
+                      gl.RGBA, gl.UNSIGNED_BYTE, null);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0,
+                                gl.TEXTURE_2D, colorTex, 0);
+
+        // Depth attachment (sampleable), only when RT_DEPTH_TEX (0x02) is set.
+        let depthTex: WebGLTexture | null = null;
+        if ((flags & 0x02) !== 0) {
+            depthTex = gl.createTexture()!;
+            gl.bindTexture(gl.TEXTURE_2D, depthTex);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT24, width, height, 0,
+                          gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT,
+                                    gl.TEXTURE_2D, depthTex, 0);
+        }
+
+        gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
+
+        const status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        if (status !== gl.FRAMEBUFFER_COMPLETE) {
+            console.error(`createFramebuffer ${name} incomplete: 0x${status.toString(16)}`);
+            gl.deleteTexture(colorTex);
+            if (depthTex) gl.deleteTexture(depthTex);
+            gl.deleteFramebuffer(fbo);
+            return false;
+        }
+
+        this._fbo_data[name] = { fbo, colorTex, depthTex, w: width, h: height };
+        console.log(`createFramebuffer OK: ${name} ${width}x${height} depth=${depthTex !== null}`);
+        return true;
+    }
+
+    /// API: bind the named FBO as draw target and set the viewport to its size.
+    bindFramebuffer(name: string): void {
+        const gl = this._context;
+        const info = this._fbo_data[name];
+        if (!info) throw `framebuffer ${name} not found`;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, info.fbo);
+        gl.viewport(0, 0, info.w, info.h);
+    }
+
+    /// API: restore the default framebuffer (canvas) as draw target.
+    bindDefaultFramebuffer(): void {
+        const gl = this._context;
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        gl.viewport(0, 0, this._canvas.width, this._canvas.height);
+    }
+
+    /// API: clear the currently bound framebuffer's color + depth.
+    clearRenderTarget(r: number, g: number, b: number, a: number): void {
+        const gl = this._context;
+        gl.clearColor(r, g, b, a);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    }
+
+    /// API: bind an FBO attachment ('color' | 'depth') as a sampler texture.
+    bindFBOTexture(name: string, which: string, texUnit: number): void {
+        const gl = this._context;
+        const info = this._fbo_data[name];
+        if (!info) throw `framebuffer ${name} not found`;
+        const tex = which === 'depth' ? info.depthTex : info.colorTex;
+        if (!tex) return;
+        gl.activeTexture(gl.TEXTURE0 + texUnit);
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+    }
+
+    /// API: read back an RGBA sub-rectangle of the named FBO's color
+    /// attachment 0 (bottom-left origin). Returns w*h*4 bytes.
+    readPixels(name: string, x: number, y: number, w: number, h: number): Uint8Array {
+        const gl = this._context;
+        const info = this._fbo_data[name];
+        if (!info) return new Uint8Array(0);
+        const buf = new Uint8Array(w * h * 4);
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, info.fbo);
+        gl.readBuffer(gl.COLOR_ATTACHMENT0);
+        gl.readPixels(x, y, w, h, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+        return buf;
+    }
+
+    /// API: delete the named FBO and its attachments.
+    deleteFramebuffer(name: string): boolean {
+        const gl = this._context;
+        const info = this._fbo_data[name];
+        if (!info) return false;
+        gl.deleteTexture(info.colorTex);
+        if (info.depthTex) gl.deleteTexture(info.depthTex);
+        gl.deleteFramebuffer(info.fbo);
+        delete this._fbo_data[name];
         return true;
     }
 };

--- a/tritium/react-gui/src/renderer/worker/server/services/exportImage.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/exportImage.service.ts
@@ -1,0 +1,71 @@
+/**
+ * @file worker/server/services/exportImage.service.ts
+ * @description Runs in the Web Worker thread. Renders the active scene to an
+ * image file via the C++ ImgSceneExporter / PngSceneExporter, which renders
+ * off-screen through the gfx::RenderTarget (WebGL FBO) abstraction and reads
+ * the pixels back. This is the same portable exporter used by the OpenGL build.
+ */
+import type { WorkerContext } from '../types/WorkerContext';
+import { getSceneOrNull } from './helpers/sceneResolver';
+
+export interface ExportImageArgs {
+    sceneId: number;
+    viewId: number;
+    filePath: string;
+    width: number;
+    height: number;
+    /** RGBA output with a transparent background. */
+    alpha?: boolean;
+    /** Capture a depth visualization (grayscale) instead of the color. */
+    depth?: boolean;
+}
+
+export interface ExportImageResult {
+    ok: boolean;
+}
+
+/** IOH_CAT_RENDTOFILE: render-to-file exporter category (qsys::InOutHandler). */
+const IOH_CAT_RENDTOFILE = 2;
+
+function exportImage(ctx: WorkerContext, args: ExportImageArgs): ExportImageResult {
+    const scene = getSceneOrNull(ctx, args.sceneId);
+    if (!scene) return { ok: false };
+
+    // Persist the live view into the transient '__current' camera so the
+    // off-screen exporter renders from the active viewpoint (UXP parity).
+    try {
+        (scene as unknown as {
+            saveViewToCam: (viewId: number, name: string) => boolean;
+        }).saveViewToCam(args.viewId, '__current');
+    } catch {
+        // ignore -- proceed with whatever camera the exporter resolves
+    }
+
+    const exporter = ctx.strMgr.createHandler('png', IOH_CAT_RENDTOFILE) as unknown as {
+        width: number;
+        height: number;
+        alpha: boolean;
+        depth: boolean;
+        camera: string;
+        attach: (scene: unknown) => void;
+        setPath: (path: string) => void;
+        write: () => void;
+        detach: () => void;
+    } | null;
+    if (!exporter) return { ok: false };
+
+    exporter.width = args.width;
+    exporter.height = args.height;
+    exporter.alpha = args.alpha ?? false;
+    exporter.depth = args.depth ?? false;
+    exporter.camera = '__current';
+
+    exporter.attach(scene);
+    exporter.setPath(args.filePath);
+    exporter.write();
+    exporter.detach();
+
+    return { ok: true };
+}
+
+export const services = { exportImage };

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -75,6 +75,10 @@ import type {
   SaveSceneResult,
 } from '../server/services/saveScene.service'
 import type {
+  ExportImageArgs,
+  ExportImageResult,
+} from '../server/services/exportImage.service'
+import type {
   SceneBgColorArgs,
   SceneBgColorResult,
   SetSceneBgColorArgs,
@@ -389,6 +393,7 @@ export interface ServiceMap {
   undo:                       { args: UndoArgs;                        result: { ok: boolean } }
   getSceneSaveInfo:           { args: GetSceneSaveInfoArgs;            result: GetSceneSaveInfoResult }
   saveScene:                  { args: SaveSceneArgs;                   result: SaveSceneResult }
+  exportImage:                { args: ExportImageArgs;                 result: ExportImageResult }
   validateSelection:          { args: ValidateSelectionArgs;           result: ValidateSelectionResult }
   getSceneBgColor:            { args: SceneBgColorArgs;                result: SceneBgColorResult }
   setSceneBgColor:            { args: SetSceneBgColorArgs;             result: SceneBgColorResult }

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -14,6 +14,7 @@ export const IPC = {
   DIALOG_STYLE_SAVE: 'dialog:styleSave',
   DIALOG_CAMERA_OPEN: 'dialog:cameraOpen',
   DIALOG_CAMERA_SAVE: 'dialog:cameraSave',
+  DIALOG_IMAGE_SAVE:  'dialog:imageSave',
   DIALOG_OBJECT_SAVE: 'dialog:objectSave',
   DIALOG_PICK_PATH:   'dialog:pickPath',
   SAVE_TEXT_AS:       'dialog:saveTextAs',

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -41,6 +41,8 @@ export interface InvokeChannels {
                               res: { canceled: boolean; filePath: string } }
   [IPC.DIALOG_CAMERA_SAVE]: { req: { defaultName: string };
                               res: { canceled: boolean; filePath: string } }
+  [IPC.DIALOG_IMAGE_SAVE]:  { req: { defaultName: string };
+                              res: { canceled: boolean; filePath: string } }
   [IPC.DIALOG_OBJECT_SAVE]: { req: {
                                 defaultDir: string
                                 defaultName: string

--- a/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.js
+++ b/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.js
@@ -32,7 +32,6 @@ onLoad: function ()
     this.mListUnit.disabled = true;
     //this.mChkReasp.disabled = true;
     document.getElementById("chk_alpha").hidden = true;
-    document.getElementById("chk_depth").hidden = true;
     document.getElementById("PNGOptDlg").setAttribute("title", "LuxRender options");
   }
 },
@@ -169,8 +168,6 @@ onAccept: function ()
       this.mDlgData.alpha = document.getElementById("chk_alpha").checked;
       //this.mDlgData.exporter.interlace = this.mDlgData.intrl;
       this.mDlgData.exporter.alpha = this.mDlgData.alpha;
-      this.mDlgData.depth = document.getElementById("chk_depth").checked;
-      this.mDlgData.exporter.depth = this.mDlgData.depth;
       this.mDlgData.exporter.resoln = this.mDlgData.fdpi;
     }
     return true;

--- a/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.js
+++ b/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.js
@@ -32,6 +32,7 @@ onLoad: function ()
     this.mListUnit.disabled = true;
     //this.mChkReasp.disabled = true;
     document.getElementById("chk_alpha").hidden = true;
+    document.getElementById("chk_depth").hidden = true;
     document.getElementById("PNGOptDlg").setAttribute("title", "LuxRender options");
   }
 },
@@ -168,6 +169,8 @@ onAccept: function ()
       this.mDlgData.alpha = document.getElementById("chk_alpha").checked;
       //this.mDlgData.exporter.interlace = this.mDlgData.intrl;
       this.mDlgData.exporter.alpha = this.mDlgData.alpha;
+      this.mDlgData.depth = document.getElementById("chk_depth").checked;
+      this.mDlgData.exporter.depth = this.mDlgData.depth;
       this.mDlgData.exporter.resoln = this.mDlgData.fdpi;
     }
     return true;

--- a/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.xul
+++ b/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.xul
@@ -64,6 +64,7 @@
   </groupbox>
 
   <checkbox id="chk_alpha" label="Transparent PNG" flex="1"/>
+  <checkbox id="chk_depth" label="Depth image (grayscale)" flex="1"/>
   <!-- <checkbox id="chk_intrl" label="Interlace" flex="1"/> -->
 </dialog>
 

--- a/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.xul
+++ b/uxp_gui/cuemol2/base/content/exportpng-opt-dlg.xul
@@ -64,7 +64,6 @@
   </groupbox>
 
   <checkbox id="chk_alpha" label="Transparent PNG" flex="1"/>
-  <checkbox id="chk_depth" label="Depth image (grayscale)" flex="1"/>
   <!-- <checkbox id="chk_intrl" label="Interlace" flex="1"/> -->
 </dialog>
 

--- a/uxp_gui/cuemol2/components/molwidget/moz.build
+++ b/uxp_gui/cuemol2/components/molwidget/moz.build
@@ -5,16 +5,21 @@
 
 warning("CUEMOL_DIR: <%s>" % CONFIG['CUEMOL_DIR'])
 
+# LOCAL_INCLUDES is a strictly-ordered list (mozbuild raises UnsortedError on
+# unsorted appends). The boost and libcuemol2 include dirs are configured via
+# --enable-cuemol-boostdir / --enable-cuemol, so their relative sort order
+# depends on the actual paths. Sort the pair at evaluation time so an in-tree
+# CUEMOL_DIR (e.g. <repo>/.build_out/cuemol2) does not break the build.
 if CONFIG['OS_ARCH'] == 'WINNT':
-    LOCAL_INCLUDES += [
+    LOCAL_INCLUDES += sorted([
         '%%%s' % CONFIG['CUEMOL_BOOST_DIR'],
         '%%%s/include' % CONFIG['CUEMOL_DIR'],
-    ]
+    ])
 else:
-    LOCAL_INCLUDES += [
+    LOCAL_INCLUDES += sorted([
         '%%%s/include' % CONFIG['CUEMOL_BOOST_DIR'],
         '%%%s/include' % CONFIG['CUEMOL_DIR'],
-    ]
+    ])
 
 
 DEFINES['HAVE_CONFIG_H'] = True


### PR DESCRIPTION
Introduce a portable gfx::RenderTarget (FBO) abstraction with an OpenGL core-profile implementation (OcRenderTarget), and use it to restore the ImgSceneExporter / PngSceneExporter image export path that regressed during the OpenGL core-profile migration (createOffScreenView / readPixels were empty stubs).

- gfx::RenderTarget: color (RGBA8) + sampleable depth texture, optional MRT normal attachment, color read-back. DisplayContext gains createRenderTarget / bindRenderTarget / bindDefaultFramebuffer (no-op defaults).
- OcRenderTarget: GL framebuffer object with attachment allocation, viewport save/restore, glReadPixels read-back, and a context-guarded destructor.
- OffScreenView borrows the parent view's display context and renders the scene into the FBO, intentionally avoiding safeSetCurrent so the on-screen geometry buffers are reused. GUIView::createOffScreenView returns it.

depth read-back / visualization and the WebGL backend are follow-up work.