### PR TITLE
feat(render): let umbreon clip the camera slab; match the edge lines to the GL view

### DIFF
--- a/src/modules/rendering/FileDisplayContext.cpp
+++ b/src/modules/rendering/FileDisplayContext.cpp
@@ -28,6 +28,9 @@ FileDisplayContext::FileDisplayContext()
   m_bUnitary = true;
   m_nDetail = 3;
   m_dUniTol = 1e-3;
+  // Slab clipping off until an exporter opts in with setClipZ(); every exporter
+  // sets it explicitly, so this only defines the bare-context (test) default.
+  m_bUseClipZ = false;
   m_dLineScale = 0.02;
   m_nPolyMode = POLY_FILL;
   m_bLighting = false;

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -575,18 +575,15 @@ void UmbreonDisplayContext::appendIntData()
   }
 
   // --- triangle mesh (de-indexed: 3 corners per triangle) ---
-  // With slab clipping on (m_dClipZ >= 0), render the near-clipped mesh:
-  // calcMeshClip() cuts triangles at z == m_dClipZ, interpolating position /
-  // normal / color, exactly as the GL view and the Lux exporter do. It returns
-  // NULL when nothing is clipped, in which case the original mesh is used.
+  // The camera slab is clipped by umbreon (Scene::clipNear, set in
+  // buildSceneAndOptions), so the mesh is handed over UNCLIPPED and
+  // RendIntData::m_dClipZ is deliberately ignored here. Cutting the triangles
+  // on this side (calcMeshClip) would turn the cross-section into real geometry
+  // -- an open mesh boundary that the native stroke pass then inks as a
+  // silhouette. umbreon clamps the primary rays instead and knows which
+  // boundaries its own planes cut, so the cut stays line-free.
   {
-    Mesh *pClipped = NULL;
     Mesh *pmesh = &pdat->m_mesh;
-    if (pdat->m_dClipZ >= 0.0) {
-      pClipped = pdat->calcMeshClip();
-      if (pClipped != NULL)
-        pmesh = pClipped;
-    }
     const int nface = pmesh->getFaceSize();
     umbreon::Mesh &um = scene.mesh;
     for (int i = 0; i < nface; ++i) {
@@ -608,18 +605,15 @@ void UmbreonDisplayContext::appendIntData()
         um.colors.push_back(resolveColor(clut, pv[k]->c));
       }
     }
-    if (pClipped != NULL)
-      delete pClipped;
   }
 
   // --- analytic spheres (shaded, not flat outline) ---
-  // umbreon cannot cut a quadric at the clip plane, so (like the Lux exporter)
-  // drop spheres that lie entirely in front of it and draw the rest whole.
+  // Emitted whole: umbreon's clip plane cuts the quadric exactly, so a sphere
+  // straddling the plane no longer has to be drawn whole (nor a fully clipped
+  // one dropped) the way the Lux exporter still does.
   for (RendIntData::SphList::const_iterator i = pdat->m_spheres.begin();
        i != pdat->m_spheres.end(); ++i) {
     const RendIntData::Sph *p = *i;
-    if (pdat->m_dClipZ >= 0.0 && p->v1.z() - p->r >= pdat->m_dClipZ)
-      continue;
     umbreon::Sphere s;
     s.center = toVec3(p->v1);
     s.radius = float(p->r);
@@ -644,14 +638,7 @@ void UmbreonDisplayContext::appendIntData()
       v2.w() = 1.0;
       p->pTransf->xform4D(v2);
     }
-    // drop cylinders entirely in front of the near clip plane (umbreon cannot
-    // cut a quadric there); the Lux exporter does the same.
-    if (pdat->m_dClipZ >= 0.0) {
-      const double zfar = (v1.z() < v2.z()) ? v1.z() : v2.z();
-      const double delw = (p->w1 > p->w2) ? p->w1 : p->w2;
-      if (zfar - delw >= pdat->m_dClipZ)
-        continue;
-    }
+    // Emitted whole, like the spheres above: the slab cut is umbreon's job.
     umbreon::Cylinder c;
     c.p0 = toVec3(v1);
     c.p1 = toVec3(v2);
