### PR TITLE
perf(tritium): trim console logging overhead in packaged builds

### DIFF
--- a/tritium/react-gui/src/main/windowManager.ts
+++ b/tritium/react-gui/src/main/windowManager.ts
@@ -155,8 +155,12 @@ export function createWindow(): void {
     win.focus()
   })
 
-  // Forward renderer/worker console messages to stdout/stderr
+  // Forward renderer/worker console messages to stdout/stderr. In a packaged
+  // app stdout is not attached to a terminal, so info/log level messages are
+  // dropped here: formatting and writing them costs main-process time for
+  // output nobody sees. warn/error are always kept for crash diagnosis.
   win.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+    if (level < 2 && app.isPackaged) return
     const src = sourceId ? ` (${sourceId}:${line})` : ''
     if (level === 3) {
       console.error('[Renderer]', message + src)
@@ -323,8 +327,10 @@ export function createOrFocusRenderWindow(mainWindow: BrowserWindow): void {
     if (!win.isDestroyed()) win.show()
   })
 
-  // Forward console messages like the main window, tagged for telling apart.
+  // Forward console messages like the main window (same packaged-build level
+  // filter), tagged for telling apart.
   win.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+    if (level < 2 && app.isPackaged) return
     const src = sourceId ? ` (${sourceId}:${line})` : ''
     if (level === 3) {
       console.error('[RenderWin]', message + src)

--- a/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
+++ b/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
@@ -283,7 +283,7 @@ export class WorkerService {
      */
     bindCanvas(canvas: any, view_id: number, dpr: number): boolean {
         if (this._gfx_mgr) {
-            console.log('bindCanvas:', canvas, view_id, dpr);
+            console.log('bindCanvas:', view_id, dpr);
             this._gfx_mgr.bindCanvas(canvas, view_id, dpr);
             this._gfx_mgr.activateView(view_id);
             return true;

--- a/tritium/react-gui/src/renderer/worker/server/gfx/ShaderStore.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx/ShaderStore.ts
@@ -156,7 +156,6 @@ export class ShaderStore {
 
         this._prog_data[name] = program;
         console.log("shader program register: name=" + name);
-        console.log("shader program register: obj=" + this._prog_data[name]);
 
         return true;
     }


### PR DESCRIPTION
## Summary

JS レベルの `console.*` がパッケージ版のパフォーマンスに与える影響を調査し、実際にコストが出ている 2 点だけを絞って修正した。

毎フレーム走る経路 (`ViewLoopController` の rAF ループ、`BufferStore.drawBuffer()`、input ハンドラ) にアクティブな log は既に 1 本もなく (hot path のものは全てコメントアウト済み、`perf.ts` も `PERF_MEASURE = false`)、残りは初期化・リソース生成時の一発ログとエラーパスの warn/error なので、定常状態のコストはもともとゼロだった。よって一括 drop などは行っていない。

## Changes

### 1. packaged 時の stdout 転送を warn/error に限定 (`main/windowManager.ts` x2)

`console-message` リスナが renderer/worker のログ 1 本ごとに main process で文字列連結 + stdout write を行っていた。パッケージ版の一般的な起動経路 (macOS Finder / Windows Explorer) では stdout がどこにも繋がっていないため、誰も見ない出力のために main process の時間を使っていた。main window と rendering window の両方に `if (level < 2 && app.isPackaged) return` を追加。

- warn/error は常に転送されるので、`IPC.CRASH_REPORT` -> stderr のクラッシュ診断経路 (`ipcHandlers.ts` の *"regardless of whether DevTools is open"*) はそのまま機能する
- **DevTools console には影響しない**。`console-message` は DevTools 表示とは独立した追加の転送イベントであり、パッケージ版でも DevTools (`webPreferences.devTools` 既定 true、View > Toggle Developer Tools) を開けば全レベル見える

### 2. console.log に生オブジェクトを渡すのをやめた

- `WorkerService.bindCanvas()` — OffscreenCanvas をそのまま渡していた (console message storage が参照を保持する)
- `ShaderStore` — `WebGLProgram` を文字列連結しており `[object WebGLProgram]` にしかならず、直前の `name=` 行と情報量が同じだったため行ごと削除

## Test plan

- `npx tsc -p tsconfig.node.json --noEmit` — エラーなし
- `npx tsc -p tsconfig.web.json --noEmit` — 出力は全て既存の noise (project-references 由来の TS6307、テストの未使用 import TS6133、`import.meta.glob`)。今回編集した 3 ファイルは 0 件
- `npx vitest run` — 271 files / 2324 tests all passed

## Note (follow-up, 本 PR 対象外)

Electron 42 では `console-message` の位置引数 `(event, level, message, line, sourceId)` は型定義上すべて `@deprecated` で、現行 API は `details.level` が `'info' | 'warning' | 'error' | 'debug'` の文字列。今は位置引数も渡ってくるため動作に問題はないが、数値 `level` 比較から文字列比較への書き換えがいずれ必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)