### PR TITLE
feat(tritium): reuse just-created scene when opening a scene file

### DIFF
--- a/tritium/react-gui/src/renderer/__test__/sceneCommandsAutoScene.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneCommandsAutoScene.test.tsx
@@ -45,7 +45,7 @@ function makeCm() {
       Promise.resolve({ types: ['simple'], objType: 'MolCoord', readerName: 'pdb' }),
     ),
     loadObject: vi.fn((..._args: unknown[]) => Promise.resolve()),
-    loadScene: vi.fn(() => Promise.resolve()),
+    loadScene: vi.fn((..._args: unknown[]) => Promise.resolve()),
     invokeService: vi.fn(() => Promise.resolve(undefined)),
   }
 }
@@ -156,6 +156,81 @@ describe('useSceneCommands - auto-create scene on load', () => {
     await drain()
 
     expect(newScene).not.toHaveBeenCalled()
+    h.unmount()
+  })
+})
+
+/**
+ * UXP openSceneImpl parity: opening a .qsc into a "just created" (empty &
+ * unmodified) current scene loads in place without a new tab; a non-empty /
+ * modified scene (or no active scene) makes a fresh scene + tab instead.
+ */
+describe('useSceneCommands - open scene into just-created scene', () => {
+  beforeEach(() => {
+    setupElectronAPI()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    teardownElectronAPI()
+    vi.restoreAllMocks()
+  })
+
+  /** cm whose isSceneJustCreated query resolves to the given verdict. */
+  function makeSceneCm(justCreated: boolean) {
+    const cm = makeCm()
+    cm.invokeService = vi.fn((name: string) =>
+      name === 'isSceneJustCreated'
+        ? Promise.resolve({ justCreated })
+        : Promise.resolve(undefined),
+    ) as unknown as typeof cm.invokeService
+    return cm
+  }
+
+  it('reuses the active scene in place when it is just created', async () => {
+    const cm = makeSceneCm(true)
+    const newScene = vi.fn(() => Promise.resolve(NEW_SCENE))
+    const h = mountWith(cm, () => ({ scene_uid: 7, view_id: 8 }), newScene)
+    await flushPromises()
+
+    await h.result.dispatch(CmdId.OpenSceneByPath, '/tmp/a.qsc' as never)
+    await drain()
+
+    expect(cm.invokeService).toHaveBeenCalledWith('isSceneJustCreated', { sceneId: 7 })
+    expect(newScene).not.toHaveBeenCalled()
+    expect(cm.loadScene).toHaveBeenCalledTimes(1)
+    // loadScene(path, sceneId) -> loads into the existing active scene (7).
+    expect(cm.loadScene.mock.calls[0][1]).toBe(7)
+    h.unmount()
+  })
+
+  it('creates a new scene when the active scene is not just created', async () => {
+    const cm = makeSceneCm(false)
+    const newScene = vi.fn(() => Promise.resolve(NEW_SCENE))
+    const h = mountWith(cm, () => ({ scene_uid: 7, view_id: 8 }), newScene)
+    await flushPromises()
+
+    await h.result.dispatch(CmdId.OpenSceneByPath, '/tmp/a.qsc' as never)
+    await drain()
+
+    expect(newScene).toHaveBeenCalledTimes(1)
+    expect(cm.loadScene).toHaveBeenCalledTimes(1)
+    // Loads into the freshly created scene, not the active one.
+    expect(cm.loadScene.mock.calls[0][1]).toBe(NEW_SCENE.scene_uid)
+    h.unmount()
+  })
+
+  it('creates a new scene (no empty-check) when no scene is active', async () => {
+    const cm = makeSceneCm(true)
+    const newScene = vi.fn(() => Promise.resolve(NEW_SCENE))
+    const h = mountWith(cm, () => undefined, newScene)
+    await flushPromises()
+
+    await h.result.dispatch(CmdId.OpenSceneByPath, '/tmp/a.qsc' as never)
+    await drain()
+
+    expect(cm.invokeService).not.toHaveBeenCalled()
+    expect(newScene).toHaveBeenCalledTimes(1)
+    expect(cm.loadScene.mock.calls[0][1]).toBe(NEW_SCENE.scene_uid)
     h.unmount()
   })
 })