@@ -736,6 +723,31 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     bg = umbreon::Vec3(float(m_bgcolor->fr()), float(m_bgcolor->fg()),
                        float(m_bgcolor->fb()));
   scene.background = bg;
+
+  // View-space slab clipping (the CueMol camera slab), done by umbreon: it
+  // clamps every primary ray to linear view-z in [clipNear, clipFar] -- the
+  // distance along the camera forward axis -- so the geometry above is handed
+  // over UNCLIPPED and the plane does the cutting. Eye-space z maps to view-z
+  // as vz = m_dViewDist - z (the camera sits at (0,0,m_dViewDist) looking down
+  // -Z, see buildCamera), so the near cutaway plane RendIntData used to cut the
+  // mesh at (m_dClipZ = slab/2 in eye z, the GL view's dist - slab/2) becomes
+  // clipNear directly.
+  //
+  // Only the near plane is set. The GL view's far plane (dist + slabDepth) has
+  // no observable effect here: the depth fog below ends at dist + slabDepth/2,
+  // in FRONT of it, so anything the far plane could remove is already blended
+  // fully into the background -- down to alpha 0 on the transparent-background
+  // path. Secondary rays (shadow / AO / GI) stay unclipped in umbreon, matching
+  // the interactive view where the slab is a display device, not scene geometry.
+  if (m_bUseClipZ) {
+    const double clipNear = m_dViewDist - m_dSlabDepth * 0.5;
+    // A near plane at or behind the camera clips nothing; leaving it at -inf
+    // keeps the whole ray (umbreon ignores a non-positive clipNear anyway).
+    if (clipNear > 0.0) {
+      scene.clipNear = float(clipNear);
+      MB_DPRINTLN("Umbreon> near clip plane: view-z %f", clipNear);
+    }
+  }
 
   // OpenGL linear depth fog (depth cue): the umbreon renderer consumes only
   // fog.start/end (plane eye-z) + color; the legacy POV fog_type/offset/alt/up

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -536,15 +536,32 @@ void UmbreonDisplayContext::appendIntData()
         eg = float(pcol->fg());
         eb = float(pcol->fb());
       }
-      // Edge line width: getEdgeLineWidth() is a world-space radius (as POV /
-      // Lux use it); convert to the native stroke width in FINAL pixels via the
-      // line scale (world units per pixel, seeded by the exporter). Fall back to
-      // the default when the width is unset (< 0).
+      // Edge line width: getEdgeLineWidth() is a world-space length (A); the
+      // native stroke width is the FULL band width in FINAL pixels, so divide
+      // by the line scale (world units per pixel, seeded by the exporter).
+      //
+      // The 1:1 conversion is what matches the INTERACTIVE GL view, which is
+      // the look this backend is reproducing. GL draws edges as an inverted
+      // hull (gfx/TrigGpuPrim::drawEdges + edge_vert.glsl): the mesh is offset
+      // by edge_width ALONG THE NORMAL and its back faces are drawn behind the
+      // surface. At a silhouette the normal lies in the screen plane, so the
+      // contour moves out by exactly edge_width and the visible band -- the
+      // sliver outside the true silhouette -- is edge_width wide. umbreon inks
+      // a band of cls.width final px centred on the same contour, so equal
+      // widths give equal line thickness (the band straddles the contour
+      // instead of sitting outside it, which shifts it by half a line width).
+      //
+      // Note this is NOT the POV convention: PovSilBuilder emits the edge as a
+      // cylinder of RADIUS getEdgeLineWidth(), i.e. a 2x wider band. Following
+      // POV here is what made rendered images look heavily over-inked next to
+      // the GL view.
+      //
+      // Falls back to the default when the width is unset (< 0).
       const double elw = getEdgeLineWidth();
       const double lscale = getLineScale();
       float widthPx = float(EDGE_THICKNESS_PX);
       if (elw > 0.0 && lscale > 0.0)
