### PR TITLE
Fix Windows local build from Git Bash via task

### DIFF
--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -68,7 +68,7 @@ tasks:
   rebuild_libcuemol2:windows:
     platforms: [windows]
     cmds:
-      - cmd /c build_libcuemol2_win.bat "{{.WORKDIR}}" "{{.CONFIG}}"
+      - cmd /c "{{.ROOT_DIR}}\build_libcuemol2_win.bat" "{{.WORKDIR}}" "{{.CONFIG}}"
 
   build_libcuemol2:
     desc: "Build libcuemol2 (using current config)"

--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -202,9 +202,11 @@ tasks:
 
   build_tritium:windows:
     platforms: [windows]
+    env:
+      OUT_DIR: '{{.OUTDIR}}'
     cmds:
       - task: build_libcuemol2
-      - '"C:/Program Files/Git/bin/bash.exe" build_tritium_posix/run.sh "{{.WORKDIR}}" "{{.CONFIG}}"'
+      - bash build_tritium_posix/run.sh "{{.WORKDIR}}" "{{.CONFIG}}"
 
   clean_tritium:
     desc: "Clean tritium build artifacts (core native addon + react-gui out)"

--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -6,8 +6,8 @@ vars:
   # Shared, branch-independent downloaded deps (boost/CGAL/fftw/glew/lcms2/python).
   WORKDIR: '{{if eq OS "windows"}}c:\tmp\proj64_deplibs{{else}}$HOME/tmp/proj64_deplibs{{end}}'
   # Per-checkout build/install output, so multiple checkouts/worktrees on the same
-  # host do not clobber each other. Windows keeps the old behavior (= WORKDIR).
-  OUTDIR: '{{if eq OS "windows"}}{{.WORKDIR}}{{else}}{{.ROOT_DIR}}/../.build_out{{end}}'
+  # host do not clobber each other.
+  OUTDIR: '{{.ROOT_DIR}}/../.build_out'
   LIBCUEMOL2_BUILDDIR: "{{.OUTDIR}}/build_libcuemol2"
   LIBCUEMOL2_INSTDIR: "{{.OUTDIR}}/cuemol2"
   CONFIG: '{{if eq OS "windows"}}Release{{else}}Debug{{end}}'

--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -8,7 +8,7 @@ vars:
   # Per-checkout build/install output, so multiple checkouts/worktrees on the same
   # host do not clobber each other. Windows keeps the old behavior (= WORKDIR).
   OUTDIR: '{{if eq OS "windows"}}{{.WORKDIR}}{{else}}{{.ROOT_DIR}}/../.build_out{{end}}'
-  LIBCUEMOL2_BUILDDIR: '{{if eq OS "windows"}}{{.WORKDIR}}/tmp/build_libcuemol2{{else}}{{.OUTDIR}}/build_libcuemol2{{end}}'
+  LIBCUEMOL2_BUILDDIR: "{{.OUTDIR}}/build_libcuemol2"
   LIBCUEMOL2_INSTDIR: "{{.OUTDIR}}/cuemol2"
   CONFIG: '{{if eq OS "windows"}}Release{{else}}Debug{{end}}'
   PARALLEL: ""

--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -67,8 +67,10 @@ tasks:
 
   rebuild_libcuemol2:windows:
     platforms: [windows]
+    env:
+      OUT_DIR: '{{.OUTDIR}}'
     cmds:
-      - cmd /c "{{.ROOT_DIR}}\build_libcuemol2_win.bat" "{{.WORKDIR}}" "{{.CONFIG}}"
+      - bash build_libcuemol2_posix/run.sh "{{.WORKDIR}}" "{{.CONFIG}}"
 
   build_libcuemol2:
     desc: "Build libcuemol2 (using current config)"

--- a/build_scripts/build_libcuemol2_posix/run.sh
+++ b/build_scripts/build_libcuemol2_posix/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# build script for libcuemol2 in posix
+# build script for libcuemol2 in posix (and Windows Git Bash)
 # usage: run.sh deplibs_dir [Debug]
 #
 
@@ -19,7 +19,19 @@ fi
 
 set -eux
 
-BASEDIR=$1
+# Detect Windows (Git Bash / MSYS2)
+IS_WINDOWS=false
+if [[ -n "${MSYSTEM:-}" || "$OSTYPE" == msys* ]]; then
+    IS_WINDOWS=true
+fi
+
+# Normalize BASEDIR: convert Windows paths (c:\...) to POSIX (/c/...)
+if $IS_WINDOWS; then
+    BASEDIR=$(cygpath -u "$1")
+else
+    BASEDIR=$1
+fi
+
 # deps root (BASEDIR) is shared; build/install root (OUTDIR) can be per-checkout.
 # OUT_DIR unset falls back to BASEDIR, preserving the original/CI behavior.
 OUTDIR="${OUT_DIR:-$BASEDIR}"
