### PR TITLE
fix(gfx): make GTAO projection-aware to fix ortho slab-dependent dark…

### DIFF
--- a/src/gfx/PostProcGpuPrim.cpp
+++ b/src/gfx/PostProcGpuPrim.cpp
@@ -15,6 +15,48 @@
 
 using namespace gfx;
 
+// static
+AoConstants AoConstants::fromCamera(double camDist, double zoom, double slabDepth,
+                                    double aspect, int bcx, int bcy, bool perspec)
+{
+    // Camera slab planes, matching GUIView::setUpProjMat's near/far derivation.
+    if (slabDepth <= 0.1) slabDepth = 0.1;
+    double slabNear = camDist - slabDepth / 2.0;
+    if (slabNear < 0.1) slabNear = 0.1;
+    const double slabFar = camDist + slabDepth;
+
+    // makePersProjMat uses t = camDist / (zoom/2), so tanHalfFOVY = (zoom/2)/camDist
+    // and the orthographic half-extents are width = zoom/2 (see makeOrthoProjMat).
+    const double width = zoom / 2.0;
+
+    AoConstants c;
+    c.isOrtho = perspec ? 0 : 1;
+    if (perspec) {
+        // Perspective: hyperbolic window depth, XY unprojected by viewZ.
+        c.depthLinearizeMul = float(slabFar * slabNear / (slabFar - slabNear));
+        c.depthLinearizeAdd = float(slabFar / (slabFar - slabNear));
+        const double tanHalfFovY = width / camDist;
+        const double tanHalfFovX = tanHalfFovY * aspect;
+        c.ndcToViewMul[0] = float(2.0 * tanHalfFovX);
+        c.ndcToViewMul[1] = float(2.0 * tanHalfFovY);
+        c.ndcToViewAdd[0] = float(-tanHalfFovX);
+        c.ndcToViewAdd[1] = float(-tanHalfFovY);
+    } else {
+        // Orthographic: window depth is linear, viewZ = near + d*(far - near),
+        // so store (near, far - near). XY is depth-independent and spans
+        // makeOrthoProjMat's extents ([-width*aspect, width*aspect] x [-width, width]).
+        c.depthLinearizeMul = float(slabNear);
+        c.depthLinearizeAdd = float(slabFar - slabNear);
+        c.ndcToViewMul[0] = float(2.0 * width * aspect);
+        c.ndcToViewMul[1] = float(2.0 * width);
+        c.ndcToViewAdd[0] = float(-width * aspect);
+        c.ndcToViewAdd[1] = float(-width);
+    }
+    c.viewportPixelSize[0] = (bcx > 0) ? 1.0f / float(bcx) : 0.0f;
+    c.viewportPixelSize[1] = (bcy > 0) ? 1.0f / float(bcy) : 0.0f;
+    return c;
+}
+
 bool PostProcGpuPrim::init(DisplayContext *pDC)
 {
     if (m_pPO != nullptr) return true;
@@ -114,6 +156,7 @@ void PostProcGpuPrim::drawComposite(DisplayContext *pDC, RenderTarget *sceneRT,
     // so a fully-fogged (background-color) pixel is not darkened by AO.
     m_pCompPO->setUniformF("u_fogEnd", consts.fogEnd);
     m_pCompPO->setUniformF("u_fogScale", consts.fogScale);
+    m_pCompPO->setUniform("u_isOrtho", consts.isOrtho);
     // Upsample only when the AO buffer is coarser than the output (half res).
     const bool upsample = consts.aoTexelSize[0] > consts.viewportPixelSize[0] * 1.5f;
     m_pCompPO->setUniform("u_upsample", upsample ? 1 : 0);
@@ -169,6 +212,7 @@ void PostProcGpuPrim::drawGtao(DisplayContext *pDC, RenderTarget *sceneRT,
     m_pGtaoPO->setUniform("u_debugMode", debugMode);
     m_pGtaoPO->setUniformF("u_aoNoiseOffset", consts.aoNoiseOffset);
     m_pGtaoPO->setUniformF("u_maxScreenspaceRadius", consts.maxScreenspaceRadius);
+    m_pGtaoPO->setUniform("u_isOrtho", consts.isOrtho);
 
     pDC->drawElem(*m_pDrawElem);
 

--- a/src/gfx/PostProcGpuPrim.hpp
+++ b/src/gfx/PostProcGpuPrim.hpp
@@ -16,15 +16,26 @@ class RenderTarget;
 class DataTexture;
 
 /// View-space reconstruction constants for the GTAO passes, derived CPU-side
-/// from the projection matrix (see GUIView). All shader-facing math uses these
-/// instead of a near/far lerp so off-center / asymmetric frusta work and the
-/// GL window-depth [0,1] convention is handled.
+/// from the projection matrix (see fromCamera). All shader-facing math uses
+/// these instead of a near/far lerp so off-center / asymmetric frusta work and
+/// the GL window-depth [0,1] convention is handled.
+///
+/// Perspective and orthographic projections reconstruct view space differently,
+/// so the depth/xy fields below are interpreted according to isOrtho.
 struct AoConstants
 {
-    /// (depthLinearizeMul, depthLinearizeAdd): viewZ = mul / (add - rawDepth).
+    /// 1 = orthographic projection, 0 = perspective. Selects how the shaders
+    /// reconstruct view-space Z and XY (see the two fields below).
+    int isOrtho = 0;
+    /// View-space Z from the [0,1] window depth d:
+    ///   perspective:  viewZ = depthLinearizeMul / (depthLinearizeAdd - d)
+    ///   orthographic: viewZ = depthLinearizeMul + d * depthLinearizeAdd
+    ///                 (= slabNear, slabFar - slabNear; depth is linear in viewZ)
     float depthLinearizeMul = 0.0f;
     float depthLinearizeAdd = 0.0f;
-    /// viewPos.xy = (ndcToViewMul * uv + ndcToViewAdd) * viewZ.
+    /// View-space XY from the bottom-up [0,1] uv:
+    ///   perspective:  xy = (ndcToViewMul * uv + ndcToViewAdd) * viewZ
+    ///   orthographic: xy = (ndcToViewMul * uv + ndcToViewAdd)  (depth-independent)
     float ndcToViewMul[2] = {0.0f, 0.0f};
     float ndcToViewAdd[2] = {0.0f, 0.0f};
     /// (1/width, 1/height) in pixels.
@@ -55,6 +66,16 @@ struct AoConstants
     /// Per-sample noise rotation [0,1) for temporal supersampling (0 = single
     /// frame). Decorrelates the GTAO noise across accumulated jitter samples.
     float aoNoiseOffset = 0.0f;
+
+    /// Fill the camera-derived geometric fields (isOrtho, depthLinearize*,
+    /// ndcToView*, viewportPixelSize) from the camera parameters. The AO tuning
+    /// fields (effectRadius / finalValuePower / slice & step counts / fog) are
+    /// filled by the caller from the Scene. `aspect` = width/height; `bcx`/`bcy`
+    /// = backing-store pixel size. The near/far derivation MUST match
+    /// GUIView::setUpProjMat, and the depth/xy formulas MUST match the matrices
+    /// from DisplayContext::makePersProjMat / makeOrthoProjMat.
+    static AoConstants fromCamera(double camDist, double zoom, double slabDepth,
+                                  double aspect, int bcx, int bcy, bool perspec);
 };
 
 /// Fullscreen post-processing primitive.

--- a/src/qsys/GUIView.cpp
+++ b/src/qsys/GUIView.cpp
@@ -735,40 +735,16 @@ void GUIView::ensurePipeline(int w, int h, bool halfRes)
 
 gfx::AoConstants GUIView::computeAoConstants() const
 {
-    // Camera slab planes, matching setUpProjMat's near/far derivation.
-    const double dist = getViewDist();
-    double slabdepth = getSlabDepth();
-    if (slabdepth <= 0.1) slabdepth = 0.1;
-    double slabnear = dist - slabdepth / 2.0;
-    if (slabnear < 0.1) slabnear = 0.1;
-    const double slabfar = dist + slabdepth;
-
-    // Perspective half-FOV: makePersProjMat uses t = dist / (zoom/2), with
-    // P[1][1] = t (so tanHalfFOVY = 1/t = (zoom/2)/dist) and P[0][0] = t/aspect
-    // (so tanHalfFOVX = aspect * tanHalfFOVY).
-    const double width = double(getZoom()) / 2.0;
+    // Geometric (camera-derived) part only. The AO tuning fields (effectRadius /
+    // finalValuePower / slice & step counts / fog) are filled by the caller from
+    // the Scene properties. Perspective and orthographic projections reconstruct
+    // view space differently, so fromCamera branches on the projection mode.
     const double aspect = double(getWidth()) / double(getHeight());
-    const double tanHalfFovY = width / dist;
-    const double tanHalfFovX = tanHalfFovY * aspect;
-
     const int bcx = convToBackingX(getWidth());
     const int bcy = convToBackingY(getHeight());
-
-    gfx::AoConstants c;
-    // viewZ = mul / (add - rawDepth); matches XeGTAO with GL window depth [0,1].
-    c.depthLinearizeMul = float(slabfar * slabnear / (slabfar - slabnear));
-    c.depthLinearizeAdd = float(slabfar / (slabfar - slabnear));
-    // GL uses a bottom-up [0,1] UV (postproc_vert v_uv), so viewY keeps the
-    // same sign as the NDC mapping (unlike XeGTAO's top-down DX convention).
-    c.ndcToViewMul[0] = float(2.0 * tanHalfFovX);
-    c.ndcToViewMul[1] = float(2.0 * tanHalfFovY);
-    c.ndcToViewAdd[0] = float(-tanHalfFovX);
-    c.ndcToViewAdd[1] = float(-tanHalfFovY);
-    c.viewportPixelSize[0] = (bcx > 0) ? 1.0f / float(bcx) : 0.0f;
-    c.viewportPixelSize[1] = (bcy > 0) ? 1.0f / float(bcy) : 0.0f;
-    // The AO tuning fields (effectRadius / finalValuePower / sliceCount) are
-    // filled by the caller from the Scene properties.
-    return c;
+    return gfx::AoConstants::fromCamera(getViewDist(), double(getZoom()),
+                                        getSlabDepth(), aspect, bcx, bcy,
+                                        isPerspec());
 }
 
 bool GUIView::renderAOColorFrame(DisplayContext *pdc, const ScenePtr &pScene,

--- a/src/sysdep/ogl_core/ao_composite_frag.glsl
+++ b/src/sysdep/ogl_core/ao_composite_frag.glsl
@@ -18,6 +18,7 @@ uniform int u_hasAO;
 uniform int u_upsample;          // 1 = edge-aware upsample the AO term
 uniform float u_fogEnd;          // linear fog far limit (view-space Z)
 uniform float u_fogScale;        // 1/(fogEnd - fogStart)
+uniform int u_isOrtho;           // 1 = orthographic projection, 0 = perspective
 
 in vec2 v_uv;
 
@@ -25,6 +26,10 @@ out vec4 o_FragColor;
 
 float linearizeZ(float d)
 {
+    // Must match gtao_frag.glsl: orthographic depth is linear in viewZ,
+    // perspective is hyperbolic.
+    if (u_isOrtho != 0)
+        return u_depthUnpack.x + d * u_depthUnpack.y;
     return u_depthUnpack.x / (u_depthUnpack.y - d);
 }
 

--- a/src/sysdep/ogl_core/gtao_frag.glsl
+++ b/src/sysdep/ogl_core/gtao_frag.glsl
@@ -25,6 +25,7 @@ uniform int u_hasNormal;                // 1 = use the stored geometry normal
 uniform int u_debugMode;                // 0 = AO, 1 = normal, 2 = linear depth
 uniform float u_aoNoiseOffset;          // per-sample noise rotation (temporal SS)
 uniform float u_maxScreenspaceRadius;   // horizon search radius cap (pass pixels)
+uniform int u_isOrtho;                  // 1 = orthographic projection, 0 = perspective
 
 in vec2 v_uv;
 
@@ -35,12 +36,28 @@ const float HALF_PI = 1.57079632679;
 
 float linearizeZ(float d)
 {
+    // Orthographic window depth is linear in viewZ (near + d * (far - near));
+    // perspective is hyperbolic (mul / (add - d)).
+    if (u_isOrtho != 0)
+        return u_depthUnpack.x + d * u_depthUnpack.y;
     return u_depthUnpack.x / (u_depthUnpack.y - d);
 }
 
 vec3 viewPos(vec2 uv, float vz)
 {
-    return vec3((u_ndcToViewMul * uv + u_ndcToViewAdd) * vz, vz);
+    // Perspective unprojects the in-plane coords by viewZ; orthographic XY is
+    // depth-independent.
+    vec2 xy = u_ndcToViewMul * uv + u_ndcToViewAdd;
+    if (u_isOrtho == 0) xy *= vz;
+    return vec3(xy, vz);
+}
+
+// View vector (fragment -> camera). Perspective rays diverge from the eye at the
+// origin; orthographic rays are all parallel to the view axis (-Z here, since
+// viewZ > 0 is forward).
+vec3 camDir(vec3 p)
+{
+    return (u_isOrtho != 0) ? vec3(0.0, 0.0, -1.0) : normalize(-p);
 }
 
 // Per-pixel interleaved gradient noise in [0,1). Spectrally blue-ish, so the
@@ -83,7 +100,7 @@ vec3 reconstructNormal(vec2 uv, vec3 pC)
     vec3 ddx = (abs(pR.z - pC.z) < abs(pC.z - pL.z)) ? (pR - pC) : (pC - pL);
     vec3 ddy = (abs(pT.z - pC.z) < abs(pC.z - pB.z)) ? (pT - pC) : (pC - pB);
     vec3 N = normalize(cross(ddx, ddy));
-    vec3 V = normalize(-pC);
+    vec3 V = camDir(pC);
     if (dot(N, V) < 0.0) N = -N;
     return N;
 }
@@ -108,7 +125,7 @@ vec3 selectNormal(vec2 uv, vec3 pC, out bool isExcluded)
             // Stored eye-space normal: +Z faces the camera, so flip Z only to
             // reach the GTAO space (vz > 0 forward).
             vec3 N = normalize(vec3(n.x, n.y, -n.z));
-            vec3 V = normalize(-pC);
+            vec3 V = camDir(pC);
             // Clamp to the visible hemisphere. The exact normal can point away
             // from the camera at grazing silhouettes (sphere/cylinder edges) or
             // on the back side of two-sided meshes (cartoon ribbons), where the
@@ -181,12 +198,15 @@ void main()
     // artifacts.
     viewspaceZ *= 0.99999;
     pixCenterPos = viewPos(v_uv, viewspaceZ);
-    vec3 viewVec = normalize(-pixCenterPos);
+    vec3 viewVec = camDir(pixCenterPos);
 
     float effectRadius = u_effectRadius;
 
     vec2 ndcToViewMul_x_pixelSize = u_ndcToViewMul * u_viewportPixelSize;
-    float pixViewSize = viewspaceZ * ndcToViewMul_x_pixelSize.x;
+    // Orthographic: a pixel's world size is constant; perspective: it scales
+    // with viewZ.
+    float pixViewSize = ndcToViewMul_x_pixelSize.x;
+    if (u_isOrtho == 0) pixViewSize *= viewspaceZ;
     float screenspaceRadius = effectRadius / max(pixViewSize, 1e-6);
 
     // Clamp the screen-space radius so the horizon samples stay cache-local

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ gtest_discover_tests(test_qlib PROPERTIES LABELS "test_qlib")
 add_executable(test_gfx
   gfx/test_solid_color.cpp
   gfx/test_gpuprim.cpp
+  gfx/test_aoconstants.cpp
 )
 target_include_directories(test_gfx PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/gfx/test_aoconstants.cpp
+++ b/src/tests/gfx/test_aoconstants.cpp
@@ -1,0 +1,143 @@
+// Tests for gfx::AoConstants::fromCamera — the GTAO view-space reconstruction
+// constants.
+//
+// These pin that the depth linearization and XY reconstruction the GTAO shaders
+// apply are consistent with the projection matrix actually used
+// (DisplayContext::makePersProjMat / makeOrthoProjMat), in BOTH perspective and
+// orthographic modes.
+//
+// Regression guard: the orthographic path once reused the perspective
+// (hyperbolic) depth unpack for the linear ortho depth buffer, so the
+// reconstructed view-space Z was wrong and grew distorted with the slab depth.
+// That made GTAO darken as the slab approached the camera distance. A failure of
+// OrthographicDepthRoundTrip would catch that class of bug.
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "gfx/PostProcGpuPrim.hpp"
+#include "gfx/DisplayContext.hpp"
+#include <qlib/Matrix4D.hpp>
+
+using gfx::AoConstants;
+using gfx::DisplayContext;
+using qlib::Matrix4D;
+
+namespace {
+
+// Slab planes, matching GUIView::setUpProjMat / AoConstants::fromCamera.
+void slabPlanes(double dist, double slab, double &outNear, double &outFar)
+{
+    if (slab <= 0.1) slab = 0.1;
+    double n = dist - slab / 2.0;
+    if (n < 0.1) n = 0.1;
+    outNear = n;
+    outFar = dist + slab;
+}
+
+// Window depth d in [0,1] for an eye-space point on the view axis at the given
+// positive view-space distance viewZ (the eye looks down -Z, so ez = -viewZ),
+// as produced by projMat with the default glDepthRange [0,1].
+double windowDepth(const Matrix4D &m, double viewZ)
+{
+    const double ez = -viewZ;
+    const double clipZ = m.getAt(3, 3) * ez + m.getAt(3, 4);
+    const double clipW = m.getAt(4, 3) * ez + m.getAt(4, 4);
+    return ((clipZ / clipW) + 1.0) * 0.5;
+}
+
+// Bottom-up [0,1] horizontal uv that an eye-space point (ex, 0, -viewZ) projects
+// to, as produced by projMat.
+double projectUvx(const Matrix4D &m, double ex, double viewZ)
+{
+    const double ez = -viewZ;
+    const double clipX = m.getAt(1, 1) * ex + m.getAt(1, 3) * ez + m.getAt(1, 4);
+    const double clipW = m.getAt(4, 1) * ex + m.getAt(4, 3) * ez + m.getAt(4, 4);
+    return ((clipX / clipW) + 1.0) * 0.5;
+}
+
+// Shader-side depth linearization (matches gtao_frag.glsl / ao_composite_frag.glsl).
+double linearizeZ(const AoConstants &c, double d)
+{
+    if (c.isOrtho != 0)
+        return double(c.depthLinearizeMul) + d * double(c.depthLinearizeAdd);
+    return double(c.depthLinearizeMul) / (double(c.depthLinearizeAdd) - d);
+}
+
+// Shader-side XY reconstruction (matches gtao_frag.glsl viewPos()).
+double reconViewX(const AoConstants &c, double uvx, double viewZ)
+{
+    double x = double(c.ndcToViewMul[0]) * uvx + double(c.ndcToViewAdd[0]);
+    if (c.isOrtho == 0) x *= viewZ;  // perspective unprojects by viewZ
+    return x;
+}
+
+constexpr double kDist = 200.0;
+constexpr double kZoom = 50.0;
+constexpr double kAspect = 1.5;
+
+}  // namespace
+
+TEST(AoConstantsTest, PerspectiveDepthRoundTrip)
+{
+    for (double slab : {20.0, 50.0, 200.0, 350.0}) {
+        double n, f;
+        slabPlanes(kDist, slab, n, f);
+        Matrix4D pm =
+            DisplayContext::makePersProjMat(kZoom / 2.0, kAspect, n, f, kDist);
+        AoConstants c =
+            AoConstants::fromCamera(kDist, kZoom, slab, kAspect, 800, 600, true);
+        ASSERT_EQ(c.isOrtho, 0);
+        for (double vz : {n + 1.0, kDist, (kDist + f) / 2.0, f - 1.0}) {
+            const double d = windowDepth(pm, vz);
+            EXPECT_NEAR(linearizeZ(c, d), vz, 1e-2) << "slab=" << slab << " vz=" << vz;
+        }
+    }
+}
+
+TEST(AoConstantsTest, OrthographicDepthRoundTrip)
+{
+    for (double slab : {20.0, 50.0, 200.0, 350.0}) {
+        double n, f;
+        slabPlanes(kDist, slab, n, f);
+        Matrix4D om = DisplayContext::makeOrthoProjMat(kZoom / 2.0, kAspect, n, f);
+        AoConstants c =
+            AoConstants::fromCamera(kDist, kZoom, slab, kAspect, 800, 600, false);
+        ASSERT_EQ(c.isOrtho, 1);
+        for (double vz : {n + 1.0, kDist, (kDist + f) / 2.0, f - 1.0}) {
+            const double d = windowDepth(om, vz);
+            EXPECT_NEAR(linearizeZ(c, d), vz, 1e-2) << "slab=" << slab << " vz=" << vz;
+        }
+    }
+}
+
+TEST(AoConstantsTest, PerspectiveXYRoundTrip)
+{
+    double n, f;
+    slabPlanes(kDist, 200.0, n, f);
+    Matrix4D pm = DisplayContext::makePersProjMat(kZoom / 2.0, kAspect, n, f, kDist);
+    AoConstants c =
+        AoConstants::fromCamera(kDist, kZoom, 200.0, kAspect, 800, 600, true);
+    for (double vz : {n + 1.0, kDist, f - 1.0}) {
+        for (double ex : {-15.0, 0.0, 9.0}) {
+            const double uvx = projectUvx(pm, ex, vz);
+            EXPECT_NEAR(reconViewX(c, uvx, vz), ex, 1e-2) << "vz=" << vz << " ex=" << ex;
+        }
+    }
+}
+
+TEST(AoConstantsTest, OrthographicXYRoundTrip)
+{
+    double n, f;
+    slabPlanes(kDist, 200.0, n, f);
+    Matrix4D om = DisplayContext::makeOrthoProjMat(kZoom / 2.0, kAspect, n, f);
+    AoConstants c =
+        AoConstants::fromCamera(kDist, kZoom, 200.0, kAspect, 800, 600, false);
+    // In ortho the reconstructed X must be both correct AND independent of depth.
+    for (double vz : {n + 1.0, kDist, f - 1.0}) {
+        for (double ex : {-15.0, 0.0, 9.0}) {
+            const double uvx = projectUvx(om, ex, vz);
+            EXPECT_NEAR(reconViewX(c, uvx, vz), ex, 1e-2) << "vz=" << vz << " ex=" << ex;
+        }
+    }
+}


### PR DESCRIPTION
…ening

GTAO reconstructed view space with perspective-only formulas regardless of the projection mode. In orthographic projection the window depth is linear (not hyperbolic), XY is depth-independent (no perspective divide), and a pixel's world size is constant. Using the perspective formulas there yielded a view-space Z that grew distorted with the slab depth, inflating the screen-space horizon radius until it hit maxScreenspaceRadius -- so AO darkened as the slab approached the camera distance and saturated beyond it. Perspective was unaffected.

Add an isOrtho flag to AoConstants and branch the depth linearization, XY reconstruction, view vector and pixel-size in gtao_frag / ao_composite_frag accordingly. Extract the camera->AoConstants math into AoConstants::fromCamera and add gtests pinning that the AO reconstruction matches the projection matrix (makePersProjMat / makeOrthoProjMat) in both modes. Perspective output is byte-for-byte unchanged.