-        widthPx = float(2.0 * elw / lscale);
+        widthPx = float(elw / lscale);
       if (widthPx < 1.0f)
         widthPx = 1.0f;
       // The stroke pass maps silhouette -> Silhouette, border -> Object,
@@ -887,11 +904,25 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     opt.strokeEdges.thickness = int(m_pImpl->edgeThicknessPx + 0.5f);
     if (opt.strokeEdges.thickness < 1)
       opt.strokeEdges.thickness = 1;
-    // Outward contour offset (world units); CueMol's edge-rise knob.
-    opt.strokeEdges.raise = float(m_dEdgeRise);
+    // strokeEdges.raise is deliberately left at 0. CueMol's edge-rise knob is a
+    // DIMENSIONLESS multiplier of half the line width (PovSilBuilder writes the
+    // offset as sl_rise * (w/2)), not a world-unit distance, so feeding
+    // m_dEdgeRise straight in would lift the contour by whole angstroms. The
+    // stroke pass has no use for the lift either: its visibility is ray-cast on
+    // the true surface point, which is why umbreon documents raise == 0 for it
+    // (only the object-space edge method reads the field).
     opt.strokeEdges.color[0] = 0.0f;
     opt.strokeEdges.color[1] = 0.0f;
     opt.strokeEdges.color[2] = 0.0f;
+    // Round caps and round joins. umbreon defaults to butt caps + a mitered
+    // join (its byte-identical legacy path), which shows up as flat stubs where
+    // a chain ends against another line and as spikes at sharp corners. The GL
+    // view has neither: its outline is an inverted hull, so an outline never
+    // terminates flat and a corner is just the hull's own rounding. Rounded
+    // ends/corners are the closer match, and they also hide the seams where the
+    // chained silhouette is cut into visible runs.
+    opt.strokeEdges.roundCap = true;
+    opt.strokeEdges.roundJoin = true;
     // Cover every group id; sections with no edge lines keep an all-disabled
     // EdgeStyle, so the stroke pass draws nothing for them.
     if (m_pImpl->groupEdgeStyle.size() < std::size_t(m_pImpl->nextGroup))

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -138,9 +138,10 @@ void UmbreonSceneExporter::setupContext(UmbreonDisplayContext &ctx,
   ctx.setPerspective(m_bPerspective);
   ctx.setBgColor(pScene->getBgColor());
 
-  // Clip geometry to the camera slab (near cutaway plane); the actual plane
-  // (z = slab/2) is computed in FileDisplayContext::startSection from the slab
-  // depth set below.
+  // Clip to the camera slab. The geometry is handed to umbreon unclipped; the
+  // context turns this flag plus the slab depth / view distance set below into
+  // umbreon's view-space near clip plane (Scene::clipNear), and umbreon does
+  // the cutting.
   ctx.setClipZ(m_bUseClipZ);
 
   ctx.enableEdgeLines(m_bEnableEdgeLines);

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -127,6 +127,83 @@ TEST(UmbreonExport, RendersSilhouetteEdgesWithoutCrashing)
     EXPECT_GT(nNonBg, 200u);
 }
 
