### PR TITLE
feat(packaging): bundle POV-Ray/ffmpeg/apbs-pdb2pqr into tritium mac & win

### DIFF
--- a/.github/workflows/build2.yml
+++ b/.github/workflows/build2.yml
@@ -156,6 +156,15 @@ jobs:
       with:
         basedir: ${{ github.workspace }}/target
 
+    # Fetch the external bundle apps (POV-Ray / apbs-pdb2pqr / ffmpeg) before
+    # packaging so collect-cuemol2-runtime.sh can stage them into the DMG (via
+    # BUNDLE_APPS below). The same download also feeds the UXP GUI build later.
+    - name: Download external packages
+      if: env.BUILD_MODE == 'full'
+      uses: ./build_scripts/download_extpkgs
+      with:
+        basedir: ${{ github.workspace }}/target
+
     # Package the tritium Electron app (macOS arm64 DMG, ad-hoc signed).
     # Runs only on the arm64 non-embed-Python leg, in full mode (develop /
     # workflow_dispatch / tags) -- not on every feature-branch push.
@@ -165,6 +174,7 @@ jobs:
       run: |
         set -eux
         export LIBCUEMOL2_ROOT=${{ github.workspace }}/target/cuemol2
+        export BUNDLE_APPS=${{ github.workspace }}/target
         cd tritium/react-gui
         pnpm run package:mac
 
