### PR TITLE
refactor(menu): drop non-portable menu items and track menus per-menu

### DIFF
--- a/docs/migration/adr/ADR-0008-get-pdb-streaming.md
+++ b/docs/migration/adr/ADR-0008-get-pdb-streaming.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Date: 2026-05-13
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) — File > Get PDB
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) — File > Get PDB
 
 ## Context
 

--- a/docs/migration/adr/ADR-0009-open-recent-mru.md
+++ b/docs/migration/adr/ADR-0009-open-recent-mru.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Date: 2026-05-13
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) — File > Open Recent
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) — File > Open Recent
 
 ## Context
 

--- a/docs/migration/adr/ADR-0010-quit-chain.md
+++ b/docs/migration/adr/ADR-0010-quit-chain.md
@@ -2,7 +2,7 @@
 
 - Status: superseded by [ADR-0016](ADR-0016-window-close-quit-funnel.md)
 - Date: 2026-05-13
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) — Quit/Exit,
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) — Quit/Exit,
   [`menu.cuemol2-macos`](../mapping/menus.md#menucuemol2-macos) — Quit CueMol,
   [`other.cuemol2`](../mapping/other.md#othercuemol2)
 

--- a/docs/migration/adr/ADR-0011-new-tab-canvas-lifecycle.md
+++ b/docs/migration/adr/ADR-0011-new-tab-canvas-lifecycle.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Date: 2026-05-13
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) — File > New Tab,
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) — File > New Tab,
   [`other.cuemol2`](../mapping/other.md#othercuemol2)
 
 ## Context

--- a/docs/migration/adr/ADR-0012-save-scene-parity.md
+++ b/docs/migration/adr/ADR-0012-save-scene-parity.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Date: 2026-05-13
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) — File > Save Scene, File > Save Scene As
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) — File > Save Scene, File > Save Scene As
 
 ## Context
 

--- a/docs/migration/adr/ADR-0014-file-menu-save-reload.md
+++ b/docs/migration/adr/ADR-0014-file-menu-save-reload.md
@@ -2,7 +2,7 @@
 
 - Status: accepted
 - Date: 2026-05-16
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) (File > Save File As, Save current view, Reload Scene)
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) (File > Save File As, Save current view, Reload Scene)
 
 ## Context
 

--- a/docs/migration/adr/ADR-0016-window-close-quit-funnel.md
+++ b/docs/migration/adr/ADR-0016-window-close-quit-funnel.md
@@ -2,7 +2,7 @@
 
 - Status: accepted (supersedes [ADR-0010](ADR-0010-quit-chain.md))
 - Date: 2026-05-17