+// Pins the edge-width unit conversion: getEdgeLineWidth() is a world-space
+// length (A) and umbreon's stroke width is the FULL band width in FINAL pixels,
+// so the conversion is edgeLineWidth / lineScale -- ONE to one, matching the GL
+// view's inverted-hull band (see the derivation in UmbreonDisplayContext). The
+// POV convention (a cylinder of RADIUS edgeLineWidth, i.e. 2x) is what this
+// guards against: it inked every rendered image twice as heavy as the GL view.
+//
+// A white quad facing the camera is bordered on a blue background; the ink is
+// the only BLACK in the frame, so the band is measured by scanning the center
+// row for its dark run. lineScale is set to 0.1 A/px and the width to 0.8 A, so
+// the band must come out ~8 px wide (16 px would be the POV convention).
+TEST(UmbreonExport, EdgeWidthConvertsAngstromToFinalPixels)
+{
+    const double kLineScale = 0.1;  // A per pixel
+    const double kEdgeWidthA = 0.8;
+    const int kExpectPx = int(kEdgeWidthA / kLineScale + 0.5);  // 8
+
+    UmbreonDisplayContext ctx;
+    ctx.init();
+
+    ctx.setPerspective(false);
+    ctx.setViewDist(100.0);
+    ctx.setZoom(6.4);  // 64 px over 6.4 A == kLineScale
+    ctx.setLineScale(kLineScale);
+    ctx.setBgColor(gfx::SolidColor::createRGB(0.0, 0.0, 1.0));
+    ctx.loadIdent();
+
+    ctx.enableEdgeLines(true);
+    ctx.setEdgeLineType(gfx::DisplayContext::ELT_EDGES);
+    ctx.setEdgeLineWidth(kEdgeWidthA);
+    ctx.setEdgeLineColor(gfx::SolidColor::createRGB(0.0, 0.0, 0.0));
+
+    ctx.startRender();
+    ctx.startSection("width");
+
+    // A white quad facing the camera: no silhouette (it is flat-on), so the
+    // only inked feature is its open border.
+    ctx.color(gfx::SolidColor::createRGB(1.0, 1.0, 1.0));
+    ctx.startTriangles();
+    const double kQuad = 2.0;
+    const Vector4D nz(0.0, 0.0, 1.0);
+    const Vector4D c0(-kQuad, -kQuad, 0.0), c1(kQuad, -kQuad, 0.0);
+    const Vector4D c2(kQuad, kQuad, 0.0), c3(-kQuad, kQuad, 0.0);
+    const Vector4D tri[6] = {c0, c1, c2, c0, c2, c3};
+    for (int i = 0; i < 6; ++i) {
+        ctx.normal(nz);
+        ctx.vertex(tri[i]);
+    }
+    ctx.end();
+
+    ctx.endSection();
+
+    UmbreonRenderParams prm;
+    prm.width = 64;
+    prm.height = 64;
+    prm.supersample = 1;
+
+    int ow = 0, oh = 0, ncomp = 0;
+    std::vector<unsigned char> pix;
+    ctx.render(prm, ow, oh, ncomp, pix);
+
+    ASSERT_EQ(pix.size(), static_cast<std::size_t>(64 * 64 * 3));
+
+    // Longest run of BLACK (all channels dark) in the center row: neither the
+    // white quad nor the blue background is dark in every channel.
+    int best = 0, run = 0;
+    for (int x = 0; x < 64; ++x) {
+        const std::size_t i = (static_cast<std::size_t>(32) * 64 + x) * 3;
+        const bool ink = pix[i] < 60 && pix[i + 1] < 60 && pix[i + 2] < 60;
+        run = ink ? run + 1 : 0;
+        if (run > best) best = run;
+    }
+    // +-2 px covers the ribbon's antialiased shoulders while still rejecting
+    // the 2x (POV radius) conversion.
+    EXPECT_NEAR(best, kExpectPx, 2);
+}
+
 // Pins the section-alpha (setAlpha) transparency path: an opaque RED triangle
 // sits at z=0, and a translucent BLUE triangle (its section drawn with
 // alpha 0.5) covers it at z=1, closer to the camera. With the section default

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -192,9 +192,10 @@ TEST(UmbreonExport, BlendsTranslucentSectionOverOpaqueGeometry)
 
 // Pins the slab near-clip path (setClipZ): with the slab depth set so the clip
 // plane is z = 1, a GREEN triangle at z=0 is inside the slab and a RED triangle