@@ -175,12 +185,6 @@ jobs:
         name: CueMol3_${{ steps.version.outputs.version }}_mac_arm64
         path: tritium/react-gui/release/*.dmg
         if-no-files-found: error
-
-    - name: Download external packages
-      if: env.BUILD_MODE == 'full'
-      uses: ./build_scripts/download_extpkgs
-      with:
-        basedir: ${{ github.workspace }}/target
 
     - name: Build UXP GUI
       if: env.BUILD_MODE == 'full'
@@ -309,6 +313,15 @@ jobs:
       with:
         basedir: ${{ github.workspace }}\target
 
+    # Fetch the external bundle apps (POV-Ray / apbs-pdb2pqr / ffmpeg) before
+    # packaging so collect-cuemol2-runtime.sh can stage them into the installer
+    # (via BUNDLE_APPS below). The same download also feeds the UXP GUI build later.
+    - name: Download external packages
+      if: env.BUILD_MODE == 'full'
+      uses: ./build_scripts/download_extpkgs
+      with:
+        basedir: ${{ github.workspace }}/target
+
     # Package the tritium Electron app (Windows x64 NSIS installer, unsigned).
     # Full mode only (develop / workflow_dispatch / tags).
     - name: Package tritium (Windows x64 NSIS)
@@ -318,6 +331,7 @@ jobs:
         set -eux
         cd "$(cygpath -u '${{ github.workspace }}')"
         export LIBCUEMOL2_ROOT="$PWD/target/cuemol2"
+        export BUNDLE_APPS="$PWD/target"
         bash tritium/packaging/package.sh --win --x64
 
     - name: Upload tritium Windows installer
@@ -337,12 +351,6 @@ jobs:
       if: env.BUILD_MODE == 'full'
       shell: bash
       run: bash ${MSYS_TOP_DIR}/build_scripts/build_uxpgui_win/make_mozconfig.sh
-
-    - name: Download external packages
-      if: env.BUILD_MODE == 'full'
-      uses: ./build_scripts/download_extpkgs
-      with:
-        basedir: ${{ github.workspace }}/target
 
     - name: Run mozilla build and build UXP
       if: env.BUILD_MODE == 'full'

--- a/build_scripts/Taskfile.yml
+++ b/build_scripts/Taskfile.yml
@@ -271,6 +271,12 @@ tasks:
       # Default install prefix used by the build tasks; collect-cuemol2-runtime.sh
       # also defaults to this, but set it explicitly so the env contract is clear.
       LIBCUEMOL2_ROOT: "{{.LIBCUEMOL2_INSTDIR}}"
+      # Root of the downloaded external packages (povray/apbs/ffmpeg), staged into
+      # the DMG by collect-cuemol2-runtime.sh. Same root as run_tritium; populate
+      # it first with `task download_extpkgs`. WORKDIR contains $HOME, which
+      # go-task does NOT expand in a plain env value -- run it through `sh: echo`.
+      BUNDLE_APPS:
+        sh: echo "{{.WORKDIR}}"
     cmds:
       - pnpm run package:mac
 

--- a/docs/migration/adr/ADR-0017-povray-rendering-ui.md
+++ b/docs/migration/adr/ADR-0017-povray-rendering-ui.md
@@ -80,6 +80,9 @@ renderers. Binary paths are configured in the SettingsPane
 - UXP parity reference: `uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/povrender.js`,
   `uxp_gui/cuemol2/base/content/tools/render-pov-dlg.{xul,js}`.
 - Plan document: `docs/plans/raytrace-rendering-ui-plan.md` (phases 1–5).
-- Deferred: animation/sequential rendering; app-bundle packaging of the
-  POV-Ray / blendpng binaries (paths currently default to a dev location and
-  are user-overridable in Settings).
+- Deferred: animation/sequential rendering.
+- App-bundle packaging of the POV-Ray / blendpng binaries: **done on macOS**
+  (staged into the DMG under `Resources/bundle_apps/povray` + `Resources/cuemol2/bin/blendpng`
+  by `collect-cuemol2-runtime.sh` + `electron-builder.yml` extraResources; see
+  ADR-0030). Paths are still user-overridable in Settings; Windows/Linux staging
+  is a follow-up.

--- a/docs/migration/adr/ADR-0030-tritium-packaging-renovation.md
+++ b/docs/migration/adr/ADR-0030-tritium-packaging-renovation.md
@@ -161,9 +161,40 @@ About ダイアログの表示バージョンは C++ 側 (`getAppInfo` -> `Scene
   ローカルビルド DMG は quarantine 無しのため Gatekeeper は無関係 (notarization は配布時の
   Phase 4 課題)。
 - **Phase 1 で入れるガード (task 1-3, 本 ADR 合意済み)**: collect-cuemol2-runtime.sh が
-  embed-python 構成 (`$LIBCUEMOL2_ROOT/lib/python` 有無 or `otool -l` の libpython 依存) を
-  検出し、python 未同梱なら**明確なエラーで即 fail** する (silent な flash-crash を防ぐ)。
-  将来的に python staging を実装して同梱対応。
+  embed-python 構成を検出し、python 未同梱なら**明確なエラーで即 fail** する (silent な
+  flash-crash を防ぐ)。判定は **libcuemol2 共有ライブラリの実 load 依存**
+  (`otool -L` / `readelf -d` / `objdump -p` で libpython への load command を検査) で行う。
+  `$LIBCUEMOL2_ROOT/lib/python` ディレクトリの有無や `@loader_path/../lib/python` rpath は
+  **非 embed でも常に baked/残存し得る**ため signal として使わない (embed ON→OFF 再ビルドで
+  dir が残る false positive を回避 ; 2026-07-12 に dir 判定から link 依存判定へ変更)。addon は
+  libpython を dlopen せず load 依存でリンクするので (`pybr` STATIC が `Python3::Python` を
+  取り込み `cuemol2` SHARED に伝播) この検査は確定的。inspection ツールも共有 lib も無い場合のみ
+  dir 有無へ conservative fallback。将来的に python staging を実装して同梱対応。
+
+### 外部 bundle apps の同梱 (POV-Ray / ffmpeg / apbs-pdb2pqr, macOS + Windows)
+
+2026-07-12 に uxp_gui (`src/osxbuild/add_povray.pl.in`) と同じ範囲の外部ソフトを
+tritium の macOS DMG / Windows NSIS へ同梱する経路を実装。配置は uxp の
+`Resources/{povray,ffmpeg,apbs-pdb2pqr}` ではなく、`getRenderBinaries()` が既に期待する
+Electron 流レイアウトに合わせる (Windows は `povray/bin/povray.exe`, `blendpng.exe` 等):
+
+- `Resources/bundle_apps/povray/{bin/povray, include}` -- `BUNDLE_APPS` (task download_extpkgs) 由来
+- `Resources/bundle_apps/apbs/{apbs, pdb2pqr, dat}`, `Resources/bundle_apps/ffmpeg/bin/ffmpeg` -- 先置きのみ (tritium 側の実行時 resolver/UI は未配線)
+- `Resources/cuemol2/bin/blendpng` -- libcuemol2 install (`<prefix>/bin`) 由来
+
+実装点: `collect-cuemol2-runtime.sh` の section (1b) が blendpng (必須) と extpkgs
+(best-effort ; 未取得は警告 skip) を `packaging/cuemol2-runtime/{bin,bundle_apps}` へ
+staging し、`electron-builder.yml` の extraResources 2 エントリが `cuemol2/bin` /
+`bundle_apps` へマップ。ローカルは `Taskfile.yml` の `package_tritium:darwin` が
+`BUNDLE_APPS` を渡す。CI は `build2.yml` の macOS / Windows 両 job で `download_extpkgs` を
+tritium package の前へ移動し、package step に `BUNDLE_APPS=<workspace>/target` を export
+(同 download は後続の UXP build も兼ねる) して配布物に同梱する。extpkgs のコピーは package
+ディレクトリ単位 (`cp -R`) なので OS ごとの実行ファイル名差 (povray vs povray.exe 等) を
+自動で吸収する。macOS は ad-hoc `codesign --deep` が同梱バイナリも自動署名する。**Phase 4
+(Developer ID + notarization + hardenedRuntime) では各バイナリの個別署名と、spawn 用の
+`com.apple.security.cs.disable-library-validation` entitlement が必要**になる点に注意。
+Windows の `blendpng.exe` は依存 DLL (lcms2 等) の同ディレクトリ配置が別途必要になり得る
+(現状は contract どおりのパスへ配置のみ)。Linux packaging への extpkgs 展開は follow-up。
 
 ### 主な実装ポインタ (現状)
 

--- a/tritium/packaging/README.md
+++ b/tritium/packaging/README.md
@@ -7,6 +7,12 @@ electron-vite + electron-builder による配布物のビルド手順と、**未
 
 - libcuemol2 (`src/`) と tritium/core の native addon (`cuemol_internal.node`) を事前にビルドし、
   `LIBCUEMOL2_ROOT`（既定: `<repo>/.build_out/cuemol2`）に install しておくこと。
+- （macOS / Windows, 任意）外部 bundle ソフト（POV-Ray / ffmpeg / apbs-pdb2pqr）を
+  配布物に同梱するには、`cd build_scripts && task download_extpkgs` を先に実行して
+  `BUNDLE_APPS`（既定: `$HOME/tmp/proj64_deplibs`）に配置しておくこと。未配置でも
+  パッケージングは通るが、警告が出て当該バイナリは同梱されない（POV-Ray レンダリングは
+  Settings でパスを手入力すれば動く）。CI（`build2.yml`）は macOS/Windows とも package
+  前に `download_extpkgs` を実行し `BUNDLE_APPS` を渡すので自動で同梱される。
 - パッケージングは各スクリプトが staging（`collect-cuemol2-runtime.sh`）→ `electron-vite build`
   → `electron-builder` を順に実行する。バージョンは `src/_version.h` の `QM_VERSION` から導出される。
 

--- a/tritium/packaging/collect-cuemol2-runtime.sh
+++ b/tritium/packaging/collect-cuemol2-runtime.sh
@@ -52,19 +52,65 @@ if [ ! -f "$LIBCUEMOL2_ROOT/share/sysconfig.xml" ]; then
   exit 1
 fi
 
-# Guard: an embedded-Python libcuemol2 (built with ENABLE_PYTHON_EMBED=ON) installs
-# a Python runtime under <prefix>/lib/python and the native addon depends on it at
-# load time. This script does not stage that runtime, so packaging such a build
-# yields an app that starts then immediately crashes (the worker fails to load
-# libcuemol2). Detect via the install layout (cross-platform) and fail loudly.
-# Rebuild libcuemol2 without ENABLE_PYTHON_EMBED, or implement Python staging
-# (ADR-0030 task 1-3).
-if [ -d "$LIBCUEMOL2_ROOT/lib/python" ]; then
-  echo "Error: libcuemol2 looks like an embedded-Python build" >&2
-  echo "  ($LIBCUEMOL2_ROOT/lib/python exists), but the Python runtime is not" >&2
-  echo "  staged into the bundle, so the packaged app would start and crash." >&2
-  echo "  Rebuild libcuemol2 without ENABLE_PYTHON_EMBED, or implement Python" >&2
-  echo "  staging (ADR-0030 task 1-3)." >&2
+# Guard: an embedded-Python libcuemol2 (built with ENABLE_PYTHON_EMBED=ON) links
+# libpython into its shared library and needs a Python runtime at load time. This
+# script does not stage that runtime, so packaging such a build yields an app that
+# starts then immediately crashes (the worker fails to load libcuemol2).
+#
+# Detect via the *actual link dependency*, not the install layout: cmake bakes the
+# @loader_path/../lib/python rpath and (a prior embed build) leaves <prefix>/lib/python
+# behind even after rebuilding with ENABLE_PYTHON_EMBED=OFF, so neither the rpath nor
+# that directory is a reliable signal. The addon links libpython (it does not dlopen),
+# so a hard load dependency on libpython in libcuemol2's shared library is definitive.
+#
+# libcuemol2_links_python(): 0 = links libpython (embed), 1 = does not, 2 = could not
+# determine (shared lib or an inspection tool -- otool/readelf/objdump -- not found).
+libcuemol2_links_python() {
+  local lib=""
+  case "$PLATFORM" in
+    mac)   lib="$LIBCUEMOL2_ROOT/lib/libcuemol2.dylib" ;;
+    linux) lib="$(ls "$LIBCUEMOL2_ROOT/lib/"libcuemol2.so* 2>/dev/null | head -n1 || true)" ;;
+    win)   lib="$(ls "$LIBCUEMOL2_ROOT/bin/"cuemol2.dll "$LIBCUEMOL2_ROOT/lib/"cuemol2.dll 2>/dev/null | head -n1 || true)" ;;
+  esac
+  [ -n "$lib" ] && [ -f "$lib" ] || return 2
+
+  local deps=""
+  case "$PLATFORM" in
+    mac)
+      command -v otool >/dev/null 2>&1 || return 2
+      deps="$(otool -L "$lib" 2>/dev/null)" || return 2
+      ;;
+    linux)
+      if command -v readelf >/dev/null 2>&1; then
+        deps="$(readelf -d "$lib" 2>/dev/null | grep NEEDED || true)"
+      elif command -v objdump >/dev/null 2>&1; then
+        deps="$(objdump -p "$lib" 2>/dev/null | grep NEEDED || true)"
+      else
+        return 2
+      fi
+      ;;
+    win)
+      command -v objdump >/dev/null 2>&1 || return 2
+      deps="$(objdump -p "$lib" 2>/dev/null | grep -i 'DLL Name' || true)"
+      ;;
+  esac
+
+  printf '%s\n' "$deps" | grep -iq 'python'
+}
+
+if libcuemol2_links_python; then
+  echo "Error: libcuemol2 is an embedded-Python build (its shared library links" >&2
+  echo "  libpython), but this script does not stage the Python runtime, so the" >&2
+  echo "  packaged app would start then immediately crash (worker fails to load" >&2
+  echo "  libcuemol2). Rebuild libcuemol2 without ENABLE_PYTHON_EMBED, or implement" >&2
+  echo "  Python staging (ADR-0030 task 1-3)." >&2
+  exit 1
+elif [ $? -eq 2 ] && [ -d "$LIBCUEMOL2_ROOT/lib/python" ]; then
+  echo "Error: could not inspect libcuemol2's link dependencies (shared library or" >&2
+  echo "  an inspection tool -- otool/readelf/objdump -- not found), and" >&2
+  echo "  $LIBCUEMOL2_ROOT/lib/python exists. Treating as an embedded-Python build" >&2
+  echo "  to be safe. If this is a non-embed build with a stale lib/python dir," >&2
+  echo "  remove that dir or install a binary-inspection tool. (ADR-0030 task 1-3.)" >&2
   exit 1
 fi
 
@@ -77,6 +123,73 @@ rm -rf "$RUNTIME_DEST"
 mkdir -p "$RUNTIME_DEST/share"
 cp -r "$LIBCUEMOL2_ROOT/share/." "$RUNTIME_DEST/share/"
 echo "  share/: $(find "$RUNTIME_DEST/share" -type f | wc -l | tr -d ' ') files"
+
+# --- (1b) external bundle apps (POV-Ray / ffmpeg / apbs-pdb2pqr) + blendpng --
+# The packaged app resolves these from process.resourcesPath (see
+# main/ipcHandlers.ts getRenderBinaries): bundle_apps/povray/{bin,include},
+# bundle_apps/{apbs,ffmpeg}, and cuemol2/bin/blendpng. blendpng ships from the
+# libcuemol2 install tree; the extpkgs come from BUNDLE_APPS (populated by
+# build_scripts: task download_extpkgs). Only POV-Ray + blendpng are wired into
+# tritium today; apbs/pdb2pqr/ffmpeg are staged for uxp_gui parity (future wiring).
+echo "Staging external bundle apps + blendpng"
+
+# Always create the target dirs so electron-builder's extraResources `from`
+# paths exist even when no extpkgs were downloaded (empty -> nothing copied).
+mkdir -p "$RUNTIME_DEST/bin"
+mkdir -p "$RUNTIME_DEST/bundle_apps"
+
+# blendpng (required): built and installed by libcuemol2 into <prefix>/bin.
+BLENDPNG_EXE="blendpng"
+[ "$PLATFORM" = "win" ] && BLENDPNG_EXE="blendpng.exe"
+BLENDPNG_SRC="$LIBCUEMOL2_ROOT/bin/$BLENDPNG_EXE"
+if [ ! -f "$BLENDPNG_SRC" ]; then
+  echo "Error: blendpng not found: $BLENDPNG_SRC" >&2
+  echo "  Build/install libcuemol2 first (build_scripts: task build_libcuemol2)." >&2
+  exit 1
+fi
+cp "$BLENDPNG_SRC" "$RUNTIME_DEST/bin/"
+echo "  blendpng: $BLENDPNG_SRC"
+
+# extpkgs (best-effort): povray / apbs / ffmpeg from BUNDLE_APPS. A missing
+# package is a loud warning, not a failure -- these back optional features and
+# the user can set explicit paths in Settings. Default BUNDLE_APPS to the dev
+# WORKDIR used by build_scripts/Taskfile.yml (run_tritium / download_extpkgs).
+if [ -z "${BUNDLE_APPS:-}" ]; then
+  BUNDLE_APPS="$HOME/tmp/proj64_deplibs"
+  echo "  BUNDLE_APPS not set; defaulting to $BUNDLE_APPS"
+fi
+
+# Copy each package as a whole tree so the per-OS executable names (povray vs
+# povray.exe, apbs vs apbs.exe, pdb2pqr vs pdb2pqr_wrap.bat) are staged without
+# special-casing. The download layout is identical on all OSes:
+# BUNDLE_APPS/{povray/{bin,include}, apbs/{<exe>,pdb2pqr*,dat}, ffmpeg/bin/<exe>}.
+#
+# POV-Ray: bin/{povray[.exe]} + include/ (both consumed by the render pipeline).
+if [ -d "$BUNDLE_APPS/povray" ]; then
+  cp -R "$BUNDLE_APPS/povray" "$RUNTIME_DEST/bundle_apps/"
+  echo "  povray: $BUNDLE_APPS/povray"
+else
+  echo "  Warning: povray not found under $BUNDLE_APPS/povray -- skipping." >&2
+  echo "    Run 'task download_extpkgs'; POV-Ray rendering will otherwise need a" >&2
+  echo "    manual path in Settings." >&2
+fi
+
+# APBS + pdb2pqr (executables + dat/).
+if [ -d "$BUNDLE_APPS/apbs" ]; then
+  cp -R "$BUNDLE_APPS/apbs" "$RUNTIME_DEST/bundle_apps/"
+  echo "  apbs/pdb2pqr: $BUNDLE_APPS/apbs"
+else
+  echo "  Warning: apbs not found under $BUNDLE_APPS/apbs -- skipping (run 'task download_extpkgs')." >&2
+fi
+
+# ffmpeg: bin/{ffmpeg[.exe]}. Strip the macOS-zip-derived __MACOSX junk if present.
+if [ -d "$BUNDLE_APPS/ffmpeg" ]; then
+  cp -R "$BUNDLE_APPS/ffmpeg" "$RUNTIME_DEST/bundle_apps/"
+  rm -rf "$RUNTIME_DEST/bundle_apps/ffmpeg/bin/__MACOSX"
+  echo "  ffmpeg: $BUNDLE_APPS/ffmpeg"
+else
+  echo "  Warning: ffmpeg not found under $BUNDLE_APPS/ffmpeg -- skipping (run 'task download_extpkgs')." >&2
+fi
 
 # --- (2) monorepo deps staging ----------------------------------------------
 echo "Staging monorepo deps"
@@ -180,6 +293,7 @@ assert_file() {
   [ -f "$1" ] || { echo "Error: staging assertion failed -- missing $1" >&2; exit 1; }
 }
 assert_file "$RUNTIME_DEST/share/sysconfig.xml"
+assert_file "$RUNTIME_DEST/bin/$BLENDPNG_EXE"
 assert_file "$STAGING_DEST/@cuemol/core/package.json"
 assert_file "$STAGING_DEST/@cuemol/core/src/index.cjs"
 assert_file "$STAGING_DEST/@cuemol/core/build/Release/cuemol_internal.node"

--- a/tritium/react-gui/electron-builder.yml
+++ b/tritium/react-gui/electron-builder.yml
@@ -108,9 +108,26 @@ files:
 #           sysconfig.xml
 #           data/
 #           ...
+#         bin/
+#           blendpng
+#       bundle_apps/
+#         povray/bin/povray, povray/include/
+#         apbs/{apbs,pdb2pqr,dat/}   (staged for uxp parity; not yet wired)
+#         ffmpeg/bin/ffmpeg          (staged for uxp parity; not yet wired)
 extraResources:
   - from: packaging/cuemol2-runtime/share
     to: cuemol2/share
+    filter:
+      - "**/*"
+  # blendpng (libcuemol2 utility) -> Resources/cuemol2/bin/blendpng
+  - from: packaging/cuemol2-runtime/bin
+    to: cuemol2/bin
+    filter:
+      - "**/*"
+  # external bundle apps (POV-Ray / apbs-pdb2pqr / ffmpeg) -> Resources/bundle_apps/
+  # collect-cuemol2-runtime.sh stages these from BUNDLE_APPS (task download_extpkgs).
+  - from: packaging/cuemol2-runtime/bundle_apps
+    to: bundle_apps
     filter:
       - "**/*"
 

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -78,8 +78,10 @@ function getUserStylePath(): string {
  * fallback when the user has not set an explicit path in Settings.
  *
  * - Packaged: resolved from the app install tree under process.resourcesPath,
- *   mirroring getSysConfigPath. NOTE: staging these binaries into the bundle is
- *   not implemented yet (see ADR-0030); the paths describe the intended layout.
+ *   mirroring getSysConfigPath. On macOS and Windows these are staged into the
+ *   bundle by tritium/packaging/collect-cuemol2-runtime.sh + electron-builder.yml
+ *   extraResources (povray/ffmpeg/apbs from BUNDLE_APPS, blendpng from the
+ *   libcuemol2 install tree). Linux staging is a follow-up (see ADR-0030).
  * - Dev: resolved from the build-output env vars the Taskfile run task exports
  *   -- LIBCUEMOL2_ROOT (cuemol2 install prefix, holds bin/blendpng) and
  *   BUNDLE_APPS (parent of the downloaded povray/ tree). A field is the empty


### PR DESCRIPTION
## Summary

Bundle the external helper apps into the packaged tritium app so POV-Ray
rendering works out of the box, matching `uxp_gui`'s bundle scope
(`src/osxbuild/add_povray.pl.in`: POV-Ray + ffmpeg + apbs/pdb2pqr) but placed
at tritium's Electron layout, which `getRenderBinaries()` already resolves:

- `Resources/bundle_apps/povray/{bin/povray[.exe], include}`
- `Resources/bundle_apps/apbs/{apbs, pdb2pqr, dat}` and `Resources/bundle_apps/ffmpeg/bin/ffmpeg[.exe]` (staged for parity; not yet wired into tritium)
- `Resources/cuemol2/bin/blendpng[.exe]`

Runtime resolution was already implemented; only the packaging/staging side was
missing (see ADR-0030). Covers **macOS + Windows**.

## Changes

- **`collect-cuemol2-runtime.sh`**: stage blendpng (from the libcuemol2 install
  tree) and the extpkgs (whole-tree `cp -R` from `BUNDLE_APPS`, best-effort with
  a warning when absent) into `packaging/cuemol2-runtime/{bin,bundle_apps}`.
  Copying whole package dirs handles per-OS exe names (`povray` vs `povray.exe`)
  without special-casing.
- **`electron-builder.yml`**: add top-level `extraResources` for `cuemol2/bin`
  and `bundle_apps` (applies to mac DMG / win NSIS / linux alike).
- **`Taskfile.yml`**: pass `BUNDLE_APPS` to `package_tritium:darwin`.
- **`build2.yml`**: run `download_extpkgs` **before** the mac and win package
  steps and export `BUNDLE_APPS` so CI artifacts bundle the extpkgs too (the same
  download still feeds the later UXP build).
- **Accurate embedded-Python guard**: detect via libcuemol2's actual libpython
  load dependency (`otool -L` / `readelf -d` / `objdump -p`) instead of the
  presence of `<prefix>/lib/python`, which persists as a false positive after an
  `ENABLE_PYTHON_EMBED` ON->OFF rebuild.
- Docs: ADR-0017, ADR-0030, `packaging/README.md`, `ipcHandlers.ts` comment.

## Verification

- **Local (macOS)**: `collect-cuemol2-runtime.sh` staged blendpng + povray/apbs/ffmpeg
  into the correct layout (exec bits preserved, ffmpeg `__MACOSX` junk stripped);
  the improved guard correctly classifies a non-embed build that still has a stale
  `lib/python` dir.
- **GHA (Windows)**: `workflow_dispatch` full-mode run on this branch
  ([run 29184850768](https://github.com/CueMol/cuemol2/actions/runs/29184850768)).
  The Windows collect log shows all three extpkgs + `blendpng.exe` staged with no
  warnings, `BUNDLE_APPS` resolved correctly under MSYS, and the NSIS installer
  (137 MB) built + uploaded successfully:

  ```
  Staging platform: win
    blendpng: /d/a/cuemol2/cuemol2/target/cuemol2/bin/blendpng.exe
    povray:  /d/a/cuemol2/cuemol2/target/povray
    apbs/pdb2pqr: /d/a/cuemol2/cuemol2/target/apbs
    ffmpeg:  /d/a/cuemol2/cuemol2/target/ffmpeg
  Staging done.
  ```

## Known follow-ups (out of scope)

- Windows `blendpng.exe` may need its dependent DLLs (lcms2, etc.) colocated to
  run (currently placed at the contract path only).
- Linux packaging extpkgs staging.
- tritium-side runtime resolver + UI wiring for apbs/pdb2pqr/ffmpeg (binaries are
  pre-placed only).
- Phase 4 signing/notarization: bundled binaries will need per-binary Developer ID
  signing + `com.apple.security.cs.disable-library-validation` (ADR-0030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