@@ -36,6 +48,11 @@ else
     CMAKE_SCCACHE_OPT=""
 fi
 
+# Windows: use the Windows-specific GLEW bundle version
+if $IS_WINDOWS; then
+    GLEW_VER=$GLEW_VER_WINDOWS
+fi
+
 # Build
 BUILD_DIR=$OUTDIR/build_libcuemol2
 mkdir -p $BUILD_DIR
@@ -47,23 +64,40 @@ else
     BUILD_TYPE=Release
 fi
 
-# Python embed
-if [ -d "${EMBED_PYTHON_ROOT:-}" ]; then
-    # if [ "${EMBED_PYTHON_ROOT+foo}" ]; then
-    ENABLE_PYTHON_EMBED=ON
-    PYTHON_ROOT=$EMBED_PYTHON_ROOT
-    echo "Using PYTHON_ROOT=$EMBED_PYTHON_ROOT"
-else
-    # PYTHON=python3
-    PYTHON_ROOT=$(python3 -c 'import sys;import pathlib; print(pathlib.Path(sys.executable).parent.parent)')
-    echo "Found PYTHON_ROOT=$PYTHON_ROOT"
+# Python embed (posix only; Windows build disables Python bindings)
+if $IS_WINDOWS; then
+    BUILD_PYTHON_BINDINGS=OFF
     ENABLE_PYTHON_EMBED=OFF
+    PYTHON_OPT="-DBUILD_PYTHON_BINDINGS=OFF -DBUILD_PYTHON_MODULE=OFF"
+else
+    if [ -d "${EMBED_PYTHON_ROOT:-}" ]; then
+        ENABLE_PYTHON_EMBED=ON
+        PYTHON_ROOT=$EMBED_PYTHON_ROOT
+        echo "Using PYTHON_ROOT=$EMBED_PYTHON_ROOT"
+    else
+        PYTHON_ROOT=$(python3 -c 'import sys;import pathlib; print(pathlib.Path(sys.executable).parent.parent)')
+        echo "Found PYTHON_ROOT=$PYTHON_ROOT"
+        ENABLE_PYTHON_EMBED=OFF
+    fi
+    echo "ENABLE_PYTHON_EMBED=$ENABLE_PYTHON_EMBED"
+    BUILD_PYTHON_BINDINGS=ON
+    PYTHON_OPT="-DBUILD_PYTHON_BINDINGS=$BUILD_PYTHON_BINDINGS \
+                -DENABLE_PYTHON_EMBED=$ENABLE_PYTHON_EMBED \
+                -DPython3_ROOT_DIR=$PYTHON_ROOT"
 fi
-echo "ENABLE_PYTHON_EMBED=$ENABLE_PYTHON_EMBED"
 
-BUILD_PYTHON_BINDINGS=ON
 BUILD_NODEJS_BINDINGS=ON
 ENABLE_TYPESCRIPT=ON
+
+# Windows-specific cmake flags: MSVC compiler, Perl without spaces in path, LibLZMA
+if $IS_WINDOWS; then
+    WIN_OPT="-DCMAKE_C_COMPILER=cl \
+             -DCMAKE_CXX_COMPILER=cl \
+             -DPERL_EXECUTABLE=C:/Strawberry/perl/bin/perl.exe \
+             -DLibLZMA_ROOT=$BASEDIR/xz-$LZMA_VER"
+else
+    WIN_OPT=""
+fi
 
 # Install location
 CMAKE_INSTALL_PREFIX=$OUTDIR/cuemol2
@@ -78,6 +112,7 @@ cmake -G "$GENERATOR" \
       -S ${WORKSPACE} -B $BUILD_DIR \
       $CMAKE_OPT \
       $CMAKE_SCCACHE_OPT \
+      $WIN_OPT \
       -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX \
       -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH \
       -DBoost_ROOT=$BASEDIR/boost_$BOOST_VER \
@@ -85,24 +120,24 @@ cmake -G "$GENERATOR" \
       -DFFTW_ROOT=$BASEDIR/fftw-$FFTW_VER \
       -DLCMS2_ROOT=$BASEDIR/lcms2-$LCMS2_VER \
       -DGLEW_ROOT=$BASEDIR/glew-$GLEW_VER \
-      -DBUILD_PYTHON_BINDINGS=$BUILD_PYTHON_BINDINGS \
-      -DENABLE_PYTHON_EMBED=$ENABLE_PYTHON_EMBED \
+      $PYTHON_OPT \
       -DBUILD_NODEJS_BINDINGS=$BUILD_NODEJS_BINDINGS \
       -DENABLE_TYPESCRIPT=$ENABLE_TYPESCRIPT \
-      -DPython3_ROOT_DIR=$PYTHON_ROOT \
       -DBUILD_XPCJS_BINDINGS=ON \
       -DCGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE=TRUE \
       -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
       -DCGAL_DISABLE_GMP=TRUE \
       -DCGAL_HEADER_ONLY=TRUE \
