### PR TITLE
test(tritium): mock the three dialog hooks missing from useSceneContextMenu test

### DIFF
--- a/tritium/react-gui/src/renderer/__test__/useSceneContextMenu.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/useSceneContextMenu.test.tsx
@@ -29,6 +29,15 @@ vi.mock('../components/dialogs/ApplyRendStyleDialogProvider', () => ({
 vi.mock('../components/dialogs/CreateRendStyleDialogProvider', () => ({
     useShowCreateRendStyleDialog: () => vi.fn().mockResolvedValue(null),
 }))
+vi.mock('../components/dialogs/EditCameraVisFlagsDialogProvider', () => ({
+    useShowEditCameraVisFlagsDialog: () => vi.fn().mockResolvedValue(null),
+}))
+vi.mock('../components/dialogs/EditInteractionListDialogProvider', () => ({
+    useShowEditInteractionListDialog: () => vi.fn().mockResolvedValue(null),
+}))
+vi.mock('../components/dialogs/StyleEditorDialogProvider', () => ({
+    useShowStyleEditorDialog: () => vi.fn().mockResolvedValue(null),
+}))
 
 function makeMockCm() {
     return {


### PR DESCRIPTION
## Summary

`useSceneContextMenu.test.tsx` の 5 テストが develop で fail していた問題の修正です。

PR #397 で `useSceneContextMenu` に `useShowEditCameraVisFlagsDialog` / `useShowEditInteractionListDialog` / `useShowStyleEditorDialog` の 3 hook が追加された際、dispatch contract テスト側の provider mock が更新されず、mount 時に "must be used inside <...Provider>" が throw されて全 5 件が落ちていました (CI は C++ build のみで react-gui の vitest を回さないため未検知)。

不足していた 3 つの `vi.mock` を追加します。テストコードのみの変更で、プロダクションコードは触りません。

## Test plan

- [x] `npx vitest run src/renderer/__test__/useSceneContextMenu.test.tsx` — 5 passed
- [x] `npm test` 全体 — 245 files / 2166 tests all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)