-// at z=2 is in front of the clip plane (closer to the camera). calcMeshClip
-// removes the red triangle entirely, so the center pixel shows the green behind
-// it. Without clipping the closer red would occlude the green (center red).
+// at z=2 is in front of the clip plane (closer to the camera). The clipping is
+// umbreon's (Scene::clipNear = viewDist - slab/2); the mesh is handed over
+// uncut, and the red triangle is removed by the plane, so the center pixel
+// shows the green behind it. Without clipping the closer red would occlude it.
 TEST(UmbreonExport, ClipsGeometryInFrontOfSlabPlane)
 {
     UmbreonDisplayContext ctx;
@@ -249,6 +250,82 @@ TEST(UmbreonExport, ClipsGeometryInFrontOfSlabPlane)
     const std::size_t c = (static_cast<std::size_t>(32) * 64 + 32) * 3;
     EXPECT_GT(pix[c + 1], 30);  // green (inside the slab) is visible
     EXPECT_LT(pix[c + 0], 30);  // red (in front of the clip plane) is gone
+}
+
+// Pins that the slab plane cuts the ANALYTIC primitives too: spheres and
+// cylinders are handed to umbreon whole and its clipNear plane does the
+// cutting. The RED sphere (center z=1.5, radius 0.6) straddles the clip plane
+// at z=1, and its rim -- everything more than ~0.37 off the view axis -- lies
+// ENTIRELY in front of that plane. The probe sits in the rim, so it shows the
+// sphere when clipping is off and the GREEN backdrop (z=0, inside the slab)
+// when it is on. The CueMol-side clip this replaces could not cut a quadric: it
+// only dropped a sphere fully in front of the plane and drew the rest whole,
+// which left the probe red in both renders.
+TEST(UmbreonExport, ClipPlaneCutsAnalyticSphere)
+{
+    // Orthographic: 64 px over a zoom (view height) of 4.0 => 16 px per world
+    // unit, so pixel x=39 is world x = (39 + 0.5 - 32) / 16 = 0.47 -- inside the
+    // sphere's 0.6 disk, and on the cut-away rim. The scene is symmetric about
+    // the view axis, so the probe does not depend on the image axis directions.
+    const int kProbeX = 39, kProbeY = 32;
+
+    auto renderProbe = [kProbeX, kProbeY](bool useClipZ, unsigned char &red,
+                                          unsigned char &green) {
+        UmbreonDisplayContext ctx;
+        ctx.init();
+
+        ctx.setPerspective(false);
+        ctx.setViewDist(100.0);
+        ctx.setZoom(4.0);
+        ctx.setSlabDepth(2.0);  // near clip plane at z = slab/2 = 1.0
+        ctx.setClipZ(useClipZ);
+        ctx.loadIdent();
+
+        ctx.startRender();
+        ctx.startSection("clipsph");
+
+        // GREEN backdrop at z=0 (inside the slab)
+        ctx.color(gfx::SolidColor::createRGB(0.0, 1.0, 0.0));
+        ctx.startTriangles();
+        ctx.normal(Vector4D(0.0, 0.0, 1.0));
+        ctx.vertex(Vector4D(-2.0, -2.0, 0.0));
+        ctx.normal(Vector4D(0.0, 0.0, 1.0));
+        ctx.vertex(Vector4D(2.0, -2.0, 0.0));
+        ctx.normal(Vector4D(0.0, 0.0, 1.0));
+        ctx.vertex(Vector4D(0.0, 2.0, 0.0));
+        ctx.end();
+
+        // RED sphere straddling the clip plane (spans z = 0.9 .. 2.1)
+        ctx.color(gfx::SolidColor::createRGB(1.0, 0.0, 0.0));
+        ctx.sphere(0.6, Vector4D(0.0, 0.0, 1.5));
+
+        ctx.endSection();
+
+        UmbreonRenderParams prm;
+        prm.width = 64;
+        prm.height = 64;
+        prm.supersample = 1;
+
+        int ow = 0, oh = 0, ncomp = 0;
+        std::vector<unsigned char> pix;
+        ctx.render(prm, ow, oh, ncomp, pix);
+        ASSERT_EQ(pix.size(), static_cast<std::size_t>(64 * 64 * 3));
+
+        const std::size_t c =
+            (static_cast<std::size_t>(kProbeY) * 64 + kProbeX) * 3;
+        red = pix[c + 0];
+        green = pix[c + 1];
+    };
+
+    unsigned char red = 0, green = 0;
+
+    renderProbe(false, red, green);
+    EXPECT_GT(red, 30);    // unclipped: the whole sphere is drawn
+    EXPECT_LT(green, 30);
+
+    renderProbe(true, red, green);
+    EXPECT_LT(red, 30);    // clipped: the sphere's rim is cut away
+    EXPECT_GT(green, 30);  // the backdrop inside the slab shows through
 }
 
 // Pins the output encoding contract: the umbreon linear HDR framebuffer is