--- a/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
+++ b/tritium/react-gui/src/renderer/commands/useSceneCommands.ts
@@ -43,6 +43,22 @@ export function useSceneCommands({
 
     const openNewScene = useCallback(async (filePath?: string): Promise<void> => {
         if (!cm) return
+        // UXP openSceneImpl parity: opening a scene file into a "just created"
+        // (empty & unmodified) current scene loads into it in place, without
+        // spawning a new tab. New Scene (no filePath) always makes a fresh tab.
+        if (filePath) {
+            const active = getActiveSceneInfo()
+            if (active) {
+                const { justCreated } = await cm.invokeService(
+                    'isSceneJustCreated', { sceneId: active.scene_uid },
+                )
+                if (justCreated) {
+                    await cm.loadScene(filePath, active.scene_uid)
+                    addRecent(filePath, 'scene')
+                    return
+                }
+            }
+        }
         // Same path as app launch and File > New Tab (UXP onNewScene).
         const created = await newScene()
         if (!created) return
@@ -50,7 +66,7 @@ export function useSceneCommands({
             await cm.loadScene(filePath, created.scene_uid)
             addRecent(filePath, 'scene')
         }
-    }, [cm, newScene])
+    }, [cm, newScene, getActiveSceneInfo])
 
     useRegisterCommand(CmdId.SceneNew, () => openNewScene())
 

--- a/tritium/react-gui/src/renderer/worker/server/services/isSceneJustCreated.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/isSceneJustCreated.service.ts
@@ -1,0 +1,31 @@
+// Runs in Web Worker thread. Wrappers are sync (no await on C++ wrappers).
+import type { WorkerContext } from '../types/WorkerContext';
+import type { Scene } from '@cuemol/core/src/wrappers/Scene';
+
+export interface IsSceneJustCreatedArgs {
+    sceneId: number;
+}
+
+export interface IsSceneJustCreatedResult {
+    justCreated: boolean;
+}
+
+/**
+ * Report whether a scene is "just created" -- unmodified with no objects and
+ * no saved cameras (C++ `Scene::isJustCreated()`).
+ *
+ * Mirrors the `scene.isJustCreated()` gate in UXP `openSceneImpl`: opening a
+ * .qsc into a just-created current scene loads into it in place, while a
+ * non-empty or modified scene gets a new scene/tab. See useSceneCommands
+ * `openNewScene` for the renderer-side branch.
+ */
+function isSceneJustCreated(
+    ctx: WorkerContext,
+    args: IsSceneJustCreatedArgs,
+): IsSceneJustCreatedResult {
+    const scene = ctx.sceMgr.getScene(args.sceneId) as Scene | null;
+    if (!scene) return { justCreated: false };
+    return { justCreated: scene.isJustCreated() };
+}
+
+export const services = { isSceneJustCreated };

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -39,6 +39,7 @@ import type { GetMtzColumnInfoArgs, GetMtzColumnInfoResult } from '../server/ser
 import type { GetReaderDefaultOptionsArgs, GetReaderDefaultOptionsResult } from '../server/services/getReaderDefaultOptions.service'
 import type { GetOpenFiltersArgs } from '../server/services/getOpenFilters.service'
 import type { GetSceneCloseInfoArgs, GetSceneCloseInfoResult } from '../server/services/getSceneCloseInfo.service'
+import type { IsSceneJustCreatedArgs, IsSceneJustCreatedResult } from '../server/services/isSceneJustCreated.service'
 import type { GetViewTabLabelArgs, GetViewTabLabelResult } from '../server/services/getViewTabLabel.service'
 import type { GetSelDefsArgs, GetSelDefsResult } from '../server/services/getSelDefs.service'
 import type { GetMaterialNamesArgs, GetMaterialNamesResult } from '../server/services/getMaterialNames.service'
@@ -470,6 +471,7 @@ export interface ServiceMap {
   getReaderDefaultOptions:    { args: GetReaderDefaultOptionsArgs;     result: GetReaderDefaultOptionsResult }
   getOpenFilters:             { args: GetOpenFiltersArgs;              result: ElectronFileFilter[] }
   getSceneCloseInfo:          { args: GetSceneCloseInfoArgs;           result: GetSceneCloseInfoResult }
+  isSceneJustCreated:         { args: IsSceneJustCreatedArgs;          result: IsSceneJustCreatedResult }
   getViewTabLabel:            { args: GetViewTabLabelArgs;             result: GetViewTabLabelResult }
   getSelDefs:                 { args: GetSelDefsArgs;                  result: GetSelDefsResult }
   getMaterialNames:           { args: GetMaterialNamesArgs;            result: GetMaterialNamesResult }


### PR DESCRIPTION
## 概要

tritium/react-gui で、`.qsc`(scene ファイル)を開くと**常に新規タブ**を作っていた。UXP の `openSceneImpl` は、current scene が「just created(未変更・object なし・保存カメラなし)」なら**その空シーンにそのまま読み込む**(新規タブを作らない)。この UXP parity を復元する。

- UXP 分岐本体: `uxp_gui/cuemol2/base/content/fileopen.js` `openSceneImpl` — `scene.isJustCreated()` で分岐
- 空判定の実体: C++ `qsys::Scene::isJustCreated()`(`src/qsys/Scene.cpp`)= 未変更 かつ `getObjectCount()==0` かつ `getCameraCount()==0`

## 変更内容

- **worker service `isSceneJustCreated` を追加**(`worker/server/services/isSceneJustCreated.service.ts`): `{ sceneId }` → `{ justCreated }`。生成 wrapper 経由で C++ `Scene::isJustCreated()` を呼ぶ。`import.meta.glob` で自動登録。
- **`WorkerCalls.ts` の ServiceMap に行追加**: `cm.invokeService('isSceneJustCreated', ...)` を型付け。
- **`useSceneCommands.ts` `openNewScene`**: `filePath` があるとき、active scene が just created なら `loadScene(filePath, active.scene_uid)` で in-place 読み込みして return。非空 / 変更済み / active scene 無しは従来通り新規タブ。New Scene(filePath 無し)は常に新規タブ。
  - タブ名は `loadScene` 内の `scene.setName(basename)` が発火する `name` PROPCHG を既存 tab title sync が拾い自動更新(追加処理不要)。
- **テスト追加**(`sceneCommandsAutoScene.test.tsx`): `OpenSceneByPath` の 3 分岐(空シーン reuse / 非空で新規 / active 無しで新規)を pin。

### なぜ起動時の空タブで reuse が発火するか(C++ 契約)

- `Scene::setName` は `propChanged("name")` を発火するだけで modified にしない。
- `createView()` は `m_camtab`(= `getCameraCount()`)を増やさない。
- よって tritium の新規シーン生成(`createScene`+`setName`+`createView`)は `isJustCreated()==true` を保ち、起動直後の空タブ・New Scene の空タブが reuse 対象になる。

## 検証

- 追加テスト単体: 8/8 pass
- react-gui 全 vitest: 2228/2228 pass(256 files)
- `tsc -p tsconfig.web.json`: 本変更起因のエラー 0(既存ノイズ 21 → 21 で不変)
- `task build_tritium`: 成功(7241 modules)
- `task run_tritium`: `launch worker OK` → `INITIALIZED` → `bindCanvas` → `shader program created OK` まで正常起動

実 GUI のファイルダイアログ経由の `.qsc` オープンは自動操作できないため、挙動はユニットテストで pin している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)