### PR TITLE
feat(cli): headless qsc -> PNG rendering with umbreon

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(CLI_LINK_LIBRARIES
 # Normal C++ source files
 SET(CLI_SRCS
 cli_main.cpp
+render_scene.cpp
 )
 
 set(DATA_DIR ${CMAKE_SOURCE_DIR}/../data/)

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,215 @@
+# cuetty -- CueMol command-line interface
+
+`cuetty` is the CLI front end to libcuemol2. It has two modes:
+
+- **Headless rendering** -- load a scene file and write a PNG image, with no
+  GUI, no window and no OpenGL context (`--render`).
+- **Interactive shell** -- an embedded Python REPL with the CueMol API bound
+  (`--interactive`).
+
+---
+
+## Build
+
+`cuetty` is a separate CMake project that links against an installed
+libcuemol2, so build libcuemol2 first. From `build_scripts/`:
+
+```sh
+task build_cli          # builds libcuemol2, then cuetty
+```
+
+The binary is installed to `<repo>/.build_out/cuemol2/bin/cuetty`. It is not
+placed on `PATH`; invoke it by path.
+
+`task build_cli` currently only has a macOS variant. Elsewhere, configure and
+build `cli/` directly (see `build_scripts/build_cuetty_posix/run.sh` for the
+cmake arguments).
+
+**Headless rendering additionally requires libcuemol2 to be built with
+`ENABLE_UMBREON=ON`**, which is *not* the default:
+
+```sh
+task install_umbreon                        # build+install umbreon into the deplibs prefix
+ENABLE_UMBREON=ON task rebuild_libcuemol2   # reconfigure libcuemol2 with umbreon
+task build_cli
+```
+
+Without it the exporter is never registered and `--render` fails with
+`umbreon exporter is not available; libcuemol2 must be built with
+ENABLE_UMBREON=ON` (exit status 1). Note that a later plain
+`task rebuild_libcuemol2` turns the option back off.
+
+---
+
+## Headless rendering
+
+### Synopsis
+
+```sh
+cuetty --input <scene.qsc> --render <out.png> [--width W] [--height H] [--camera NAME]
+```
+
+The scene is rendered with **umbreon**, the Embree-based CPU ray tracer.
+Nothing in this path touches OpenGL: `UmbreonSceneExporter` needs only the
+scene and a camera, and walks the scene through a file `DisplayContext`. No
+`qsys::View` is created, so it runs on a machine with no display.
+
+(The GL-based `PngSceneExporter` cannot be used this way -- it requires
+`View::createOffScreenView()`, hence an OpenGL context.)
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--input <path>` | -- | Input scene file (`.qsc`). Required with `--render`. |
+| `-r`, `--render <path>` | -- | Output PNG path. Supplying it selects render mode: the image is written and cuetty exits. |
+| `--width <px>` | `640` | Image width. Must be positive. |
+| `--height <px>` | `480` | Image height. Must be positive. |
+| `--camera <name>` | `__current` | Camera to render from. Must exist in the scene. |
+| `-c`, `--config <path>` | build-time default | `sysconfig.xml` to initialise from. |
+| `-h`, `--help` | -- | Print the option list. |
+
+The default camera name is `__current`, which is where the GUI stores the
+current view when it writes a `.qsc`, so a GUI-authored scene always has it.
+Any other camera saved in the scene can be named instead.
+
+### Exit status
+
+| Status | Meaning |
+|---|---|
+| `0` | Image written. |
+| `1` | Scene could not be loaded, the named camera does not exist, an argument was invalid, or umbreon is not built in. |
+
+The reason is printed to the log in every failure case, so a script can
+branch on the status alone.
+
+### Examples
+
+```sh
+CUETTY=.build_out/cuemol2/bin/cuetty
+
+# Defaults (640x480, "__current" camera)
+$CUETTY --input scene.qsc --render out.png
+
+# Explicit size
+$CUETTY --input scene.qsc --render out.png --width 1920 --height 1080
+
+# A named camera saved in the scene
+$CUETTY --input scene.qsc --render side.png --camera side_view
+
+# In a shell script
+if ! $CUETTY --input scene.qsc --render out.png --width 1200 --height 900; then
+    echo "render failed" >&2
+    exit 1
+fi
+```
+
+### What is configurable, and what is not
+
+Only the image size and the camera are exposed. Every other render setting
+stays at the `UmbreonSceneExporter` constructor default:
+
+| Setting | Value |
+|---|---|
+| supersampling | 3 |
+| clip-Z (camera slab near plane) | on |
+| edge / silhouette lines | on |
+| ambient occlusion | off |
+| shadows | off |
+| global illumination, denoiser | off |
+| transparent background | off |
+
+**Projection is the one exception**: it is taken from the scene's camera
+rather than the exporter default. `View::setCameraAnim` copies the whole
+`Camera` (including `perspec`) into the view's current camera, so the camera
+saved in the `.qsc` records the projection the GL view was showing. Using the
+exporter default instead would render an orthographic scene in perspective.
+
+### Text labels are not rendered
+
+Labels (atom names, distance measurements, and other `drawString` output) do
+**not** appear in the image. The file `DisplayContext` inherits the no-op
+`gfx::DisplayContext::drawString`, so labels are silently skipped -- this is
+not an error and does not stop the render. Everything else in a
+label-bearing scene, including the measurement lines themselves, renders
+normally.
+
+---
+
+## Interactive shell
+
+```sh
+cuetty --interactive [--input scene.qsc]
+```
+
+Starts the embedded Python interpreter with the CueMol API available. When
+`--input` is given, the scene is loaded first, so the shell starts with it
+already in the scene manager.
+
+Requires libcuemol2 built with `ENABLE_PYTHON_EMBED=ON`; otherwise cuetty
+prints `interactive shell is not available in this build` and exits normally.
+
+---
+
+## Rendering from Python instead
+
+The same render is available from the `cuemol` Python module, driving the
+identical C++ path (`load_scene` command, then the umbreon exporter) and
+producing byte-identical images:
+
+```sh
+python -m cuemol.umbreon_render scene.qsc out.png -W 1920 -H 1080 [-c CAMERA]
+```
+
+```python
+from cuemol import umbreon_render
+
+# render_file returns the loaded scene, so further images (e.g. other
+# cameras) can be rendered without reloading it
+scene = umbreon_render.render_file("scene.qsc", "front.png", 1920, 1080)
+umbreon_render.render(scene, "side.png", 1920, 1080, camera="side_view")
+```
+
+Prefer the Python entry point for batch work -- several cameras, a sweep over
+scenes, or anything that would otherwise be a shell loop. Use `cuetty` when a
+self-contained binary with no Python environment is what you want.
+
+Building the module: `task build_pytest`.
+
+---
+
+## Troubleshooting
+
+**`umbreon exporter is not available`** -- libcuemol2 was built with
+`ENABLE_UMBREON=OFF` (the default). See [Build](#build).
+
+**`scene has no camera named '__current'`** -- the scene was not written by
+the GUI, or was written without saving the view. Pass an existing camera with
+`--camera`; `Scene::getCameraInfoJSON()` lists what a scene has.
+
+**`cannot load scene file`** -- the path is wrong, or the file is not a
+format any registered scene reader recognises. The format is guessed from the
+file name, so the extension must be `.qsc`.
+
+**The Python module fails to import with `Library not loaded:
+libpython3.12.dylib`** -- libcuemol2 is built against a bundled Python that
+differs from the interpreter running the module. Point the loader at the
+bundled runtime, and use the interpreter's real path (a pyenv shim is a shell
+script, and macOS SIP strips `DYLD_*` across it):
+
+```sh
+DYLD_LIBRARY_PATH=$HOME/tmp/proj64_deplibs/python/lib \
+    .venv/bin/python -m cuemol.umbreon_render scene.qsc out.png
+```
+
+---
+
+## See also
+
+- `cli/render_scene.{hpp,cpp}` -- the render implementation, kept in its own
+  translation unit so it can be reused from another entry point.
+- `src/modules/rendering/UmbreonSceneExporter.qif` -- the full exporter
+  property set, including the AO / shadow / GI knobs this CLI does not expose.
+- `docs/architecture/umbreon-process-isolation.md` -- why umbreon renders
+  in-process, and the Electron-specific memory limits that do **not** apply to
+  a plain CLI process.

--- a/cli/cli_main.cpp
+++ b/cli/cli_main.cpp
@@ -2,6 +2,8 @@
 #include <common.h>
 #include <libcuemol2_api/loader.hpp>
 
+#include "render_scene.hpp"
+
 #include <iostream>
 #include <string>
 #include <optional>
@@ -23,8 +25,7 @@
 #endif
 
 using qlib::LString;
-void process_input(const LString &loadscr, const std::deque<LString> &args,
-                   bool bInvokeIntrShell);
+void process_input(const LString &loadscr, bool bInvokeIntrShell);
 
 #ifndef DEFAULT_CONFIG
 #define DEFAULT_CONFIG "./sysconfig.xml"
@@ -37,19 +38,30 @@ struct Config
     bool interactive;
     std::string input_file;
     std::string config_file;
+
+    /// Output PNG path; non-empty selects headless render mode.
+    std::string render_file;
+    int width;
+    int height;
+    std::string camera;
 };
 
 std::optional<Config> parse_arguments(int argc, const char *argv[])
 {
     /// argment parser
     po::options_description desc("Allowed options");
+    const cuetty::RenderOpts defs;
     desc.add_options()("help,h", "Show help message")("interactive,i",
                                                       "Run in interactive mode")(
         "input", po::value<std::string>()->default_value(""), "Input file")(
-        "config,c", po::value<std::string>()->default_value(""), "Config file");
-    // ("output,o", po::value<std::string>()->default_value("out.txt"), "Output file")
-    // ("verbose,v", po::bool_switch()->default_value(false), "Enable verbose mode")
-    // ("count,n", po::value<int>()->default_value(10), "Number of iterations");
+        "config,c", po::value<std::string>()->default_value(""), "Config file")(
+        "render,r", po::value<std::string>()->default_value(""),
+        "Render the input scene into this PNG file and exit (headless)")(
+        "width", po::value<int>()->default_value(defs.width), "Render width in pixels")(
+        "height", po::value<int>()->default_value(defs.height),
+        "Render height in pixels")("camera",
+                                   po::value<std::string>()->default_value(defs.camera),
+                                   "Camera name to render from");
 
     po::variables_map vm;
 
@@ -70,9 +82,26 @@ std::optional<Config> parse_arguments(int argc, const char *argv[])
         return std::nullopt;
     }
 
-    return Config{vm.count("interactive") > 0,
+    Config config{vm.count("interactive") > 0,
                   vm["input"].as<std::string>(),
-                  vm["config"].as<std::string>()};
+                  vm["config"].as<std::string>(),
+                  vm["render"].as<std::string>(),
+                  vm["width"].as<int>(),
+                  vm["height"].as<int>(),
+                  vm["camera"].as<std::string>()};
+
+    if (!config.render_file.empty()) {
+        if (config.input_file.empty()) {
+            std::cerr << "Error: --render requires --input <scene file>" << std::endl;
+            return std::nullopt;
+        }
+        if (config.width <= 0 || config.height <= 0) {
+            std::cerr << "Error: --width and --height must be positive" << std::endl;
+            return std::nullopt;
+        }
+    }
+
+    return config;
 }
 
 // //
@@ -102,52 +131,43 @@ int internal_main(int argc, const char *argv[])
         return -1;
     }
 
-    int i;
-    LString loadscr;
-    std::deque<LString> args2;
-
-    bool bInvokeIntrShell = config->interactive;
     LString confpath = config->config_file;
     if (confpath.isEmpty()) {
         confpath = DEFAULT_CONFIG;
     }
 
-    // for (i = 1; i < argc; ++i) {
-    //     MB_DPRINTLN("arg%d=%s", i, argv[i]);
-    //     LString value = argv[i];
+    // Render mode never creates a qsys::View (the umbreon exporter walks the
+    // scene through a file DisplayContext), so skip registering the platform's
+    // OpenGL view factory and stay headless.
+    const bool bRender = !config->render_file.empty();
 
-    //     if (value.equals("-i")) {
-    //         bInvokeIntrShell = true;
-    //         continue;
-    //     } else if (value.equals("-conf")) {
-    //         ++i;
-    //         if (i >= argc) break;
-    //         confpath = argv[i];
-    //         // ++i;
-    //         continue;
-    //     } else {
-    //         break;
-    //     }
-    // }
-
-    // for (; i < argc; ++i) {
-    //     MB_DPRINTLN("arg%d=%s", i, argv[i]);
-    //     args2.push_back(argv[i]);
-    // }
-
-    // if (args2.size() > 0) loadscr = args2.front();
-
-    int result = cuemol2::init(confpath, true);
+    int result = cuemol2::init(confpath, !bRender);
     if (result < 0) {
         return result;
     }
 
-    // if (!loadscr.isEmpty()) {
-    process_input(loadscr, args2, bInvokeIntrShell);
-    //}
+    int rc = 0;
+    if (bRender) {
+        cuetty::RenderOpts opts;
+        opts.width = config->width;
+        opts.height = config->height;
+        opts.camera = config->camera;
+        rc = cuetty::renderSceneToPng(config->input_file, config->render_file, opts);
+        // Tear the loaded scene down before the modules are finalized below;
+        // process_input() does the same for the non-render path. Skipping this
+        // crashes in cuemol2::fini().
+        qsys::SceneManager::getInstance()->destroyAllScenes();
+    } else {
+        process_input(config->input_file.c_str(), config->interactive);
+    }
 
     cuemol2::fini();
     cuemol2::fini_qlib();
+
+    if (rc != 0) {
+        printf("=== Terminated with error ===\n");
+        return rc;
+    }
 
     printf("=== Terminated normaly ===\n");
     return 0;
@@ -170,25 +190,22 @@ int main(int argc, const char *argv[])
 
 namespace fs = boost::filesystem;
 
-void process_input(const LString &loadscr, const std::deque<LString> &args,
-                   bool bInvokeIntrShell)
+void process_input(const LString &loadscr, bool bInvokeIntrShell)
 {
     qsys::SceneManager *pSM = qsys::SceneManager::getInstance();
     LOG_DPRINTLN("CueMol version %s build %s", pSM->getVersion().c_str(),
                  pSM->getBuildID().c_str());
 
-    fs::path scr_path(loadscr.c_str());
-
-    fs::path full_path = fs::system_complete(scr_path);
-    if (full_path.extension() == ".qsc") {
-        qsys::LoadSceneCommand cmd;
-        cmd.m_filePath = full_path.string().c_str();
-        cmd.m_fileFmt = "qsc";
-        cmd.run();
-
-        // qsys::ScenePtr rscene = pSM->loadSceneFrom(scr_path.string(), "xml");
-        // qlib::FileOutStream &fos = qlib::FileOutStream::getStdErr();
-        // rscene->writeTo(fos, true);
+    if (!loadscr.isEmpty()) {
+        fs::path full_path = fs::system_complete(fs::path(loadscr.c_str()));
+        if (full_path.extension() == ".qsc") {
+            qsys::LoadSceneCommand cmd;
+            cmd.m_filePath = full_path.string().c_str();
+            // m_fileFmt is left empty on purpose: the command then guesses the
+            // format from the file name. Naming it "qsc" would not resolve --
+            // the registered scene-reader nickname is "qsc_xml".
+            cmd.run();
+        }
     }
 
     if (bInvokeIntrShell) {

--- a/cli/render_scene.cpp
+++ b/cli/render_scene.cpp
@@ -1,0 +1,85 @@
+//
+//  Headless scene rendering (qsc -> PNG) with the umbreon ray tracer
+//
+
+#include <common.h>
+
+#include "render_scene.hpp"
+
+#include <qlib/LVariant.hpp>
+#include <qsys/Camera.hpp>
+#include <qsys/InOutHandler.hpp>
+#include <qsys/Scene.hpp>
+#include <qsys/SceneExporter.hpp>
+#include <qsys/StreamManager.hpp>
+#include <qsys/command/LoadSceneCommand.hpp>
+
+namespace cuetty {
+
+using qlib::LString;
+
+int renderSceneToPng(const std::string &qscPath, const std::string &outPng,
+                     const RenderOpts &opts)
+{
+    // Load the scene. m_fileFmt is deliberately left empty so the command
+    // guesses the format from the file name: the registered scene-reader
+    // nickname is "qsc_xml", not "qsc", and a wrong nickname makes
+    // StreamManager::createHandler return null.
+    qsys::LoadSceneCommand cmd;
+    cmd.m_filePath = qscPath.c_str();
+    cmd.run();
+
+    qsys::ScenePtr pScene = cmd.m_pResScene;
+    if (pScene.isnull()) {
+        LOG_DPRINTLN("render> cannot load scene file: %s", qscPath.c_str());
+        return 1;
+    }
+
+    const LString camName(opts.camera.c_str());
+    if (!pScene->hasCamera(camName)) {
+        LOG_DPRINTLN("render> scene has no camera named '%s'", opts.camera.c_str());
+        return 1;
+    }
+    qsys::CameraPtr pCam = pScene->getCamera(camName);
+
+    // umbreon renders in-process and writes the PNG itself. Its writer is only
+    // registered when libcuemol2 is built with ENABLE_UMBREON=ON, so a null
+    // handler here means the backend is missing rather than a bad name.
+    auto pHandler = qsys::StreamManager::getInstance()->createHandler(
+        "umbreon", qsys::InOutHandler::IOH_CAT_RENDTOFILE);
+    auto *pExporter = dynamic_cast<qsys::SceneExporter *>(pHandler.get());
+    if (pExporter == nullptr) {
+        LOG_DPRINTLN(
+            "render> umbreon exporter is not available; "
+            "libcuemol2 must be built with ENABLE_UMBREON=ON");
+        return 1;
+    }
+
+    pExporter->setWidth(opts.width);
+    pExporter->setHeight(opts.height);
+    pExporter->setCameraName(camName);
+
+    // Follow the projection the scene was saved with. View::setCameraAnim
+    // copies the whole Camera (perspec included) into the view's current
+    // camera, so this is what the GL view showed; the exporter's own
+    // perspective property defaults to true regardless. Set through the
+    // scriptable interface because it belongs to UmbreonSceneExporter, whose
+    // header the render module does not install.
+    pExporter->setProperty("perspective", qlib::LVariant(pCam->isPerspec()));
+
+    pExporter->attach(pScene);
+    try {
+        pExporter->setPath(outPng.c_str());
+        pExporter->write();
+    } catch (...) {
+        pExporter->detach();
+        throw;
+    }
+    pExporter->detach();
+
+    LOG_DPRINTLN("render> wrote %s (%dx%d, camera '%s')", outPng.c_str(),
+                 opts.width, opts.height, opts.camera.c_str());
+    return 0;
+}
+
+}  // namespace cuetty

--- a/cli/render_scene.hpp
+++ b/cli/render_scene.hpp
@@ -1,0 +1,42 @@
+// -*-Mode: C++;-*-
+//
+//  Headless scene rendering (qsc -> PNG) with the umbreon ray tracer
+//
+
+#ifndef CUETTY_RENDER_SCENE_HPP_INCLUDED
+#define CUETTY_RENDER_SCENE_HPP_INCLUDED
+
+#include <string>
+
+namespace cuetty {
+
+/// Options for a headless scene render. Everything not listed here is left
+/// at the UmbreonSceneExporter constructor defaults (supersample 3, clip-Z
+/// and edge lines on, AO / shadows / GI off); the projection comes from the
+/// scene's camera.
+struct RenderOpts
+{
+    /// image width in pixels; matches the exporter's own fallback
+    int width = 640;
+
+    /// image height in pixels; matches the exporter's own fallback
+    int height = 480;
+
+    /// camera name to render from. The GUI saves the current view under this
+    /// name when writing a .qsc, so a GUI-authored scene always has it.
+    std::string camera = "__current";
+};
+
+/// Load a CueMol scene file and render it into a PNG image with umbreon.
+///
+/// Needs neither a qsys::View nor an OpenGL context: the exporter walks the
+/// scene through a file DisplayContext. Text labels are not drawn (the file
+/// DisplayContext inherits the no-op gfx::DisplayContext::drawString).
+///
+/// Returns 0 on success and 1 on failure, logging the reason.
+int renderSceneToPng(const std::string &qscPath, const std::string &outPng,
+                     const RenderOpts &opts);
+
+}  // namespace cuetty
+
+#endif

--- a/pymod/python/cuemol/umbreon_render.py
+++ b/pymod/python/cuemol/umbreon_render.py
@@ -1,0 +1,133 @@
+"""
+Headless scene rendering with the umbreon (Embree) ray tracer.
+
+Renders a CueMol scene straight to a PNG without an OpenGL context and
+without a qsys View. UmbreonSceneExporter only needs the scene and a camera
+(the scene walk goes through a file DisplayContext, not GL), so this works on
+a headless machine. The GL-based PngSceneExporter cannot: it requires
+View::createOffScreenView().
+
+Requires libcuemol2 built with ENABLE_UMBREON=ON. Without it StreamManager
+has no "umbreon" writer registered and createHandler() returns None.
+
+Everything except the image size, the camera and the projection is left at
+the C++ ctor defaults of UmbreonSceneExporter (supersample 3, clip-Z and
+edge lines on, AO / shadows / GI off). The projection is taken from the
+camera the scene was saved with rather than the exporter default, so the
+image matches the saved view.
+
+Text labels are not drawn: the file DisplayContext inherits the no-op
+gfx::DisplayContext::drawString.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import cuemol as cm
+
+__all__ = ["render", "render_file"]
+
+# StreamManager category ID for scene exporters.
+EXPORTER_CATEGORY = 2
+
+# Camera the GUI saves the current view into when writing a .qsc file
+# (see uxp qsc-io.js saveViewToCam), so a GUI-authored scene always has it.
+DEFAULT_CAMERA = "__current"
+
+# Image size fallback, matching UmbreonSceneExporter::setupContext when no
+# size and no view are available. Kept identical so an unspecified size means
+# the same thing at every layer.
+DEFAULT_WIDTH = 640
+DEFAULT_HEIGHT = 480
+
+
+def render(scene, out_png, width=DEFAULT_WIDTH, height=DEFAULT_HEIGHT,
+           camera=DEFAULT_CAMERA):
+    """Render a scene into a PNG file with umbreon.
+
+    scene may be a Scene wrapper or anything cuemol.scene() accepts. The
+    render is synchronous: write() blocks until the ray trace finishes.
+    """
+    sc = cm.scene(scene)
+    if sc is None:
+        raise RuntimeError("scene ({}) does not exist".format(scene))
+
+    if not sc.hasCamera(camera):
+        raise RuntimeError(
+            "scene has no camera named '{}'; "
+            "pass an existing camera name".format(camera)
+        )
+    cam = sc.getCamera(camera)
+
+    exporter = cm.strMgr().createHandler("umbreon", EXPORTER_CATEGORY)
+    if exporter is None:
+        raise RuntimeError(
+            "umbreon exporter is not available; "
+            "libcuemol2 must be built with ENABLE_UMBREON=ON"
+        )
+
+    # Follow the projection the scene was saved with. View::setCameraAnim
+    # copies the whole Camera (including perspec) into the view's current
+    # camera, so cam.perspec is what the GL view showed. The exporter's own
+    # perspective property defaults to true regardless, so without this the
+    # render would differ from the saved view for orthographic scenes.
+    exporter.perspective = cam.perspec
+
+    exporter.width = width
+    exporter.height = height
+    exporter.camera = camera
+
+    exporter.attach(sc)
+    try:
+        exporter.setPath(str(out_png))
+        exporter.write()
+    finally:
+        exporter.detach()
+
+
+def render_file(qsc_path, out_png, width=DEFAULT_WIDTH, height=DEFAULT_HEIGHT,
+                camera=DEFAULT_CAMERA):
+    """Load a .qsc scene file and render it into a PNG file.
+
+    Returns the loaded scene so the caller can render further images (e.g.
+    other cameras) without reloading.
+    """
+    # Load through the load_scene command rather than a hand-picked reader:
+    # leaving file_format empty makes LoadSceneCommand guess it from the file
+    # name (the registered scene-reader nickname is "qsc_xml", not "qsc").
+    result = cm.svc("CmdMgr").runCmdArgs("load_scene", {"file_path": str(qsc_path)})
+    scene = result["result_scene"]
+    if scene is None:
+        raise RuntimeError("cannot load scene file: {}".format(qsc_path))
+
+    render(scene, out_png, width, height, camera)
+    return scene
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="python -m cuemol.umbreon_render",
+        description="Render a CueMol scene file (.qsc) to a PNG image "
+                    "with the umbreon ray tracer (headless).",
+    )
+    parser.add_argument("qsc", help="input scene file (.qsc)")
+    parser.add_argument("png", help="output image file (.png)")
+    parser.add_argument("-W", "--width", type=int, default=DEFAULT_WIDTH,
+                        help="image width in pixels (default: %(default)s)")
+    parser.add_argument("-H", "--height", type=int, default=DEFAULT_HEIGHT,
+                        help="image height in pixels (default: %(default)s)")
+    parser.add_argument("-c", "--camera", default=DEFAULT_CAMERA,
+                        help="camera name in the scene (default: %(default)s)")
+    args = parser.parse_args(argv)
+
+    if args.width <= 0 or args.height <= 0:
+        parser.error("width and height must be positive")
+
+    render_file(args.qsc, args.png, args.width, args.height, args.camera)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/rendering_tests/test_umbreon_render.py
+++ b/tests/rendering_tests/test_umbreon_render.py
@@ -1,0 +1,102 @@
+"""Tests for headless qsc -> PNG rendering with the umbreon ray tracer.
+
+These pin the observable contract of cuemol.umbreon_render, not image
+quality: that a scene file renders to a PNG of the requested size without a
+View or a GL context, that the projection comes from the scene's camera
+rather than the exporter default, and that an unknown camera fails with a
+clear error instead of a null-pointer throw from the C++ side.
+
+Skipped when libcuemol2 was built with ENABLE_UMBREON=OFF (the default), in
+which case StreamManager has no "umbreon" writer registered.
+"""
+
+import struct
+
+import pytest
+
+import cuemol
+from cuemol import umbreon_render
+
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+# A non-LFS scene file, so this runs on a plain clone without `git lfs pull`.
+# It carries a "__current" camera saved with perspec=false, plus an atomintr
+# renderer whose distance labels exercise the no-op drawString path.
+_SCENE_FILE = "number_chain_atomintr1.qsc"
+
+
+def _umbreon_available():
+    return cuemol.strMgr().createHandler("umbreon", 2) is not None
+
+
+umbreon_required = pytest.mark.skipif(
+    not _umbreon_available(),
+    reason="libcuemol2 was built without ENABLE_UMBREON",
+)
+
+
+def _png_size(path):
+    """Return (width, height) read from a PNG's IHDR chunk."""
+    with open(path, "rb") as f:
+        head = f.read(24)
+    assert head[:8] == _PNG_SIGNATURE, "not a PNG file"
+    assert head[12:16] == b"IHDR", "first chunk is not IHDR"
+    return struct.unpack(">II", head[16:24])
+
+
+@pytest.fixture
+def scene_path(test_data_path):
+    return test_data_path / _SCENE_FILE
+
+
+@umbreon_required
+def test_render_file_writes_png_of_requested_size(scene_path, tmp_path):
+    out = tmp_path / "out.png"
+
+    umbreon_render.render_file(scene_path, out, width=120, height=80)
+
+    assert out.is_file()
+    assert _png_size(out) == (120, 80)
+
+
+@umbreon_required
+def test_projection_follows_scene_camera(scene_path, tmp_path):
+    # The scene's camera is orthographic while UmbreonSceneExporter defaults
+    # to perspective, so "follows the camera" is observable: the rendered
+    # bytes must match an explicit orthographic render and differ from an
+    # explicit perspective one. Both renders are deterministic because AO and
+    # GI (the only stochastic parts) are off by default.
+    auto = tmp_path / "auto.png"
+    scene = umbreon_render.render_file(scene_path, auto, width=120, height=80)
+    assert not scene.getCamera("__current").perspec, "scene camera must be ortho"
+
+    def render_with(perspective, out):
+        exporter = cuemol.strMgr().createHandler("umbreon", 2)
+        exporter.width, exporter.height = 120, 80
+        exporter.camera = "__current"
+        exporter.perspective = perspective
+        exporter.attach(scene)
+        try:
+            exporter.setPath(str(out))
+            exporter.write()
+        finally:
+            exporter.detach()
+
+    ortho = tmp_path / "ortho.png"
+    persp = tmp_path / "persp.png"
+    render_with(False, ortho)
+    render_with(True, persp)
+
+    assert auto.read_bytes() == ortho.read_bytes()
+    assert auto.read_bytes() != persp.read_bytes()
+
+
+@umbreon_required
+def test_unknown_camera_raises_before_export(scene_path, tmp_path):
+    out = tmp_path / "never.png"
+
+    with pytest.raises(RuntimeError, match="no camera named"):
+        umbreon_render.render_file(scene_path, out, width=120, height=80,
+                                   camera="no_such_camera")
+
+    assert not out.exists()


### PR DESCRIPTION
## Summary

qsc シーンを headless (GL コンテキスト・`qsys::View` なし) で PNG にレンダリングできるようにした。CLI と Python の両方から使える。

```sh
cuetty --input scene.qsc --render out.png --width 400 --height 300 [--camera NAME]
python -m cuemol.umbreon_render scene.qsc out.png -W 400 -H 300 [-c NAME]
```

`UmbreonSceneExporter` が必要とするのは Scene と Camera だけで、シーンの走査は file DisplayContext を通るため GL に一切触れない。GL ベースの `PngSceneExporter` は `createOffScreenView()` を要求するので headless では使えず、**umbreon が唯一の実用経路**。

両エントリポイントは同じ C++ 経路 (`load_scene` command -> umbreon exporter) を通り、**出力はバイト単位で一致**する。

## Scope

設定できるのは画像サイズとカメラ名のみ。それ以外は `UmbreonSceneExporter` の ctor 既定のまま (supersample 3 / clip-Z・edge lines on / AO・shadows・GI off)。

**projection だけは例外**で、exporter 既定 (`perspective=true`) ではなく**シーンのカメラの `perspec` に従う**。`View::setCameraAnim` が Camera 全体 (perspec 含む) を view の current camera にコピーするため、camera の値が「GL view で見えていた状態」を記録しているから。テストデータの qsc は `perspec="false"` で、既定のままだと保存時と違う投影で描かれてしまう。

ラベル (テキスト) は描画されない。file DisplayContext が `gfx::DisplayContext::drawString` の空実装を継承しているため、**例外にはならず静かに省略される**。

`ENABLE_UMBREON=ON` でビルドされた libcuemol2 が必要。exporter はその場合のみ registWriter されるので、未ビルド時は null handler で落ちるのではなく「ENABLE_UMBREON=ON が必要」と明示して exit 1 する。

## 途中で見つけて直したバグ 3 件

1. **`cuetty --input` が未結線** — `config->input_file` がどこにも渡っておらず、cuetty はそもそも qsc を読めなかった
2. **`LoadSceneCommand` の `m_fileFmt = "qsc"` が誤り** — 登録されている scene-reader の nickname は `"qsc_xml"` なので `createHandler` が null を返す。空にして `guessFileFormat()` にファイル名から推測させる形に修正
3. **render 経路の終了時 SIGSEGV** — 非 render 経路は `process_input()` が `destroyAllScenes()` を呼ぶのに対し、render 経路はシーンを残したまま `cuemol2::fini()` に入ってクラッシュしていた (当初 exit=139)

## Design note

render 本体は `cli/render_scene.{hpp,cpp}` として独立 TU に切ってある。将来 cuetty とは別の qsc->png 専用実行形式に切り出したくなった場合、argv parsing の追加だけで済む形。

## Test plan

- `tests/rendering_tests/test_umbreon_render.py` (新規 3 件) — 要求サイズの PNG が出ること / projection がシーンのカメラに従うこと / 未知のカメラが分かりやすいエラーになること。**非 LFS の fixture** を使うので plain clone でも実行され、umbreon 無しビルドでは self-skip する
- Python: **853 passed** (`pytest tests/`)
- C++: **1237 passed** (`task run_gtest`、`ENABLE_UMBREON=ON` により `test_umbreon` 15 件含む)
- cuetty と Python の出力が `cmp` でバイト一致
- exit code: 成功 0 / カメラ不在 1 / 引数不正 1
- ラベル入りシーン (atomintr) も完走を確認

## Note

CI (build2.yml / build_linux.yml) は `ENABLE_UMBREON=OFF` なので新規テストは skip される。umbreon 有効の検証は既存の `umbreon_smoke.yml` (workflow_dispatch) が担当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)