### PR TITLE
feat(molstr): line-renderer coordinate-texture direct update (phase 3a/3b: Selection, Trace)

### DIFF
--- a/docs/plans/260718-line-cyl-coord-texture-direct-update-phase3-plan.md
+++ b/docs/plans/260718-line-cyl-coord-texture-direct-update-phase3-plan.md
@@ -1,0 +1,294 @@
+# 実装計画: 線・円柱系レンダラの座標テクスチャ direct update (Phase 3)
+
+Phase 1 (CPK, PR #441 / commit `8fc30dd0`) で確立した座標テクスチャ direct update を、線・円柱系のレンダラへ展開する。頂点シェーダが原子 index で座標テクスチャを `texelFetch` し、座標変化時はテクスチャ更新だけで済ませる方式を、`SelectionRenderer` / `TraceRenderer` / `BallStickRenderer` / `SimpleRenderer` に広げる。
+
+**Phase 3 のマイルストーン: 汎用の index 版線プリミティブ `gfx::LineIdxGpuPrim` と円柱プリミティブ `gfx::CylinderIdxGpuPrim` を新設し、上記 4 レンダラを direct update 化する。** valence (二重/三重結合) を持たない Selection/Trace/BallStick を先に片付け、valence が生きている SimpleRenderer を最後に回す。
+
+Phase 2 (`AnimMol` / `Trajectory` / DCD reader) は別計画。Phase 3 は Phase 2 と独立に進められる。
+
+---
+
+## 0. 前提・規約
+
+- Phase 1 plan (`docs/plans/260717-cpk-coord-texture-direct-update-plan.md`) の §0 と同じ。コードコメントは英語 ASCII、文字列は英語、コミットは英語で `Co-Authored-By` 無し、ビルド/テストは Taskfile の task を使う。
+- 2 つの作業ツリーを参照する (Phase 1 と同一)。
+
+| 役割 | パス | ブランチ | 位置づけ |
+|---|---|---|---|
+| **実装先** | `/Users/user1/proj64/cuemol2` | `develop` | CMake ビルド。tritium (Electron/WebGL2) を含む現行本流 |
+| **参照実装** | `/Users/user1/proj64/cuemol2_png` | `dev201608` | autotools の 2016-2018 レガシー。**読むだけ。変更しない** |
+
+- 性能測定は Release ビルドで行う (Ninja 単一構成なので `task rebuild_libcuemol2 CONFIG=Release` / `task build_tritium CONFIG=Release` で再構成が要る。`perf.ts` の `PERF_MEASURE` トグル)。
+- direct update の目視・性能検証は **tritium のみ**。native (Oc 系) はビルドが通ることだけ確認 (uxp_gui は起動しない)。Phase 1 と同じ方針。
+
+---
+
+## 1. 目的とマイルストーン
+
+### 解決する問題
+
+Phase 1 で CPK は座標変化時の全再構築が消えたが、同じシーンに同居する線・円柱系レンダラは依然として `atomsMoved` のたびに全再構築される。特に `SelectionRenderer` は Phase 1 のテストシーンに同居しており「床」として残っている (Phase 1 plan §7.4)。
+
+### Phase 3 のゴール
+
+- 汎用の index 版線プリミティブ `gfx::LineIdxGpuPrim` を新設し、`SelectionRenderer` / `TraceRenderer` / `SimpleRenderer` の線描画を direct update 化する
+- index 版円柱プリミティブ `gfx::CylinderIdxGpuPrim` を新設し、`BallStickRenderer` のスティックを direct update 化する。ボールは Phase 1 の `gfx::SphereIdxGpuPrim` を再利用する
+- `MolCoord` / `MolAtom` / `MorphMol` / `AnimMgr` を変更しない (Phase 1 と同じ制約)
+- 各レンダラ単独のシーンで、変更前後の描画一致と、再構築が消えることを確認する
+
+### Phase 3 で意図的にやらないこと
+
+- Spline / Tube への展開 (係数テクスチャが必要な別課題。Phase 1 plan §8.2)
+- `AnimMol` の導入と、レンダラ間での座標テクスチャ共有 (Phase 2)。Phase 3 では **レンダラごとに 1 枚所有**する (§4.4)
+- `SelectionRenderer` の `MODE_POINT` (点スプライト描画)。当面レガシー経路のまま (§4.8)
+- `BallStickRenderer` の dead な valence コードの移植・削除 (§4.9)
+
+---
+
+## 2. 背景 — Phase 1 で確立した基盤
+
+Phase 3 はこれらを土台にする。すべて `develop` (PR #441) に存在する。
+
+- **`gfx::FloatDataTexture`** (`src/gfx/FloatDataTexture.hpp`): 可変 RGB32F データテクスチャ抽象。`DisplayContext::createFloatDataTexture()` で生成 (既定 `nullptr` → 従来経路フォールバック)。バックエンドは `OcFloatDataTexture` (native) と `EcFloatDataTexture` (WebGL2)。TS 側 peer API は `createFloatDataTexture` / `updateFloatDataTexture` (`TextureStore.ts` / `gfx_manager.ts`)。
+- **`gfx::SphereIdxGpuPrim`** (`src/gfx/SphereIdxGpuPrim.{hpp,cpp}`): index 版球インポスタ。`setData(i, idx, rad, devcode)` で index を積み、`setCoordTex(tex, unit)` でテクスチャを bind。**BallStick のボールでそのまま再利用する。**
+- **シェーダ基盤**: `src/sysdep/ogl_core/lib_atoms.glsl` の `getAtomPos(tex, ind)` / `getAtomPos3(tex, ind)` (sampler2D + 幅 `TEX2D_WIDTH=1024` 折り返し、`texelFetch`)。body + `#define` 違いの薄いラッパ 2 ファイルで direct/idx を出し分ける (`sphere2_body_vert.glsl` + `sphere2_vertex.glsl` / `sphere2idx_vertex.glsl`)。ビルド時に C プリプロセッサで解決 (`src/glsl.cmake`)。
+- **レンダラ側パターン** (`CPK2Renderer`):
+  - `renderCoordTexImpl(pdc)`: VBO (index/半径/色) と座標テクスチャを **初回 1 回だけ**構築。`m_aidcache` に AID を記録。
+  - `updateCoordTex()`: 座標だけ再収集して `texSubImage2D`。`display()` からダーティ時に 1 回だけ呼ぶ。
+  - `objectChanged()`: `OBE_CHANGED` + `descr=="atomsMoved"` でダーティフラグ + `setUpdateFlag()`。GL は叩かない。
+  - `display()`: ダーティなら `updateCoordTex()` を 1 回、その後ドロー。`createFloatDataTexture()` が `nullptr` なら従来 GpuPrim にフォールバック。
+
+---
+
+## 3. 調査で判明した事実 (実コードで確認済み)
+
+### 3.1 現 develop の線は「三角形化した幅付き線」
+
+`gfx::LineGpuPrim` は `DRAW_TRIANGLES` + `setNumInstances(nlines)` の真のインスタンシング (`src/gfx/LineGpuPrim.cpp:61-62`)。シェーダ `linew2_vert.glsl` (`:38` でロード) が、2 端点属性 `a_vertex1` / `a_vertex2` + bicolor `a_color1` / `a_color2` から、`screenSize` / `lineWidth` uniform を使って**スクリーン空間で幅 quad を展開**する (`a_index` が quad の 4 隅を選ぶ)。
+
+core profile / WebGL2 では**太い `GL_LINES` 自体がサポートされない** (lineWidth が 1 にクランプされる)。したがって幅を出すには三角形 quad が必須で、細線に戻す選択肢はない。
+
+**帰結**: 参照実装 (dev201608) の座標テクスチャ線経路は **`GL_LINES` (細線・2 頂点/線)** 前提だったので (§3.5)、素直な移植はできない。**`linew2_vert.glsl` の幅 quad 展開と `lib_atoms.glsl` の `texelFetch` を 1 つのシェーダに合体**させる必要がある。これが Phase 3 の中核的な新規シェーダ作業。
+
+### 3.2 `SelectionRenderer` — 即時描画だが GPU 上は LineGpuPrim・単色・アスター
+
+- `MolAtomRenderer` を継承し、`rendAtom` / `rendBond` で **DisplayContext 即時描画** (`pdl->vertex`)。この即時描画は display-list バックエンドが **`LineGpuPrim` にコンパイル**する (`src/gfx/DisplayList.cpp:302`)。レンダラ自身は GpuPrim / シェーダ経路を持たない。
+- **単色**: `beginRend` で `pdl->color(m_color)` を一度だけ (`SelectionRenderer.cpp:112`)。bicolor なし。
+- **結合**: `drawSelInterAtomLine` → `vertex(pos1); vertex(pos2);` (`:80-87`)。1 本線。
+- **孤立原子 (非結合のみ)**: `rendAtom` は `if (!fbonded)` のとき `drawSelAtom` → **`drawAster(pos, 0.25)`** (`:89-92, 127-138`)。`drawAster` は model 空間の X/Y/Z 軸に沿った ±rad の**3 本線** (`DisplayContext.hpp` の実装、`pos±Xr` / `pos±Yr` / `pos±Zr`)。
+- **モード**: `MODE_STICK` (`m_nMode==0`, 線) と `MODE_POINT` (`m_nMode==1`, `startPoints` の点スプライト) の 2 モード (`:102-138`)。
+- **`objectChanged`**: `OBE_PROPCHG` + `"sel"` しか特別扱いせず、`atomsMoved` は `super_t` に落ちて全 invalidate (`:178-188`)。direct update 用のフックが無い。
+
+### 3.3 `TraceRenderer` — 残基 (CA) 連結の線・valence なし
+
+- 自前 VBO `m_pVBO` (`gfx::DrawElemVC`) を `DRAW_LINES` で持ち (`TraceRenderer.cpp:161`)、`pdl->vertex(curpt)` で残基 (CA) を連結する (`:109`)。valence なし。
+
+### 3.4 `BallStickRenderer` — 既にシェーダ経路あり・valence は dead code
+
+- CPK と同型のシェーダ経路: `m_pSphGpuPrim` (`SphereGpuPrim`) + `m_pCylGpuPrim` (`CylinderGpuPrim`)、`m_bUseShader`、`renderShaderImpl` (`BallStickRenderer.cpp:32-33, 438`)。`display()` の末尾で 2 プリミティブを別ドローする。
+- **`renderShaderImpl` は valence を扱わない** (`:438-555`)。全結合を**単一円柱**として `m_pCylGpuPrim->setData(i, pos1, pos2, bondw, devcode)` に積むだけ (bicolor は中点で 2 分割)。`getType()` / `DOUBLE` / `TRIPLE` を見ていない。
+- valence コード (`drawVBondType1` の `getDblBondDir`, `:210-227`) は**即時描画経路 `rendBond` からのみ**呼ばれ、`display()` が `isFile() || m_nVBMode!=VBMODE_OFF` のときだけそこに入る (`:49-51`)。**通常のシェーダ描画では dead**。
+- `CylinderGpuPrim::setData(i, pos1, pos2, bondw, devcode)` は 2 端点を受け取る。
+
+**帰結**: BallStick の座標テクスチャ化は **valence 不要**。ボールは `SphereIdxGpuPrim` 再利用、スティックは `CylinderIdxGpuPrim` (2 端点 index) で、CPK の自然な拡張になる。
+
+### 3.5 `SimpleRenderer` — シェーダ経路の valence が live・参照は ind_d 方式
+
+- シェーダ経路 `renderShaderImpl` (`SimpleRendererGLSL.cpp:49`) が **valence を実描画**する。`m_bValBond` (既定 `true`, `SimpleRenderer.cpp:29`) + `getDblBondDir` で二重/三重の平行線を描く (`SimpleRendererGLSL.cpp:76-138`)。`m_lineGpuPrim` を使う。
+- `objectChanged` は既に `atomsMoved` で `m_lineGpuPrim.invalidate()` している (`:218-230`) が、これは「次 display で全再構築」であって direct update ではない。
+- **参照実装 (dev201608) は valence をアニメ正確に実装していた**。`dblbon_vert.glsl` が `a_ind` = ivec3 (ind1, ind2, **ind_d**) を受け取り、`getNormalVec(pos1, pos2, posd)` で**シェーダ内**にオフセット方向を計算する (3 点とも texture から fetch するので分子が動いても方向が追従)。専用シェーダ `gpu_dblbonrend` + 専用 VBO (`SimpleRendGLSL.cpp:138, 399-432`)。主経路は `DRAW_LINES` (GL_LINES, `:320, 416`)。`simple_vertex.glsl` は `a_ind12` = ivec2 で、`ind2<0` を孤立原子アスター、`ind2>=0` を結合にエンコードしていた (`:28, 55-60`)。
+
+**帰結**: SimpleRenderer だけが concern 2 (二重結合オフセット) を持つ。参照の ind_d 方式が移植の下敷きになる。ただし GL_LINES 前提なので、幅 quad 展開 (§3.1) と合体させる必要がある。
+
+### 3.6 結合・アスターは AID→テクセル index マップが要る
+
+CPK は「`AtomIterator` の列挙順 i = テクセル index」で済んだ (Phase 1 §3.4)。だが Selection/Simple の**結合**、BallStick の**円柱**は原子を AID で参照して列挙するため、「列挙順 = index」が成立しない。アスターも AID 参照。したがって **`AID → テクセル index` のマップ**が要る (参照実装の `SimpleRendGLSL` の `m_sels` に相当)。
+
+---
+
+## 4. 設計方針 (確定事項)
+
+以下は設計議論の結果、確定した決定である。実装時に再検討しないこと。異論があれば実装を止めて相談。
+
+### 4.1 shader はプリミティブ単位。複合レンダラに統合シェーダを作らない
+
+Phase 1 plan §8.3 の方針を踏襲。BallStick のように複数プリミティブを複合するレンダラは、**統合シェーダを書かず、各プリミティブの index 版を再利用し、1 枚の共有座標テクスチャを bind する**。理由:
+
+- 現 BallStick も既に球・円柱の 2 シェーダ・2 ドローで、統合シェーダを持たない
+- 球 (ビルボード quad) と円柱 (円柱インポスタ) は頂点レイアウトも frag レイキャストも別物で、統合すると per-vertex type 分岐 + union レイアウトが必要になり複雑化するだけ。GPU はどのみち別ドロー
+- 統合シェーダにすると CPK が同じ球シェーダを再利用できなくなる
+
+### 4.2 `gfx::LineIdxGpuPrim` = 「index + 静的オフセット」を持つ汎用幅線プリミティブ
+
+`LineGpuPrim` を雛形に、真のインスタンシング (`setNumInstances` + `DRAW_TRIANGLES`) を踏襲。**各端点を「テクセル index + model 空間の静的オフセット」で表す**。`LineGpuPrim` の `a_vertex1` / `a_vertex2` (vec4) をそのまま再利用し、**`xyz = offset`, `w = index`** にパッキングする (属性レイアウトを最小限しか変えない)。
+
+シェーダ (body 分割、§4.7): `pos = getAtomPos3(coordTex, int(a_p1.w)) + a_p1.xyz;` を端点ごとに行い、その後 `linew2_vert.glsl` と同じスクリーン空間幅 quad 展開 + bicolor。これで以下が同一プリミティブ・同一シェーダで表せる:
+
+| 描くもの | 端点データ (index, offset) |
+|---|---|
+| 結合線 | `(idx1, 0)`, `(idx2, 0)` |
+| 孤立原子アスター | 3 本線、全端点が**同じ idx**: `(idx, -X·r),(idx, +X·r)` / Y / Z |
+| 二重結合の静的オフセット版 (§4.6 の fallback) | `(idx1, dvd·s),(idx2, dvd·s)` |
+
+**アスターが特別扱い不要な理由**: `drawAster` のオフセットは model 空間の軸固定・静的なので、原子がアニメで動いても十字マーカーは軸固定サイズで追従する。シェーダ内計算も stale も無い。参照実装は負 index の符号トリック + シェーダ内方向テーブルでアスターを分岐処理していたが、**「index + 静的オフセット」ならオフセットは単なるデータ**で、シェーダは分岐なしの汎用のまま (参照より綺麗)。
+
+### 4.3 `gfx::CylinderIdxGpuPrim` = 2 端点 index の円柱。ボールは SphereIdxGpuPrim 再利用
+
+`CylinderGpuPrim` を雛形に、`setData(i, idx1, idx2, radius, devcode)` で 2 端点 index を積む。シェーダで `pos1 = getAtomPos3(idx1); pos2 = getAtomPos3(idx2);` を fetch し、既存の円柱インポスタ展開に流す。bicolor は現 BallStick と同じく中点 2 分割 (2 インスタンス) でよい。offset は Phase 3 の BallStick では不要 (単一円柱のみ) なので持たせない。
+
+BallStick のボールは Phase 1 の `SphereIdxGpuPrim` を**そのまま再利用**。
+
+### 4.4 座標テクスチャは「レンダラごとに 1 枚」所有し、レンダラ内の複数プリミティブで共有する
+
+- 1 レンダラ内 (BallStick の球+円柱、Selection の結合+アスター) は**同じ 1 枚**を共有する。レンダラがテクスチャを所有し、各プリミティブに `setCoordTex(tex, unit)` で渡す (2 回アップロードしない)。
+- **レンダラ間の共有はしない**。1 分子に CPK と BallStick が付けば座標を 2 枚持つ (Phase 1 と同じ割り切り)。これを 1 枚に集約するのは Phase 2 (`AnimMol` が所有権を持つ、Phase 1 plan §8.4)。Phase 3 では per-renderer 所有を維持し、複雑化しない。
+
+### 4.5 `AID→テクセル index` マップをレンダラが持つ
+
+レンダラが `renderCoordTexImpl` で「テクセル layout に載せる原子リスト (= `m_aidcache`)」と「`AID → index` の逆引きマップ (`std::unordered_map<int,int>` 等)」を構築する。結合/円柱/アスターはこのマップで各原子の index を引く。Phase 2 で `AnimMol::getCrdArrayInd(aid)` が入れば、このマップは不要になる (インターフェースは変えない)。
+
+### 4.6 SimpleRenderer の二重結合: ind_d 方式を目標、静的オフセットを v1 fallback として許容
+
+- **目標 (アニメ正確)**: 参照の ind_d 方式。二重/三重結合ごとに「方向決定用の第 3 原子」の index を build 時に取り出し、シェーダで `getNormalVec` により垂線を計算する。分子が動いても方向が追従する。
+- **build 時の課題**: 現 `MolBond::getDblBondDir` は内部で `getNormalVec(pAtom1, pAtom2, this, pMol, nb1, bOK1)` が参照隣接原子を選ぶ。その原子の AID をきれいに取り出せるか要検証 (方向ベクトルでなく参照原子 index を返す小さなヘルパを足す)。
+- **v1 fallback**: `getDblBondDir` の CPU 計算値を `LineIdxGpuPrim` の静的オフセット (§4.2) に焼く。実装は楽だが、アニメ中にオフセット方向が model 空間で凍る (小さな morph では目立たない、大きな回転では誤差)。`LineIdxGpuPrim` の offset がそのまま使えるので **ほぼ無料**。まず fallback で SimpleRenderer を成立させ、その後 ind_d に上げる段階化が可能。
+
+### 4.7 シェーダ body 分割 (Phase 1 の sphere2 と同型)
+
+`linew2_vert.glsl` と円柱シェーダを、Phase 1 の `sphere2_body_vert.glsl` と同じく **共通 body + `#define USE_COORD_TEX` 違いの薄いラッパ 2 ファイル**に分割する。direct 版は `a_vertex1/2` をそのまま、idx 版は `a_p1/2` を `getAtomPos3(int(.w)) + .xyz` で解決。`SHADER_DEPS` / `SHADER_INCLUDE_DIRS` の追記は Phase 1 と同じ手順。実ファイル名 (`linew2_vert.glsl` vs 生成物 `linew_vert.glsl`) は実装時に確認する。
+
+### 4.8 `SelectionRenderer` の `MODE_POINT` はレガシー維持
+
+点スプライト描画は線プリミティブで表せない。当面 `MODE_POINT` はレガシー経路 (即時描画→display-list) のまま残す。将来 `PointIdxGpuPrim` を作るのは別課題。`MODE_STICK` (既定・主用途) を `LineIdxGpuPrim` で direct update 化する。
+
+### 4.9 `BallStickRenderer` の dead valence コードは触らない
+
+`drawVBondType1` / `getDblBondDir` 経路は `isFile() || VBMODE!=OFF` のときだけ生きている。座標テクスチャ化では移植不要。POV-Ray 等のファイル出力経路がまだ使う可能性があるので**削除もしない** (触らない)。
+
+---
+
+## 5. 成果物サマリ
+
+sub-phase ごとに区切って実装・検証・コミットする (Phase 1 と同じく、各段でビルドと目視/性能を確認)。
+
+### Phase 3a: `LineIdxGpuPrim` + シェーダ + SelectionRenderer (MODE_STICK)
+
+| 層 | ファイル | 種別 |
+|---|---|---|
+| gfx prim | `src/gfx/LineIdxGpuPrim.hpp` / `.cpp` | 新規 |
+| gfx build | `src/gfx/CMakeLists.txt` | 変更 |
+| shader | 線 body (`linew2_body_vert.glsl` 等) + direct/idx ラッパ | 新規/変更 |
+| shader build | `src/gfx/CMakeLists.txt` or 該当 GLSL_SHADER_FILES | 変更 |
+| renderer | `src/modules/molstr/SelectionRenderer.hpp` / `.cpp` | 変更 (renderCoordTexImpl/updateCoordTex/objectChanged/display + AID map) |
+
+### Phase 3b: TraceRenderer
+
+| 層 | ファイル | 種別 |
+|---|---|---|
+| renderer | `src/modules/molstr/TraceRenderer.hpp` / `.cpp` | 変更 (LineIdxGpuPrim 再利用) |
+
+### Phase 3c: `CylinderIdxGpuPrim` + BallStickRenderer
+
+| 層 | ファイル | 種別 |
+|---|---|---|
+| gfx prim | `src/gfx/CylinderIdxGpuPrim.hpp` / `.cpp` | 新規 |
+| gfx build | `src/gfx/CMakeLists.txt` | 変更 |
+| shader | 円柱 body + direct/idx ラッパ | 新規/変更 |
+| renderer | `src/modules/molvis/BallStickRenderer.hpp` / `.cpp` | 変更 (球=SphereIdxGpuPrim 再利用, 円柱=CylinderIdxGpuPrim, 共有テクスチャ, AID map) |
+
+### Phase 3d: SimpleRenderer (最難関)
+
+| 層 | ファイル | 種別 |
+|---|---|---|
+| shader | 二重結合 idx シェーダ (ind_d 版) | 新規 (ind_d 採用時) |
+| core | `MolBond` に方向原子 index を返すヘルパ | 変更 (ind_d 採用時, 要検証) |
+| renderer | `src/modules/molstr/SimpleRenderer*.cpp` | 変更 (LineIdxGpuPrim 再利用 + valence) |
+
+**変更しないファイル (重要)**: `MolCoord.*`, `MolAtom.*`, `MorphMol.*`, `AnimMgr.*`, `SphereGpuPrim.*`, `LineGpuPrim.*` (direct 版として残す), `CylinderGpuPrim.*`, `EcBufferRep.*`, Phase 1 の `FloatDataTexture` / `SphereIdxGpuPrim` (再利用のみ)。
+
+---
+
+## 6. 実装手順
+
+Phase 1 の `CPK2Renderer` の実装 (`renderCoordTexImpl` / `updateCoordTex` / `objectChanged` / `display` の 4 点セット + フォールバック) を各レンダラの雛形にする。
+
+### Step 3a-1: `gfx::LineIdxGpuPrim`
+
+`LineGpuPrim` を雛形に新規作成 (§4.2)。per-instance に `a_p1` / `a_p2` (vec4, xyz=offset/w=index) + `a_color1` / `a_color2`。`init()` で idx 版線シェーダをロード、`alloc(pDC, nlines)`、`setData(i, idx1, off1, idx2, off2, col1, col2)`、`setCoordTex(tex, unit)`、`draw()` で coordTex bind + `u_coordTex` uniform。`invalidate()` / `isValid()` / `getSize()`。
+
+### Step 3a-2: 線シェーダの body 分割 (§4.7)
+
+`linew2_vert.glsl` を body + direct/idx ラッパに分割。idx 版は `#include <lib_atoms.glsl>` して端点を `getAtomPos3(int(a_p1.w)) + a_p1.xyz` で解決、その後既存の幅 quad 展開へ。**確認**: `processed_shaders/` に direct 版 (`a_vertex1`) と idx 版 (`u_coordTex` / `texelFetch`) が正しく展開されること。
+
+### Step 3a-3: `SelectionRenderer` の direct update 化
+
+1. `SelectionRenderer.hpp` に `m_lineIdxGpuPrim` / `m_pCoordTex` / `m_coordbuf` / `m_aidcache` / `m_aid2idx` / dirty フラグを追加 (CPK と同型 + AID map)。
+2. `renderCoordTexImpl(pdc)`: `AtomIterator` で描画対象原子を列挙し `m_aidcache` / `m_aid2idx` を構築、座標テクスチャに書く。結合 (`BondIterator`) は `m_aid2idx` で index を引いて `setData(i, idx1, 0, idx2, 0, m_color, m_color)`。孤立原子 (非結合) は `drawAster` 相当を 3 本の instance として `setData` (同一 idx + ±軸オフセット)。`createFloatDataTexture()` が `nullptr` ならフォールバック。
+3. `updateCoordTex()`: `m_aidcache` の座標だけ再収集して `texSubImage2D`。
+4. `objectChanged()`: `atomsMoved` でダーティ + `setUpdateFlag()` + `invalidateHittestCache()`。GL を叩かない。
+5. `display()`: `MODE_STICK` かつ座標テクスチャ経路が使えるときに idx 経路、ダーティなら `updateCoordTex()` 1 回 → ドロー。`MODE_POINT` と `isFile()` は従来経路。
+6. **tritium で検証**: Phase 1 のテストシーンで再生し、SelectionRenderer 由来の再構築が消えること (§7)。
+
+### Step 3b: `TraceRenderer`
+
+`LineIdxGpuPrim` を再利用。残基 (CA) を列挙して `m_aidcache` / `m_aid2idx` を作り、連続 CA を `setData(i, idxA, 0, idxB, 0, ...)` で結ぶ。valence なしなので Selection より単純。
+
+### Step 3c: `CylinderIdxGpuPrim` + `BallStickRenderer`
+
+1. `CylinderIdxGpuPrim` を `CylinderGpuPrim` 雛形に新規 (§4.3)。円柱シェーダも body 分割。
+2. `BallStickRenderer` の `renderShaderImpl` を idx 版に:ボールは `SphereIdxGpuPrim` (Phase 1 の `setData(i, idx, rad, devcode)`)、円柱は `CylinderIdxGpuPrim` (`setData(i, idx1, idx2, bondw, devcode)`)。**1 枚の座標テクスチャを両プリミティブに `setCoordTex`** (§4.4)。`updateCoordTex` は 1 枚を更新。
+3. valence は無視 (現 `renderShaderImpl` と同じ、§3.4)。dead コードは触らない。
+
+### Step 3d: `SimpleRenderer`
+
+1. まず **valence 無効 (単線のみ)** で `LineIdxGpuPrim` に載せ、bicolor (中点)・孤立原子アスターを成立させる (Selection の実装が下敷き)。
+2. 次に二重/三重結合を追加。まず §4.6 の **v1 fallback (静的オフセット)** で成立させる (`LineIdxGpuPrim` の offset に `getDblBondDir` を焼く)。
+3. 余力があれば **ind_d 方式**へ (方向原子 index を build 時に抽出、シェーダ内 `getNormalVec`)。`MolBond` のヘルパ追加が要るか実装時に判断。
+
+---
+
+## 7. 受け入れ条件と検証
+
+各 sub-phase で以下を確認する (Phase 1 §7 と同じ枠組み)。
+
+1. 対象レンダラ**単独**のシーンで、変更前後の描画が視覚的に同一 (色・線幅・アスター・二重結合・シルエット)
+2. 再生中に `renderCoordTexImpl()` が再実行されない (ログで確認)
+3. 座標テクスチャ経路が使えない状況で従来 GpuPrim / 従来経路にフォールバックして正常描画
+4. `pdc->isFile()` (レイトレース/ファイル出力) が従来どおり
+5. `MolCoord` / `MolAtom` / `MorphMol` / `AnimMgr` / `LineGpuPrim` / `CylinderGpuPrim` / `SphereGpuPrim` / `SphereIdxGpuPrim` に破壊的変更が無いこと (`git diff --stat`)
+6. `objectChanged()` から GL 呼び出しが発生しないこと (アップロードは `display()` に遅延)
+7. tritium: `pnpm test` の `gfxManagerContract.test.ts` が通ること (peer API を追加した場合)
+8. native (Oc 系): `task build_libcuemol2` が通ること (目視はしない)
+
+**性能検証** (Phase 1 §7.4 と同じ): tritium (Release) で `perf.ts` の `PERF_MEASURE=true`。特に **Phase 3a 完了で、Phase 1 のテストシーン (`animtest_molmorph3_frame_cpk.qsc`) の SelectionRenderer 再構築が消え、selection on/off の差が縮まること**を確認する (Phase 1 では床として残っていた)。
+
+---
+
+## 8. 範囲外 / 既知の制限
+
+1. **`SelectionRenderer` の `MODE_POINT`**: 点スプライトはレガシー維持。将来 `PointIdxGpuPrim` (§4.8)。
+2. **レンダラ間の座標テクスチャ共有**: Phase 3 は per-renderer 所有。1 分子に複数レンダラが付くと座標が複数枚。集約は Phase 2 (`AnimMol`, Phase 1 plan §8.4)。
+3. **`BallStickRenderer` の dead valence**: 移植も削除もしない (§4.9)。
+4. **SimpleRenderer の二重結合**: v1 は静的オフセット (アニメ中に方向が凍る)。ind_d 方式への upgrade は同 sub-phase 内の後段 or 別課題。
+5. **AID→index マップのコスト**: `unordered_map` の構築は `renderCoordTexImpl` 時のみ (毎フレームではない)。Phase 2 の `AnimMol::getCrdArrayInd` で不要化。
+6. **トポロジ変化の検知**: Phase 1 と同じく `updateCoordTex` は `m_aidcache` の AID で引き直すので、原子削除は `getAtom()` null → 全再構築フォールバック。原子入れ替えは非検知 (`atomsMoved` は座標のみの意味なので実用上問題なし)。
+
+---
+
+## 9. 参照
+
+### 本リポジトリ (develop)
+
+- `docs/plans/260717-cpk-coord-texture-direct-update-plan.md` — Phase 1 plan (基盤・設計方針・rAF/GL タイミング)
+- Phase 1 実装 (PR #441 / `8fc30dd0`): `src/gfx/FloatDataTexture.hpp`, `src/gfx/SphereIdxGpuPrim.*`, `src/sysdep/ogl_core/lib_atoms.glsl`, `sphere2_body_vert.glsl`, `CPK2Renderer.*`
+- `src/gfx/LineGpuPrim.cpp` — 幅付き線の真インスタンシング + `linew2_vert.glsl` 展開 (Line プリミティブの雛形)
+- `src/gfx/CylinderGpuPrim.*` — 円柱の雛形
+- `src/gfx/DisplayList.cpp:302` — 即時描画→LineGpuPrim コンパイル
+- `src/modules/molstr/SelectionRenderer.cpp` / `TraceRenderer.cpp`, `src/modules/molvis/BallStickRenderer.cpp`, `src/modules/molstr/SimpleRendererGLSL.cpp` — 各対象レンダラの現状
+- `tritium/CLAUDE.md` — Worker 内 rAF / GL 規約 (Phase 1 で追記)
+
+### 参照実装 (`/Users/user1/proj64/cuemol2_png`, dev201608)
+
+- `src/modules/molstr/SimpleRendGLSL.{hpp,cpp}`, `simple_vertex.glsl` — 座標テクスチャ線経路 (GL_LINES, `a_ind12` の符号でアスター/結合を分岐)
+- `src/modules/molstr/dblbon_vert.glsl` — 二重結合の ind_d 方式 (`getNormalVec` でシェーダ内垂線、アニメ正確)
+- `src/modules/molstr/lib_atoms.glsl` — 元の fetch ヘルパ (Phase 1 で移植済み)

--- a/src/gfx/CMakeLists.txt
+++ b/src/gfx/CMakeLists.txt
@@ -25,6 +25,7 @@ Hittest.cpp
 SphereGpuPrim.cpp
 SphereIdxGpuPrim.cpp
 CylinderGpuPrim.cpp
+LineIdxGpuPrim.cpp
 TrigGpuPrim.cpp
 LineGpuPrim.cpp
 PixGpuPrim.cpp
@@ -57,6 +58,7 @@ SphereIdxGpuPrim.hpp
 CylinderGpuPrim.hpp
 TrigGpuPrim.hpp
 LineGpuPrim.hpp
+LineIdxGpuPrim.hpp
 PixGpuPrim.hpp
 PostProcGpuPrim.hpp
 Hittest.hpp

--- a/src/gfx/LineIdxGpuPrim.cpp
+++ b/src/gfx/LineIdxGpuPrim.cpp
@@ -1,0 +1,164 @@
+// -*-Mode: C++;-*-
+//
+// LineIdxGpuPrim implementations
+//
+
+#include <common.h>
+
+#include "LineIdxGpuPrim.hpp"
+#include "ShaderObject.hpp"
+#include "DisplayContext.hpp"
+#include "FloatDataTexture.hpp"
+#include "AbstractColor.hpp"
+#include <qlib/LTypes.hpp>
+
+using namespace gfx;
+
+//////////////////////////////////////////////////////////////////////////
+// LineIdxGpuPrim
+
+LineIdxGpuPrim::LineIdxGpuPrim()
+    : m_pPO(nullptr),
+      m_pDrawAry(nullptr),
+      m_pCoordTex(nullptr),
+      m_nCoordTexUnit(COORD_TEX_UNIT),
+      m_linew(1.0f),
+      m_bStipple(false),
+      m_bNoDepth(false)
+{
+}
+
+LineIdxGpuPrim::~LineIdxGpuPrim()
+{
+    invalidate();
+}
+
+bool LineIdxGpuPrim::init(DisplayContext *pDC)
+{
+    if (m_pPO != nullptr) return true;
+
+    m_pPO = pDC->loadShaderObject("gpu_lineidx",
+                                  "%%CONFDIR%%/data/shaders/linew2idx_vert.glsl",
+                                  "%%CONFDIR%%/data/shaders/linew_frag.glsl");
+    if (m_pPO == nullptr) {
+        LOG_DPRINTLN("LineIdxGpuPrim> ERROR: cannot load shader.");
+        return false;
+    }
+
+    m_pPO->initDrawParamsUBO(sizeof(DrawParams));
+    return true;
+}
+
+void LineIdxGpuPrim::alloc(DisplayContext *pDC, int nlines)
+{
+    MB_ASSERT(m_pPO != nullptr);
+    MB_ASSERT(pDC != nullptr);
+
+    m_pDrawAry = MB_NEW LineIdxArray();
+    LineIdxArray &data = *m_pDrawAry;
+
+    pDC->allocBuffer(data, nlines, 6);
+    data.assignInds({0, 1, 2, 2, 1, 3});
+    data.setDrawMode(gfx::AbstDrawElem::DRAW_TRIANGLES);
+    data.setNumInstances(nlines);
+}
+
+void LineIdxGpuPrim::setupAttrs()
+{
+    MB_ASSERT(m_pDrawAry != nullptr);
+    LineIdxArray &data = *m_pDrawAry;
+
+    if (data.getAttrSize() > 0) return;  // already set up
+
+    data.setAttrSize(4);
+    data.setAttrInfo(0, ATTRLOC_P1, 4, qlib::type_consts::QTC_FLOAT32,
+                     offsetof(LineIdxElem, ox1));
+    data.setAttrInfo(1, ATTRLOC_P2, 4, qlib::type_consts::QTC_FLOAT32,
+                     offsetof(LineIdxElem, ox2));
+    data.setAttrInfo(2, ATTRLOC_COLOR1, 4, qlib::type_consts::QTC_UINT8,
+                     offsetof(LineIdxElem, r1));
+    data.setAttrInfo(3, ATTRLOC_COLOR2, 4, qlib::type_consts::QTC_UINT8,
+                     offsetof(LineIdxElem, r2));
+
+    const int ndiv = 1;
+    data.setAttrDivisor(0, ndiv);
+    data.setAttrDivisor(1, ndiv);
+    data.setAttrDivisor(2, ndiv);
+    data.setAttrDivisor(3, ndiv);
+}
+
+void LineIdxGpuPrim::setData(int i, int idx1, const qlib::Vector4D &off1,
+                             quint32 devcode1, int idx2,
+                             const qlib::Vector4D &off2, quint32 devcode2)
+{
+    LineIdxElem &elem = m_pDrawAry->at(i);
+
+    elem.ox1 = (qfloat32)off1.x();
+    elem.oy1 = (qfloat32)off1.y();
+    elem.oz1 = (qfloat32)off1.z();
+    elem.idx1 = (qfloat32)idx1;
+    elem.r1 = getRCode(devcode1);
+    elem.g1 = getGCode(devcode1);
+    elem.b1 = getBCode(devcode1);
+    elem.a1 = getACode(devcode1);
+
+    elem.ox2 = (qfloat32)off2.x();
+    elem.oy2 = (qfloat32)off2.y();
+    elem.oz2 = (qfloat32)off2.z();
+    elem.idx2 = (qfloat32)idx2;
+    elem.r2 = getRCode(devcode2);
+    elem.g2 = getGCode(devcode2);
+    elem.b2 = getBCode(devcode2);
+    elem.a2 = getACode(devcode2);
+}
+
+void LineIdxGpuPrim::setCoordTex(FloatDataTexture *pTex, int texUnit)
+{
+    m_pCoordTex = pTex;
+    m_nCoordTexUnit = texUnit;
+}
+
+void LineIdxGpuPrim::draw(DisplayContext *pDC)
+{
+    if (m_pDrawAry == nullptr || m_pPO == nullptr) return;
+    if (m_pCoordTex == nullptr) return;
+
+    setupAttrs();
+
+    qlib::Vector4D vp = pDC->getViewport();
+    float w = (float)vp.z();
+    float h = (float)vp.w();
+
+    float linew = (m_linew < 0.0f) ? 1.0f : m_linew;
+    float stippleLen = m_bStipple ? 8.0f : 0.0f;
+
+    DrawParams ubo = {};
+    ubo.frag_alpha  = (float)pDC->getAlpha();
+    ubo.lineWidth   = linew;
+    ubo.stippleLen  = stippleLen;
+    ubo.u_nodepth   = m_bNoDepth ? 1 : 0;
+    ubo.screenSize[0] = w;
+    ubo.screenSize[1] = h;
+
+    m_pPO->enable();
+    m_pPO->setupFog(pDC);
+    m_pPO->setupMat(pDC);
+    m_pPO->updateDrawParamsUBO(&ubo, sizeof(ubo));
+
+    m_pCoordTex->bind(m_nCoordTexUnit);
+    m_pPO->setUniform("u_coordTex", m_nCoordTexUnit);
+
+    pDC->drawElem(*m_pDrawAry);
+
+    m_pCoordTex->unbind();
+    m_pPO->disable();
+}
+
+void LineIdxGpuPrim::invalidate()
+{
+    if (m_pDrawAry != nullptr) {
+        delete m_pDrawAry;
+        m_pDrawAry = nullptr;
+    }
+    m_pCoordTex = nullptr;
+}

--- a/src/gfx/LineIdxGpuPrim.hpp
+++ b/src/gfx/LineIdxGpuPrim.hpp
@@ -1,0 +1,141 @@
+// -*-Mode: C++;-*-
+//
+// LineIdxGpuPrim: Wide-line draw primitive with texture-fetched endpoints
+//
+
+#pragma once
+
+#include "GpuPrim.hpp"
+#include "DrawAttrElems.hpp"
+
+#include <qlib/Vector4D.hpp>
+
+namespace gfx {
+
+class FloatDataTexture;
+
+/**
+ * Wide-line draw primitive with texture-fetched endpoints.
+ *
+ * Same instanced screen-space width-quad expansion as LineGpuPrim, but each
+ * endpoint is not stored as a position. Instead it carries an index into a
+ * coordinate texture (bound via setCoordTex()) plus a static model-space
+ * offset. The vertex shader computes the endpoint as fetched_atom_pos + offset.
+ *
+ * The offset makes the primitive general enough to express, with one shader:
+ *   - a bond line:            (idx1, 0), (idx2, 0)
+ *   - an isolated-atom aster: 3 segments, same idx on both ends, +-axis offset
+ *   - a static double-bond:   (idx1, dir*scale), (idx2, dir*scale)
+ *
+ * Only the coordinate texture needs re-uploading when positions change; this
+ * VBO stays immutable.
+ */
+class GFX_API LineIdxGpuPrim : public GpuPrim
+{
+public:
+    /** Per-instance vertex attribute layout (one segment = 1 instance). */
+    struct LineIdxElem
+    {
+        qfloat32 ox1, oy1, oz1, idx1;  ///< a_p1: xyz = model-space offset, w = index
+        qfloat32 ox2, oy2, oz2, idx2;  ///< a_p2: xyz = model-space offset, w = index
+        qbyte r1, g1, b1, a1;          ///< Start point RGBA colour
+        qbyte r2, g2, b2, a2;          ///< End point RGBA colour
+    };
+
+    /**
+     * std140 DrawParamsBlock layout (binding=2, 48 bytes).
+     * Must match the DrawParamsBlock uniform block in linew2idx_vert.glsl /
+     * linew_frag.glsl. Identical to LineGpuPrim::DrawParams.
+     */
+    struct DrawParams
+    {
+        qfloat32 frag_alpha;        // offset 0
+        qfloat32 lineWidth;         // offset 4
+        qfloat32 stippleLen;        // offset 8
+        qint32   u_nodepth;         // offset 12
+        qfloat32 screenSize[2];     // offset 16
+        qint32   use_u_color;       // offset 24
+        qfloat32 _pad;              // offset 28
+        qfloat32 u_color[4];        // offset 32
+    };
+
+    using LineIdxArray = gfx::DrawAttrElems<quint32, LineIdxElem>;
+
+    // ---- Lifecycle ----
+
+    LineIdxGpuPrim();
+    ~LineIdxGpuPrim() override;
+
+    /** Load the wide-line (coordinate texture) shader. */
+    bool init(DisplayContext *pDC) override;
+
+    /** Allocate GPU storage for nlines line segments. Must call init() first. */
+    void alloc(DisplayContext *pDC, int nlines);
+
+    // ---- Data upload ----
+
+    /**
+     * Set line segment data at the given instance index.
+     * @param idx1,idx2 coordinate-texture indices of the two endpoints.
+     * @param off1,off2 static model-space offset added to each fetched position.
+     * @param devcode1,devcode2 pre-resolved device RGBA colours.
+     */
+    void setData(int i, int idx1, const qlib::Vector4D &off1, quint32 devcode1,
+                 int idx2, const qlib::Vector4D &off2, quint32 devcode2);
+
+    /** Bind the coordinate texture to this unit before draw(). Non-owning. */
+    void setCoordTex(FloatDataTexture *pTex, int texUnit);
+
+    // ---- Properties ----
+
+    void setLineWidth(float lw) { m_linew = lw; }
+    float getLineWidth() const { return m_linew; }
+
+    void setStipple(bool f) { m_bStipple = f; }
+    bool isStipple() const { return m_bStipple; }
+
+    void setNoDepth(bool f) { m_bNoDepth = f; }
+    bool isNoDepth() const { return m_bNoDepth; }
+
+    // ---- Draw / cleanup ----
+
+    /** Upload draw parameters, bind the coordinate texture, and draw. */
+    void draw(DisplayContext *pDC) override;
+
+    /** Delete GPU buffers and reset to uninitialized state. */
+    void invalidate() override;
+
+    // ---- State queries ----
+
+    bool isValid() const override
+    {
+        return m_pPO != nullptr && m_pDrawAry != nullptr;
+    }
+
+    int getSize() const
+    {
+        return (m_pDrawAry != nullptr) ? m_pDrawAry->getSize() : 0;
+    }
+
+private:
+    // Predefined attribute locations (must match layout(location=N) in
+    // linew2idx_vert.glsl).
+    static constexpr int ATTRLOC_P1     = 0;
+    static constexpr int ATTRLOC_P2     = 1;
+    static constexpr int ATTRLOC_COLOR1 = 2;
+    static constexpr int ATTRLOC_COLOR2 = 3;
+    static constexpr int COORD_TEX_UNIT = 0;
+
+    gfx::ShaderObject *m_pPO;
+    LineIdxArray *m_pDrawAry;
+    FloatDataTexture *m_pCoordTex;   ///< non-owning
+    int m_nCoordTexUnit;
+
+    float m_linew;
+    bool m_bStipple;
+    bool m_bNoDepth;
+
+    void setupAttrs();
+};
+
+}  // namespace gfx

--- a/src/modules/molstr/SelectionRenderer.cpp
+++ b/src/modules/molstr/SelectionRenderer.cpp
@@ -11,26 +11,49 @@
 #include "MolChain.hpp"
 #include "MolResidue.hpp"
 #include "ResiToppar.hpp"
+#include "BondIterator.hpp"
+#include "AtomIterator.hpp"
 
 #include "SelCommand.hpp"
 
 #include <gfx/DisplayContext.hpp>
 #include <gfx/SolidColor.hpp>
+#include <gfx/FloatDataTexture.hpp>
+#include <qsys/Scene.hpp>
 #include <qsys/SceneManager.hpp>
+
+#include <set>
 
 using namespace molstr;
 
 using qlib::Vector4D;
 using gfx::ColorPtr;
 
+namespace {
+// Fixed coordinate texture width (matches TEX2D_WIDTH in lib_atoms.glsl).
+constexpr int TEX2D_WIDTH = 1024;
+}  // namespace
+
 SelectionRenderer::SelectionRenderer()
 {
   m_nMode = MODE_STICK;
   m_pSel = molstr::SelectionPtr(MB_NEW molstr::SelCommand(LString("!*")));
+
+  m_bUseShader = false;
+  m_bCheckShaderOK = false;
+  m_pCoordTex = nullptr;
+  m_nTexW = 0;
+  m_nTexH = 0;
+  m_bUseCoordTex = false;
+  m_bCoordDirty = false;
 }
 
 SelectionRenderer::~SelectionRenderer()
 {
+  if (m_pCoordTex != nullptr) {
+    delete m_pCoordTex;
+    m_pCoordTex = nullptr;
+  }
 }
 
 const char *SelectionRenderer::getTypeName() const
@@ -97,6 +120,206 @@ bool SelectionRenderer::isRendBond() const
     return true;
   else
     return false;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// coordinate texture path (direct update)
+
+void SelectionRenderer::display(DisplayContext *pdc)
+{
+  // File output or point mode: use the legacy display-list path.
+  if (pdc->isFile() || m_nMode != MODE_STICK) {
+    super_t::display(pdc);
+    return;
+  }
+
+  if (!m_bCheckShaderOK) {
+    m_bUseShader = m_lineIdxGpuPrim.init(pdc);
+    m_bUseCoordTex = m_bUseShader;
+    m_bCheckShaderOK = true;
+  }
+
+  if (m_bUseCoordTex) {
+    if (!m_lineIdxGpuPrim.isValid()) {
+      renderCoordTexImpl(pdc);
+      // renderCoordTexImpl clears m_bUseCoordTex if the backend cannot
+      // provide a float data texture.
+    }
+    if (m_bUseCoordTex && m_lineIdxGpuPrim.isValid()) {
+      // Deferred coordinate upload: at most once per frame, inside the rAF
+      // tick, right before the draw.
+      if (m_bCoordDirty) {
+        if (!updateCoordTex()) {
+          // Topology changed under us: fall back to a full rebuild.
+          invalidateDisplayCache();
+          return;
+        }
+        m_bCoordDirty = false;
+      }
+      preRender(pdc);
+      m_lineIdxGpuPrim.setLineWidth(static_cast<float>(m_linew) * pdc->getPixSclFac());
+      m_lineIdxGpuPrim.draw(pdc);
+      postRender(pdc);
+      return;
+    }
+  }
+
+  // Shader/texture not available: legacy rendering.
+  super_t::display(pdc);
+}
+
+void SelectionRenderer::invalidateDisplayCache()
+{
+  super_t::invalidateDisplayCache();
+  m_lineIdxGpuPrim.invalidate();
+  if (m_pCoordTex != nullptr) {
+    delete m_pCoordTex;
+    m_pCoordTex = nullptr;
+  }
+  m_aidcache.clear();
+  m_aid2idx.clear();
+  m_coordbuf.clear();
+  m_bCoordDirty = false;
+}
+
+void SelectionRenderer::renderCoordTexImpl(DisplayContext *pdc)
+{
+  MolCoordPtr pMol = getClientMol();
+  if (pMol.isnull()) return;
+
+  // Build the atom texel layout (all selected atoms) + AID -> index map.
+  m_aidcache.clear();
+  m_aid2idx.clear();
+  {
+    AtomIterator aiter(pMol, getSelection());
+    int i = 0;
+    for (aiter.first(); aiter.hasMore(); aiter.next()) {
+      int aid = aiter.getID();
+      MolAtomPtr pAtom = pMol->getAtom(aid);
+      if (pAtom.isnull()) continue;
+      m_aidcache.push_back(aid);
+      m_aid2idx[aid] = i;
+      ++i;
+    }
+  }
+  const int natoms = static_cast<int>(m_aidcache.size());
+  if (natoms == 0) return;
+
+  // Count line segments: bonds (1 each) + isolated atoms (3-axis aster).
+  int nlines = 0;
+  std::set<int> bonded;
+  {
+    BondIterator biter(pMol, getSelection());
+    for (biter.first(); biter.hasMore(); biter.next()) {
+      MolBond *pMB = biter.getBond();
+      int aid1 = pMB->getAtom1();
+      int aid2 = pMB->getAtom2();
+      if (m_aid2idx.find(aid1) == m_aid2idx.end() ||
+          m_aid2idx.find(aid2) == m_aid2idx.end())
+        continue;
+      bonded.insert(aid1);
+      bonded.insert(aid2);
+      ++nlines;
+    }
+  }
+  std::vector<int> iso_atoms;
+  for (int aid : m_aidcache) {
+    if (bonded.find(aid) == bonded.end()) {
+      iso_atoms.push_back(aid);
+      nlines += 3;
+    }
+  }
+  if (nlines == 0) return;
+
+  // Allocate the coordinate texture (RGB32F, one texel per atom, width 1024).
+  m_nTexW = TEX2D_WIDTH;
+  m_nTexH = (natoms + TEX2D_WIDTH - 1) / TEX2D_WIDTH;
+  m_coordbuf.resize(static_cast<size_t>(m_nTexW) * m_nTexH * 3);
+
+  m_pCoordTex = pdc->createFloatDataTexture();
+  if (m_pCoordTex == nullptr) {
+    m_bUseCoordTex = false;
+    m_aidcache.clear();
+    m_aid2idx.clear();
+    m_coordbuf.clear();
+    return;
+  }
+  if (!m_pCoordTex->create(m_nTexW, m_nTexH, 3)) {
+    delete m_pCoordTex;
+    m_pCoordTex = nullptr;
+    m_bUseCoordTex = false;
+    m_aidcache.clear();
+    m_aid2idx.clear();
+    m_coordbuf.clear();
+    return;
+  }
+
+  // Write atom positions into the staging buffer.
+  for (int i = 0; i < natoms; ++i) {
+    MolAtomPtr pAtom = pMol->getAtom(m_aidcache[i]);
+    const Vector4D pos = pAtom->getPos();
+    m_coordbuf[i * 3 + 0] = static_cast<qfloat32>(pos.x());
+    m_coordbuf[i * 3 + 1] = static_cast<qfloat32>(pos.y());
+    m_coordbuf[i * 3 + 2] = static_cast<qfloat32>(pos.z());
+  }
+
+  m_lineIdxGpuPrim.alloc(pdc, nlines);
+
+  const quint32 cc = m_color->getDevCode(getSceneID());
+  const Vector4D zero(0, 0, 0);
+  int iline = 0;
+
+  // Bonds: a single line between the two atom indices (no offset).
+  {
+    BondIterator biter(pMol, getSelection());
+    for (biter.first(); biter.hasMore(); biter.next()) {
+      MolBond *pMB = biter.getBond();
+      auto it1 = m_aid2idx.find(pMB->getAtom1());
+      auto it2 = m_aid2idx.find(pMB->getAtom2());
+      if (it1 == m_aid2idx.end() || it2 == m_aid2idx.end()) continue;
+      m_lineIdxGpuPrim.setData(iline++, it1->second, zero, cc, it2->second, zero, cc);
+    }
+  }
+
+  // Isolated atoms: 3-axis aster (same index, +-axis offset, model space).
+  const double rad = 0.25;
+  const Vector4D xdel(rad, 0, 0), ydel(0, rad, 0), zdel(0, 0, rad);
+  const Vector4D nxdel = xdel.scale(-1.0), nydel = ydel.scale(-1.0),
+                 nzdel = zdel.scale(-1.0);
+  for (int aid : iso_atoms) {
+    const int idx = m_aid2idx[aid];
+    m_lineIdxGpuPrim.setData(iline++, idx, nxdel, cc, idx, xdel, cc);
+    m_lineIdxGpuPrim.setData(iline++, idx, nydel, cc, idx, ydel, cc);
+    m_lineIdxGpuPrim.setData(iline++, idx, nzdel, cc, idx, zdel, cc);
+  }
+
+  m_pCoordTex->update(&m_coordbuf[0]);
+  m_lineIdxGpuPrim.setCoordTex(m_pCoordTex, 0);
+  m_bCoordDirty = false;
+
+  LOG_DPRINTLN("SelectionRenderer> rendered %d line segments (coord texture %dx%d)",
+               nlines, m_nTexW, m_nTexH);
+}
+
+bool SelectionRenderer::updateCoordTex()
+{
+  if (!m_bUseCoordTex || m_pCoordTex == nullptr) return false;
+  if (m_aidcache.empty()) return false;
+
+  MolCoordPtr pMol = getClientMol();
+  if (pMol.isnull()) return false;
+
+  const int natoms = static_cast<int>(m_aidcache.size());
+  for (int i = 0; i < natoms; ++i) {
+    MolAtomPtr pAtom = pMol->getAtom(m_aidcache[i]);
+    if (pAtom.isnull()) return false;   // topology changed; force rebuild
+    const Vector4D pos = pAtom->getPos();
+    m_coordbuf[i * 3 + 0] = static_cast<qfloat32>(pos.x());
+    m_coordbuf[i * 3 + 1] = static_cast<qfloat32>(pos.y());
+    m_coordbuf[i * 3 + 2] = static_cast<qfloat32>(pos.z());
+  }
+  m_pCoordTex->update(&m_coordbuf[0]);
+  return true;
 }
 
 void SelectionRenderer::beginRend(DisplayContext *pdl)
@@ -177,6 +400,19 @@ void SelectionRenderer::postRender(DisplayContext *pdc)
 
 void SelectionRenderer::objectChanged(qsys::ObjectEvent &ev)
 {
+  if (ev.getType() == qsys::ObjectEvent::OBE_CHANGED &&
+      ev.getDescr().equals("atomsMoved")) {
+    // Positions changed but topology/selection did not. Mark the coordinate
+    // texture dirty and let display() do the upload (once per frame, inside
+    // the rAF tick). No hittest cache here (SelectionRenderer has none).
+    if (m_bUseCoordTex && m_lineIdxGpuPrim.isValid()) {
+      m_bCoordDirty = true;
+      qsys::ScenePtr pScene = getScene();
+      if (!pScene.isnull()) pScene->setUpdateFlag();
+      return;
+    }
+  }
+
   if (ev.getType()==qsys::ObjectEvent::OBE_PROPCHG) {
     if (ev.getDescr().equals("sel")) {
       invalidateDisplayCache();

--- a/src/modules/molstr/SelectionRenderer.hpp
+++ b/src/modules/molstr/SelectionRenderer.hpp
@@ -10,6 +10,10 @@
 #include "molstr.hpp"
 #include "MolAtomRenderer.hpp"
 #include <gfx/PixelBuffer.hpp>
+#include <gfx/LineIdxGpuPrim.hpp>
+
+#include <vector>
+#include <unordered_map>
 
 class SelectionRenderer_wrap;
 
@@ -53,6 +57,44 @@ private:
 
   // gfx::PixelBuffer m_boximg;
 
+  //////////////////////////////////////////////////////
+  // coordinate texture path (direct update)
+
+  bool m_bUseShader;
+  bool m_bCheckShaderOK;
+
+  /// Line primitive with texture-fetched endpoints (used when available)
+  gfx::LineIdxGpuPrim m_lineIdxGpuPrim;
+
+  /// Coordinate texture (owned). Null when the backend does not support it.
+  gfx::FloatDataTexture *m_pCoordTex;
+
+  /// CPU-side staging buffer for the coordinate texture (w*h*3 floats)
+  std::vector<qfloat32> m_coordbuf;
+
+  /// AIDs in the same order as the coordinate texture texels
+  std::vector<int> m_aidcache;
+
+  /// AID -> texel index (bonds/asters reference atoms by AID)
+  std::unordered_map<int, int> m_aid2idx;
+
+  int m_nTexW, m_nTexH;
+
+  /// True when the coordinate texture path is in use
+  bool m_bUseCoordTex;
+
+  /// Set by objectChanged(); consumed by display() (deferred upload, once/frame)
+  bool m_bCoordDirty;
+
+  /// Build the immutable VBO (indices/offsets/colour) and the coordinate
+  /// texture. Falls back (clears m_bUseCoordTex) when the backend cannot
+  /// provide a float data texture.
+  void renderCoordTexImpl(DisplayContext *pdc);
+
+  /// Re-gather atom positions into the coordinate texture. Called from
+  /// display() when m_bCoordDirty.
+  bool updateCoordTex();
+
 public:
   enum {
     MODE_STICK = 0,
@@ -77,6 +119,10 @@ public:
   //////////////////////////////////////////////////////
 
   bool isRendBond() const override;
+
+  void display(DisplayContext *pdc) override;
+
+  void invalidateDisplayCache() override;
 
   void preRender(DisplayContext *pdc) override;
   void postRender(DisplayContext *pdc) override;

--- a/src/modules/molstr/TraceRenderer.cpp
+++ b/src/modules/molstr/TraceRenderer.cpp
@@ -15,23 +15,237 @@
 #include "ResiToppar.hpp"
 
 #include <gfx/DisplayContext.hpp>
+#include <gfx/FloatDataTexture.hpp>
+#include <qsys/Scene.hpp>
 
 using namespace molstr;
+
+namespace {
+// Fixed coordinate texture width (matches TEX2D_WIDTH in lib_atoms.glsl).
+constexpr int TEX2D_WIDTH = 1024;
+}  // namespace
 
 TraceRenderer::TraceRenderer()
 {
   //m_bUseVBO = true;
   m_bUseVBO = false;
   // m_pVBO = NULL;
+
+  m_bUseShader = false;
+  m_bCheckShaderOK = false;
+  m_pCoordTex = nullptr;
+  m_nTexW = 0;
+  m_nTexH = 0;
+  m_bUseCoordTex = false;
+  m_bCoordDirty = false;
+
+  m_bCollecting = false;
+  m_bHavePrev = false;
+  m_prevAid = -1;
+  m_curSegFirstAid = -1;
+  m_curSegCount = 0;
 }
 
 TraceRenderer::~TraceRenderer()
 {
+  if (m_pCoordTex != nullptr) {
+    delete m_pCoordTex;
+    m_pCoordTex = nullptr;
+  }
 }
 
 const char *TraceRenderer::getTypeName() const
 {
   return "trace";
+}
+
+//////////////////////////////////////////////////////////////////////////
+// coordinate texture path (direct update)
+
+void TraceRenderer::display(DisplayContext *pdc)
+{
+  if (pdc->isFile()) {
+    super_t::display(pdc);
+    return;
+  }
+
+  if (!m_bCheckShaderOK) {
+    m_bUseShader = m_lineIdxGpuPrim.init(pdc);
+    m_bUseCoordTex = m_bUseShader;
+    m_bCheckShaderOK = true;
+  }
+
+  if (m_bUseCoordTex) {
+    if (!m_lineIdxGpuPrim.isValid()) {
+      renderCoordTexImpl(pdc);
+      // renderCoordTexImpl clears m_bUseCoordTex if the backend cannot
+      // provide a float data texture.
+    }
+    if (m_bUseCoordTex && m_lineIdxGpuPrim.isValid()) {
+      if (m_bCoordDirty) {
+        if (!updateCoordTex()) {
+          invalidateDisplayCache();
+          return;
+        }
+        m_bCoordDirty = false;
+      }
+      preRender(pdc);
+      m_lineIdxGpuPrim.setLineWidth(static_cast<float>(m_lw) * pdc->getPixSclFac());
+      m_lineIdxGpuPrim.draw(pdc);
+      postRender(pdc);
+      return;
+    }
+  }
+
+  super_t::display(pdc);
+}
+
+void TraceRenderer::invalidateDisplayCache()
+{
+  super_t::invalidateDisplayCache();
+  m_lineIdxGpuPrim.invalidate();
+  if (m_pCoordTex != nullptr) {
+    delete m_pCoordTex;
+    m_pCoordTex = nullptr;
+  }
+  m_aidcache.clear();
+  m_aid2idx.clear();
+  m_aidColor.clear();
+  m_traceBonds.clear();
+  m_traceIso.clear();
+  m_coordbuf.clear();
+  m_bCoordDirty = false;
+}
+
+void TraceRenderer::objectChanged(qsys::ObjectEvent &ev)
+{
+  if (ev.getType() == qsys::ObjectEvent::OBE_CHANGED &&
+      ev.getDescr().equals("atomsMoved")) {
+    if (m_bUseCoordTex && m_lineIdxGpuPrim.isValid()) {
+      m_bCoordDirty = true;
+      qsys::ScenePtr pScene = getScene();
+      if (!pScene.isnull()) pScene->setUpdateFlag();
+      invalidateHittestCache();
+      return;
+    }
+  }
+  super_t::objectChanged(ev);
+}
+
+void TraceRenderer::renderCoordTexImpl(DisplayContext *pdc)
+{
+  MolCoordPtr pMol = getClientMol();
+  if (pMol.isnull()) return;
+
+  // Gather the trace topology by running the mainchain traversal in collect
+  // mode. render() starts/ends the coloring scheme itself, so getColor() is
+  // valid inside the collect callbacks; do not start it again here.
+  m_aidcache.clear();
+  m_aid2idx.clear();
+  m_aidColor.clear();
+  m_traceBonds.clear();
+  m_traceIso.clear();
+
+  m_bCollecting = true;
+  render(pdc);
+  m_bCollecting = false;
+
+  const int natoms = static_cast<int>(m_aidcache.size());
+  if (natoms == 0) return;
+
+  const int nbonds = static_cast<int>(m_traceBonds.size());
+  const int niso = static_cast<int>(m_traceIso.size());
+  const int nlines = nbonds + 3 * niso;
+  if (nlines == 0) return;
+
+  // Allocate the coordinate texture (RGB32F, one texel per pivot atom).
+  m_nTexW = TEX2D_WIDTH;
+  m_nTexH = (natoms + TEX2D_WIDTH - 1) / TEX2D_WIDTH;
+  m_coordbuf.resize(static_cast<size_t>(m_nTexW) * m_nTexH * 3);
+
+  m_pCoordTex = pdc->createFloatDataTexture();
+  if (m_pCoordTex == nullptr) {
+    m_bUseCoordTex = false;
+    m_aidcache.clear();
+    m_aid2idx.clear();
+    m_coordbuf.clear();
+    return;
+  }
+  if (!m_pCoordTex->create(m_nTexW, m_nTexH, 3)) {
+    delete m_pCoordTex;
+    m_pCoordTex = nullptr;
+    m_bUseCoordTex = false;
+    m_aidcache.clear();
+    m_aid2idx.clear();
+    m_coordbuf.clear();
+    return;
+  }
+
+  // Write pivot positions into the staging buffer.
+  for (int i = 0; i < natoms; ++i) {
+    MolAtomPtr pAtom = pMol->getAtom(m_aidcache[i]);
+    const Vector4D pos = pAtom->getPos();
+    m_coordbuf[i * 3 + 0] = static_cast<qfloat32>(pos.x());
+    m_coordbuf[i * 3 + 1] = static_cast<qfloat32>(pos.y());
+    m_coordbuf[i * 3 + 2] = static_cast<qfloat32>(pos.z());
+  }
+
+  m_lineIdxGpuPrim.alloc(pdc, nlines);
+
+  const Vector4D zero(0, 0, 0);
+  int iline = 0;
+
+  // Trace bonds: line between two pivot indices (per-residue colours).
+  for (const auto &b : m_traceBonds) {
+    auto it1 = m_aid2idx.find(b.first);
+    auto it2 = m_aid2idx.find(b.second);
+    if (it1 == m_aid2idx.end() || it2 == m_aid2idx.end()) continue;
+    m_lineIdxGpuPrim.setData(iline++, it1->second, zero, m_aidColor[b.first],
+                             it2->second, zero, m_aidColor[b.second]);
+  }
+
+  // Isolated residues: 3-axis aster (same index, +-axis offset, model space).
+  const double rad = 0.25;
+  const Vector4D xdel(rad, 0, 0), ydel(0, rad, 0), zdel(0, 0, rad);
+  const Vector4D nxdel = xdel.scale(-1.0), nydel = ydel.scale(-1.0),
+                 nzdel = zdel.scale(-1.0);
+  for (int aid : m_traceIso) {
+    auto it = m_aid2idx.find(aid);
+    if (it == m_aid2idx.end()) continue;
+    const int idx = it->second;
+    const quint32 cc = m_aidColor[aid];
+    m_lineIdxGpuPrim.setData(iline++, idx, nxdel, cc, idx, xdel, cc);
+    m_lineIdxGpuPrim.setData(iline++, idx, nydel, cc, idx, ydel, cc);
+    m_lineIdxGpuPrim.setData(iline++, idx, nzdel, cc, idx, zdel, cc);
+  }
+
+  m_pCoordTex->update(&m_coordbuf[0]);
+  m_lineIdxGpuPrim.setCoordTex(m_pCoordTex, 0);
+  m_bCoordDirty = false;
+
+  LOG_DPRINTLN("TraceRenderer> rendered %d line segments (coord texture %dx%d)",
+               nlines, m_nTexW, m_nTexH);
+}
+
+bool TraceRenderer::updateCoordTex()
+{
+  if (!m_bUseCoordTex || m_pCoordTex == nullptr) return false;
+  if (m_aidcache.empty()) return false;
+
+  MolCoordPtr pMol = getClientMol();
+  if (pMol.isnull()) return false;
+
+  const int natoms = static_cast<int>(m_aidcache.size());
+  for (int i = 0; i < natoms; ++i) {
+    MolAtomPtr pAtom = pMol->getAtom(m_aidcache[i]);
+    if (pAtom.isnull()) return false;   // topology changed; force rebuild
+    const Vector4D pos = pAtom->getPos();
+    m_coordbuf[i * 3 + 0] = static_cast<qfloat32>(pos.x());
+    m_coordbuf[i * 3 + 1] = static_cast<qfloat32>(pos.y());
+    m_coordbuf[i * 3 + 2] = static_cast<qfloat32>(pos.z());
+  }
+  m_pCoordTex->update(&m_coordbuf[0]);
+  return true;
 }
 
 /*
@@ -79,6 +293,8 @@ void TraceRenderer::preRender(DisplayContext *pdc)
 
 void TraceRenderer::beginRend(DisplayContext *pdl)
 {
+  if (m_bCollecting) return;
+
   if (!m_bUseVBO) {
     pdl->setLineWidth(m_lw);
     return;
@@ -90,6 +306,13 @@ void TraceRenderer::beginRend(DisplayContext *pdl)
 
 void TraceRenderer::beginSegment(DisplayContext *pdl, MolResiduePtr pRes)
 {
+  if (m_bCollecting) {
+    m_bHavePrev = false;
+    m_curSegCount = 0;
+    m_curSegFirstAid = -1;
+    return;
+  }
+
   if (!m_bUseVBO) {
     pdl->startLineStrip();
     return;
@@ -102,6 +325,26 @@ void TraceRenderer::beginSegment(DisplayContext *pdl, MolResiduePtr pRes)
 void TraceRenderer::rendResid(DisplayContext *pdl, MolResiduePtr pRes)
 {
   MolAtomPtr pAtom1 = getPivotAtom(pRes);
+
+  if (m_bCollecting) {
+    if (pAtom1.isnull()) return;
+    const int aid = pAtom1->getID();
+    const quint32 cc = ColSchmHolder::getColor(pRes)->getDevCode(getSceneID());
+    if (m_aid2idx.find(aid) == m_aid2idx.end()) {
+      m_aid2idx[aid] = static_cast<int>(m_aidcache.size());
+      m_aidcache.push_back(aid);
+    }
+    m_aidColor[aid] = cc;
+    if (m_bHavePrev) {
+      m_traceBonds.push_back(std::make_pair(m_prevAid, aid));
+    } else {
+      m_curSegFirstAid = aid;
+      m_bHavePrev = true;
+    }
+    m_prevAid = aid;
+    ++m_curSegCount;
+    return;
+  }
 
   if (!m_bUseVBO) {
     Vector4D curpt = pAtom1->getPos();
@@ -129,6 +372,13 @@ void TraceRenderer::rendResid(DisplayContext *pdl, MolResiduePtr pRes)
 
 void TraceRenderer::endSegment(DisplayContext *pdl, MolResiduePtr pRes)
 {
+  if (m_bCollecting) {
+    // A segment with a single residue produced no bond: draw it as an aster.
+    if (m_curSegCount == 1 && m_curSegFirstAid >= 0)
+      m_traceIso.push_back(m_curSegFirstAid);
+    return;
+  }
+
   if (!m_bUseVBO) {
     pdl->end();
     return;
@@ -148,6 +398,8 @@ void TraceRenderer::endSegment(DisplayContext *pdl, MolResiduePtr pRes)
 
 void TraceRenderer::endRend(DisplayContext *pdl)
 {
+  if (m_bCollecting) return;
+
   if (!m_bUseVBO) {
     pdl->setLineWidth(1.0f);
     return;

--- a/src/modules/molstr/TraceRenderer.hpp
+++ b/src/modules/molstr/TraceRenderer.hpp
@@ -9,6 +9,11 @@
 
 #include "molstr.hpp"
 #include "MainChainRenderer.hpp"
+#include <gfx/LineIdxGpuPrim.hpp>
+
+#include <vector>
+#include <utility>
+#include <unordered_map>
 
 class TraceRenderer_wrap;
 
@@ -27,10 +32,55 @@ namespace molstr {
   private:
     /// Line width
     double m_lw;
-    
+
     // ColoringSchemePtr m_pcoloring;
 
     bool m_bUseVBO;
+
+    //////////////////////////////////////////////////////
+    // coordinate texture path (direct update)
+
+    bool m_bUseShader;
+    bool m_bCheckShaderOK;
+
+    /// Line primitive with texture-fetched endpoints (used when available)
+    gfx::LineIdxGpuPrim m_lineIdxGpuPrim;
+
+    /// Coordinate texture (owned). Null when the backend does not support it.
+    gfx::FloatDataTexture *m_pCoordTex;
+
+    /// CPU-side staging buffer for the coordinate texture (w*h*3 floats)
+    std::vector<qfloat32> m_coordbuf;
+
+    /// Pivot AIDs in the same order as the coordinate texture texels
+    std::vector<int> m_aidcache;
+
+    /// pivot AID -> texel index
+    std::unordered_map<int, int> m_aid2idx;
+
+    int m_nTexW, m_nTexH;
+
+    bool m_bUseCoordTex;
+    bool m_bCoordDirty;
+
+    // ---- collection state (filled during a collect-mode traversal) ----
+
+    /// True while render() is being run only to gather the trace topology.
+    bool m_bCollecting;
+
+    /// Pivot AID pairs of consecutive residues within a segment.
+    std::vector<std::pair<int, int>> m_traceBonds;
+
+    /// Pivot AIDs of single-residue (isolated) segments.
+    std::vector<int> m_traceIso;
+
+    /// pivot AID -> device colour code
+    std::unordered_map<int, quint32> m_aidColor;
+
+    bool m_bHavePrev;
+    int m_prevAid;
+    int m_curSegFirstAid;
+    int m_curSegCount;
 
     // struct IntBond {
     //   quint32 aid1, aid2;
@@ -56,12 +106,13 @@ namespace molstr {
 
     //////////////////////////////////////////////////////
     // Renderer interface
-    
-    // new rendering interface (using GL VBO)
-    // virtual void display(DisplayContext *pdc);
-    
-    // virtual void invalidateDisplayCache();
-    
+
+    void display(DisplayContext *pdc) override;
+
+    void invalidateDisplayCache() override;
+
+    void objectChanged(qsys::ObjectEvent &ev) override;
+
     //////////////////////////////////////////////////////
     // DispCacheRenderer interface
 
@@ -88,9 +139,18 @@ namespace molstr {
     
   private:
     void renderSimpleHittest(DisplayContext *phl);
-    
+
     void renderDLSel(DisplayContext *pdl);
-    
+
+    /// Gather trace topology (collect-mode traversal), build the coordinate
+    /// texture, the AID->index map, and the immutable line VBO. Falls back
+    /// (clears m_bUseCoordTex) when no float data texture is available.
+    void renderCoordTexImpl(DisplayContext *pdc);
+
+    /// Re-gather pivot positions into the coordinate texture. Called from
+    /// display() when m_bCoordDirty.
+    bool updateCoordTex();
+
   };
 
 }

--- a/src/sysdep/CMakeLists.txt
+++ b/src/sysdep/CMakeLists.txt
@@ -85,6 +85,7 @@ SET(SHADER_SOURCES
   ogl_core/pixdraw_frag.glsl
   ogl_core/linew_vert.glsl
   ogl_core/linew2_vert.glsl
+  ogl_core/linew2idx_vert.glsl
   ogl_core/linew_frag.glsl
   ogl_core/postproc_vert.glsl
   ogl_core/depthvis_frag.glsl
@@ -101,6 +102,8 @@ SET(SHADER_DEPS
   ogl_core/lighting_inc.glsl
   ogl_core/fog_inc.glsl
   ogl_core/matrices_inc.glsl
+  ogl_core/linew_inc.glsl
+  ogl_core/lib_atoms.glsl
 )
 set_target_properties(sysdep PROPERTIES SHADER_SOURCES "${SHADER_SOURCES}")
 GLSL_PREPROC(sysdep "${SHADER_DEPS}")

--- a/src/sysdep/ogl_core/linew2idx_vert.glsl
+++ b/src/sysdep/ogl_core/linew2idx_vert.glsl
@@ -1,0 +1,75 @@
+// -*-Mode: C++;-*-
+//
+//  Vertex shader for wide lines with texture-fetched endpoints.
+//
+//  Thin wrapper around linew_inc.glsl (the shared screen-space width-quad
+//  expansion). Each endpoint attribute packs a model-space offset in xyz and
+//  the coordinate-texture atom index in w. The fetched atom position plus the
+//  offset is written to the global a_vertex1 / a_vertex2 that linew_func()
+//  consumes, so linew_inc.glsl is reused unchanged.
+//
+#define attribute in
+#define varying out
+
+#include "fog_inc.glsl"
+#include "matrices_inc.glsl"
+#include "lib_atoms.glsl"
+
+////////////////////
+// DrawParamsBlock UBO: binding point 2
+
+layout(std140) uniform DrawParamsBlock {
+    float frag_alpha;   // offset 0
+    float lineWidth;    // offset 4
+    float stippleLen;   // offset 8
+    int   u_nodepth;    // offset 12
+    vec2  screenSize;   // offset 16
+    int   use_u_color;  // offset 24
+    float _pad;         // offset 28
+    vec4  u_color;      // offset 32
+};
+
+////////////////////
+// Vertex attributes (index variant)
+
+// endpoint 1: xyz = model-space offset, w = atom index into the coordinate texture
+layout(location = 0) in vec4 a_p1;
+layout(location = 1) in vec4 a_p2;
+
+// color
+layout(location = 2) in vec4 a_color1;
+layout(location = 3) in vec4 a_color2;
+
+uniform sampler2D u_coordTex;
+
+////////////////////
+// Endpoint positions consumed by linew_func() (globals, filled in main)
+
+vec4 a_vertex1;
+vec4 a_vertex2;
+
+////////////////////
+// Varying
+
+varying float v_length;
+varying vec4 v_frontColor;
+varying float v_fogCoord;
+
+////////////////////
+
+#include "linew_inc.glsl"
+
+void main(void)
+{
+    a_vertex1 = vec4(getAtomPos3(u_coordTex, int(a_p1.w)) + a_p1.xyz, 1.0);
+    a_vertex2 = vec4(getAtomPos3(u_coordTex, int(a_p2.w)) + a_p2.xyz, 1.0);
+
+    linew_func(stippleLen, v_length, v_fogCoord);
+
+    if (u_nodepth > 0) {
+        // billboarded line without depth
+        gl_Position.z = -0.99;
+        gl_Position.w = 1.0;
+        v_fogCoord = 0.0;
+    }
+}


### PR DESCRIPTION
## 概要

Phase 1 (CPK, PR #441) の座標テクスチャ direct update を線系レンダラへ展開する Phase 3 の最初の 2 段。汎用の index 版線プリミティブ `gfx::LineIdxGpuPrim` を新設し、**SelectionRenderer** と **TraceRenderer** を direct update 化した。座標変化 (morphing / MD) 時にジオメトリを全再構築せず、座標テクスチャの再アップロードだけで済む。

設計の全体像 (Selection → Trace → BallStick → Simple の段階化、concern の切り分け) は `docs/plans/260718-line-cyl-coord-texture-direct-update-phase3-plan.md` を参照。

## 変更点

### gfx::LineIdxGpuPrim (新規)
`LineGpuPrim` と同じインスタンス化幅線だが、各端点を「座標テクスチャの index + 静的 model 空間オフセット」で表す (`a_p1`/`a_p2` の xyz=offset, w=index)。オフセットにより 1 プリミティブ・1 シェーダで以下を表現:
- 結合線: `(idx1, 0), (idx2, 0)`
- 孤立原子アスター: 同一 index の両端に ±軸オフセット (model 空間固定なのでアニメ中も正しい)

### linew2idx_vert.glsl (新規)
各端点を `getAtomPos3(index) + offset` で解決し、**`linew_inc.glsl` の幅 quad 展開を無改変で再利用**。direct 版 `linew2_vert.glsl` は無変更。

### SelectionRenderer (phase 3a)
即時描画 → coord-texture パスへ。`renderCoordTexImpl` が VBO + 座標テクスチャ + AID→index マップを 1 回構築、`objectChanged` が `atomsMoved` でダーティ化、`display()` がフレーム 1 回アップロード。単色・結合線・孤立原子アスター。MODE_POINT / file 出力は従来経路。

### TraceRenderer (phase 3b)
`LineIdxGpuPrim` を再利用。`MainChainRenderer::render()` の traversal を **collect モード**で走らせ、セグメント分割ロジックと coloring scheme を無改変で再利用して topology (残基 pivot 間の結合線 + 孤立残基アスター + per-residue 色) を収集。

## 不変条件

`MolCoord` / `MolAtom` / `MorphMol` / `AnimMgr` / `LineGpuPrim` (direct 版) は無変更。未対応バックエンドは従来経路へフォールバック。React 側は無変更。

## 検証 (tritium, release)

- native / tritium 両ビルド成功 (Release)。`gpu_lineidx` シェーダが WebGL2 で実機コンパイル成功 (GLSL エラーなし)。
- **SelectionRenderer**: 46770 線分を座標テクスチャ経路で描画、`renderCoordTexImpl` は初期化 2 回のみ (毎フレーム再構築なし)。morph 再生で線が原子に追従、目視確認済み。Phase 1 で残っていた selection の「床」が解消。
- **TraceRenderer**: 4489 線分を座標テクスチャ経路で描画、`renderCoordTexImpl` 2 回のみ。trace 表示を目視確認済み。

## Phase 3 の残り (別 PR)

- BallStick (balls=SphereIdxGpuPrim 再利用, sticks=CylinderIdxGpuPrim 新規, shader 経路の valence は dead code)
- SimpleRenderer (concern 1 幅 quad + concern 2 二重結合 ind_d、最難関)

🤖 Generated with [Claude Code](https://claude.com/claude-code)