### PR TITLE
Fix numeric text boxes that could not be cleared, and use dropdowns for fixed-value numbers

### DIFF
--- a/tritium/react-gui/src/renderer/__test__/NumericField.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/NumericField.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @file __test__/NumericField.test.tsx
+ * @description Unit tests for the h3-kit NumericField. Pins the contract for
+ * the bug it had: Blueprint's `NumericInput` is fully controlled once `value`
+ * is set, so an `onChange` that only fires for a parseable number left
+ * `value` unmoved while the field was empty / mid-edit (e.g. "-", "1."), and
+ * the field snapped back to the last digit every keystroke -- making it
+ * impossible to clear and retype. Same class of bug as SliderNumericField
+ * (see SliderNumericField.test.tsx), now fixed at the shared component so
+ * every consumer (MakeMolSurfDialog density, renderer property rows, etc.)
+ * gets it once.
+ */
+
+import React, { act } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { NumericField } from '../h3-kit/form/NumericField'
+
+void React
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+})
+
+function setInputValue(el: HTMLInputElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype, 'value',
+    )?.set
+    setter?.call(el, value)
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+function getNumberInput(): HTMLInputElement {
+    const el = container.querySelector('input.h3-form-numeric')
+    if (!el) throw new Error('number input not found')
+    return el as HTMLInputElement
+}
+
+// React 18 tracks focus via delegated focusin/focusout; the element must be
+// focused first for `focusout` to map to onBlur.
+function blurInput(el: HTMLInputElement) {
+    el.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+}
+
+const base = {
+    value: 5,
+    min: 0,
+    max: 50,
+    step: 1,
+    slider: false,
+    onChange: () => {},
+}
+
+function render(props: Partial<React.ComponentProps<typeof NumericField>> = {}) {
+    act(() => {
+        root.render(<NumericField {...base} {...props} />)
+    })
+}
+
+/**
+ * A controlled wrapper mirroring real consumers (MakeMolSurfDialog,
+ * MultiNumInputRow, ...): `onChange` updates the state that feeds `value`
+ * back in, so `onRelease`'s read of the latest `value` prop is meaningful.
+ * `NumericField` itself does not manage `value` -- an inline no-op `onChange`
+ * would leave `value` frozen and make a commit-on-blur/Enter assertion
+ * meaningless.
+ */
+function ControlledNumericField(
+    props: Partial<React.ComponentProps<typeof NumericField>> & { onRelease?: (v: number) => void },
+) {
+    const [value, setValue] = React.useState(props.value ?? base.value)
+    return (
+        <NumericField
+            {...base}
+            {...props}
+            value={value}
+            onChange={setValue}
+        />
+    )
+}
+
+function renderControlled(
+    props: Partial<React.ComponentProps<typeof NumericField>> & { onRelease?: (v: number) => void } = {},
+) {
+    act(() => {
+        root.render(<ControlledNumericField {...props} />)
+    })
+}
+
+describe('NumericField', () => {
+    it('shows the current value', () => {
+        render({ value: 12 })
+        expect(getNumberInput().value).toBe('12')
+    })
+
+    it('lets the field go empty mid-edit instead of snapping back to the old digit', () => {
+        const onChange = vi.fn()
+        render({ value: 9, onChange })
+        const input = getNumberInput()
+        act(() => { input.focus() })
+        act(() => { setInputValue(input, '') })
+        // No parseable number yet -- onChange must not fire for empty text,
+        // but the field itself must stay empty (not revert to "9").
+        expect(onChange).not.toHaveBeenCalled()
+        expect(input.value).toBe('')
+    })
+
+    it('allows retyping a multi-digit value after clearing', () => {
+        const onChange = vi.fn()
+        render({ value: 9, onChange })
+        const input = getNumberInput()
+        act(() => { input.focus() })
+        act(() => { setInputValue(input, '') })
+        act(() => { setInputValue(input, '2') })
+        act(() => { setInputValue(input, '25') })
+        expect(onChange).toHaveBeenLastCalledWith(25)
+        expect(input.value).toBe('25')
+    })
+
+    it('reverts the display to the current value when blurred while empty', () => {
+        const onChange = vi.fn()
+        const onRelease = vi.fn()
+        render({ value: 7, onChange, onRelease })
+        const input = getNumberInput()
+        act(() => { input.focus() })
+        act(() => { setInputValue(input, '') })
+        act(() => { blurInput(input) })
+        expect(onChange).not.toHaveBeenCalled()
+        expect(onRelease).toHaveBeenCalledWith(7)
+        expect(input.value).toBe('7')
+    })
+
+    it('commits the latest typed value via onRelease on blur', () => {
+        const onRelease = vi.fn()
+        renderControlled({ value: 5, onRelease })
+        const input = getNumberInput()
+        act(() => { input.focus() })
+        act(() => { setInputValue(input, '30') })
+        act(() => { blurInput(input) })
+        expect(onRelease).toHaveBeenCalledWith(30)
+    })
+
+    it('commits the latest typed value via onRelease on Enter', () => {
+        const onRelease = vi.fn()
+        renderControlled({ value: 5, onRelease })
+        const input = getNumberInput()
+        act(() => { input.focus() })
+        act(() => { setInputValue(input, '8') })
+        act(() => {
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+        })
+        expect(onRelease).toHaveBeenCalledWith(8)
+    })
+
+    it('renders the slider by default and omits it when slider=false', () => {
+        render({ slider: true })
+        expect(container.querySelector('.h3-form-slider')).not.toBeNull()
+        render({ slider: false })
+        expect(container.querySelector('.h3-form-slider')).toBeNull()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/makeMolSurfDialog.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/makeMolSurfDialog.test.tsx
@@ -150,6 +150,54 @@ describe('MakeMolSurfDialog commit wire', () => {
         handle.unmount()
     })
 
+    it('density is an editable combobox with 1-5 presets; picking one updates the commit payload', async () => {
+        routeInvoke(() => ({ ok: true }))
+        const handle = mount()
+        await flushPromises()
+
+        const chevron = document.body.querySelector(
+            '.h3-form-combobox-caret',
+        ) as HTMLButtonElement
+        expect(chevron).toBeTruthy()
+        await act(async () => { chevron.click() })
+        const items = Array.from(document.querySelectorAll('.bp5-menu-item')).map(
+            (el) => el.textContent,
+        )
+        expect(items).toEqual(['1', '2', '3', '4', '5'])
+        const three = Array.from(document.querySelectorAll('.bp5-menu-item')).find(
+            (el) => el.textContent === '3',
+        ) as HTMLElement
+        await act(async () => { three.click() })
+
+        await act(async () => { okButton().click() })
+        await flushPromises()
+
+        expect((commitCalls()[0][1] as Record<string, unknown>).density).toBe(3)
+        handle.unmount()
+    })
+
+    it('density accepts free-typed values outside the preset list', async () => {
+        routeInvoke(() => ({ ok: true }))
+        const handle = mount()
+        await flushPromises()
+
+        const input = document.body.querySelector('.h3-form-combobox input') as HTMLInputElement
+        expect(input).toBeTruthy()
+        const setter = Object.getOwnPropertyDescriptor(
+            window.HTMLInputElement.prototype, 'value',
+        )?.set
+        act(() => {
+            setter?.call(input, '7')
+            input.dispatchEvent(new Event('input', { bubbles: true }))
+        })
+
+        await act(async () => { okButton().click() })
+        await flushPromises()
+
+        expect((commitCalls()[0][1] as Record<string, unknown>).density).toBe(7)
+        handle.unmount()
+    })
+
     it('reset-on-open clears the error while the molecule id persists', async () => {
         routeInvoke(() => ({ ok: false, error: 'surf failed' }))
         const handle = mount(true)

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -192,6 +192,32 @@ describe('SceneAntialiasingSection', () => {
     expect(onSet).toHaveBeenCalledWith('aa_method', 'enum', 'smaa')
     unmount()
   })
+
+  it('Jitter SS is a 0-5 dropdown (not a numeric stepper) and commits a number', () => {
+    const onSet = vi.fn()
+    const { container, unmount } = mountTree(
+      <SceneAntialiasingSection
+        entries={fullEntries()}
+        onSet={onSet}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    const row = rowByLabel(container, 'Jitter SS')!
+    // A dropdown (SelectField), not the NumericField/DragNumericField stepper.
+    const sel = row.querySelector('select') as HTMLSelectElement
+    expect(sel).not.toBeNull()
+    expect(row.querySelector('.h3-form-numeric, .h3-form-drag')).toBeNull()
+    expect(Array.from(sel.options).map((o) => [o.value, o.textContent])).toEqual([
+      ['0', 'Off'], ['1', '1'], ['2', '2'], ['3', '3'], ['4', '4'], ['5', '5'],
+    ])
+    act(() => {
+      sel.value = '3'
+      sel.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(onSet).toHaveBeenCalledWith('aaJitterLevel', 'integer', 3)
+    unmount()
+  })
 })
 
 describe('SceneBackgroundSection', () => {

--- a/tritium/react-gui/src/renderer/components/dialogs/MakeMolSurfDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/MakeMolSurfDialog.tsx
@@ -8,8 +8,11 @@
  *   - Surface object name (`TextField`; prefilled with a unique `sf_<molname>`
  *     via `proposeMolSurfName` and refreshed when the molecule changes, like
  *     UXP `makeSugName`).
- *   - Point density (/A) and probe radius (A) numeric inputs. Defaults match
- *     the UXP XUL: density = 1 (min, no explicit value), probe radius = 1.4.
+ *   - Point density (/A): an editable `ComboBoxField` with common presets
+ *     (1-5) -- picking a typical density is more common than dialing in an
+ *     arbitrary one, so a preset list beats a bare numeric stepper. Probe
+ *     radius (A) stays a plain numeric input. Defaults match the UXP XUL:
+ *     density = 1 (min, no explicit value), probe radius = 1.4.
  *   - OK commits via the `makeMolSurf` worker service under one undo txn.
  *
  * The caller passes only `{ sceneId }`. The last-picked molecule persists
@@ -17,10 +20,10 @@
  * regeneration mode is intentionally out of scope.
  */
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useCueMol } from '../../hooks/useCueMol'
 import { useMolEditCommit } from '../../hooks/useMolEditCommit'
-import { Field, FieldSection, NumericField, SwitchField, TextField } from '../../h3-kit/form'
+import { ComboBoxField, Field, FieldSection, NumericField, SwitchField, TextField } from '../../h3-kit/form'
 import { DialogShell } from './DialogShell'
 import { MolPicker } from './MolPicker'
 import { MolSelList } from '../../h3-kit/MolSelList/MolSelList'
@@ -44,6 +47,10 @@ interface Props {
 const DEFAULT_DENSITY = 1
 const DEFAULT_PROBE_RADIUS = 1.4
 
+// Common point-density values shown in the ComboBoxField dropdown; typing a
+// different positive integer is still accepted (see handleDensityChange).
+const DENSITY_PRESETS = ['1', '2', '3', '4', '5']
+
 export function MakeMolSurfDialog({
     visible, sceneId, onConfirm, onCancel,
 }: Props): React.JSX.Element {
@@ -55,6 +62,17 @@ export function MakeMolSurfDialog({
     const [surfName, setSurfName] = useState<string>('')
     const [density, setDensity] = useState<number>(DEFAULT_DENSITY)
     const [probeRadius, setProbeRadius] = useState<number>(DEFAULT_PROBE_RADIUS)
+
+    // Raw text for the density combobox: free typing stays local until it
+    // parses to a positive integer, and the draft re-syncs whenever the
+    // committed value changes from outside (preset pick, reset-on-open).
+    const [densityDraft, setDensityDraft] = useState<string>(String(DEFAULT_DENSITY))
+    useEffect(() => setDensityDraft(String(density)), [density])
+    const handleDensityChange = useCallback((text: string) => {
+        setDensityDraft(text)
+        const n = Math.round(Number(text))
+        if (Number.isFinite(n) && n >= 1) setDensity(n)
+    }, [])
 
     // Commit handler + submitting/errorMsg state + reset-on-open. The molecule
     // id is intentionally NOT reset (last-picked persists); the surface name is
@@ -158,13 +176,10 @@ export function MakeMolSurfDialog({
                             />
                         </Field>
                         <Field label="Point density (/A)">
-                            <NumericField
-                                value={density}
-                                onChange={setDensity}
-                                min={1}
-                                max={50}
-                                step={1}
-                                slider={false}
+                            <ComboBoxField
+                                value={densityDraft}
+                                onChange={handleDensityChange}
+                                options={DENSITY_PRESETS}
                                 disabled={submitting}
                             />
                         </Field>

--- a/tritium/react-gui/src/renderer/components/dialogs/SymmetryChangeDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/SymmetryChangeDialog.tsx
@@ -252,24 +252,38 @@ export function SymmetryChangeDialog({
     const displayCell = restricted.cell
     const disabled = restricted.disabled
 
+    // Raw text held per-field while it is being edited. Blueprint's
+    // NumericInput is fully controlled once `value` is set, so without this an
+    // empty / transiently-invalid keystroke has no onValueChange to move
+    // `value`, and the field immediately snaps back to the last digit instead
+    // of letting the user clear it. Mirrors the fix applied to the h3-kit
+    // NumericField.
+    const [editing, setEditing] = useState<Partial<Record<keyof CellState, string>>>({})
+
     const numericFor = useCallback(
         (key: keyof CellState, label: string): React.ReactElement => (
             <FormGroup label={label} inline style={{ marginBottom: 4 }}>
                 <NumericInput
-                    value={displayCell[key]}
+                    value={editing[key] ?? String(displayCell[key])}
                     disabled={disabled[key] || submitting}
                     buttonPosition="none"
                     fill={false}
                     selectAllOnFocus
-                    onValueChange={(v) => {
+                    onValueChange={(v, s) => {
+                        setEditing((prev) => ({ ...prev, [key]: s }))
                         if (Number.isFinite(v)) {
                             setCell((prev) => ({ ...prev, [key]: v }))
                         }
                     }}
+                    onBlur={() => setEditing((prev) => {
+                        const next = { ...prev }
+                        delete next[key]
+                        return next
+                    })}
                 />
             </FormGroup>
         ),
-        [displayCell, disabled, submitting],
+        [displayCell, disabled, submitting, editing],
     )
 
     const isNear = (x: number, y: number, eps = 1e-3): boolean => Math.abs(x - y) < eps

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/Ccp4MapOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/Ccp4MapOptionsPane.tsx
@@ -3,7 +3,7 @@
  * @description Option pane for CCP4/MRC electron density map files.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Switch, NumericInput, FormGroup, Divider } from '@blueprintjs/core';
 import type { Ccp4MapOptions } from '../types';
 
@@ -12,9 +12,26 @@ interface Ccp4MapOptionsPaneProps {
   onChange: (updated: Ccp4MapOptions) => void;
 }
 
+type TruncateKey = 'truncateMin' | 'truncateMax';
+
 export const Ccp4MapOptionsPane: React.FC<Ccp4MapOptionsPaneProps> = ({ options, onChange }) => {
-  const setNum = (key: keyof Pick<Ccp4MapOptions, 'truncateMin' | 'truncateMax'>) =>
-    (val: number) => {
+  // Raw text held per-field while it is being edited. Blueprint's
+  // NumericInput is fully controlled once `value` is set, so without this an
+  // empty / transiently-invalid keystroke has no onValueChange to move
+  // `value`, and the field immediately snaps back to the last digit instead
+  // of letting the user clear it. Mirrors the fix applied to the h3-kit
+  // NumericField.
+  const [editing, setEditing] = useState<Partial<Record<TruncateKey, string>>>({});
+  const clearEditing = (key: TruncateKey) =>
+    setEditing((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+
+  const setNum = (key: TruncateKey) =>
+    (val: number, s: string) => {
+      setEditing((prev) => ({ ...prev, [key]: s }));
       if (!isNaN(val)) onChange({ ...options, [key]: val });
     };
 
@@ -38,8 +55,9 @@ export const Ccp4MapOptionsPane: React.FC<Ccp4MapOptionsPaneProps> = ({ options,
       <FormGroup label="Minimum" labelFor="ccp4-min" className="fod-form-group">
         <NumericInput
           id="ccp4-min"
-          value={options.truncateMin}
+          value={editing.truncateMin ?? String(options.truncateMin)}
           onValueChange={setNum('truncateMin')}
+          onBlur={() => clearEditing('truncateMin')}
           disabled={!options.truncateMinEnabled}
           stepSize={0.5}
           minorStepSize={0.1}
@@ -55,8 +73,9 @@ export const Ccp4MapOptionsPane: React.FC<Ccp4MapOptionsPaneProps> = ({ options,
       <FormGroup label="Maximum" labelFor="ccp4-max" className="fod-form-group">
         <NumericInput
           id="ccp4-max"
-          value={options.truncateMax}
+          value={editing.truncateMax ?? String(options.truncateMax)}
           onValueChange={setNum('truncateMax')}
+          onBlur={() => clearEditing('truncateMax')}
           disabled={!options.truncateMaxEnabled}
           stepSize={0.5}
           minorStepSize={0.1}

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/MtzOptionsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/panes/MtzOptionsPane.tsx
@@ -7,7 +7,7 @@
  * of that type), and resolution / grid spacing follow the UXP controls.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Checkbox, HTMLSelect, NumericInput, FormGroup } from '@blueprintjs/core';
 import type { MtzOptions } from '../types';
 import type { GetMtzColumnInfoResult } from '../../../worker/server/services/getMtzColumnInfo.service';
@@ -33,6 +33,14 @@ function round1(x: number): number {
 }
 
 export const MtzOptionsPane: React.FC<MtzOptionsPaneProps> = ({ options, onChange, columnInfo }) => {
+  // Raw text held while the resolution field is being edited. Blueprint's
+  // NumericInput is fully controlled once `value` is set, so without this an
+  // empty / transiently-invalid keystroke has no onValueChange to move
+  // `value`, and the field immediately snaps back to the last digit instead
+  // of letting the user clear it. Mirrors the fix applied to the h3-kit
+  // NumericField.
+  const [resoEdit, setResoEdit] = useState<string | null>(null);
+
   if (!columnInfo || !columnInfo.ok) {
     return (
       <div className="fod-section">
@@ -116,8 +124,12 @@ export const MtzOptionsPane: React.FC<MtzOptionsPaneProps> = ({ options, onChang
       <FormGroup label="Max resolution (A)" labelFor="mtz-reso" className="fod-form-group">
         <NumericInput
           id="mtz-reso"
-          value={options.resolutionLimit}
-          onValueChange={(val) => { if (!isNaN(val)) onChange({ ...options, resolutionLimit: round1(val) }); }}
+          value={resoEdit ?? String(options.resolutionLimit)}
+          onValueChange={(val, s) => {
+            setResoEdit(s);
+            if (!isNaN(val)) onChange({ ...options, resolutionLimit: round1(val) });
+          }}
+          onBlur={() => setResoEdit(null)}
           min={resoMin > 0 ? resoMin : undefined}
           max={resoMax > 0 ? resoMax : undefined}
           stepSize={0.1}

--- a/tritium/react-gui/src/renderer/components/inspector/RendererCommonSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/RendererCommonSection.tsx
@@ -350,6 +350,48 @@ export const MappedEnumRow: React.FC<MappedEnumRowProps> = ({
   );
 };
 
+export interface NumEnumRowProps extends RowProps {
+  /** Allowed integer values, in display order. */
+  options: number[];
+  /** Optional friendly label per value (e.g. 0 -> "Off"); falls back to the number itself. */
+  labels?: Record<number, string>;
+  disabled?: boolean;
+}
+
+/**
+ * Dropdown for an integer property restricted to a small fixed set of values
+ * (e.g. Scene antialiasing Jitter SS, 0-5) -- a `SelectField` is a clearer
+ * affordance than a numeric stepper when the domain is this small, and it
+ * makes an out-of-range value unreachable through the UI instead of merely
+ * clamped. Commits the parsed number immediately, like `EnumRow` /
+ * `MappedEnumRow`.
+ *
+ * Exported so other small-integer-domain properties reuse the same contract.
+ */
+export const NumEnumRow: React.FC<NumEnumRowProps> = ({
+  entry,
+  label,
+  options,
+  labels,
+  onSet,
+  onReset,
+  disabled,
+}) => (
+  <PropertyField label={label} {...resetProps(entry, onReset)}>
+    <SelectField
+      value={String(entry.value)}
+      disabled={disabled || entry.readonly}
+      onChange={(v) => onSet(entry.key, entry.type, Number(v))}
+    >
+      {options.map((opt) => (
+        <option key={opt} value={opt}>
+          {labels?.[opt] ?? String(opt)}
+        </option>
+      ))}
+    </SelectField>
+  </PropertyField>
+);
+
 /** Cap-type enum labels shared by the spline-family renderers (cartoon / tube). */
 export const CAP_LABELS: Record<string, string> = {
   sphere: "Round",

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -24,7 +24,7 @@ import React from "react";
 import {
   BoolRow,
   NumRow,
-  NumInputRow,
+  NumEnumRow,
   MappedEnumRow,
   ColorRow,
   TextRow,
@@ -137,10 +137,17 @@ const AA_METHOD_LABELS: Record<string, string> = {
   smaa: "SMAA",
 };
 
+// aaJitterLevel only takes 0-5 (GUIView.cpp clamps to this range: levels
+// above 5 have no jitter table). 0 disables temporal jitter while AO stays
+// on; 1-5 select the jitter sample-count table (1<<level samples).
+const JITTER_LEVELS = [0, 1, 2, 3, 4, 5];
+const JITTER_LEVEL_LABELS: Record<number, string> = { 0: "Off" };
+
 /**
  * Post-process anti-aliasing: method (none / FXAA / SMAA) and temporal jitter
  * supersampling level. Jitter only accumulates on the AO path, so it is
- * disabled while AO is off.
+ * disabled while AO is off. The level is a dropdown (`NumEnumRow`), not a
+ * numeric stepper: it only takes the six values in `JITTER_LEVELS`.
  */
 export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   entries,
@@ -164,15 +171,13 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
         />
       )}
       {aaJitter && (
-        <NumInputRow
-          key={`jitter:${aaJitter.value}`}
+        <NumEnumRow
           entry={aaJitter}
           label="Jitter SS"
+          options={JITTER_LEVELS}
+          labels={JITTER_LEVEL_LABELS}
           onSet={onSet}
           onReset={onReset}
-          min={0}
-          max={5}
-          step={1}
           disabled={jitterOff}
         />
       )}

--- a/tritium/react-gui/src/renderer/h3-kit/colorpicker/RgbHsbPanel.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/colorpicker/RgbHsbPanel.tsx
@@ -12,7 +12,7 @@
  * the colour string and the resolved RGB (for instant swatch preview).
  */
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { NumericInput } from '@blueprintjs/core'
 import { ColorSlider } from './ColorSlider'
 import { hsbToRgb, packToHex, packToHsbString, rgbToHsb, type Hsb, type Rgb } from './colorMath'
@@ -103,6 +103,20 @@ export const RgbHsbPanel: React.FC<RgbHsbPanelProps> = ({ mode, initialRgb, onCh
     const [rgb, setRgb] = useState<Rgb>(initialRgb)
     const [hsb, setHsb] = useState<Hsb>(() => rgbToHsb(initialRgb))
 
+    // Raw text held per-row while its spinner is being edited (index-aligned
+    // with `rows`). Blueprint's NumericInput is fully controlled once `value`
+    // is set, so without this an empty / transiently-invalid keystroke has no
+    // onValueChange to move `value`, and the spinner immediately snaps back to
+    // the last digit instead of letting the field clear. Mirrors the fix
+    // applied to the h3-kit NumericField.
+    const [drafts, setDrafts] = useState<(string | null)[]>([null, null, null])
+    // Row semantics change with mode (R/G/B vs H/S/B); drop any in-progress
+    // edit rather than carry stale text into the other space.
+    useEffect(() => setDrafts([null, null, null]), [mode])
+    const setDraftAt = (i: number, text: string | null) => {
+        setDrafts((prev) => prev.map((d, idx) => (idx === i ? text : d)))
+    }
+
     const rows = mode === 'rgb' ? rgbRows(rgb) : hsbRows(hsb)
 
     const edit = (index: number, next: number, completed: boolean) => {
@@ -137,12 +151,14 @@ export const RgbHsbPanel: React.FC<RgbHsbPanelProps> = ({ mode, initialRgb, onCh
                         className="h3-color-slider-spinner"
                         min={row.min}
                         max={row.max}
-                        value={row.value}
+                        value={drafts[i] ?? String(row.value)}
                         clampValueOnBlur
-                        onValueChange={(v) => {
+                        onValueChange={(v, s) => {
+                            setDraftAt(i, s)
                             if (Number.isNaN(v)) return
                             edit(i, Math.max(row.min, Math.min(row.max, v)), true)
                         }}
+                        onBlur={() => setDraftAt(i, null)}
                     />
                 </div>
             ))}

--- a/tritium/react-gui/src/renderer/h3-kit/form/NumericField.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/form/NumericField.tsx
@@ -4,11 +4,24 @@
  * numeric input. Sizing comes from `.h3-form-numeric-row` / `.h3-form-slider` /
  * `.h3-form-numeric` (see `styles/_form-kit.css`); no size prop is exposed.
  *
+ * The numeric input is a bare `<input type="number">`, not Blueprint's
+ * `NumericInput`: Blueprint's component is fully controlled by `props.value`
+ * whenever it is non-null, so it always redisplays `value.toString()` and
+ * ignores whatever the user just typed unless the parent's `value` changes in
+ * lockstep. Since `onChange` here only fires for a parseable number, clearing
+ * the field (or typing a transient state like "-" or "1.") produced no
+ * `onChange`, so `value` never moved and the field snapped back to the old
+ * digit(s) on every keystroke -- making it impossible to clear and retype.
+ * `editText` tracks the user's literal keystrokes while editing so the field
+ * can go empty; the display falls back to `value` once editing ends. Mirrors
+ * the same fix already applied to `SliderField` / `RejectNumberInput` /
+ * `NumberCell`.
+ *
  * @module form/NumericField
  */
 
-import React, { useCallback } from 'react';
-import { NumericInput, Slider } from '@blueprintjs/core';
+import React, { useCallback, useState } from 'react';
+import { Slider } from '@blueprintjs/core';
 
 export interface NumericFieldProps {
     value: number;
@@ -41,15 +54,33 @@ export const NumericField: React.FC<NumericFieldProps> = ({
     disabled,
     onRelease,
 }) => {
+    // Raw text held while the user is editing the numeric input. When null,
+    // the input mirrors `value`. When non-null, the user is mid-edit and we
+    // show their literal keystrokes -- this is what lets an empty field stay
+    // empty instead of snapping back to the last committed value.
+    const [editText, setEditText] = useState<string | null>(null);
+
     const handleSlider = useCallback((v: number) => onChange(v), [onChange]);
-    const handleNumeric = useCallback(
-        (_vn: number, vs: string) => {
-            const parsed = parseFloat(vs);
+
+    const handleNumericChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const text = e.target.value;
+            setEditText(text);
+            const parsed = parseFloat(text);
             if (!isNaN(parsed)) onChange(parsed);
         },
         [onChange],
     );
-    const commit = useCallback(() => onRelease?.(value), [onRelease, value]);
+
+    // Commit reads `value` (not `editText`): every parseable keystroke already
+    // pushed itself through `onChange` above, so by the time blur/Enter fires
+    // the prop already carries the latest valid number. An edit that was never
+    // parseable (left empty, or stuck on "-" / "1.") simply reverts the
+    // display -- `value` itself never moved, so there is nothing to commit.
+    const commit = useCallback(() => {
+        setEditText(null);
+        onRelease?.(value);
+    }, [onRelease, value]);
 
     return (
         <div className="h3-form-numeric-row">
@@ -66,18 +97,15 @@ export const NumericField: React.FC<NumericFieldProps> = ({
                     className="h3-form-slider"
                 />
             )}
-            <NumericInput
-                small
-                value={value}
-                onValueChange={handleNumeric}
+            <input
+                type="number"
+                className="h3-form-numeric"
                 min={min}
                 max={max}
-                stepSize={step}
-                minorStepSize={null}
-                majorStepSize={null}
+                step={step}
+                value={editText ?? String(value)}
                 disabled={disabled}
-                className="h3-form-numeric"
-                fill={false}
+                onChange={handleNumericChange}
                 onBlur={commit}
                 onKeyDown={(e) => {
                     if (e.key === "Enter") commit();

--- a/tritium/react-gui/src/renderer/styles/_form-kit.css
+++ b/tritium/react-gui/src/renderer/styles/_form-kit.css
@@ -240,7 +240,7 @@
 .h3-form-input.bp5-input-group .bp5-input:disabled,
 .h3-form-input.bp5-input-group input:disabled,
 .h3-form-select.bp5-html-select select:disabled,
-.h3-form-numeric .bp5-input-group .bp5-input:disabled {
+.h3-form-numeric:disabled {
   color: var(--text-muted) !important;
 }
 
@@ -427,39 +427,39 @@
   box-shadow: 0 0 0 2px var(--accent), 0 1px 3px var(--slider-handle-shadow);
 }
 
-/* Fixed compact numeric column that never shrinks or overflows. */
-.h3-form-numeric.bp5-numeric-input {
+/* Fixed compact numeric column that never shrinks or overflows. A bare
+ * `<input type="number">` (see NumericField.tsx for why this is not
+ * Blueprint's NumericInput), so no nested `.bp5-input-group` / spinner
+ * button-group to style or hide -- only the native spin buttons remain. */
+.h3-form-numeric {
   flex: 0 0 68px;
   width: 68px;
-  min-width: 68px;
-}
-
-.h3-form-numeric .bp5-input-group {
-  width: 100%;
   min-width: 0;
-}
-
-.h3-form-numeric .bp5-input-group .bp5-input {
-  background: var(--bg-input) !important;
-  border: 1px solid var(--border) !important;
-  color: var(--text-primary) !important;
+  box-sizing: border-box;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  font-family: inherit;
   font-size: var(--fs-lg);
   height: var(--field-h-sm);
-  width: 100%;
   text-align: right;
   padding-right: var(--space-2);
   border-radius: var(--radius-md);
+  outline: none;
   caret-color: var(--accent);
+  -moz-appearance: textfield;
 }
 
-.h3-form-numeric .bp5-input-group .bp5-input:focus {
-  border-color: var(--accent) !important;
-  box-shadow: 0 0 0 1px var(--accent) !important;
+.h3-form-numeric::-webkit-outer-spin-button,
+.h3-form-numeric::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
 }
 
-/* Hide the numeric spinner buttons for the compact layout. */
-.h3-form-numeric .bp5-button-group {
-  display: none;
+.h3-form-numeric:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
 /* Unit suffix after a numeric input. */


### PR DESCRIPTION
## Summary

Three related fixes to the react-gui numeric input controls, all found from one report: the mol surface **density** field could not be cleared while editing.

### 1. Numeric text boxes could not be cleared (`fix`)

**Root cause**: Blueprint's `NumericInput` is fully controlled whenever `props.value` is non-null -- it always redisplays `value.toString()` and ignores what the user just typed unless the parent's `value` moves in lockstep. Since the change handlers only fired for a *parseable* number, clearing the field (or typing a transient state like `-` or `1.`) produced no callback, `value` never moved, and the box snapped back to the old digits on every keystroke.

Fixed at the **shared `h3-kit/form/NumericField`** so all 15+ call sites are covered at once (mol surface density / probe radius, renderer property stepper rows, settings rows, ...). Blueprint's `NumericInput` is replaced by a bare `<input type="number">` driven by an `editText` draft holding the user's literal keystrokes while editing -- the same draft-string model already used by `SliderField`, `RejectNumberInput` and `NumberCell` (and the same class of bug fixed there in 7311c40e).

The same guard is applied to the four places that used Blueprint's `NumericInput` directly and had the identical defect:
- colour picker RGB/HSB spinners (`RgbHsbPanel`)
- crystal cell parameters (`SymmetryChangeDialog`)
- CCP4 truncate min/max (`Ccp4MapOptionsPane`)
- MTZ resolution limit (`MtzOptionsPane`)

`GenericTab` was already correct (it drives its own draft string) and is untouched.

### 2. Mol surface point density presets (`feat`)

Density is nearly always picked from a handful of typical values, so it now uses the existing h3-kit `ComboBoxField` (the same editable-textbox-plus-dropdown the movie settings panel uses for frame rate / bit rate) with **1-5** as suggestions. Free typing still commits any positive integer. Probe radius keeps its plain numeric input -- it has no comparable set of canonical values.

### 3. Scene `Jitter SS` is a dropdown (`feat`)

`aaJitterLevel` only takes **0-5** (`GUIView.cpp` clamps to that range; levels above 5 have no jitter table). A numeric stepper implies a continuous range and leaves an out-of-range entry merely clamped, so it is now a dropdown -- the six values are the whole domain, and an invalid one is unreachable through the UI. `0` is labelled "Off" and matches the C++ default.

Adds `NumEnumRow` to the shared inspector row helpers (the integer counterpart of the existing `EnumRow` / `MappedEnumRow`) rather than special-casing this one section, so other small-fixed-domain integer properties can reuse it.

## Test plan

- [x] `npm test` -- 280 files / 2498 tests pass (+7 new)
  - new `NumericField.test.tsx` pins: field can go empty mid-edit, multi-digit retype after clearing, blur-while-empty reverts without committing, blur/Enter commit the latest value
  - `makeMolSurfDialog.test.tsx`: preset pick and free-typed value both reach the commit payload
  - `sceneRenderingSection.test.tsx`: Jitter SS renders as a 0-5 `<select>` (not a stepper) and commits a number
- [x] `npx tsc -p tsconfig.web.json --noEmit` -- no new errors
- [x] `npm run lint:style` -- unchanged at the existing 15-item baseline
- [x] `task build_tritium` -- production bundle builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)