### PR TITLE
fix(surface): separate multigrad color_mapname storage from elepot

### DIFF
--- a/src/modules/surface/MolSurfRenderer.cpp
+++ b/src/modules/surface/MolSurfRenderer.cpp
@@ -244,12 +244,17 @@ void MolSurfRenderer::render(DisplayContext *pdl)
   else if (m_nMode==SFREND_SCAPOT||
            m_nMode==SFREND_MULTIGRAD) {
     //
-    // ELEPOT mode --> resolve target name
+    // ELEPOT/MULTIGRAD mode --> resolve target scalar object name.
+    // The target name is stored separately per mode:
+    //   SCAPOT (potential) --> elepot (m_sTgtElePot)
+    //   MULTIGRAD          --> color_mapname (m_sColorMap)
     //
+    LString tgtName = (m_nMode==SFREND_MULTIGRAD) ? getColorMapName() : m_sTgtElePot;
+
     qsys::ObjectPtr pobj;
     m_pScaObj = NULL;
-    if (!m_sTgtElePot.isEmpty()) {
-      pobj = ensureNotNull(getScene())->getObjectByName(m_sTgtElePot);
+    if (!tgtName.isEmpty()) {
+      pobj = ensureNotNull(getScene())->getObjectByName(tgtName);
       m_pScaObj = dynamic_cast<qsys::ScalarObject*>(pobj.get());
     }
     if (m_pScaObj==NULL) {
@@ -260,9 +265,9 @@ void MolSurfRenderer::render(DisplayContext *pdl)
         m_pScaObj = dynamic_cast<qsys::ScalarObject*>(pobj.get());
       }
     }
-    
+
     if (m_pScaObj==NULL) {
-      LOG_DPRINTLN("MolSurfRend> \"%s\" is not a scalar object.", m_sTgtElePot.c_str());
+      LOG_DPRINTLN("MolSurfRend> \"%s\" is not a scalar object.", tgtName.c_str());
     }
   }
   else if (m_nMode==SFREND_MOLFANC) {

--- a/src/modules/surface/MolSurfRenderer.hpp
+++ b/src/modules/surface/MolSurfRenderer.hpp
@@ -188,11 +188,19 @@ namespace surface {
       m_pGrad = val;
     }
 
+  private:
+
+    /// Scalar field object name for MULTIGRAD mode (independent from elepot)
+    LString m_sColorMap;
+
   public:
 
     /// reference coloring map target (used in MULTIGRAD mode)
-    LString getColorMapName() const { return getTgtElePotName(); }
-    void setColorMapName(const LString &n) { setTgtElePotName(n); }
+    LString getColorMapName() const { return m_sColorMap; }
+    void setColorMapName(const LString &n) {
+      m_sColorMap = n;
+      invalidateDisplayCache();
+    }
 
     /// get color-map object (valid in MULTIGRAD mode)
     qsys::ObjectPtr getColorMapObj() const;

--- a/src/modules/surface/MolSurfRenderer.qif
+++ b/src/modules/surface/MolSurfRenderer.qif
@@ -89,10 +89,11 @@ runtime_class MolSurfRenderer extends Renderer
 
   property object<MultiGradient$> multi_grad => redirect(getMultiGrad, xxx) (readonly);
 
-  /// Coloring map (density/elepot) name property. The same as elepot property.
+  /// Coloring map (density/elepot) name property (used in multigrad mode).
   property string color_mapname => redirect(getColorMapName, setColorMapName);
+  default color_mapname = "";
 
-  /// Get coloring map (map/elepot) name. The same as elepot property.
+  /// Get coloring map (map/elepot) object (used in multigrad mode).
   object<Object$> getColorMapObj();
 
   //////////

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -154,6 +154,7 @@ add_executable(test_surface
   modules/surface/test_main.cpp
   modules/surface/test_distfield_surf.cpp
   modules/surface/test_ply_reader.cpp
+  modules/surface/test_molsurf_serialize.cpp
 )
 target_include_directories(test_surface PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/surface/test_main.cpp
+++ b/src/tests/modules/surface/test_main.cpp
@@ -2,14 +2,28 @@
 #include <common.h>
 #include "qlib/qlib.hpp"
 #include "qsys/qsys.hpp"
+#include "qsys/style/StyleMgr.hpp"
+#include "qsys/RendererFactory.hpp"
+#include "molstr/molstr.hpp"
+#include "surface/surface.hpp"
+
+#ifndef CUEMOL2_SYSCONFIG_PATH
+#define CUEMOL2_SYSCONFIG_PATH ""
+#endif
 
 class SurfaceEnvironment : public ::testing::Environment {
 public:
     void SetUp() override {
         qlib::init();
-        qsys::init("");
+        qsys::init(CUEMOL2_SYSCONFIG_PATH);
+        qsys::StyleMgr::init();
+        qsys::RendererFactory::init();
+        molstr::init();
+        surface::init();
     }
     void TearDown() override {
+        surface::fini();
+        molstr::fini();
         qsys::fini();
         qlib::fini();
     }

--- a/src/tests/modules/surface/test_molsurf_serialize.cpp
+++ b/src/tests/modules/surface/test_molsurf_serialize.cpp
@@ -1,0 +1,177 @@
+//
+// Round-trip serialization tests for MolSurfRenderer coloring-target names.
+//
+// Regression guard for the multigrad target-wipe bug: color_mapname (multigrad
+// mode) and elepot (potential mode) use independent storage. A real qsc load
+// performs readFrom2() followed by reapplyStyle(); the latter resets any
+// property still flagged "default", which previously wiped the shared storage.
+// So a target must survive not just readFrom2() but also reapplyStyle().
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "surface/MolSurfRenderer.hpp"
+
+#include <qsys/RendererFactory.hpp>
+#include <qlib/LDOM2Tree.hpp>
+#include <qlib/LDOM2Stream.hpp>
+#include <qlib/PipeStream.hpp>
+
+#include <string>
+
+using qlib::LString;
+using qlib::LDom2Tree;
+using qlib::LDom2OutStream;
+using qlib::LDom2InStream;
+using qlib::PipeStreamImpl;
+using qlib::PipeInStream;
+using qlib::PipeOutStream;
+using surface::MolSurfRenderer;
+
+namespace {
+
+std::string drainPipe(PipeStreamImpl &impl)
+{
+    std::string result;
+    char buf[256];
+    while (impl.ready()) {
+        int n = impl.read(buf, 0, sizeof buf);
+        if (n <= 0) break;
+        result.append(buf, static_cast<size_t>(n));
+    }
+    return result;
+}
+
+std::string writeTree(LDom2Tree &tree)
+{
+    auto impl = qlib::sp<PipeStreamImpl>(new PipeStreamImpl());
+    PipeOutStream raw_out;
+    raw_out.setImpl(impl);
+    LDom2OutStream out(raw_out);
+    out.write(&tree);
+    impl->o_close();
+    return drainPipe(*impl);
+}
+
+void parseRawXML(const std::string &xml, LDom2Tree &tree)
+{
+    auto impl = qlib::sp<PipeStreamImpl>(new PipeStreamImpl());
+    impl->write(xml.c_str(), 0, static_cast<int>(xml.size()));
+    impl->o_close();
+    PipeInStream raw_in;
+    raw_in.setImpl(impl);
+    LDom2InStream in(raw_in);
+    in.read(tree);
+}
+
+MolSurfRenderer *asMolSurf(const qsys::RendererPtr &p)
+{
+    return dynamic_cast<MolSurfRenderer *>(p.get());
+}
+
+// Serialize pSrc to qsc XML, parse it back into a fresh molsurf renderer, and
+// run the same post-load steps as a real scene load (readFrom2 + reapplyStyle).
+qsys::RendererPtr roundTrip(qsys::RendererFactory *pRF, const qsys::RendererPtr &pSrc)
+{
+    LDom2Tree tree("renderer");
+    pSrc->writeTo2(tree.top());
+    std::string xml = writeTree(tree);
+
+    LDom2Tree rtree;
+    parseRawXML(xml, rtree);
+
+    qsys::RendererPtr pDst = pRF->create("molsurf");
+    pDst->readFrom2(rtree.top());
+    // scene-load step that previously reset (wiped) the shared target storage
+    pDst->reapplyStyle();
+    return pDst;
+}
+
+}  // namespace
+
+// multigrad target (color_mapname) survives write -> read -> reapplyStyle,
+// and stays independent from the (unset) elepot storage.
+TEST(MolSurfSerialize, MultiGradTargetRoundTrip)
+{
+    qsys::RendererFactory *pRF = qsys::RendererFactory::getInstance();
+    qsys::RendererPtr pRend = pRF->create("molsurf");
+    ASSERT_FALSE(pRend.isnull());
+
+    pRend->setPropStr("colormode", "multigrad");
+    pRend->setPropStr("color_mapname", "my_map.cif");
+
+    MolSurfRenderer *pSrc = asMolSurf(pRend);
+    ASSERT_NE(pSrc, nullptr);
+    EXPECT_TRUE(pSrc->getColorMapName().equals("my_map.cif"));
+    EXPECT_TRUE(pSrc->getTgtElePotName().isEmpty());  // elepot untouched
+
+    qsys::RendererPtr pReloaded = roundTrip(pRF, pRend);
+    MolSurfRenderer *pOut = asMolSurf(pReloaded);
+    ASSERT_NE(pOut, nullptr);
+    EXPECT_EQ(pOut->getColorMode(), MolSurfRenderer::SFREND_MULTIGRAD);
+    EXPECT_TRUE(pOut->getColorMapName().equals("my_map.cif"))
+        << "color_mapname = '" << pOut->getColorMapName().c_str() << "'";
+    EXPECT_TRUE(pOut->getTgtElePotName().isEmpty())
+        << "elepot leaked = '" << pOut->getTgtElePotName().c_str() << "'";
+}
+
+// potential target (elepot) survives the same cycle (regression: the elepot
+// path is unchanged by the color_mapname separation).
+TEST(MolSurfSerialize, PotentialTargetRoundTrip)
+{
+    qsys::RendererFactory *pRF = qsys::RendererFactory::getInstance();
+    qsys::RendererPtr pRend = pRF->create("molsurf");
+    ASSERT_FALSE(pRend.isnull());
+
+    pRend->setPropStr("colormode", "potential");
+    pRend->setPropStr("elepot", "my_map.cif");
+
+    MolSurfRenderer *pSrc = asMolSurf(pRend);
+    ASSERT_NE(pSrc, nullptr);
+    EXPECT_TRUE(pSrc->getTgtElePotName().equals("my_map.cif"));
+    EXPECT_TRUE(pSrc->getColorMapName().isEmpty());  // color_mapname untouched
+
+    qsys::RendererPtr pReloaded = roundTrip(pRF, pRend);
+    MolSurfRenderer *pOut = asMolSurf(pReloaded);
+    ASSERT_NE(pOut, nullptr);
+    EXPECT_EQ(pOut->getColorMode(), MolSurfRenderer::SFREND_SCAPOT);
+    EXPECT_TRUE(pOut->getTgtElePotName().equals("my_map.cif"))
+        << "elepot = '" << pOut->getTgtElePotName().c_str() << "'";
+    EXPECT_TRUE(pOut->getColorMapName().isEmpty())
+        << "color_mapname leaked = '" << pOut->getColorMapName().c_str() << "'";
+}
+
+// A legacy multigrad qsc (only color_mapname persisted, no elepot attribute,
+// same shape the failing file has) must load with its target intact through
+// readFrom2 + reapplyStyle.
+TEST(MolSurfSerialize, LegacyMultiGradQscLoads)
+{
+    const char *xml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+        "<renderer type=\"molsurf\" color_mapname=\"my_map.cif\" "
+        "colormode=\"multigrad\" group=\"\" name=\"molsurf1\" sel=\"i;1:37\" "
+        "target=\"my_mol.pdb\">\n"
+        "<coloring type=\"CPKColoring\"/>\n"
+        "<multi_grad>\n"
+        "<gradnode par=\"-1.000000\" col=\"#0000FF\"/>\n"
+        "<gradnode par=\"0.000000\" col=\"#FF0000\"/>\n"
+        "<gradnode par=\"0.500000\" col=\"hsb(63.058824,1,1)\"/>\n"
+        "</multi_grad>\n"
+        "</renderer>\n";
+
+    LDom2Tree rtree;
+    parseRawXML(xml, rtree);
+
+    qsys::RendererFactory *pRF = qsys::RendererFactory::getInstance();
+    qsys::RendererPtr pRend = pRF->create("molsurf");
+    ASSERT_FALSE(pRend.isnull());
+    pRend->readFrom2(rtree.top());
+    pRend->reapplyStyle();
+
+    MolSurfRenderer *pOut = asMolSurf(pRend);
+    ASSERT_NE(pOut, nullptr);
+    EXPECT_EQ(pOut->getColorMode(), MolSurfRenderer::SFREND_MULTIGRAD);
+    EXPECT_TRUE(pOut->getColorMapName().equals("my_map.cif"))
+        << "color_mapname = '" << pOut->getColorMapName().c_str() << "'";
+}

--- a/uxp_gui/cuemol2/base/content/coloring-panel.js
+++ b/uxp_gui/cuemol2/base/content/coloring-panel.js
@@ -1891,16 +1891,12 @@ panel.loadMultigradWidgets = function ()
 
 panel.updateMultigradWidgets = function (aRend)
 {
-  if ('elepot' in aRend)
+  // multigrad target is color_mapname; fall back to elepot for renderers
+  // that only expose elepot (potential-only renderers).
+  if ('color_mapname' in aRend)
+    this.mColMapSel.selectObjectByName(aRend.color_mapname);
+  else if ('elepot' in aRend)
     this.mColMapSel.selectObjectByName(aRend.elepot);
-  else if ('color_mapname' in aRend) {
-    let res = this.mColMapSel.selectObjectByName(aRend.color_mapname);
-    //dd("this.mColMapSel._data = "+debug.dumpObjectTree(this.mColMapSel._data));
-    debug.trace();
-    dd("this.mColMapSel._data = "+this.mColMapSel._data);
-    dd("this.mColMapSel._data.length = "+this.mColMapSel._data.length);
-    //alert("update color_mapname to: "+aRend.color_mapname+" res="+res);
-  }
 };
 
 /// elepot selector change event listener
@@ -1912,16 +1908,17 @@ panel.onColMapSelChanged = function (aEvent)
 
   var rend = cuemol.getUIDObj(this.mTgtRendID);
 
-  if ('elepot' in rend) {
+  // multigrad target is color_mapname; fall back to elepot for renderers
+  // that only expose elepot (potential-only renderers).
+  if ('color_mapname' in rend) {
+    if (rend.color_mapname==obj.name)
+      return;
+    this.commitElepotPropChange("color_mapname", obj.name);
+  }
+  else if ('elepot' in rend) {
     if (rend.elepot==obj.name)
       return;
     this.commitElepotPropChange("elepot", obj.name);
-  }
-  else if ('color_mapname' in rend) {
-    if (rend.color_mapname==obj.name)
-      return;
-    //alert("change color_mapname to: "+obj.name);
-    this.commitElepotPropChange("color_mapname", obj.name);
   }
 };
 

--- a/uxp_gui/cuemol2/base/content/workspace_panel_ctxtmenu.js
+++ b/uxp_gui/cuemol2/base/content/workspace_panel_ctxtmenu.js
@@ -307,7 +307,7 @@ ws.onGenSurfObj = function ()
     if (rend.colormode=="multigrad") {
       newrend.colormode = "multigrad";
       newrend.multi_grad.copyFrom(rend.multi_grad);
-      newrend.elepot = rend.color_mapname;
+      newrend.color_mapname = rend.color_mapname;
     }
     else {
       //newrend.colormode = "solid";


### PR DESCRIPTION
## 概要

`MolSurfRenderer` を multigrad mode で使い、qsc に保存 → 読み込むと target scalar object が `""` になり `MolSurfRend> "" is not a scalar object.` エラーで正しく描画されない問題を修正します。

## 原因

`color_mapname`（multigrad 用）と `elepot`（potential 用）の2プロパティが同じストレージ `m_sTgtElePot` を alias していた。default flag はプロパティ名ごとに独立管理されるため:

1. multigrad qsc は `color_mapname` のみ永続化（`elepot` は flag=default で skip）
2. 読み込みで `color_mapname` を適用（`m_sTgtElePot` に値が入る）が、`elepot` の flag は default のまま
3. シーン登録時の `reapplyStyle()` が「flag=default かつ style 値無し」の `elepot` を reset し、**共有ストレージごと `""` に wipe**

## 修正

姉妹クラス `MapRenderer`（既に `color_mapname` 専用 `m_sColorMap` を持つ）と同じ separate-storage パターンに揃える。`elepot`/potential 経路は無改変。

**C++ core**
- `MolSurfRenderer.hpp` — 専用 `m_sColorMap` を新設、`getColorMapName/setColorMapName` を専用ストレージ経由に
- `MolSurfRenderer.qif` — `default color_mapname = ""` を追加（`elepot` と対称）
- `MolSurfRenderer.cpp` — `render()` でモード別に対象名を選択（MULTIGRAD→`m_sColorMap`、SCAPOT→`m_sTgtElePot`）

**UXP GUI** — alias 前提だった multigrad 経路を `color_mapname` に修正
- `coloring-panel.js` — `updateMultigradWidgets` / `onColMapSelChanged` の分岐優先順を反転
- `workspace_panel_ctxtmenu.js` — renderer 複製時の書き込み先を `color_mapname` に

**テスト** — degrade 検出テスト3本を新設
- `MultiGradTargetRoundTrip` — multigrad target が `reapplyStyle` 後も保持、elepot に漏れない
- `PotentialTargetRoundTrip` — potential 経路の回帰防止
- `LegacyMultiGradQscLoads` — 既存の壊れたファイルと同形状の qsc renderer XML が正しく読める

## 互換性

既存の壊れた multigrad qsc も修正後は正しく読める（`color_mapname` が `m_sColorMap` に入り、applyStyle が触らないため）。

## 検証

- 全 1182 gtest が PASS（回帰なし）。新規3テストも PASS。
- 手動確認（未実施）: UXP アプリで実ファイルを開いての描画目視。`LegacyMultiGradQscLoads` が同一 XML 形状での読み込み成功を C++ レベルで証明済み。

## Out of scope

- tritium は multigrad UI 未実装のため別タスク（C++ wrapper は build 時自動再生成）
- 他 renderer（MapRenderer 系は既に分離済み、DirectSurfRenderer 系は multigrad 非対応）は無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)