-- Mapping rows: [`menu.cuemol2`](../mapping/menus.md#menucuemol2) — Quit/Exit,
+- Mapping rows: [`menu.cuemol2.file`](../mapping/menus.md#menucuemol2file) — Quit/Exit,
   [`menu.cuemol2-macos`](../mapping/menus.md#menucuemol2-macos) — Quit CueMol,
   [`other.cuemol2`](../mapping/other.md#othercuemol2)
 

--- a/docs/migration/mapping/_index.md
+++ b/docs/migration/mapping/_index.md
@@ -1,5 +1,7 @@
 # Migration Mapping — Index
 
+- Updated: 2026-07-11 (menu 実装の整理 + item 明細の実態是正。**コード変更**: New Window を削除 (Electron は単一 backend で複数 OS window 不可、`menuTemplate`/`menuActionMap`/`ipcChannels` から除去)、Window メニュー全削除 (UI 構造変更で非対応)、Help を About のみに縮小 (mozilla 特異の plugins/config/addon-mgr/console/check-updates を dropped)、Tools > Mol bond editor を削除 (viewport tool `activeTool 'bondEdit'` で実装済み = merged)、Rendering > Animation rendering を削除 (render window の Still/Animation モードへ統合予定 = deferred)。`main/menu.ts` に空 submenu group の drop を追加 (macOS の About-only Help が空になるため)。exhaustiveness test の UNIMPLEMENTED_ALLOWLIST を 19->8 に。vitest 2219 / tsc node 0err pass。**docs 是正**: item 明細表が stale で、実際は menuActionMap 上 wired だった Edit の merge/delete/change-chain/change-resid、Tools の interaction/reassign-2ndry/mol-surf/surf-cutter、View の view-props、Rendering の pov-render(=render window) を wired に是正。これにより menu.cuemol2.{file,view,help,window} が done 化 (window は dropped/done)。Menu category done 2->6 / wip 8->5 / todo 1->0、Total done 88->92 / wip 34->31 / todo 18->17、split 37->36 / dropped 6->7。inventory は UXP 側の棚卸しなので不変 (migration 判断は mapping 側)。POV-Ray は既に modeless window で実装済みだった)
+- Updated: 2026-07-11 (`menu.cuemol2` を per-menu の 8 行 (`menu.cuemol2.{file,edit,rendering,scene,view,tools,window,help}`) に split。単一行では 55 item の per-item status が粗すぎたため、`panel.workspace`/`panel.coloring` split の先例に倣い inventory (`uxp-inventory/menus.md`: 4->11 entries、header を hand-maintained 化) と mapping 主表を group 単位に分割。各 group 行は既存 item 明細表の `X/Y wired` を集計 (file 13/14, edit 2/8, rendering 1/3, scene 2/4, view 6/7, tools 1/10, window 0/3, help 1/6)。Completion Summary を per-group 化し、cuemol2 subtotal の旧 27/28 誤集計を 26/29 に、menu Total を 34/30 に是正。Menu category 4->11 (done 2 / wip 8 / todo 1)、Total 133->140 / wip 28->34 / todo 17->18、split 30->37。In Progress に 7 group 行を追加 (window は todo)。native/React コード変更なし — tracking 粒度のみの変更)
 - Updated: 2026-07-05 (`overlay.config-misc` todo->wip / split + `overlay.config-mouse` 拡充: SettingsPane の mock を実配線し整理。atom-label 既定 (font/size/color/bold/italic) を StyleManager `DefaultLabel.*` へ (`labelDefaults.service`、read `getStyleValue(0,"",..)` / write `setStyleValue(0,"user",..)` + `firePendingEvents`)、mouse の XY-rot 感度 (`tbrad`) と pick 精度 (`hitprec`) を ViewInputConfig singleton + `UserViewConf.*` へ (`viewInputParams.service`) 配線。**user-defined style は electron-store でなく uxp_gui 同様に `user_styles.xml` へ save-style 配線**: tritium に欠けていた `saveUserStyle` (worker lifecycle → `saveStyleSetToFile(0,hasStyleSet('user',0),path)`) を追加し、`useWindowCloseHandler` の `onBeforeProceed` から window close 時に保存 (UXP `Qm2Main.onUnLoad` 相当)。全て `AppSettingsContext` 経由。backend/consumer 無しの mock (rendering AA/shadow/AO/fog/HiDPI・extra colors・keyboard・trackpad・general/updates/privacy・language・momentum・mouse-preset) を削除し空 category を剪定 (32->13 設定)。test 3 新規 + windowCloseFlow/dispatch 更新 (計 +18)。Overlay wip 3->4/todo 4->3、Total wip 27->28/todo 18->17、split 29->30/unassigned 18->17。host E2E pending。ADR-0036)
 - Updated: 2026-06-29 (`menu.cuemol2` Rendering > Export scene wired: PNG 固定だった単一項目を **ファイルタイプ別サブメニュー**に分割 (PNG / Umbreon ray-traced PNG / POV-Ray SDL / STL / MQO)。各項目が exporter を固定するため png/umbreon (共に `*.png`) が Electron の失われる filter index に依存せず区別可能。共通フロー `runSceneExportFlow`(静的 `SCENE_EXPORTERS` テーブル) が `getSceneExportInfo`(scene 名+view size)→保存ダイアログ(`DIALOG_SCENE_EXPORT`)→(画像系のみ)`ExportPngOptionsDialog`→`exportScene` worker(`StreamManager.createHandler(name,2)`、POV は `.inc` サブパス自動) を実行。旧 `exportImage`/`getExportImageInfo`/`DIALOG_IMAGE_SAVE`/`handleImageSaveDialog`/`CmdId.ExportImage` を `exportScene`/`getSceneExportInfo`/`DIALOG_SCENE_EXPORT`/`handleSceneExportDialog`/`CmdId.Export{Png,Umbreon,Pov,Stl,Mqo}` に一般化。LuxRender/Warabi/raw/qsl は当面除外。fileCommands test を新フローに更新(PNG/POV/キャンセル 4 ケース)、vitest/tsc(node 0 err) pass。menu item-level 26/55 -> 27/55 (`menu.cuemol2` complete 26->27 / stub 29->28、Menu Total 30->31 / stub 34->33)。Category Summary は inventory-entry 単位のため不変。native(C++)変更なし)
 - Updated: 2026-06-15 (`overlay.config-mouse` Phase 3 = Auto-detect 入力デバイス。Electron 42 では OS シグナルで mouse/trackpad を判別不可（スパイクで確認: 観測 `input-event` は `type`/`modifiers` のみ、trackpad plain scroll も `mouseWheel`、`scroll-touch-*` は v23 削除）。→ renderer 側 DOM WheelEvent ヒューリスティック（`input/wheelDeviceClassifier`: 横/小数 delta→trackpad、大整数縦→mouse）+ state machine（`input/inputDeviceDetector`: hysteresis + pinch/rotate latch）で判定し `setViewInputConfigStyle` 切替。preference を 3 値化（`mouse|trackpad|auto`、既定 auto、`UiState.inputDeviceMode`）+ `inputDeviceDetected` seed。`ViewInputConfigContext` が detector を駆動、`MolViewPane` が wheel/pinch/rotate を feed。Settings に Auto-detect 追加（Detected 表示）。main 変更なし。test 4 ファイル 25 件。status 不変（wip 継続、counts 変化なし）。host E2E pending。ADR-0032 Phase 3)
@@ -78,7 +80,7 @@
 | Category | File | Total | done | wip | review | todo | frozen |
 |----------|------|------:|-----:|----:|-------:|-----:|-------:|
 | Panel | [panels.md](panels.md) | 27 | 14 | 11 | 0 | 2 | 0 |
-| Menu | [menus.md](menus.md) | 4 | 2 | 2 | 0 | 0 | 0 |
+| Menu | [menus.md](menus.md) | 11 | 6 | 5 | 0 | 0 | 0 |
 | Toolbar | [toolbars.md](toolbars.md) | 2 | 1 | 1 | 0 | 0 | 0 |
 | Dialog\_property | [prop\_dlgs.md](prop_dlgs.md) | 16 | 14 | 2 | 0 | 0 | 0 |
 | Dialog\_other | [other\_dlgs.md](other_dlgs.md) | 18 | 11 | 2 | 0 | 5 | 0 |
@@ -86,7 +88,7 @@
 | Custom Widget | [custom\_widgets.md](custom_widgets.md) | 13 | 7 | 5 | 0 | 1 | 0 |
 | Overlay | [overlay.md](overlay.md) | 28 | 21 | 4 | 0 | 3 | 0 |
 | Other | [other.md](other.md) | 4 | 2 | 1 | 0 | 1 | 0 |
-| **Total** | | **133** | **88** | **28** | **0** | **17** | **0** |
+| **Total** | | **140** | **92** | **31** | **0** | **17** | **0** |
 
 > frozen = `blocked` status in mapping files
 
@@ -108,6 +110,15 @@
 > rows (Output tab vs Sequence tab) per the spec's "one user-visible
 > surface per entry" rule.
 
+> Menu category grew from 4 → 11 on 2026-07-11: `menu.cuemol2` (the single
+> main-menubar overlay) was split into 8 per-menu rows
+> (`menu.cuemol2.{file,edit,rendering,scene,view,tools,window,help}`), one
+> per `<menupopup>` surface, because a single row's 55 item-level points
+> were too coarse to track per-phase progress. See `mapping/menus.md` for
+> the header note (each group's `X/Y wired` is aggregated from the
+> item-level detail table) and `uxp-inventory/menus.md` for the inventory
+> split. The macOS Application menu stays its own row (`menu.cuemol2-macos`).
+
 ---
 
 ## Mapping Type Breakdown
@@ -116,9 +127,9 @@
 |---------|------:|
 | 1:1 (`direct`) | 27 |
 | merged | 53 |
-| split | 30 |
+| split | 36 |
 | redesign | 0 |
-| deprecated (`dropped`) | 6 |
+| deprecated (`dropped`) | 7 |
 | *(not yet assigned)* | 17 |
 
 ---
@@ -131,8 +142,11 @@
 | [`overlay.config-misc`](overlay.md#overlayconfig-misc) | `SettingsPane` / `AppSettingsContext` | Atom-label defaults (font/size/color/bold/italic) wired to StyleManager `DefaultLabel.*`; live-applied via `labelDefaults.service` + `firePendingEvents`, persisted to `user_styles.xml` on window close (new `saveUserStyle`, UXP `onUnLoad` parity). HiDPI/language dropped (no consumer); key-binding editor separate. Host E2E pending (ADR-0036) |
 | [`overlay.config-mouse`](overlay.md#overlayconfig-mouse) | `SettingsPane` / `ViewInputConfigContext` / `AppSettingsContext` / `input/wheelDeviceClassifier`+`inputDeviceDetector` | Wheel zooms by default; tritium adds a Mouse / Mac-trackpad / Auto-detect device preset (auto default; renderer DOM-wheel heuristic + pinch/rotate latch -- no OS signal exists in Electron 42). Persisted in `UiState.inputDeviceMode`, re-applied live via `setViewInputConfigStyle`. XY-rot sensitivity (`tbrad`) + pick precision (`hitprec`) wired to the ViewInputConfig singleton + persisted via `UserViewConf.*` (ADR-0036); mouse-preset picker dropped. Full UXP key-binding editor deferred. Phase 1/2 host E2E done; Phase 3 (auto) pending (ADR-0032) |
 | [`toolbar.cuemol2-ribbon`](toolbars.md#toolbarcuemol2-ribbon) | `Toolbar` / `ViewportToolPalette` / `useNaviClickHandler` / `useMeasureClickHandler` / `NaviContextMenu` / `MeasureOptionsPopover` | Context menu actions (center/select/around/invert/sidechain) done; measure tool distance/angle/torsion done (ADR-0023); Create SYMM mol deferred; rect-select drag pending |
-| [`menu.cuemol2`](menus.md#menucuemol2) | `menuTemplate` / `MenuBar` / `useMenuDispatch` | Full 9-group structure added; View > Center mark wired; Scene > Background color wired; File > Get PDB wired (streaming via StreamManager); File > Open Recent wired (electron-store-backed MRU, app.addRecentDocument); Hardware stereo and Open web page dropped; File > Save File As / Save current view / Reload Scene wired; Rendering > Export scene wired (per-file-type submenu: PNG/Umbreon/POV/STL/MQO); item-level completion 27/55; MenuBar suppressed on macOS |
-| [`menu.cuemol2-macos`](menus.md#menucuemol2-macos) | `main/menu.ts` | macOS App menu added; item-level completion 6/7 |
+| [`menu.cuemol2.edit`](menus.md#menucuemol2edit) | `menuTemplate` / `MenuBar` / `useMenuDispatch` | 6/8 wired (Undo / Redo + Merge / Delete / Change chain / Change resid open their tool dialogs). Clear undo + Options stub |
+| [`menu.cuemol2.rendering`](menus.md#menucuemol2rendering) | `menuTemplate` / `runSceneExportFlow` / `RenderWindowApp` | 2/3 wired (POV-Ray = modeless Rendering window; Export scene submenu). Animation rendering deferred to render-window Still/Animation mode |
+| [`menu.cuemol2.scene`](menus.md#menucuemol2scene) | `menuTemplate` / `sceneBgColor.service` | 2/4 wired (Background White / Black). Use color proofing + Properties stubbed |
+| [`menu.cuemol2.tools`](menus.md#menucuemol2tools) | `menuTemplate` / `useToolCommands` | 6/10 resolved (Superpose / Interaction / Reassign-2ndry / Mol-surf / Surf-cutter wired + Bond editor merged to viewport tool). Morph anim / APBS / Exec script / Perf measure stub |
+| [`menu.cuemol2-macos`](menus.md#menucuemol2-macos) | `main/menu.ts` | macOS App menu added; item-level completion 6/7 (Preferences stubbed) |
 | [`dialog.apply-rend-style`](other_dlgs.md#dialogapply-rend-style) | `ApplyRendStyleDialog` / `getRendererStyleEditInfo` / `applyRendererStyleList` | List view + Add popup + Delete/Up/Down on the working style list; commit calls `rend.applyStyles` under "Change style" txn |
 | [`dialog.rendstyle-create`](other_dlgs.md#dialogrendstyle-create) | `CreateRendStyleDialog` / `getCreateRendStyleInfo` / `createStyleFromRenderer` | Writable style-set listbox + base-name input; commit calls `StyleManager.createStyleFromObj`. Same-name overwrite handled in C++ |
 | [`other.cuemol2`](other.md#othercuemol2) | `App` / `ContentArea` / `TabBar` / `SidePanel` / `BottomPanel` / `StatusBar` / `ConfirmCloseTabDialog` / `useWindowCloseHandler` | Main window layout (panels, tab view, status bar) + window-close/quit funnel wired (cmd-Q + close button share one confirm funnel, ADR-0016 supersedes ADR-0010). Canvas lifecycle: ADR-0011 |
@@ -159,4 +173,4 @@
 
 ## Unstarted
 
-**19 / 132** items are `todo` (not yet started).
+**17 / 140** items are `todo` (not yet started).

--- a/docs/migration/mapping/menus.md
+++ b/docs/migration/mapping/menus.md
@@ -16,24 +16,49 @@ Status values:
 
 # Mapping — Menu
 
+> `menu.cuemol2` (the single main-menubar overlay) was split into 8
+> per-menu rows (File / Edit / Rendering / Scene / View / Tools / Window /
+> Help) on 2026-07-11 — each menubar dropdown is a distinct `<menupopup>`
+> surface and progresses on its own phase, so a single row's per-item
+> status was too coarse. See `uxp-inventory/menus.md` for the inventory
+> split. The item-level detail table further down is the source of truth
+> for each group's completion count (`X/Y wired`); the `MenuBar` (React)
+> is suppressed on macOS — native Electron menu only. The macOS
+> Application menu is tracked in its own row (`menu.cuemol2-macos`).
+
 | ID | React | Mapping | Status | PR | ADR | Notes |
 |----|-------|---------|--------|----|-----|-------|
 | [`menu.color`](../uxp-inventory/menus.md#menucolor) | `h3-kit/colorpicker/PalettePanel.tsx` | merged | done | | [ADR-0020](../adr/ADR-0020-color-picker-widget.md) | UXP color-menu presets merged into the color picker Palette panel (grayscale + 7 hue rows x 7 sat/bri variations). |
-| [`menu.cuemol2`](../uxp-inventory/menus.md#menucuemol2) | `menuTemplate` / `MenuBar` / `useMenuDispatch` | split | wip | | | Full 9-group menu structure added (File/Edit/Rendering/Scene/View/Tools/Window/Help); per-item implementation status is tracked below; `MenuBar` (React) is suppressed on macOS -- native Electron menu only |
-| [`menu.cuemol2-macos`](../uxp-inventory/menus.md#menucuemol2-macos) | `main/menu.ts` (`macOnlyGroups`) | direct | wip | | | macOS App menu added; per-item implementation status is tracked below |
+| [`menu.cuemol2.file`](../uxp-inventory/menus.md#menucuemol2file) | `menuTemplate` / `MenuBar` / `useMenuDispatch` / `useFileCommands` | split | done | | [ADR-0008](../adr/ADR-0008-get-pdb-streaming.md), [ADR-0009](../adr/ADR-0009-open-recent-mru.md), [ADR-0012](../adr/ADR-0012-save-scene-parity.md), [ADR-0014](../adr/ADR-0014-file-menu-save-reload.md), [ADR-0016](../adr/ADR-0016-window-close-quit-funnel.md) | 14/14 resolved. All items wired; New Window dropped (Electron cannot host multiple OS windows on one shared backend, 2026-07-11) and Open web page dropped. |
+| [`menu.cuemol2.edit`](../uxp-inventory/menus.md#menucuemol2edit) | `menuTemplate` / `MenuBar` / `useMenuDispatch` | split | wip | | | 6/8 wired (Undo / Redo + Merge molecule / Delete mol atoms / Change chain ID / Change residue number, each opening its tool dialog via `ui.*Dialog`). Clear undo data + Options remain stubbed. |
+| [`menu.cuemol2.rendering`](../uxp-inventory/menus.md#menucuemol2rendering) | `menuTemplate` / `MenuBar` / `useMenuDispatch` / `runSceneExportFlow` / `RenderWindowApp` | split | wip | | | 2/3 wired: POV-Ray rendering opens the modeless Rendering window (`ui.renderWindow`), Export scene submenu (PNG / Umbreon / POV / STL / MQO) wired. Animation rendering deferred -- to be folded into the Rendering window as a Still/Animation mode (menu item removed 2026-07-11). |
+| [`menu.cuemol2.scene`](../uxp-inventory/menus.md#menucuemol2scene) | `menuTemplate` / `MenuBar` / `useMenuDispatch` / `sceneBgColor.service` | split | wip | | | 2/4 wired (Background White / Black). Use color proofing + Properties… stubbed (scene ctxmenu has color-proofing wired; menu path + scene property editor still pending). |
+| [`menu.cuemol2.view`](../uxp-inventory/menus.md#menucuemol2view) | `menuTemplate` / `MenuBar` / `useMenuDispatch` / `useViewCommands` / `viewProjection.service` | split | done | | | 7/7 resolved. Perspective / Orthographic + Center mark Cross / Axis / None + View property (`ui.viewProperty` -> docked Generic inspector) wired; Hardware stereo dropped. |
+| [`menu.cuemol2.tools`](../uxp-inventory/menus.md#menucuemol2tools) | `menuTemplate` / `MenuBar` / `useMenuDispatch` / `useToolCommands` | split | wip | | [ADR-0022](../adr/ADR-0022-mol-superpose.md) | 6/10 resolved: Molecular superposition / Interaction / Reassign secondary str / Mol surface generation / Mol surface cutter wired to their dialogs; Mol bond editor merged into the viewport "Add Bond" tool (menu item removed 2026-07-11). Morph animation / APBS / Execute script / Performance measure remain stubbed. |
+| [`menu.cuemol2.window`](../uxp-inventory/menus.md#menucuemol2window) | (removed) | dropped | done | | | Whole Window menu dropped 2026-07-11: Show/Hide Topbar + Clear log contents + Restore default panel location no longer map onto the tritium UI structure. |
+| [`menu.cuemol2.help`](../uxp-inventory/menus.md#menucuemol2help) | `menuTemplate` / `MenuBar` / `useMenuDispatch` | split | done | | | 6/6 resolved. About CueMol3-tritium wired (`ui.aboutDialog`); the Mozilla-specific About plugins / About config / Addon manager / Console / Check for updates were dropped 2026-07-11. On macOS the single-item Help group is empty (About lives in the App menu) and is filtered out. |
+| [`menu.cuemol2-macos`](../uxp-inventory/menus.md#menucuemol2-macos) | `main/menu.ts` (`macOnlyGroups`) | direct | wip | | | macOS App menu added; per-item implementation status is tracked below (6/7; Preferences stubbed) |
 | [`menu.cuemol2-scripts`](../uxp-inventory/menus.md#menucuemol2-scripts) | — | dropped | done | | | XUL script loader overlay; Electron app handles module loading natively — no migration needed |
 
 ## Completion Summary
 
-Completion counts treat `wired` and `native` as complete. `stub` means the menu item exists in Tritium but still falls through to the generic unimplemented menu warning.
+Completion counts treat `wired` / `native` as complete and `dropped` / `merged` as resolved (intentional migration decisions). Only `stub` (falls through to the generic unimplemented warning) and `deferred` (planned follow-up) count against completion. Counts are derived from the source-of-truth `menuActionMap.ts`.
 
 | Scope | Complete | Stub / todo | Completion | Notes |
 |-------|---------:|------------:|-----------:|-------|
 | `menu.color` | 1 | 0 | 100% | Presets merged into the color picker Palette panel (see ADR-0020) |
-| `menu.cuemol2` | 27 | 28 | 49% | Main menubar structure exists; 55 item-level migration points tracked (1 dropped counted as complete) |
+| `menu.cuemol2.file` | 14 | 0 | 100% | All wired; New Window + Open web page dropped (both count resolved) |
+| `menu.cuemol2.edit` | 6 | 2 | 75% | Undo / Redo + Merge / Delete / Change chain / Change resid all wired; Clear undo + Options stub |
+| `menu.cuemol2.rendering` | 2 | 1 | 67% | POV-Ray (render window) + Export scene wired; Animation rendering deferred (render-window integration) |
+| `menu.cuemol2.scene` | 2 | 2 | 50% | Background White / Black wired; Use color proofing + Properties stubbed |
+| `menu.cuemol2.view` | 7 | 0 | 100% | Projection + Center mark + View property wired; Hardware stereo dropped |
+| `menu.cuemol2.tools` | 6 | 4 | 60% | Superpose / Interaction / Reassign-2ndry / Mol-surf / Surf-cutter wired + Bond editor merged (viewport tool); Morph anim / APBS / Exec script / Perf measure stub |
+| `menu.cuemol2.window` | 3 | 0 | 100% | Whole Window menu dropped (topbar / log / panel-layout no longer map onto tritium) |
+| `menu.cuemol2.help` | 6 | 0 | 100% | About wired; plugins / config / addon-mgr / console / updates dropped (Mozilla-specific) |
 | `menu.cuemol2-macos` | 6 | 1 | 86% | OS-native items complete; Preferences is stubbed |
 | `menu.cuemol2-scripts` | 1 | 0 | 100% | Dropped intentionally because Electron module loading replaces the XUL script overlay |
-| **Total** | **31** | **33** | **48%** | 64 inventory-derived menu migration points |
+| **`menu.cuemol2` subtotal** | **46** | **9** | **84%** | Sum of the 8 `menu.cuemol2.*` group rows (55 item-level points; 6 dropped + 1 merged count resolved, 1 deferred + 8 stub outstanding) |
+| **Total** | **54** | **10** | **84%** | 64 inventory-derived menu migration points (color 1 + cuemol2 55 + macos 7 + scripts 1) |
 
 ## Menu Item Implementation Status
 
@@ -46,7 +71,7 @@ Implementation status values:
 - `deferred` -- intentionally left for later
 - `dropped` -- not migrated
 
-Current source of truth: `tritium/react-gui/src/shared/menuTemplate.ts`, `tritium/react-gui/src/main/menu.ts`, `tritium/react-gui/src/renderer/hooks/useMenuDispatch.ts`, `tritium/react-gui/src/renderer/commands/useViewCommands.ts`, and `tritium/react-gui/src/renderer/worker/services/viewProjection.service.ts`.
+Current source of truth: `tritium/react-gui/src/shared/menuActionMap.ts` (the channel -> dispatch map that drives wired-vs-stub), `tritium/react-gui/src/shared/menuTemplate.ts`, `tritium/react-gui/src/main/menu.ts`, `tritium/react-gui/src/renderer/hooks/useMenuDispatch.ts`, `tritium/react-gui/src/renderer/commands/useViewCommands.ts`, and `tritium/react-gui/src/renderer/worker/services/viewProjection.service.ts`.
 
 View menu state notes:
 
@@ -63,7 +88,7 @@ View menu state notes:
 | macOS App | Hide Others | `role: hideOthers` | Electron role | native | OS-level item |
 | macOS App | Show All | `role: unhide` | Electron role | native | OS-level item |
 | macOS App | Quit CueMol | `role: quit` | Electron role + `before-quit` closes every window → `win.on('close')` funnel → `IPC.WINDOW_CLOSE_REQUEST` → `useWindowCloseHandler` walks all tabs through `handleCloseTab` → `IPC.WINDOW_CLOSE_PROCEED` | wired | Window close button and Cmd+Q share one per-window confirm funnel; cancel aborts. See [ADR-0016](../adr/ADR-0016-window-close-quit-funnel.md). |
-| File | New Window | `new-window` / `menu:new-window` | `MENU_GENERIC` -> `console.warn` | stub | Entry exists in native menu and React `MenuBar` |
+| File | New Window | (removed) | -- | dropped | Electron cannot host multiple OS windows against one shared libcuemol2 backend, so the UXP multi-window model is not carried forward (use New Tab). Menu item + channel removed 2026-07-11. |
 | File | New Tab | `new-tab` / `menu:new-tab` | `CmdId.TabNew` → `useNewTabCommand` → `NewTabDialog` | done | UXP parity dialog (New Scene / New View + inherit camera); New Scene → `createNewSceneAndView`, New View → `createViewInScene`. Canvas one-shot bind / `addView` lifecycle and constraints recorded in [ADR-0011](../adr/ADR-0011-new-tab-canvas-lifecycle.md). |
 | File | Open File... | `open-file` / `menu:open-file` | `CmdId.UiOpenObjDialog` | wired | Opens object-file dialog path |
 | File | Get PDB... | `get-pdb` / `menu:get-pdb` | `CmdId.UiGetPdbDialog` → `GetPdbDialog` → `streamLoadFromUrl` / `streamLoadDensityMap` / `cancelStreamLoad` services | wired | Streaming via `StreamManager.supplyDataAsync` (no temp file); cancel drains IOThread. Coord (RCSB CIF / PDB) + density map (RCSB cif.gz / EBI MTZ) supported. Streaming path, .cif disambiguation, and PDB-ID history recorded in [ADR-0008](../adr/ADR-0008-get-pdb-streaming.md). |
@@ -80,13 +105,13 @@ View menu state notes:
 | Edit | Undo | `undo` / `menu:undo` | `CmdId.Undo` | wired | Owned by `useUndoRedoState`; disabled at stack bottom via `MENU_UPDATE_STATE` (UXP `updateCmdUndoState` parity). Toolbar has a multi-step history dropdown ([ADR-0013](../adr/ADR-0013-toolbar-ribbon-port.md)) |
 | Edit | Redo | `redo` / `menu:redo` | `CmdId.Redo` | wired | Owned by `useUndoRedoState`; disabled when redo stack empty. macOS accelerator override |
 | Edit | Clear undo data | `clear-undo` / `menu:clear-undo` | `MENU_GENERIC` -> `console.warn` | stub | Command not connected |
-| Edit | Merge molecule... | `merge-mol` / `menu:merge-mol` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected from menu |
-| Edit | Delete mol atoms... | `delete-mol-atoms` / `menu:delete-mol-atoms` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected from menu |
-| Edit | Change chain ID... | `change-chain-id` / `menu:change-chain-id` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected from menu |
-| Edit | Change residue number... | `change-resid-num` / `menu:change-resid-num` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected from menu |
+| Edit | Merge molecule... | `merge-mol` / `menu:merge-mol` | `ui.mergeMolDialog` command -> merge-molecule dialog | wired | Opens the merge-molecule tool dialog (`dialog.tool.mol-merge`) |
+| Edit | Delete mol atoms... | `delete-mol-atoms` / `menu:delete-mol-atoms` | `ui.deleteMolDialog` command -> delete-atoms dialog | wired | Opens the delete-atoms tool dialog (`dialog.tool.mol-delete`) |
+| Edit | Change chain ID... | `change-chain-id` / `menu:change-chain-id` | `ui.changeChainIdDialog` command -> change-chain dialog | wired | Opens the change-chain-ID tool dialog (`dialog.tool.chg-chname`) |
+| Edit | Change residue number... | `change-resid-num` / `menu:change-resid-num` | `ui.changeResidueIndexDialog` command -> change-residue-index dialog | wired | Opens the change-residue-index tool dialog (`dialog.tool.chg-resindex`) |
 | Edit | Options | `options` / `menu:options` | `MENU_GENERIC` -> `console.warn` | stub | Non-macOS Edit menu item; macOS Preferences uses same channel |
-| Rendering | POV-Ray rendering... | `pov-render` / `menu:pov-render` | `MENU_GENERIC` -> `console.warn` | stub | Render dialog not connected |
-| Rendering | Animation rendering... | `anim-render` / `menu:anim-render` | `MENU_GENERIC` -> `console.warn` | stub | Animation render dialog not connected |
+| Rendering | POV-Ray rendering... | `pov-render` / `menu:pov-render` | `ui.renderWindow` command -> modeless Rendering window (`RenderWindowApp`) | wired | Opens the modeless Rendering window (target-view picker + backend settings + Start/progress/result); also on the Toolbar "Render" button. Backends include POV-Ray (`PovrayBackend`). |
+| Rendering | Animation rendering... | (removed) | to be folded into the Rendering window as a Still/Animation mode | deferred | UXP had a separate animation-render window; tritium will add an Animation mode to the existing modeless Rendering window (follow-up). Menu item + channel removed 2026-07-11. |
 | Rendering | Export scene | `export-scene` submenu (`menu:export-{png,umbreon,pov,stl,mqo}`) | `CmdId.Export{Png,Umbreon,Pov,Stl,Mqo}` -> `runSceneExportFlow` -> `exportScene` worker (StreamManager `createHandler(name, 2)`) | wired | Split into a per-file-type submenu (PNG / Umbreon ray-traced PNG / POV-Ray SDL / STL / MQO). One item per exporter so png vs umbreon (both `*.png`) stay distinct without relying on Electron's lost filter index. Image types reuse `ExportPngOptionsDialog` (size/alpha/DPI); POV writes a sibling `.inc`. Curated subset of UXP's category-2 exporters (LuxRender/Warabi/raw/qsl deferred). |
 | Scene | Background > White | `bg-white` / `menu:bg-white` | `CmdId.SceneBgWhite` + `AsyncCueMol.setSceneBgColor('white')` + `updateMenuState` | wired | Radio state derived from scene.bgcolor RGB; uses StyleManager.compileColor('white') via makeColor helper |
 | Scene | Background > Black | `bg-black` / `menu:bg-black` | `CmdId.SceneBgBlack` + `AsyncCueMol.setSceneBgColor('black')` + `updateMenuState` | wired | Radio state derived from scene.bgcolor RGB; uses StyleManager.compileColor('black') via makeColor helper |
@@ -98,23 +123,23 @@ View menu state notes:
 | View | Center mark > Axis | `center-mark-axis` / `menu:center-mark-axis` | `CmdId.ViewCenterMarkAxis` + `AsyncCueMol.setViewCenterMark('axis')` + `updateMenuState` | wired | Uses CueMol enum value `axis`; menu state is updated from the successful command request |
 | View | Center mark > None | `center-mark-none` / `menu:center-mark-none` | `CmdId.ViewCenterMarkNone` + `AsyncCueMol.setViewCenterMark('none')` + `updateMenuState` | wired | Uses CueMol enum value `none`; menu state is updated from the successful command request |
 | View | Hardware stereo | — | removed from Tritium View menu | dropped | Removed by migration decision; hardware stereo menu is not carried forward |
-| View | View property... | `view-props` / `menu:view-props` | `MENU_GENERIC` -> `console.warn` | stub | View property dialog not connected |
+| View | View property... | `view-props` / `menu:view-props` | `ui.viewProperty` command -> docked Generic inspector (View target) | wired | Routes the active view into the docked property inspector's Generic tab (`overlay.propeditor-generic`). |
 | Tools | Molecular superposition... | `mol-superpose` / `menu:mol-superpose` | `CmdId.UiMolSuperpose` → `MolSuperposeDialog` → `superposeMol` service | wired | LSQ/SSM superposition via `MolAnlManager` under undo txn; RMSD-file output deferred. See [ADR-0022](../adr/ADR-0022-mol-superpose.md). |
-| Tools | Mol bond editor... | `bond-editor` / `menu:bond-editor` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
-| Tools | Interaction... | `interaction` / `menu:interaction` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
-| Tools | Reassign secondary str... | `reassign-2ndry` / `menu:reassign-2ndry` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
-| Tools | Mol morphing animation... | `morph-anim` / `menu:morph-anim` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
-| Tools | Mol surface generation... | `mol-surf` / `menu:mol-surf` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
-| Tools | Mol surface cutter... | `surf-cutter` / `menu:surf-cutter` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
+| Tools | Mol bond editor... | (removed) | viewport tool: `ViewportToolPalette` "Add Bond" (`activeTool 'bondEdit'`, `useBondEditClickHandler` + `bondEdit.service`) | merged | UXP modal replaced by a viewport pick-to-add tool (`dialog.tool.bond-edit`); no menu entry needed. Menu item + channel removed 2026-07-11. |
+| Tools | Interaction... | `interaction` / `menu:interaction` | `ui.interactionAnalysisDialog` command -> interaction dialog | wired | Opens the interaction-analysis dialog (`dialog.tool.intr-tool`) |
+| Tools | Reassign secondary str... | `reassign-2ndry` / `menu:reassign-2ndry` | `ui.reassignProt2ndryDialog` command -> reassign-2ndry dialog | wired | Opens the secondary-structure reassign dialog (`dialog.tool.prot2ndry-tool`) |
+| Tools | Mol morphing animation... | `morph-anim` / `menu:morph-anim` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected (`dialog.tool.morphanim-tool` todo) |
+| Tools | Mol surface generation... | `mol-surf` / `menu:mol-surf` | `ui.makeMolSurfDialog` command -> make-surface dialog | wired | Opens the mol-surface dialog (`dialog.tool.makesurf`) |
+| Tools | Mol surface cutter... | `surf-cutter` / `menu:surf-cutter` | `ui.cutSurfByPlaneDialog` command -> cut-surface dialog | wired | Opens the surface cut-by-plane dialog (`dialog.tool.surf-cutbyplane`) |
 | Tools | APBS elepot calculation... | `apbs` / `menu:apbs` | `MENU_GENERIC` -> `console.warn` | stub | Tool dialog not connected |
 | Tools | Execute script... | `exec-script` / `menu:exec-script` | `MENU_GENERIC` -> `console.warn` | stub | Script execution dialog not connected |
 | Tools | Performance measure | `perf-meas` / `menu:perf-meas` | `MENU_GENERIC` -> `console.warn` | stub | Checkbox behavior not connected |
-| Window | Show/Hide Topbar | `toggle-topbar` / `menu:toggle-topbar` | `MENU_GENERIC` -> `console.warn` | stub | Window layout action not connected |
-| Window | Clear log contents | `clear-log` / `menu:clear-log` | `MENU_GENERIC` -> `console.warn` | stub | Log action not connected |
-| Window | Restore default panel location | `restore-panels` / `menu:restore-panels` | `MENU_GENERIC` -> `console.warn` | stub | Layout reset action not connected |
-| Help | About CueMol3-tritium | `about` / `menu:about` | `CmdId.UiAboutDialog` | wired | Non-macOS Help menu item; macOS uses App menu |
-| Help | About plugins... | `about-plugins` / `menu:about-plugins` | `MENU_GENERIC` -> `console.warn` | stub | Dialog not connected |
-| Help | About config... | `about-config` / `menu:about-config` | `MENU_GENERIC` -> `console.warn` | stub | Dialog not connected |
-| Help | Addon manager... | `addon-mgr` / `menu:addon-mgr` | `MENU_GENERIC` -> `console.warn` | stub | Dialog not connected |
-| Help | Console | `console` / `menu:console` | `MENU_GENERIC` -> `console.warn` | stub | Console action not connected |
-| Help | Check for updates | `check-updates` / `menu:check-updates` | `MENU_GENERIC` -> `console.warn` | stub | Update check not connected |
+| Window | Show/Hide Topbar | (removed) | -- | dropped | Window menu dropped 2026-07-11: the topbar / log / panel-layout actions no longer map onto the tritium UI structure. |
+| Window | Clear log contents | (removed) | -- | dropped | Window menu dropped 2026-07-11 (see above). |
+| Window | Restore default panel location | (removed) | -- | dropped | Window menu dropped 2026-07-11 (see above). |
+| Help | About CueMol3-tritium | `about` / `menu:about` | `ui.aboutDialog` command -> `AboutDialog` | wired | The only carried-forward Help item; non-macOS Help menu (macOS shows it in the App menu, so the Help group is empty and dropped there). |
+| Help | About plugins... | (removed) | -- | dropped | Mozilla-platform specific (`about:plugins`); dropped 2026-07-11. |
+| Help | About config... | (removed) | -- | dropped | Mozilla-platform specific (`about:config`); dropped 2026-07-11. |
+| Help | Addon manager... | (removed) | -- | dropped | Mozilla add-on manager; dropped 2026-07-11. |
+| Help | Console | (removed) | -- | dropped | Mozilla error console; dropped 2026-07-11. |
+| Help | Check for updates | (removed) | -- | dropped | Mozilla update system; dropped 2026-07-11. |

--- a/docs/migration/uxp-inventory/menus.md
+++ b/docs/migration/uxp-inventory/menus.md
@@ -1,19 +1,31 @@
-<!-- AUTO-GENERATED — DO NOT EDIT MANUALLY. See specs/260420_uxpgui_step1_menu.md for generation instructions. -->
-
 # UXP Inventory — Menu
 
-> ⚠️ このファイルは Claude Code による自動生成です。手修正しないでください。
-> 再生成する場合は `_spec.md` に従ってください。
+> Hand-maintained. See [`_spec.md`](./_spec.md) for entry format and
+> editing guidance.
+>
+> `menu.cuemol2` (the main menubar overlay) was split into 8 per-menu
+> surface entries (File / Edit / Rendering / Scene / View / Tools /
+> Window / Help) on 2026-07-11 — each menubar dropdown is a distinct
+> `<menupopup>` surface that migrates on its own phase. All eight share
+> the source file `base/content/cuemol2-menus.xul` and the inline
+> `gQm2Main` controller. The macOS Application-menu block in the same
+> file is tracked separately as `menu.cuemol2-macos`.
 
-- Generated: 2026-04-20
-- Source: `uxp_gui/cuemol2/`
+- Origin: one-time scan of `uxp_gui/cuemol2/` (2026-04-20)
 - Spec: [_spec.md](./_spec.md)
-- Entries: 4
+- Entries: 11
 
 ## Index
 
 - [`menu.color`](#menucolor)
-- [`menu.cuemol2`](#menucuemol2)
+- [`menu.cuemol2.file`](#menucuemol2file)
+- [`menu.cuemol2.edit`](#menucuemol2edit)
+- [`menu.cuemol2.rendering`](#menucuemol2rendering)
+- [`menu.cuemol2.scene`](#menucuemol2scene)
+- [`menu.cuemol2.view`](#menucuemol2view)
+- [`menu.cuemol2.tools`](#menucuemol2tools)
+- [`menu.cuemol2.window`](#menucuemol2window)
+- [`menu.cuemol2.help`](#menucuemol2help)
 - [`menu.cuemol2-macos`](#menucuemol2-macos)
 - [`menu.cuemol2-scripts`](#menucuemol2-scripts)
 
@@ -49,27 +61,17 @@
 
 ---
 
-### `menu.cuemol2`
+### `menu.cuemol2.file`
 
 - **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
-- **Root element**: `<overlay>`
-- **Title**: unknown (overlay has no title; it injects a full `<menubar>` into the main window)
+- **Root element**: `<menu>` / `<menupopup>` (File dropdown of the injected `<menubar>`)
+- **Title**: "File" (`&menu_file.label;` in `cuemol2.dtd`)
 - **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
-- **Associated JS**: inline `<script>` CDATA block only; no external same-name `.js` file
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main`
 - **Overlays applied**: none
 
 #### User-visible features
-- **File menu**: New Window, New Tab, Open File…, Get PDB (accession code), Open Recent (MRU list), Save File As…, Save current view…, Close Tab, Open Scene…, Reload Scene, Save Scene, Save Scene As…, Open web page…, Quit/Exit
-- **Edit menu**: Undo, Redo, Clear undo data, Merge molecule…, Delete mol atoms…, Change chain ID…, Change residue number…, Options (non-macOS)
-- **Rendering menu**: POV-Ray rendering…, Animation rendering…, Export scene…
-- **Scene menu**: Background color (White/Black), Use color proofing (checkbox), Properties…
-- **View menu**: Perspective / Orthographic projection (checkboxes), Center mark sub-menu (Cross/Axis/None radio), Hardware stereo (checkbox), View property…
-- **Tools menu**: Molecular superposition…, Mol bond editor…, Interaction…, Reassign secondary str…, Mol morphing animation…, Mol surface generation…, Mol surface cutter…, APBS elepot calculation…, Execute script…, Performance measure (checkbox), Mol client tools (hidden)
-- **Window menu**: Show/Hide Topbar, Clear log contents, Restore default panel location, Panels sub-menu, Windows sub-menu
-- **Help menu**: About plugins…, About config…, Addon manager…, About CueMol2, Console, Test crash reporter, Check for updates
-- **macOS Application menu** (`#ifdef XP_MACOSX`): Preferences…, Services, Hide CueMol2, Hide Others, Show All, Quit CueMol2
-- **Update alert popup** (`update-alert-popup`): dismissible panel showing update message, "Don't check for updates" checkbox, "Check!!" button
-- **Global keybindings**: Ctrl/Cmd+N (new tab), Ctrl/Cmd+Shift+N (new window), Ctrl/Cmd+O (open file), Ctrl/Cmd+Shift+O (open scene), Ctrl/Cmd+R (reload scene), Ctrl/Cmd+S (save scene), Ctrl/Cmd+Z (undo), Ctrl/Cmd+Y (redo), Ctrl/Cmd+K (options), F1 (hardware stereo), F2 (perf measure)
+- New Window, New Tab, Open File…, Get PDB… (accession code), Open Recent (MRU list), Save File As…, Save current view…, Close Tab, Open Scene…, Reload Scene, Save Scene, Save Scene As…, Open web page…, Quit/Exit
 
 #### Commands / Handlers
 | Trigger | Handler | Description |
@@ -89,6 +91,34 @@
 | File > Save Scene As… | `gQm2Main.onSaveSceneAs()` | Opens save-scene-as dialog |
 | File > Open web page… | `gQm2Main.onOpenURL()` | Opens a URL |
 | File > Quit (non-macOS) | `gQm2Main.onCloseEvent()` | Exits the application |
+
+#### i18n keys used
+- `&menu_file.label;`, `&menu_file.accesskey;` (dtd: `cuemol2.dtd`)
+- `&new_window.*;`, `&new_tab.*;`, `&open_file.*;`, `&save_file_as.*;`, `&open_PDB.label;`, `&saveCurrCam.label;`, `&close_tab.label;`, `&open_scene.*;`, `&reload_scene.*;`, `&save_scene.*;` (dtd: `cuemol2.dtd`)
+- `&quitApplicationCmd.*;` (non-Windows non-macOS), `&quitApplicationCmdWin.*;` (`#ifdef XP_WIN`) (dtd: `cuemol2.dtd`)
+
+#### Notes
+- Open Recent is populated dynamically via `populateFileMRUMenu` on `onpopupshowing`.
+- Keybindings: Ctrl/Cmd+N (new tab), Ctrl/Cmd+Shift+N (new window), Ctrl/Cmd+O (open file), Ctrl/Cmd+Shift+O (open scene), Ctrl/Cmd+R (reload scene), Ctrl/Cmd+S (save scene).
+- Shares the source file `cuemol2-menus.xul` and the inline `gQm2Main` controller (loaded by `cuemol2-scripts.xul`) with the other seven `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.edit`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (Edit dropdown of the injected `<menubar>`)
+- **Title**: "Edit" (`&menu_edit.label;` in `cuemol2.dtd`)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main`
+- **Overlays applied**: none
+
+#### User-visible features
+- Undo, Redo, Clear undo data, Merge molecule…, Delete mol atoms…, Change chain ID…, Change residue number…, Options (non-macOS)
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | Edit > Undo | `gQm2Main.undo()` | Undoes last action |
 | Edit > Redo | `gQm2Main.redo()` | Redoes last undone action |
 | Edit > Clear undo data | `gQm2Main.clearUndoData()` | Clears all undo history |
@@ -97,14 +127,92 @@
 | Edit > Change chain ID… | `gQm2Main.onChgChName1()` | Opens chain ID change dialog |
 | Edit > Change residue number… | `gQm2Main.onShiftResIndex1()` | Opens residue index shift dialog |
 | Edit > Options (non-macOS) | `gQm2Main.showConfigDlg()` | Opens preferences dialog |
+
+#### i18n keys used
+- `&menu_edit.label;`, `&menu_edit.accesskey;` (dtd: `cuemol2.dtd`)
+- `&edit_undo.*;`, `&edit_redo.*;`, `&edit_config.*;` (dtd: `cuemol2.dtd`)
+
+#### Notes
+- Keybindings: Ctrl/Cmd+Z (undo), Ctrl/Cmd+Y (redo), Ctrl/Cmd+K (options).
+- On macOS, Options is presented as Preferences… in the Application menu (`menu.cuemol2-macos`), same `showConfigDlg()` handler.
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.rendering`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (Rendering dropdown of the injected `<menubar>`)
+- **Title**: "Rendering" (`&menu_render.label;` in `cuemol2.dtd`)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main` / `cuemolui`
+- **Overlays applied**: none
+
+#### User-visible features
+- POV-Ray rendering…, Animation rendering…, Export scene…
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | Rendering > POV-Ray rendering… | `gQm2Main.showPovRenderDlg()` | Opens POV-Ray render dialog |
 | Rendering > Animation rendering… | `cuemolui.onAnimRender()` | Opens animation render dialog |
 | Rendering > Export scene… | `gQm2Main.exportScene()` | Exports the current scene |
+
+#### i18n keys used
+- `&menu_render.label;`, `&menu_render.accesskey;` (dtd: `cuemol2.dtd`)
+- `&render_exportscene.label;`, `&render_exportscene.accesskey;` (dtd: `cuemol2.dtd`)
+
+#### Notes
+- `cuemolui.onAnimRender` is defined in `anim/anim-ribbon.js:214` (window-global `cuemolui` namespace).
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.scene`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (Scene dropdown of the injected `<menubar>`)
+- **Title**: "Scene" (`&menu_scene.label;` in `cuemol2.dtd`)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main`
+- **Overlays applied**: none
+
+#### User-visible features
+- Background color (White / Black), Use color proofing (checkbox), Properties…
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | Scene > onpopupshowing | `gQm2Main.onSceneMenuShowing(event)` | Updates checkbox/radio state for scene menu |
 | Scene > Background > White | `gQm2Main.setBgColor('white')` | Sets scene background to white |
 | Scene > Background > Black | `gQm2Main.setBgColor('black')` | Sets scene background to black |
 | Scene > Use color proofing | `gQm2Main.onToggleColProof(event)` | Toggles color proofing mode |
 | Scene > Properties… | `gQm2Main.showScenePropDlg(event)` | Opens scene properties dialog |
+
+#### i18n keys used
+- `&menu_scene.label;`, `&menu_scene.accesskey;` (dtd: `cuemol2.dtd`)
+
+#### Notes
+- `onSceneMenuShowing` syncs the Background radio and Use-color-proofing checkbox before display.
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.view`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (View dropdown of the injected `<menubar>`)
+- **Title**: "View" (`&menu_view.label;` in `cuemol2.dtd` — label defined in the DTD but not individually enumerated in the original scan)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main`
+- **Overlays applied**: none
+
+#### User-visible features
+- Perspective / Orthographic projection (checkboxes), Center mark sub-menu (Cross / Axis / None radio), Hardware stereo (checkbox), View property…
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | View > onpopupshowing | `gQm2Main.onViewMenuShowing(event)` | Syncs projection checkboxes |
 | View > Perspective | `gQm2Main.onViewProjChg(event)` | Switches to perspective projection |
 | View > Orthographic | `gQm2Main.onViewProjChg(event)` | Switches to orthographic projection |
@@ -112,6 +220,32 @@
 | View > Center mark items | `gQm2Main.onViewMarkChg(event)` | Changes center mark style |
 | View > Hardware stereo | `gQm2Main.toggleHWStereo()` | Toggles hardware stereo mode |
 | View > View property… | `gQm2Main.showViewPropDlg()` | Opens view property dialog |
+
+#### i18n keys used
+- View menu label + item entities are defined in `cuemol2.dtd`; the original scan did not enumerate them individually (guessing prohibited).
+
+#### Notes
+- The `view-menu-stereo-type` attribute on the Hardware stereo checkbox is used as a radio-group name (non-standard XUL) — migration concern.
+- Keybinding: F1 (hardware stereo).
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.tools`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (Tools dropdown of the injected `<menubar>`)
+- **Title**: "Tools" (`&menu_tools.label;` in `cuemol2.dtd`)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main` / `cuemolui`
+- **Overlays applied**: none
+
+#### User-visible features
+- Molecular superposition…, Mol bond editor…, Interaction…, Reassign secondary str…, Mol morphing animation…, Mol surface generation…, Mol surface cutter…, APBS elepot calculation…, Execute script…, Performance measure (checkbox), Mol client tools (hidden)
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | Tools > Molecular superposition… | `gQm2Main.onSSMSup1()` | Opens SSM superposition dialog |
 | Tools > Mol bond editor… | `gQm2Main.onMolBondEditor()` | Opens bond editor dialog |
 | Tools > Interaction… | `cuemolui.onIntrTool()` | Opens interaction tool dialog |
@@ -122,10 +256,63 @@
 | Tools > APBS elepot calculation… | `gQm2Main.calcApbsPot()` | Runs APBS electrostatic potential |
 | Tools > Execute script… | `gQm2Main.onExecScr()` | Opens script execution dialog |
 | Tools > Performance measure | `gQm2Main.togglePerfMeas(event)` | Toggles performance measurement mode |
+
+#### i18n keys used
+- `&menu_tools.label;`, `&menu_tools.accesskey;` (dtd: `cuemol2.dtd`)
+
+#### Notes
+- `cuemolui.onIntrTool` → `tools/intr-tool.js:5`, `cuemolui.onProt2ndry` → `tools/prot2ndry-tool.js:5`, `cuemolui.onMorphAnimSetup` → `tools/morphanim-tool.js:5`.
+- The `tools-menu-perf-meas` attribute on the Performance measure checkbox is used as a radio-group name (non-standard XUL) — migration concern. Keybinding: F2 (perf measure).
+- Mol client tools is hidden by default.
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.window`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (Window dropdown of the injected `<menubar>`)
+- **Title**: "Window" (`&menu_window.label;` in `cuemol2.dtd`)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main` / window globals
+- **Overlays applied**: none
+
+#### User-visible features
+- Show/Hide Topbar, Clear log contents, Restore default panel location, Panels sub-menu, Windows sub-menu
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | Window > Show/Hide Topbar | `window.gToolRibbon.toggleCollapse()` | Collapses or expands the ribbon toolbar |
 | Window > Clear log contents | `gQm2Main.clearLogContents()` | Clears the log panel |
 | Window > Restore default panel location | `restoreDefaultPanels()` | Restores side panel to default layout |
 | Window > Windows > onpopupshowing | `gQm2Main.onWinListPopupShowing(event)` | Populates open-windows list |
+
+#### i18n keys used
+- `&menu_window.label;`, `&menu_window.accesskey;` (dtd: `cuemol2.dtd`)
+
+#### Notes
+- The Panels sub-menu toggles individual side panels; the Windows sub-menu is populated dynamically via `onWinListPopupShowing`.
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
+
+---
+
+### `menu.cuemol2.help`
+
+- **File**: `uxp_gui/cuemol2/base/content/cuemol2-menus.xul`
+- **Root element**: `<menu>` / `<menupopup>` (Help dropdown of the injected `<menubar>`)
+- **Title**: "Help" (`&menu_help.label;` in `cuemol2.dtd`)
+- **Chrome URL**: `chrome://cuemol2/content/cuemol2-menus.xul`
+- **Associated JS**: inline `<script>` CDATA block only; handlers on `gQm2Main` + inline helpers
+- **Overlays applied**: none
+
+#### User-visible features
+- About plugins…, About config…, Addon manager…, About CueMol2, Console, Test crash reporter, Check for updates
+- Update alert popup (`update-alert-popup`): dismissible panel showing update message, "Don't check for updates" checkbox, "Check!!" button
+
+#### Commands / Handlers
+| Trigger | Handler | Description |
+|---------|---------|-------------|
 | Help > About plugins… | `window.open('about:plugins', ...)` | Opens plugins info page |
 | Help > About config… | `showConfig()` (inline) | Opens `about:config` page |
 | Help > Addon manager… | `showAddonMgr()` (inline) | Opens addon manager |
@@ -135,50 +322,16 @@
 | Help > Check for updates | `gQm2Main.checkForUpdates()` | Initiates update check |
 | Update popup > Check!! | `gQm2Main.goDownloadSite()` | Opens download site |
 | Update popup > close button | `gQm2Main.closeUpdatePopup()` | Dismisses update popup |
-| macOS > Preferences… | `gQm2Main.showConfigDlg()` | Opens preferences dialog (macOS) |
-| macOS > Quit CueMol2 | `gQm2Main.onCloseEvent()` | Exits application (macOS) |
 
 #### i18n keys used
-- `&menu_file.label;`, `&menu_file.accesskey;` (dtd: `cuemol2.dtd`)
-- `&new_window.label;`, `&new_window.accesskey;`, `&new_window.commandkey;` (dtd: `cuemol2.dtd`)
-- `&new_tab.label;`, `&new_tab.accesskey;`, `&new_tab.commandkey;` (dtd: `cuemol2.dtd`)
-- `&open_file.label;`, `&open_file.accesskey;`, `&open_file.commandkey;` (dtd: `cuemol2.dtd`)
-- `&save_file_as.label;`, `&save_file_as.accesskey;`, `&save_file_as.commandkey;` (dtd: `cuemol2.dtd`)
-- `&open_PDB.label;` (dtd: `cuemol2.dtd`)
-- `&saveCurrCam.label;` (dtd: `cuemol2.dtd`)
-- `&close_tab.label;` (dtd: `cuemol2.dtd`)
-- `&open_scene.label;`, `&open_scene.accesskey;` (dtd: `cuemol2.dtd`)
-- `&reload_scene.label;`, `&reload_scene.accesskey;`, `&reload_scene.commandkey;` (dtd: `cuemol2.dtd`)
-- `&save_scene.label;`, `&save_scene.accesskey;`, `&save_scene.commandkey;` (dtd: `cuemol2.dtd`)
-- `&menu_edit.label;`, `&menu_edit.accesskey;` (dtd: `cuemol2.dtd`)
-- `&edit_undo.label;`, `&edit_undo.accesskey;`, `&edit_undo.commandkey;` (dtd: `cuemol2.dtd`)
-- `&edit_redo.label;`, `&edit_redo.accesskey;`, `&edit_redo.commandkey;` (dtd: `cuemol2.dtd`)
-- `&edit_config.label;`, `&edit_config.accesskey;`, `&edit_config.commandkey;` (dtd: `cuemol2.dtd`)
-- `&menu_render.label;`, `&menu_render.accesskey;` (dtd: `cuemol2.dtd`)
-- `&render_exportscene.label;`, `&render_exportscene.accesskey;` (dtd: `cuemol2.dtd`)
-- `&menu_scene.label;`, `&menu_scene.accesskey;` (dtd: `cuemol2.dtd`)
-- `&menu_tools.label;`, `&menu_tools.accesskey;` (dtd: `cuemol2.dtd`)
-- `&menu_window.label;`, `&menu_window.accesskey;` (dtd: `cuemol2.dtd`)
 - `&menu_help.label;`, `&menu_help.accesskey;` (dtd: `cuemol2.dtd`)
 - `&help_about.label;`, `&help_about.accesskey;` (dtd: `cuemol2.dtd`)
 - `&help_aboutCmdMac.label;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- `&quitApplicationCmd.label;`, `&quitApplicationCmd.accesskey;` (dtd: `cuemol2.dtd`, non-Windows non-macOS)
-- `&quitApplicationCmdWin.label;`, `&quitApplicationCmdWin.accesskey;` (dtd: `cuemol2.dtd`, `#ifdef XP_WIN` only)
-- `&quitApplicationCmdMac.label;`, `&quitApplicationCmdMac.key;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- `&configCmdMac.label;`, `&configCmdMac.commandkey;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- `&servicesMenuMac.label;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- `&hideThisAppCmdMac.label;`, `&hideThisAppCmdMac.commandkey;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- `&hideOtherAppsCmdMac.label;`, `&hideOtherAppsCmdMac.commandkey;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- `&showAllAppsCmdMac.label;` (dtd: `cuemol2.dtd`, `#ifdef XP_MACOSX` only)
-- Inherits `%brandDTD;` (`chrome://global/locale/brand.dtd`) — `&brandShortName;` etc. used indirectly via the above entities
-- Inherits `%updateDTD;` (`chrome://mozapps/locale/update/updates.dtd`) — referenced in DOCTYPE but no update entities appear directly in this file's markup
+- Inherits `%updateDTD;` (`chrome://mozapps/locale/update/updates.dtd`) for the update-alert popup
 
 #### Notes
-- This is the primary menu overlay; it targets `menus-overlay-target` in `cuemol2.xul`.
-- Contains preprocessor directives (`#ifdef XP_MACOSX`, `#ifdef XP_WIN`) — the macOS Application menu block duplicates logic also found in `cuemol2-macos-menus.xul`; the relationship between the two files should be clarified during migration.
-- `gQm2Main` is an instance of `Qm2Main` class loaded by `cuemol2-scripts.xul`; all `gQm2Main.*` handlers depend on that overlay being applied first.
-- `cuemolui` is a window-global namespace object declared at `base/content/cuemol2-utils.js:30` (`var cuemolui = new Object()`). Methods called from this menu are defined in specific content JS files: `cuemolui.onAnimRender` → `anim/anim-ribbon.js:214`, `cuemolui.onIntrTool` → `tools/intr-tool.js:5`, `cuemolui.onProt2ndry` → `tools/prot2ndry-tool.js:5`, `cuemolui.onMorphAnimSetup` → `tools/morphanim-tool.js:5`. Underlying implementation modules live in `components/jsmods/cuemol2ui-lib/` and are loaded via CommonJS `require()`.
-- The `tools-menu-perf-meas` and `view-menu-stereo-type` attributes on checkboxes are used as radio-group names, not standard XUL behavior — migration concern.
+- Several handlers are inline helpers (`showConfig` / `showAddonMgr` / `showConsole` / `showCrashReporter`) defined in the overlay's script block rather than on `gQm2Main`.
+- Shares the source file and `gQm2Main` controller with the other `menu.cuemol2.*` groups.
 
 ---
 
@@ -256,7 +409,7 @@
 
 ## Statistics
 
-- Total entries: 4
+- Total entries: 11
 - With JS handler: 3
 - With i18n keys: 2
 - Unresolved: 0

--- a/tritium/react-gui/src/main/menu.ts
+++ b/tritium/react-gui/src/main/menu.ts
@@ -225,7 +225,9 @@ function buildAndSetMenu(mainWindow: BrowserWindow): void {
   const template: MenuItemConstructorOptions[] = [
     ...macOnlyGroups.map((g) => buildGroup(g, specificHandlers, mainWindow)),
     ...appMenuGroups.map((g) => buildGroup(g, specificHandlers, mainWindow)),
-  ]
+    // Drop groups that build to an empty submenu (e.g. Help on macOS, whose
+    // only item -- About -- is othersOnly and lives in the App menu instead).
+  ].filter((g) => !Array.isArray(g.submenu) || g.submenu.length > 0)
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template))
 

--- a/tritium/react-gui/src/renderer/__test__/menuPipelineExhaustiveness.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/menuPipelineExhaustiveness.test.ts
@@ -103,25 +103,14 @@ const DISPATCH_HANDLED: ReadonlySet<string> = new Set<string>([
  * intentional placeholder from an accidental typo.
  */
 const UNIMPLEMENTED_ALLOWLIST: ReadonlySet<string> = new Set<string>([
-  'menu:new-window',
   'menu:clear-undo',
   'menu:options',
   'menu:scene-props',
   'menu:color-proof',
-  'menu:anim-render',
   'menu:morph-anim',
-  'menu:bond-editor',
   'menu:apbs',
   'menu:exec-script',
   'menu:perf-meas',
-  'menu:toggle-topbar',
-  'menu:clear-log',
-  'menu:restore-panels',
-  'menu:about-plugins',
-  'menu:about-config',
-  'menu:addon-mgr',
-  'menu:console',
-  'menu:check-updates',
 ])
 
 describe('menu pipeline -- exhaustiveness', () => {
@@ -136,8 +125,8 @@ describe('menu pipeline -- exhaustiveness', () => {
     expect(uncovered).toEqual([])
   })
 
-  it('the unimplemented allowlist has exactly 19 entries (UXP-parity placeholders)', () => {
-    expect(UNIMPLEMENTED_ALLOWLIST.size).toBe(19)
+  it('the unimplemented allowlist has exactly 8 entries (not-yet-ported placeholders)', () => {
+    expect(UNIMPLEMENTED_ALLOWLIST.size).toBe(8)
   })
 
   it('no allowlisted channel is also dispatch-handled (the two sets are disjoint)', () => {

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -60,7 +60,6 @@ export const IPC = {
   // --- Menu action channels (carried as the payload of MENU_GENERIC, or
   // sent on their own dedicated push channel). Single source of truth for the
   // menu-action strings so menuTemplate / menu.ts / useMenuDispatch agree. ---
-  MENU_NEW_WINDOW:    'menu:new-window',
   MENU_CLEAR_RECENT:  'menu:clear-recent',
   MENU_SAVE_FILE_AS:  'menu:save-file-as',
   MENU_SAVE_CURRENT_VIEW: 'menu:save-current-view',
@@ -73,7 +72,6 @@ export const IPC = {
   MENU_CHANGE_RESID_NUM: 'menu:change-resid-num',
   MENU_OPTIONS:       'menu:options',
   MENU_POV_RENDER:    'menu:pov-render',
-  MENU_ANIM_RENDER:   'menu:anim-render',
   MENU_EXPORT_PNG:     'menu:export-png',
   MENU_EXPORT_UMBREON: 'menu:export-umbreon',
   MENU_EXPORT_POV:     'menu:export-pov',
@@ -83,7 +81,6 @@ export const IPC = {
   MENU_SCENE_PROPS:   'menu:scene-props',
   MENU_VIEW_PROPS:    'menu:view-props',
   MENU_MOL_SUPERPOSE: 'menu:mol-superpose',
-  MENU_BOND_EDITOR:   'menu:bond-editor',
   MENU_INTERACTION:   'menu:interaction',
   MENU_REASSIGN_2NDRY: 'menu:reassign-2ndry',
   MENU_MORPH_ANIM:    'menu:morph-anim',
@@ -92,14 +89,6 @@ export const IPC = {
   MENU_APBS:          'menu:apbs',
   MENU_EXEC_SCRIPT:   'menu:exec-script',
   MENU_PERF_MEAS:     'menu:perf-meas',
-  MENU_TOGGLE_TOPBAR: 'menu:toggle-topbar',
-  MENU_CLEAR_LOG:     'menu:clear-log',
-  MENU_RESTORE_PANELS: 'menu:restore-panels',
-  MENU_ABOUT_PLUGINS: 'menu:about-plugins',
-  MENU_ABOUT_CONFIG:  'menu:about-config',
-  MENU_ADDON_MGR:     'menu:addon-mgr',
-  MENU_CONSOLE:       'menu:console',
-  MENU_CHECK_UPDATES: 'menu:check-updates',
 
   // invoke channels (renderer -> main, with reply) -- menu role actions
   MENU_INVOKE_ROLE: 'menu:invoke-role',

--- a/tritium/react-gui/src/shared/menuActionMap.ts
+++ b/tritium/react-gui/src/shared/menuActionMap.ts
@@ -83,7 +83,6 @@ export const MENU_DISPATCH_UNIMPLEMENTED = 'unimplemented'
  */
 export const MENU_ACTION_MAP = {
   // --- File ---
-  [IPC.MENU_NEW_WINDOW]:       { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
   [IPC.MENU_NEW_TAB]:          { dispatch: 'tab.new',            deliver: 'dedicated-direct' },
   [IPC.MENU_OPEN_FILE]:        { dispatch: 'ui.openObjDialog',   deliver: 'dedicated-direct' },
   [IPC.MENU_GET_PDB]:          { dispatch: 'ui.getPdbDialog',    deliver: 'generic' },
@@ -111,7 +110,6 @@ export const MENU_ACTION_MAP = {
 
   // --- Rendering ---
   [IPC.MENU_POV_RENDER]:       { dispatch: 'ui.renderWindow',    deliver: 'generic' },
-  [IPC.MENU_ANIM_RENDER]:      { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
   [IPC.MENU_EXPORT_PNG]:       { dispatch: 'scene.export.png',     deliver: 'generic' },
   [IPC.MENU_EXPORT_UMBREON]:   { dispatch: 'scene.export.umbreon', deliver: 'generic' },
   [IPC.MENU_EXPORT_POV]:       { dispatch: 'scene.export.pov',     deliver: 'generic' },
@@ -134,7 +132,6 @@ export const MENU_ACTION_MAP = {
 
   // --- Tools ---
   [IPC.MENU_MOL_SUPERPOSE]:    { dispatch: 'ui.molSuperpose',    deliver: 'generic' },
-  [IPC.MENU_BOND_EDITOR]:      { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
   [IPC.MENU_INTERACTION]:      { dispatch: 'ui.interactionAnalysisDialog', deliver: 'generic' },
   [IPC.MENU_REASSIGN_2NDRY]:   { dispatch: 'ui.reassignProt2ndryDialog', deliver: 'generic' },
   [IPC.MENU_MORPH_ANIM]:       { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
@@ -144,18 +141,11 @@ export const MENU_ACTION_MAP = {
   [IPC.MENU_EXEC_SCRIPT]:      { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
   [IPC.MENU_PERF_MEAS]:        { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
 
-  // --- Window ---
-  [IPC.MENU_TOGGLE_TOPBAR]:    { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-  [IPC.MENU_CLEAR_LOG]:        { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-  [IPC.MENU_RESTORE_PANELS]:   { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-
   // --- Help ---
+  // Only About is carried forward (see menuTemplate.ts). The Window menu and
+  // the Mozilla-specific Help items (plugins / config / addon-mgr / console /
+  // check-updates) were dropped, so they no longer appear here.
   [IPC.MENU_ABOUT]:            { dispatch: 'ui.aboutDialog',     deliver: 'generic' },
-  [IPC.MENU_ABOUT_PLUGINS]:    { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-  [IPC.MENU_ABOUT_CONFIG]:     { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-  [IPC.MENU_ADDON_MGR]:        { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-  [IPC.MENU_CONSOLE]:          { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
-  [IPC.MENU_CHECK_UPDATES]:    { dispatch: MENU_DISPATCH_UNIMPLEMENTED, deliver: 'generic' },
 } as const satisfies Record<string, MenuActionEntry>
 
 /** Union of all valid menu-action channel keys. */

--- a/tritium/react-gui/src/shared/menuTemplate.ts
+++ b/tritium/react-gui/src/shared/menuTemplate.ts
@@ -50,7 +50,9 @@ export const APP_MENU: AppMenuGroup[] = [
   {
     label: 'File',
     submenu: [
-      { id: 'new-window',  label: 'New Window',       accelerator: 'CmdOrCtrl+Shift+N', ipcChannel: IPC.MENU_NEW_WINDOW },
+      // New Window intentionally omitted: Electron cannot host multiple OS
+      // windows against a single shared libcuemol2 backend, so the UXP
+      // multi-window model is not carried forward (use New Tab instead).
       { id: 'new-tab',     label: 'New Tab',           accelerator: 'CmdOrCtrl+T',       ipcChannel: IPC.MENU_NEW_TAB },
       { type: 'separator' },
       { id: 'open-file',   label: 'Open File...',      accelerator: 'CmdOrCtrl+O',       ipcChannel: IPC.MENU_OPEN_FILE },
@@ -112,8 +114,10 @@ export const APP_MENU: AppMenuGroup[] = [
   {
     label: 'Rendering',
     submenu: [
+      // POV-Ray rendering opens the modeless Rendering window (ui.renderWindow).
+      // Animation rendering will be folded into that same window as a
+      // Still / Animation mode (follow-up), so it has no separate menu item.
       { id: 'pov-render',    label: 'POV-Ray rendering...',   ipcChannel: IPC.MENU_POV_RENDER },
-      { id: 'anim-render',   label: 'Animation rendering...', ipcChannel: IPC.MENU_ANIM_RENDER },
       {
         id: 'export-scene', label: 'Export scene',
         submenu: [
@@ -171,7 +175,8 @@ export const APP_MENU: AppMenuGroup[] = [
     label: 'Tools',
     submenu: [
       { id: 'mol-superpose',  label: 'Molecular superposition...',  ipcChannel: IPC.MENU_MOL_SUPERPOSE },
-      { id: 'bond-editor',    label: 'Mol bond editor...',           ipcChannel: IPC.MENU_BOND_EDITOR },
+      // Bond editing is a viewport tool (ViewportToolPalette "Add Bond",
+      // activeTool 'bondEdit'), not a modal dialog -- no menu entry needed.
       { id: 'interaction',    label: 'Interaction...',               ipcChannel: IPC.MENU_INTERACTION },
       { id: 'reassign-2ndry', label: 'Reassign secondary str...',    ipcChannel: IPC.MENU_REASSIGN_2NDRY },
       { id: 'morph-anim',     label: 'Mol morphing animation...',    ipcChannel: IPC.MENU_MORPH_ANIM },
@@ -185,29 +190,18 @@ export const APP_MENU: AppMenuGroup[] = [
     ],
   },
 
-  // Window menu
-  {
-    label: 'Window',
-    submenu: [
-      { id: 'toggle-topbar',    label: 'Show/Hide Topbar',             ipcChannel: IPC.MENU_TOGGLE_TOPBAR },
-      { type: 'separator' },
-      { id: 'clear-log',        label: 'Clear log contents',           ipcChannel: IPC.MENU_CLEAR_LOG },
-      { id: 'restore-panels',   label: 'Restore default panel location', ipcChannel: IPC.MENU_RESTORE_PANELS },
-    ],
-  },
+  // Window menu intentionally omitted: the topbar / log / panel-layout actions
+  // it hosted in UXP no longer map onto the tritium UI structure.
 
   // Help menu
+  // Only About is carried forward; the UXP plugins / config / addon-manager /
+  // console / update-check items were Mozilla-platform specific. On macOS About
+  // lives in the Application menu, so this single-item group is empty there and
+  // is dropped by buildAndSetMenu (empty-submenu groups are filtered out).
   {
     label: 'Help',
     submenu: [
       { id: 'about', label: `About ${APP_PRODUCT_NAME}`, ipcChannel: IPC.MENU_ABOUT, othersOnly: true },
-      { type: 'separator' },
-      { id: 'about-plugins',  label: 'About plugins...',  ipcChannel: IPC.MENU_ABOUT_PLUGINS },
-      { id: 'about-config',   label: 'About config...',   ipcChannel: IPC.MENU_ABOUT_CONFIG },
-      { id: 'addon-mgr',      label: 'Addon manager...',  ipcChannel: IPC.MENU_ADDON_MGR },
-      { type: 'separator' },
-      { id: 'console',        label: 'Console',           ipcChannel: IPC.MENU_CONSOLE },
-      { id: 'check-updates',  label: 'Check for updates', ipcChannel: IPC.MENU_CHECK_UPDATES },
     ],
   },
 ]


### PR DESCRIPTION
## Overview

Cleans up menu items that do not map onto the tritium architecture, and
brings the migration tracking in line with the actual menu implementation.

This is **menu-tracking + cleanup only** (no new feature). Animation
rendering is *deferred*, not implemented — see follow-up below.

## Code changes (`tritium/react-gui`)

Removed menu items (+ their `menuActionMap` entries and IPC channel constants):

| Item | Why |
|------|-----|
| **File > New Window** | Electron cannot host multiple OS windows against a single shared libcuemol2 backend — the UXP multi-window model does not carry forward (use New Tab). |
| **Window menu** (whole group) | Show/Hide Topbar, Clear log, Restore panel location no longer map onto the tritium UI structure. |
| **Help > About plugins / config / Addon manager / Console / Check for updates** | Mozilla-platform specific. Only **About** is kept (non-macOS Help; macOS shows it in the App menu). |
| **Tools > Mol bond editor** | Already implemented as a viewport tool (`ViewportToolPalette` "Add Bond", `activeTool 'bondEdit'`). |
| **Rendering > Animation rendering** | To be folded into the existing modeless Rendering window as a Still/Animation mode (follow-up). |

`main/menu.ts` now drops empty-submenu groups, so the About-only Help group
(empty on macOS) is not shown. The exhaustiveness-test allowlist shrinks 19 → 8.

## Docs changes (`docs/migration`)

- Split the single `menu.cuemol2` tracking row into **8 per-menu surface rows**
  (File/Edit/Rendering/Scene/View/Tools/Window/Help), following the
  `panel.workspace` / `panel.coloring` split precedent. Menu category 4 → 11.
- **Reconciled the item-level status table with `menuActionMap.ts`** (the source
  of truth), which had drifted stale: several Edit/Tools/View/Rendering items
  were already wired but listed as `stub` — notably **POV-Ray rendering was
  already implemented** as the modeless render window.
- Category totals: done 88 → 92, wip 34 → 31, todo 18 → 17.

## Verification

- `npm test` (Vitest): **2219 passed**
- `tsc -p tsconfig.node.json`: 0 errors (web project has only pre-existing project-reference noise)
- `npm run build` (electron-vite production): ✓

## Follow-up (not in this PR)

Integrate animation rendering into the modeless Rendering window as a
**Still / Animation mode** (frame range / fps / output naming + frame-sequence
job model). Tracked as `deferred` on `menu.cuemol2.rendering`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