-      -DBUILD_TESTS=ON
+      -DBUILD_TESTS=$(if $IS_WINDOWS; then echo OFF; else echo ON; fi)
 
 cmake --build $BUILD_DIR --parallel --config $BUILD_TYPE
 # ctest --test-dir $BUILD_DIR --output-on-failure
 cmake --install $BUILD_DIR --config $BUILD_TYPE
 
-# Copy dependent shared libs
-cp $BASEDIR/boost_$BOOST_VER/lib/lib* $OUTDIR/cuemol2/lib/
+# Copy dependent shared libs (posix only; Windows DLLs are handled separately)
+if ! $IS_WINDOWS; then
+    cp $BASEDIR/boost_$BOOST_VER/lib/lib* $OUTDIR/cuemol2/lib/
+fi
 
 # Python embed
 if [ -n "${EMBED_PYTHON_ROOT:-}" ]; then

--- a/build_scripts/build_libcuemol2_posix/run.sh
+++ b/build_scripts/build_libcuemol2_posix/run.sh
@@ -34,7 +34,11 @@ fi
 
 # deps root (BASEDIR) is shared; build/install root (OUTDIR) can be per-checkout.
 # OUT_DIR unset falls back to BASEDIR, preserving the original/CI behavior.
-OUTDIR="${OUT_DIR:-$BASEDIR}"
+if $IS_WINDOWS && [ -n "${OUT_DIR:-}" ]; then
+    OUTDIR=$(cygpath -u "$OUT_DIR")
+else
+    OUTDIR="${OUT_DIR:-$BASEDIR}"
+fi
 
 REPOS_DIR=$(cd $(dirname $0)/../..; pwd)
 WORKSPACE=${GITHUB_WORKSPACE:-$REPOS_DIR}

--- a/build_scripts/build_libcuemol2_win.bat
+++ b/build_scripts/build_libcuemol2_win.bat
@@ -50,6 +50,9 @@ if %CONFIG%=="Debug" (
 )
 
 cmake -G Ninja -S %TOP_DIR% -B %BUILDDIR% ^
+ -DCMAKE_C_COMPILER=cl ^
+ -DCMAKE_CXX_COMPILER=cl ^
+ -DPERL_EXECUTABLE=C:\Strawberry\perl\bin\perl.exe ^
  -DCMAKE_INSTALL_PREFIX=%INSTPATH% ^
  -DBoost_ROOT=%BASEDIR%\boost_%BOOST_VER% ^
  -DCGAL_ROOT=%BASEDIR%\CGAL-%CGAL_VER%\lib\cmake\CGAL ^

--- a/build_scripts/build_tritium_posix/run.sh
+++ b/build_scripts/build_tritium_posix/run.sh
@@ -1,16 +1,32 @@
-#!/bin/sh
+#!/bin/bash
 #
-# Build script for tritium (Electron + React GUI app) on POSIX
+# Build script for tritium (Electron + React GUI app) on POSIX and Windows Git Bash
 # Usage: run.sh deplibs_dir [Debug|Release]
 #
 
 set -eux
 
-BASEDIR=$1
+# Detect Windows (Git Bash / MSYS2)
+IS_WINDOWS=false
+if [[ -n "${MSYSTEM:-}" || "$OSTYPE" == msys* ]]; then
+    IS_WINDOWS=true
+fi
+
+# Normalize BASEDIR: convert Windows paths (c:\...) to POSIX (/c/...)
+if $IS_WINDOWS; then
+    BASEDIR=$(cygpath -u "$1")
+else
+    BASEDIR=$1
+fi
+
 CONFIG=${2:-Release}
 # deps root (BASEDIR) is shared; build/install root (OUTDIR) can be per-checkout.
 # OUT_DIR unset falls back to BASEDIR, preserving the original/CI behavior.
-OUTDIR="${OUT_DIR:-$BASEDIR}"
+if $IS_WINDOWS && [ -n "${OUT_DIR:-}" ]; then
+    OUTDIR=$(cygpath -u "$OUT_DIR")
+else
+    OUTDIR="${OUT_DIR:-$BASEDIR}"
+fi
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 REPOS_DIR=$(cd $(dirname $0)/../..; pwd)


### PR DESCRIPTION
- Taskfile: use full path ({{.ROOT_DIR}}) for bat file so task's internal shell can locate it regardless of how cmd.exe resolves relative paths
- bat: explicitly set CMAKE_C/CXX_COMPILER=cl so cmake picks MSVC even when gcc appears first in PATH (common in Git Bash environments)
- bat: pin PERL_EXECUTABLE to Strawberry Perl to avoid unquoted-path failures in ninja rules when cmake auto-detects Git's perl under C:\Program Files (spaces in path)