@@ -1164,4 +1241,70 @@ TEST(UmbreonExport, AsyncRenderCanBeCancelled)
         // Finished before the first cancel check: a normal complete frame.
         ASSERT_EQ(pix.size(), static_cast<std::size_t>(256 * 256 * 3));
     }
+}
+// Pins the slab clip running together with the native stroke edge pass and
+// supersampling -- the combination the app actually renders with, and the one
+// that has to agree inside umbreon (the clip-cut G-buffer is captured only when
+// clip planes AND stroke edges are both on). The scene is the near-clip scene
+// above: a GREEN triangle inside the slab and a RED one in front of the plane.
+TEST(UmbreonExport, ClipsWithEdgeLinesAndSupersampling)
+{
+    UmbreonDisplayContext ctx;
+    ctx.init();
+
+    ctx.setPerspective(false);
+    ctx.setViewDist(100.0);
+    ctx.setZoom(6.0);
+    ctx.setSlabDepth(2.0);  // near clip plane at z = slab/2 = 1.0
+    ctx.setClipZ(true);
+    ctx.setLineScale(6.0 / 64.0);
+    ctx.loadIdent();
+
+    ctx.enableEdgeLines(true);
+    ctx.setEdgeLineType(gfx::DisplayContext::ELT_EDGES);
+    ctx.setEdgeLineWidth(0.06);
+    ctx.setEdgeLineColor(gfx::SolidColor::createRGB(0.0, 0.0, 0.0));
+
+    ctx.startRender();
+    ctx.startSection("clipedges");
+
+    // GREEN triangle at z=0 (inside the slab) -- kept
+    ctx.color(gfx::SolidColor::createRGB(0.0, 1.0, 0.0));
+    ctx.startTriangles();
+    ctx.normal(Vector4D(0.0, 0.0, 1.0));
+    ctx.vertex(Vector4D(-2.0, -2.0, 0.0));
+    ctx.normal(Vector4D(0.0, 0.0, 1.0));
+    ctx.vertex(Vector4D(2.0, -2.0, 0.0));
+    ctx.normal(Vector4D(0.0, 0.0, 1.0));
+    ctx.vertex(Vector4D(0.0, 2.0, 0.0));
+    ctx.end();
+
+    // RED triangle at z=2 (in front of the clip plane) -- removed by the plane
+    ctx.color(gfx::SolidColor::createRGB(1.0, 0.0, 0.0));
+    ctx.startTriangles();
+    ctx.normal(Vector4D(0.0, 0.0, 1.0));
+    ctx.vertex(Vector4D(-2.0, -2.0, 2.0));
+    ctx.normal(Vector4D(0.0, 0.0, 1.0));
+    ctx.vertex(Vector4D(2.0, -2.0, 2.0));
+    ctx.normal(Vector4D(0.0, 0.0, 1.0));
+    ctx.vertex(Vector4D(0.0, 2.0, 2.0));
+    ctx.end();
+
+    ctx.endSection();
+
+    UmbreonRenderParams prm;
+    prm.width = 64;
+    prm.height = 64;
+    prm.supersample = 3;
+
+    int ow = 0, oh = 0, ncomp = 0;
+    std::vector<unsigned char> pix;
+    ctx.render(prm, ow, oh, ncomp, pix);
+
+    ASSERT_EQ(pix.size(), static_cast<std::size_t>(64 * 64 * 3));
+
+    // Center pixel: well inside the green triangle, away from any outline.
+    const std::size_t c = (static_cast<std::size_t>(32) * 64 + 32) * 3;
+    EXPECT_GT(pix[c + 1], 30);  // green (inside the slab) is visible
+    EXPECT_LT(pix[c + 0], 30);  // red (in front of the clip plane) is gone
 }


