### PR TITLE
fix(tritium): commit paint-coloring selection edits + collapse empty inspector

### DIFF
--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -531,10 +531,15 @@ const App: React.FC = () => {
                     </Allotment.Pane>
 
                     {/* Right: Inspector */}
+                    {/* Collapse the pane whenever nothing is being inspected
+                        (no target), even if the open flag is still set -- an
+                        empty inspector shows no useful content, so it should not
+                        take space. Selecting a node re-applies a target (via
+                        applyTarget, which also re-opens) and the pane reappears. */}
                     <Allotment.Pane
                       minSize={240}
                       preferredSize={300}
-                      visible={inspectorOpen}
+                      visible={inspectorOpen && inspectorTarget !== null}
                       snap
                     >
                       <InspectorPanel

--- a/tritium/react-gui/src/renderer/__test__/PaintSelCell.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/PaintSelCell.test.tsx
@@ -2,21 +2,16 @@
  * Degrade-detection tests for `PaintSelCell` (Paint table's inline-edit
  * cell that wraps `MolSelList`).
  *
- * Pins the observable contract:
- *   - typing in the input updates the draft only; no commit happens
- *     until focus leaves the cell entirely
- *   - blurring into a sibling inside the cell (e.g. the picker trigger
- *     button) does NOT commit -- prevents stale-draft commits when the
- *     user opens the picker mid-edit
- *   - blurring into the picker popover (rendered in a portal outside the
- *     cell) also does NOT commit -- the popover is "inside the edit"
- *   - blurring out of the cell commits and pushes the value into the
- *     shared selection history
- *   - picking from the popover updates the draft and commits on the
- *     subsequent outside-blur
- *   - Enter on the input commits and blurs
- *   - changing the external `value` prop re-syncs the draft (event-
- *     driven refetch)
+ * Pins the observable commit contract:
+ *   - typing in the input updates the draft only; no commit until blur
+ *   - blurring the input commits the changed value and pushes it to history
+ *   - blurring without a change does not commit
+ *   - picking from the popover commits immediately (regression guard: an
+ *     earlier version swallowed popover picks, so the scene kept the old
+ *     selection)
+ *   - "*" / empty / "none" commits are not pushed to the shared history
+ *   - changing the external `value` prop re-syncs the draft (event-driven
+ *     refetch)
  */
 
 import React from 'react'
@@ -60,15 +55,9 @@ function typeInto(input: HTMLInputElement, value: string): void {
     input.dispatchEvent(new Event('input', { bubbles: true }))
 }
 
-/**
- * Fire a focusout event manually with a chosen `relatedTarget`. jsdom's
- * `.blur()` clears focus but emits a focusout whose `relatedTarget` is
- * always `null`, so to exercise the picker-blur branch we synthesise the
- * event directly.
- */
-function fireBlur(target: HTMLElement, relatedTarget: HTMLElement | null): void {
-    const ev = new FocusEvent('focusout', { bubbles: true, relatedTarget })
-    target.dispatchEvent(ev)
+/** React maps onBlur to the delegated focusout event. */
+function blur(input: HTMLInputElement): void {
+    input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
 }
 
 /** Click a button/menu-item by visible text, searched in document. */
@@ -116,7 +105,7 @@ describe('PaintSelCell', () => {
         unmount()
     })
 
-    it('does NOT commit when focus moves to the picker trigger (sibling inside the cell)', async () => {
+    it('commits + pushes history when the input blurs with a change', async () => {
         const onCommit = vi.fn()
         const { container, unmount } = mountTree(
             <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
@@ -124,112 +113,41 @@ describe('PaintSelCell', () => {
         await flushPromises()
         const input = getInput(container)
         await act(async () => { typeInto(input, 'chain B') })
-        // Clicking the picker trigger mid-edit: input loses focus to the
-        // trigger button, which lives inside the cell wrapper.
-        await act(async () => { fireBlur(input, getTrigger(container)) })
-        expect(onCommit).not.toHaveBeenCalled()
-        unmount()
-    })
-
-    it('does NOT commit when focus moves into the picker popover (portal outside the cell)', async () => {
-        const onCommit = vi.fn()
-        // Simulate the popover portal: a menu item living under the picker's
-        // portal class, which the cell wrapper does not contain.
-        const portal = document.createElement('div')
-        portal.className = 'h3-mol-sel-list-popover'
-        const item = document.createElement('a')
-        portal.appendChild(item)
-        document.body.appendChild(portal)
-        const { container, unmount } = mountTree(
-            <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
-        )
-        await flushPromises()
-        const input = getInput(container)
-        await act(async () => { typeInto(input, 'chain B') })
-        await act(async () => { fireBlur(input, item) })
-        expect(onCommit).not.toHaveBeenCalled()
-        unmount()
-    })
-
-    it('commits + pushes history when focus leaves the cell entirely', async () => {
-        const onCommit = vi.fn()
-        const outside = document.createElement('button')
-        document.body.appendChild(outside)
-        const { container, unmount } = mountTree(
-            <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
-        )
-        await flushPromises()
-        const input = getInput(container)
-        await act(async () => { typeInto(input, 'chain B') })
-        await act(async () => { fireBlur(input, outside) })
+        await act(async () => { blur(input) })
         expect(onCommit).toHaveBeenCalledWith('chain B')
         expect(getHistory()).toContain('chain B')
         unmount()
-        outside.remove()
     })
 
-    it('does not commit when blur exits without a change', async () => {
+    it('does not commit when the input blurs without a change', async () => {
         const onCommit = vi.fn()
-        const outside = document.createElement('button')
-        document.body.appendChild(outside)
         const { container, unmount } = mountTree(
             <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
         )
         await flushPromises()
-        await act(async () => { fireBlur(getInput(container), outside) })
+        await act(async () => { blur(getInput(container)) })
         expect(onCommit).not.toHaveBeenCalled()
         unmount()
-        outside.remove()
     })
 
-    it('picking from the popover updates the draft and commits on outside blur', async () => {
+    it('picking from the popover commits immediately (no blur required)', async () => {
         const onCommit = vi.fn()
-        const outside = document.createElement('button')
-        document.body.appendChild(outside)
         // Seed history so the picker has a real entry to choose.
         globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(['chain Z']))
         const { container, unmount } = mountTree(
             <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
         )
         await flushPromises()
-        // Open the picker, switch to History, pick the seeded entry.
         await act(async () => { getTrigger(container).click() })
         await flushPromises()
         await act(async () => { clickByText('History') })
         await flushPromises()
         await act(async () => { clickByText('chain Z') })
         await flushPromises()
-        // Pick alone does not commit.
-        expect(onCommit).not.toHaveBeenCalled()
-        expect(getInput(container).value).toBe('chain Z')
-        // Focus leaves the cell -> commit the picked value.
-        await act(async () => { fireBlur(getInput(container), outside) })
+        // The pick alone commits -- this is the regression guard.
         expect(onCommit).toHaveBeenCalledWith('chain Z')
+        expect(getInput(container).value).toBe('chain Z')
         unmount()
-        outside.remove()
-    })
-
-    it('Enter on the input commits (via blur)', async () => {
-        const onCommit = vi.fn()
-        const outside = document.createElement('button')
-        document.body.appendChild(outside)
-        const { container, unmount } = mountTree(
-            <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
-        )
-        await flushPromises()
-        const input = getInput(container)
-        await act(async () => { typeInto(input, 'chain B') })
-        const blurSpy = vi.spyOn(input, 'blur').mockImplementation(() => {
-            // Mimic the focusout into `outside` that real blur() would trigger.
-            fireBlur(input, outside)
-        })
-        await act(async () => {
-            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
-        })
-        expect(blurSpy).toHaveBeenCalled()
-        expect(onCommit).toHaveBeenCalledWith('chain B')
-        unmount()
-        outside.remove()
     })
 
     it('re-syncs the draft when the value prop changes (event-driven refetch)', async () => {
@@ -246,21 +164,18 @@ describe('PaintSelCell', () => {
         unmount()
     })
 
-    it('does not push history for empty / "*" / "none" commits', async () => {
+    it('does not push history for "*" commits (but still commits)', async () => {
         const onCommit = vi.fn()
-        const outside = document.createElement('button')
-        document.body.appendChild(outside)
         const { container, unmount } = mountTree(
             <PaintSelCell sceneID={1} value="chain A" onCommit={onCommit} />,
         )
         await flushPromises()
         const input = getInput(container)
         await act(async () => { typeInto(input, '*') })
-        await act(async () => { fireBlur(input, outside) })
+        await act(async () => { blur(input) })
         expect(onCommit).toHaveBeenCalledWith('*')
         expect(getHistory()).not.toContain('*')
         unmount()
-        outside.remove()
     })
 
     it('forwards molID to MolSelList getSelDefs', async () => {

--- a/tritium/react-gui/src/renderer/components/panes/PaintSelCell.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/PaintSelCell.tsx
@@ -5,27 +5,26 @@
  *
  * Replaces the plain `<input>` used in the selection column with a full
  * `MolSelList` (free-text InputGroup + caret button opening a Named/History
- * picker popover). The wrapper preserves the Paint table's existing
- * blur-commit semantics:
+ * picker popover).
  *
- *   - Keystrokes update a local `draft` state only; the worker is not
- *     touched until the user moves focus out of the cell.
- *   - Focus shifts *within* the cell (e.g. clicking the picker trigger
- *     while the input is focused) must NOT commit -- otherwise an
- *     in-progress edit would be flushed with the stale draft before the
- *     picker selection has updated it. We detect this by checking
- *     whether the blur's `relatedTarget` is contained in the cell.
- *   - The picker menu renders in a portal *outside* the cell, so focus
- *     moving into it (`.h3-mol-sel-list-popover`) is also treated as staying
- *     inside the edit -- otherwise opening the picker would prematurely
- *     commit the draft.
- *   - Enter on the input commits and blurs (matches the other inline
- *     editors).
- *   - Successful commits push the value to the shared selection history
- *     (same store the `MolSelList` picker reads from).
+ * Commit semantics are owned by `MolSelList`, which fires `onCommit` for
+ * BOTH of the ways a selection is finalised:
+ *   - the free-text input losing focus (blur), and
+ *   - picking an entry from the Named/History popover.
+ *
+ * Keystrokes only update the local `draft` (via `onSelectedSelChange`); the
+ * worker is not touched until one of the commit events above. We de-duplicate
+ * against the last-known `value` so an unchanged blur (e.g. opening the
+ * picker without editing) neither spams the worker nor pollutes the shared
+ * selection history.
+ *
+ * @remarks An earlier version committed only from a wrapper-level blur handler
+ * that deliberately ignored focus moving into the popover portal -- which meant
+ * a value chosen from the picker was never committed (the scene kept the old
+ * selection). Delegating to `MolSelList.onCommit` fixes that.
  */
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { MolSelList, pushHistory } from '../../h3-kit/MolSelList'
 
 export interface PaintSelCellProps {
@@ -34,9 +33,9 @@ export interface PaintSelCellProps {
     molID?: number
     value: string
     /**
-     * Called once the user finishes editing (blur outside the cell, or
-     * Enter on the input). `next` may equal `value`, in which case the
-     * caller may decide to no-op.
+     * Called once the user finishes editing (input blur or popover pick).
+     * `next` always differs from the current `value` (unchanged commits are
+     * filtered out here).
      */
     onCommit: (next: string) => void
     /** Fired when any focusable child gains focus (row-select hook). */
@@ -58,46 +57,31 @@ export const PaintSelCell: React.FC<PaintSelCellProps> = ({
 }) => {
     const [draft, setDraft] = useState(value)
     // Re-sync when the underlying entry value changes underneath us
-    // (event-driven refetch). Mirrors the local-buffer reset logic in
-    // PaintTable's parent-level draft state.
+    // (event-driven refetch).
     useEffect(() => {
         setDraft(value)
     }, [value])
 
-    const handleBlur = (e: React.FocusEvent<HTMLDivElement>): void => {
-        const related = e.relatedTarget as HTMLElement | null
-        // Blur into a sibling inside the cell (e.g. the picker trigger) is not
-        // a real exit -- ignore so the in-progress draft is not committed
-        // prematurely.
-        if (e.currentTarget.contains(related)) return
-        // The picker menu renders in a portal outside the cell; focus moving
-        // into it is also "inside the edit", not a real exit.
-        if (related && related.closest('.h3-mol-sel-list-popover')) return
-        if (draft === value) return
-        onCommit(draft)
-        pushHistory(draft)
-    }
-
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-        if (e.key !== 'Enter') return
-        const t = e.target as HTMLElement
-        // Only the free-text input commits on Enter.
-        if (t.tagName !== 'INPUT') return
-        t.blur()
-    }
+    const handleCommit = useCallback(
+        (next: string): void => {
+            // Skip no-op commits (e.g. blurring the field without editing, or
+            // re-picking the current value) so the worker and the selection
+            // history are only touched on real changes.
+            if (next === value) return
+            onCommit(next)
+            pushHistory(next)
+        },
+        [onCommit, value],
+    )
 
     return (
-        <div
-            className="color-paint-sel-cell"
-            onBlur={handleBlur}
-            onFocus={onFocus}
-            onKeyDown={handleKeyDown}
-        >
+        <div className="color-paint-sel-cell" onFocus={onFocus}>
             <MolSelList
                 sceneID={sceneID}
                 molID={molID}
                 selectedSel={draft}
                 onSelectedSelChange={setDraft}
+                onCommit={handleCommit}
                 refreshKey={refreshKey}
                 showSelectionIcon={false}
                 fill


### PR DESCRIPTION
## Summary

Two independent tritium (react-gui) fixes, one commit each.

### 1. Paint coloring: selection edits from the picker are now committed
The Paint coloring table's selection cell relied on its own wrapper blur
handler, which intentionally skipped commits when focus moved into the
`MolSelList` picker popover. So a selection chosen from the Named/History
popover (e.g. `sheet` / `helix`) was **never sent to the worker**: the panel
showed the new value via its local draft while the scene kept the old
selection, and reordering a row (↑/↓) moved the color but not the
never-persisted selection.

Fix: delegate commits to `MolSelList.onCommit`, which fires for both the
free-text input blur and a popover pick (deduping no-op commits against the
current value). This was diagnosed from runtime `[PAINT-DBG]` logging that
showed the selection commit was skipped (`blur SKIP: related in popover`) and
`updatePaintEntry(selStr)` was never invoked, while color edits committed fine.

### 2. Inspector pane collapses when nothing is inspected
Bind the inspector `Allotment` pane's visibility to *having a target*, not just
the open flag, so an empty inspector no longer takes horizontal space showing
"No node selected.". Selecting a node re-applies a target (which also re-opens)
and the pane reappears.

## Testing
- `PaintSelCell` degrade-detection tests updated to pin that a popover pick
  commits immediately.
- `cd tritium/react-gui && npm test` — passing.
- `npx tsc -p tsconfig.web.json --noEmit` — no new errors.
- `npm run build` (electron-vite production bundle) — OK.
- Manually verified in the running app: picking `sheet`/`helix` now recolors
  the scene and ↑/↓ moves the selection together with the color; the inspector
  collapses when no node is selected.

## Notes
An earlier, more speculative change (partial `updatePaintEntry` writes so a
stale panel snapshot could not clobber the un-edited field) was reverted after
manual testing showed the race it guarded against does not occur in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
