### PR TITLE
test(ci): skip LFS-backed pytest fixtures when their data is unavailable

### DIFF
--- a/.github/workflows/build2.yml
+++ b/.github/workflows/build2.yml
@@ -59,7 +59,10 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
-        lfs: true
+        # Do NOT fetch Git LFS objects: the repo is over its LFS budget, so an
+        # LFS fetch fails the checkout. The only LFS files are two pytest
+        # fixtures whose tests self-skip when the data is absent (conftest.py).
+        lfs: false
 
     - name: Get version
       id: version
@@ -183,7 +186,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        lfs: true
+        # Do NOT fetch Git LFS objects: the repo is over its LFS budget, so an
+        # LFS fetch fails the checkout. The only LFS files are two pytest
+        # fixtures whose tests self-skip when the data is absent (conftest.py).
+        lfs: false
 
     - uses: ilammy/msvc-dev-cmd@v1
       with:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -26,7 +26,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        lfs: true
+        # Do NOT fetch Git LFS objects: the repo is over its LFS budget, so an
+        # LFS fetch fails the checkout. The only LFS files are two pytest
+        # fixtures whose tests self-skip when the data is absent (conftest.py).
+        lfs: false
 
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,52 @@ import pytest
 import cuemol
 from pathlib import Path
 
+_TEST_DATA_DIR = Path(__file__).parent / "test_data"
+
+# Git LFS pointer files begin with this line; a checked-out but un-fetched
+# LFS file is a small text stub that starts with it rather than the real data.
+_LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+
+
+def _lfs_data_available(filename):
+    """True only when the real (non-pointer) data file is present on disk."""
+    try:
+        with open(_TEST_DATA_DIR / filename, "rb") as f:
+            head = f.read(len(_LFS_POINTER_PREFIX))
+    except OSError:
+        return False  # missing or unreadable
+    return not head.startswith(_LFS_POINTER_PREFIX)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "requires_lfs_data(*files): test reads the named Git LFS-tracked "
+        "files under test_data; skipped when any is absent or is an un-fetched "
+        "LFS pointer stub. Runs wherever the real files exist.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    # Skip on the actual condition -- the real data file not being present --
+    # rather than on any CI-specific signal, so the same rule holds anywhere
+    # (GitHub Actions, a fresh clone without `git lfs pull`, etc.).
+    for item in items:
+        marker = item.get_closest_marker("requires_lfs_data")
+        if marker is None:
+            continue
+        missing = [fn for fn in marker.args if not _lfs_data_available(fn)]
+        if missing:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="Git LFS test data not available: " + ", ".join(missing)
+                )
+            )
+
 
 @pytest.fixture
 def test_data_path():
-    here = Path(__file__).parent
-    return here / "test_data"
+    return _TEST_DATA_DIR
 
 
 @pytest.fixture

--- a/tests/qsys_tests/test_new_scene_command.py
+++ b/tests/qsys_tests/test_new_scene_command.py
@@ -1,3 +1,5 @@
+import pytest
+
 import cuemol
 
 
@@ -17,6 +19,7 @@ def test_new_scene_command():
     assert cuemol.isview(result["result_view"])
 
 
+@pytest.mark.requires_lfs_data("1crn_test1.qsc")
 def test_load_scene_command(test_data_path, create_scene):
     mgr = cuemol.svc("CmdMgr")
 

--- a/tests/xtal_tests/test_cifmap_reader.py
+++ b/tests/xtal_tests/test_cifmap_reader.py
@@ -1,6 +1,9 @@
+import pytest
+
 import cuemol
 
 
+@pytest.mark.requires_lfs_data("2ydo_test.cif.gz")
 def test_cifmap_reader(test_data_path):
     svc = cuemol.getService("StreamManager")
     reader = svc.createHandler("mmcifmap", 0)


### PR DESCRIPTION
## Summary

リポジトリが Git LFS 予算を超過しており、`actions/checkout` の `lfs: true` が **全 CI ジョブの LFS フェッチ段階で失敗**しています（コードと無関係のインフラ障害）。LFS 管理されているのは pytest フィクスチャ 2 ファイルだけです:
- `tests/test_data/1crn_test1.qsc` (6.6KB)
- `tests/test_data/2ydo_test.cif.gz` (124KB)

## 対応

- CI の checkout を `lfs: false` に（`build_linux.yml` × 1 / `build2.yml` × 2）→ フェッチ段階の予算超過エラーを回避。working tree には LFS ポインタ stub が置かれる
- `requires_lfs_data(*files)` pytest マーカーを追加。collection hook が、指定ファイルが **不在 or 未フェッチの LFS ポインタ stub** のときそのテストを skip
- 判定は **「実データファイルがディスク上に在るか」という実条件**で行い、`GITHUB_ACTIONS` 等の CI 固有シグナルに依存しない。GHA に限らず `git lfs pull` していない fresh clone でも自動 skip。実データがある **ローカルでは通常どおり実行**される

該当テスト（`test_load_scene_command` / `test_cifmap_reader`）にマーカーを付与。

## Test plan

- [x] 判定ロジックを実ファイルで検証: 実データ(xml/gzip)→RUN、pointer stub→SKIP、不在→SKIP
- [x] conftest / test / workflow の構文チェック
- [ ] CI: checkout が LFS 予算超過で落ちず、pytest が該当2テストを skip して通過（この PR の CI で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)