### PR DESCRIPTION
> **依存**: libumbreon 側の clip plane / round cap PR ([CueMol/umbreon#69](https://github.com/CueMol/umbreon/pull/69), [#70](https://github.com/CueMol/umbreon/pull/70)) を先に merge・install する必要があります（`task install_umbreon`）。
>
> **umbreon 更新後は libcuemol2 のクリーンリビルドが必須です**（静的リンクで ABI 保証が無いため）。今回これを踏んで `endRender` が `strokeEdges and objectSpaceEdges are mutually exclusive` で落ちる状態になりました。`ENABLE_UMBREON=ON task rebuild_libcuemol2` で復旧します（`task rebuild_libcuemol2` は素で走らせると `ENABLE_UMBREON=OFF` で再 configure されるので注意）。

コミットは2本、独立しています。

---

## 1. `feat(render)`: z-clipping を umbreon に任せる

### 背景

umbreon に view-space clip plane（`Scene::clipNear` / `clipFar`）が入ったので、CueMol 側で幾何をカットする必要が無くなりました。

これまで `UmbreonDisplayContext::appendIntData` は
- mesh を `RendIntData::calcMeshClip()` で切断
- 解析プリミティブ（sphere / cylinder）は clip 面より完全に手前なら丸ごと捨て、そうでなければ丸ごと描く

としていましたが、これは **2つの artifact** を生んでいました。

### 変更

未クリップのジオメトリを渡し、`clipNear = viewDist - slabDepth/2` を設定するだけにします（eye 空間 z と view-z は `vz = viewDist - z`）。umbreon が primary ray を slab に clamp します。secondary ray（shadow / AO / GI）はクリップされないので、slab が「表示装置であって scene geometry ではない」という GL ビューの挙動と一致します。

これで直るもの:

| | before | after |
|---|---|---|
| 断面の輪郭線 | CueMol 側で切ると断面が**本物の開いたメッシュ境界**になり、stroke edge pass がシルエットとして描いていた | umbreon は自分の clip 面が作った境界を識別して line-free にする |
| quadric の切断 | 球・円柱は切れないので、面をまたぐものは**丸ごと描画**（断面から突き出る） | clip 面でちょうど切られる |

**far plane は設定していません。** GL の far plane（`viewDist + slabDepth`）は depth fog の終端（`viewDist + slabDepth/2`）より奥にあり、far plane が消せる領域は既に完全に背景色へ blend されています。透明背景の alpha も同様であることを実測（clip 無しでも中心 alpha = 0）で確認したうえで、観測不能な設定は入れない判断です。理由はコードコメントに残してあります。

あわせて `FileDisplayContext::m_bUseClipZ` をコンストラクタで初期化しました（未初期化のまま読まれていた）。実 exporter は全て明示的に `setClipZ()` を呼ぶので、影響は素の context（テスト）の既定値のみです。

---

## 2. `fix(render)`: エッジラインを GL ビューに合わせる

### 背景

レンダ画像のエッジが GL ビューよりはるかに太くなっていました。

<!-- 左: GL / 右: umbreon (修正前) -->

線幅の換算が **POV の流儀**になっており、これは GL の 2 倍です。

| | エッジの定義 | 帯の全幅 |
|---|---|---|
| POV (`PovSilBuilder`) | `getEdgeLineWidth()` を**半径**とする cylinder | `2w` |
| GL (`TrigGpuPrim::drawEdges` + `edge_vert.glsl`) | inverted hull: mesh を法線方向に `edge_width` 押し出して裏面描画 | `w` |

GL では、シルエット上で法線がスクリーン平面内を向くため、輪郭はちょうど `edge_width` だけ外側に移動し、見える帯（真のシルエットの外側のスリバー）の幅は `edge_width` になります。

umbreon の `EdgeClassStyle::width` は**最終解像度 px での帯の全幅**（実装 `stroke_render.cpp: resolveStrokeStyle`。ヘッダのコメント "dilation radius, hi-res px" は古く実装が正）。したがって GL に合わせる換算は `edgeLineWidth / lineScale` で、2倍は不要でした。

**実測での裏付け**: 同一シーンの GL / umbreon 画像から線に垂直な線幅を測ったところ、画像高さ比で 4.45‰ vs 10.0‰ の **2.25 倍**。導出した係数 2 に、2枚の zoom 差（≈1.13）を掛けた値と一致し、他に誤差要因が無いことを確認しました。

### 変更

1. **線幅**: `widthPx = elw / lscale`（2倍を除去）
2. **`strokeEdges.raise` を渡すのをやめる** — CueMol の `edgeRise` は**無次元の倍率**で、POV では `sl_rise * (w/2)` として使われます（`PovSilBuilder.cpp:163,198`）。それを world 単位として渡していたため、既定値 0.5 が「0.5 Å の輪郭オフセット」を意味していました。加えて umbreon の stroke pass はこのフィールドを読みません（可視判定が真の表面点での ray-cast なので lift 不要と明記されている / 読むのは object-space edge 方式のみ）。
3. **`roundCap` / `roundJoin` を有効化** — umbreon の既定は butt cap + miter join で、線の終端に平らな切り口、鋭角に miter スパイクが出ます。GL の inverted hull にはどちらも無いので round のほうが近く、チェーン化されたシルエットが可視スパンに分割される継ぎ目も目立たなくなります。

---

## テスト

`src/tests/modules/rendering/test_umbreon_export.cpp` に3件追加（`test_umbreon` 20 → 23 件）。

| test | pin する内容 |
|---|---|
| `ClipPlaneCutsAnalyticSphere` | clip 面をまたぐ球が**切られる**こと。clip on/off の2回レンダで、切り取られる縁の probe pixel が赤（球）→ 緑（背後の面）に変わる。旧実装では両方赤 |
| `ClipsWithEdgeLinesAndSupersampling` | clip + stroke edge + supersample 3（アプリの実構成）。clip-cut G-buffer は「clip 面 **かつ** stroke edges が両方 on」のときだけ確保されるので、この組み合わせが噛み合っているかを pin |
| `EdgeWidthConvertsAngstromToFinalPixels` | Å → 最終 px の換算。`lineScale = 0.1 Å/px`, `edgeLineWidth = 0.8 Å` で白い quad を青背景に描き、中央行の黒インク帯が **8 px** であること |

既存の `ClipsGeometryInFrontOfSlabPlane` はそのまま pass（コメントのみ更新）。

**退行検知の確認**: `EdgeWidthConvertsAngstromToFinalPixels` は旧式（2倍）に戻すと **16 px** になって FAIL することを実際に確認済みです。

## 検証

- `task run_gtest` — **1248 / 1248 pass**
- **各コミット単体でも** build + 全テスト pass を確認（commit 1 単体で 1247/1247）
- `task build_tritium` 成功
- 実機で render 動作確認済み

## 補足

`roundCap` / `roundJoin` は backend 固定（exporter の qif プロパティにはしていません）。UI から切り替えたい場合は言ってください。

エッジについてもう1点、GL の帯はシルエットの**外側だけ**に出るのに対し umbreon の帯は輪郭を**中心に跨ぐ**ため、半線幅ぶんの位置ズレは残ります（太さは一致）。気になるようなら別途調整します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
