### PR TITLE
Decouple the scene AA from AO, and control both with preset dropdowns

### DIFF
--- a/docs/architecture/gtao-screen-space-ao.md
+++ b/docs/architecture/gtao-screen-space-ao.md
@@ -39,8 +39,9 @@ libcuemol2 の OpenGL (core profile) バックエンドに実装した、リア�
 > default FB が阻んでいた depth blit (UI overlay の遮蔽) を優先 -- ため直描き時は AA なし)。
 
 AO/AA/jitter を全く使わない (全て無効・stereo・FBO 非対応) 場合は従来パス
-(clearBuffer + display) にフォールバックする。デフォルト設定は `aa_method = smaa` なので、
-既定ではパイプライン経由で描画される。
+(clearBuffer + display) にフォールバックする。デフォルト設定は `aa_method = fxaa` なので、
+既定ではパイプライン経由で描画される (SMAA は選択肢。分子シーンでは細線・オブジェクト間
+境界への効きから FXAA を既定とした)。
 
 ### 主要ファイル
 
@@ -366,6 +367,7 @@ output location も確認。これらで「location は正しい→書き込み�
 | `aoHalfRes` | false | adaptive 半解像度 GTAO: drag 中 half / idle full / export 常に full (負荷削減, §4.7) |
 | `aa_method` | fxaa | post-process AA (none/fxaa/smaa, §4.5) |
 | `aaJitterLevel` | 0 | temporal jitter SS レベル (0=off, 1..5=2..32 枚, §4.6) |
+| `aaSmaaThreshold` | 0.05 | SMAA エッジ検出閾値 (RGB 差の最大値。0.1=Medium/High, 0.05=Ultra 相当) |
 
 FalloffRange / SampleDistributionPower / RadiusMultiplier 等の XeGTAO ヒューリスティックは
 shader 定数のまま (必要なら同様に Scene プロパティへ昇格できる構造)。

--- a/docs/architecture/gtao-screen-space-ao.md
+++ b/docs/architecture/gtao-screen-space-ao.md
@@ -16,22 +16,29 @@ libcuemol2 の OpenGL (core profile) バックエンドに実装した、リア�
 
 ```
 1. scene  -> off-screen FBO (m_pAOSceneRT)  ※常にフル解像度
-              COLOR0 = 色 (RGBA8) / DEPTH = 深度tex (DEPTH24) / COLOR1 = 法線 (RGBA16F, MRT)
+              COLOR0 = 色 (RGBA8) / DEPTH = 深度tex (DEPTH24)
+              / COLOR1 = 法線 (RGBA16F, MRT; AO 有効時のみ attach)
 2. GTAO   -> AO RT (m_pAoRT, RGBA8)        R=遮蔽 G=packed edges  ※aoHalfRes 時は半解像度 (§4.7)
+              ※AO 有効時のみ。AO off (AA-only) では 2-3 をスキップ
 3. denoise-> denoise RT (m_pAoDenRT)       edge-aware 3x3 blur (単一パス)  ※AO RT と同解像度
 4. composite (color * AO, 半解像度時は edge-aware upsample) + post-AA -> default framebuffer  (§4.5/§4.7)
+     AO off 時は AO RT を渡さず u_hasAO=0 の単純コピー (shader は AO 系 uniform を読まない)
      aa_method=none: composite を直接 default fb へ
-     aa_method=fxaa: composite -> m_pCompRT(LINEAR) -> FXAA -> default fb
+     aa_method=fxaa/smaa: composite -> m_pCompRT(LINEAR) -> FXAA/SMAA -> default fb
 5. depth blit (scene depth -> default fb)  UI overlay の depth test 用
 6. UI overlay / 2D-UI / swapBuffers        AO/AA の影響を受けない
 ```
 
-> **AA は AO 経路でのみ必要**: scene を single-sample off-screen FBO に描くため、AO 有効時は
-> default FB の MSAA が効かず edge AA が失われる (非 AO 経路は従来どおり MSAA)。これを後段の
-> post-process AA で補う (§4.5)。
+> **AA と AO は独立**: パイプライン起動条件は `hasFBO() && CSM_NONE &&
+> Scene::requiresFramePipeline()` (= `aoEnabled || aa_method != none || aaJitterLevel > 0`)。
+> どれか 1 つでも有効なら off-screen パイプラインに乗り、AO off なら GTAO/denoise パスを
+> スキップして composite は単純コピーになる。scene を single-sample off-screen FBO に描くため
+> パイプライン経由時は default FB の MSAA が効かず、edge AA は post-process AA (§4.5) が担う。
+> 全て off のときのみ従来の直描き (default FB の MSAA) に戻る。
 
-AO を使わない (無効・stereo・FBO 非対応) 場合は従来パス (clearBuffer + display) に
-フォールバックする。判定は `pScene->isAOEnabled() && hasFBO() && getStereoMode()==CSM_NONE`。
+AO/AA/jitter を全く使わない (全て無効・stereo・FBO 非対応) 場合は従来パス
+(clearBuffer + display) にフォールバックする。デフォルト設定は `aa_method = smaa` なので、
+既定ではパイプライン経由で描画される。
 
 ### 主要ファイル
 
@@ -41,7 +48,8 @@ AO を使わない (無効・stereo・FBO 非対応) 場合は従来パス (clea
 | FBO 抽象 | `src/gfx/RenderTarget.hpp` | `RTFlags` / `RTTexUnit` / `RenderTarget` IF |
 | FBO 実装 | `src/sysdep/ogl_core/OcRenderTarget.{hpp,cpp}` | MRT (color+depth+normal)、clear、blit |
 | フルスクリーン描画 | `src/gfx/PostProcGpuPrim.{hpp,cpp}` | `drawGtao` / `drawDenoise` / `drawComposite` / `drawFxaa` + `struct AoConstants` |
-| ライブ経路 | `src/qsys/GUIView.cpp` | `drawScene` の AO 分岐 / `ensureAORTs` / `computeAoConstants` / `cleanupAORTs` / `unloading` |
+| ライブ経路 | `src/qsys/GUIView.cpp` | `drawScene` のパイプライン分岐 / `ensurePipeline` / `computeAoConstants` / `unloading` |
+| パス連結 | `src/qsys/FrameRenderPipeline.{hpp,cpp}` | RT 群の所有 (`setSize`, AO off 時は AO 項 RT / MRT 法線を確保しない) と `render` のパス実行 |
 | GTAO 本体 | `src/sysdep/ogl_core/gtao_frag.glsl` | horizon 積分・法線選択・line 除外 |
 | denoise | `src/sysdep/ogl_core/ao_denoise_frag.glsl` | edge-aware blur |
 | composite | `src/sysdep/ogl_core/ao_composite_frag.glsl` | `color.rgb * AO` (+ 半解像度時 joint bilateral upsample) |
@@ -200,7 +208,8 @@ AO 経路は scene を **single-sample** off-screen FBO に描くため、MSAA �
 平均する。フル TAA (motion vector 再投影) ではなく、動いたらリセットする「静止時 SS」。
 
 ### 制御
-- `Scene.aaJitterLevel` (0=off, 1..5 → 2/4/8/16/32 サンプル)。AO 経路・CSM_NONE のみ。
+- `Scene.aaJitterLevel` (0=off, 1..5 → 2/4/8/16/32 サンプル)。パイプライン経路 (CSM_NONE)
+  のみ。AO 非依存 (jitter 単独でもパイプラインに乗る)。
 - jitter オフセット表は Mol* JitterVectors (1/16px 単位) を `GUIView.cpp` に複製。
 
 ### 1 フレーム (jitterActive 時)
@@ -230,7 +239,8 @@ sampleIndex++ / 収束で停止
 
 ### 既知の制限 / 将来
 - AO は毎サンプル再計算 (Mol* reuseOcclusion 最適化は未実装 = 重いが正しい)。
-- フル TAA (動作中 AA)、hold バッファによるフリッカ低減、非 AO 経路統一、stereo は未対応。
+- フル TAA (動作中 AA)、hold バッファによるフリッカ低減、stereo は未対応。
+  (AA/jitter の AO 非依存化 = 経路統一は実装済み: §1)
 
 ---
 
@@ -401,8 +411,11 @@ shader 定数のまま (必要なら同様に Scene プロパティへ昇格で�
 
 ### AA ロードマップ (§4.5/§4.6 の続き)
 - **フル TAA**: motion vector 再投影で動作中も AA。reuseOcclusion 最適化、hold バッファ。
-- **全経路統一**: 非 AO 経路も offscreen+post-AA/jitter に通し AA を context MSAA 非依存にする
-  (tritium と整合)。現状は AO 経路のみ、非 AO は default FB MSAA。stereo 対応。
+- ~~**全経路統一**~~ 実装済み: AA/jitter は AO 非依存でパイプラインに乗る (§1)。全 off 時のみ
+  default FB MSAA の直描き。stereo 対応は未実装 (stereo では AO も AA も効かない)。
+- **オフスクリーン書き出しの post-AA**: `renderAOColorFrame` (`enablePostAA=false`) は
+  composite までで、書き出しの AA は上位の jitter SS ループ (常時 32 サンプル) が担う。
+  書き出しへ FXAA/SMAA を適用する場合は `params.enableAO` と同様に分岐を追加する。
 
 ---
 

--- a/docs/architecture/gtao-screen-space-ao.md
+++ b/docs/architecture/gtao-screen-space-ao.md
@@ -34,7 +34,9 @@ libcuemol2 の OpenGL (core profile) バックエンドに実装した、リア�
 > どれか 1 つでも有効なら off-screen パイプラインに乗り、AO off なら GTAO/denoise パスを
 > スキップして composite は単純コピーになる。scene を single-sample off-screen FBO に描くため
 > パイプライン経由時は default FB の MSAA が効かず、edge AA は post-process AA (§4.5) が担う。
-> 全て off のときのみ従来の直描き (default FB の MSAA) に戻る。
+> 全て off のときのみ従来の直描きに戻る (uxp_gui は default FB の MSAA が効く。tritium は
+> WebGL2 context を `antialias: false` で作る -- パイプラインが AA を担う前提で、multisampled
+> default FB が阻んでいた depth blit (UI overlay の遮蔽) を優先 -- ため直描き時は AA なし)。
 
 AO/AA/jitter を全く使わない (全て無効・stereo・FBO 非対応) 場合は従来パス
 (clearBuffer + display) にフォールバックする。デフォルト設定は `aa_method = smaa` なので、
@@ -412,7 +414,7 @@ shader 定数のまま (必要なら同様に Scene プロパティへ昇格で�
 ### AA ロードマップ (§4.5/§4.6 の続き)
 - **フル TAA**: motion vector 再投影で動作中も AA。reuseOcclusion 最適化、hold バッファ。
 - ~~**全経路統一**~~ 実装済み: AA/jitter は AO 非依存でパイプラインに乗る (§1)。全 off 時のみ
-  default FB MSAA の直描き。stereo 対応は未実装 (stereo では AO も AA も効かない)。
+  直描き (MSAA の有無は §1 参照)。stereo 対応は未実装 (stereo では AO も AA も効かない)。
 - **オフスクリーン書き出しの post-AA**: `renderAOColorFrame` (`enablePostAA=false`) は
   composite までで、書き出しの AA は上位の jitter SS ループ (常時 32 サンプル) が担う。
   書き出しへ FXAA/SMAA を適用する場合は `params.enableAO` と同様に分岐を追加する。

--- a/src/gfx/PostProcGpuPrim.cpp
+++ b/src/gfx/PostProcGpuPrim.cpp
@@ -327,6 +327,7 @@ void PostProcGpuPrim::drawSmaaEdges(DisplayContext *pDC, RenderTarget *srcColorR
     m_pSmaaEdgePO->setUniform("u_colorTex", RT_TU_COLOR);
     m_pSmaaEdgePO->setUniformF("u_rcpFrame", consts.viewportPixelSize[0],
                                consts.viewportPixelSize[1]);
+    m_pSmaaEdgePO->setUniformF("u_threshold", consts.smaaThreshold);
 
     pDC->drawElem(*m_pDrawElem);
 

--- a/src/gfx/PostProcGpuPrim.hpp
+++ b/src/gfx/PostProcGpuPrim.hpp
@@ -66,6 +66,10 @@ struct AoConstants
     /// Per-sample noise rotation [0,1) for temporal supersampling (0 = single
     /// frame). Decorrelates the GTAO noise across accumulated jitter samples.
     float aoNoiseOffset = 0.0f;
+    /// SMAA edge-detection threshold (max RGB delta between neighbor pixels),
+    /// mirrored from Scene.aaSmaaThreshold. 0.1 = SMAA Medium/High preset,
+    /// 0.05 = Ultra.
+    float smaaThreshold = 0.05f;
 
     /// Fill the camera-derived geometric fields (isOrtho, depthLinearize*,
     /// ndcToView*, viewportPixelSize) from the camera parameters. The AO tuning

--- a/src/qsys/FrameRenderPipeline.cpp
+++ b/src/qsys/FrameRenderPipeline.cpp
@@ -1,6 +1,7 @@
 // -*-Mode: C++;-*-
 //
-// FrameRenderPipeline: off-screen multi-pass orchestration for the GTAO AO path.
+// FrameRenderPipeline: off-screen multi-pass orchestration for the GTAO AO and
+// post-process AA paths.
 //
 
 #include <common.h>
@@ -163,6 +164,11 @@ bool FrameRenderPipeline::render(gfx::DisplayContext *pdc, const ScenePtr &pScen
     if (!isReady()) return false;
 
     const bool jitter = params.jitterActive && m_jitterSupported;
+    // AA-only mode skips the GTAO/denoise passes and composites without an AO
+    // term. The RT guards also cover the case where the AO targets were not
+    // allocated (setSize with aoEnabled=false).
+    const bool aoActive =
+        params.enableAO && m_pAoRT != nullptr && m_pAoDenRT != nullptr;
 
     // 1. Render the 3D scene into the off-screen target (color + depth + MRT
     // normal). The clear precedes the scene callback; the model-matrix setup the
@@ -177,45 +183,56 @@ bool FrameRenderPipeline::render(gfx::DisplayContext *pdc, const ScenePtr &pScen
 
     // 2. AO constants: camera part from params, AO tuning read from the Scene.
     gfx::AoConstants aoc = params.camAoc;
-    aoc.effectRadius = float(pScene->getAORadius());
-    aoc.finalValuePower = float(pScene->getAOIntensity());
-    aoc.sliceCount = pScene->getAOSlices();
-    aoc.stepsPerSlice = pScene->getAOSteps();
-    aoc.aoNoiseOffset = params.aoNoiseOffset;
-    // AO buffer texel size (= full res, or 2x coarser at half res). The GTAO /
-    // denoise passes run at this resolution, so they use it as their pixel size;
-    // the composite reads both to know whether (and how) to upsample.
-    aoc.aoTexelSize[0] = 1.0f / float(m_pAoRT->getWidth());
-    aoc.aoTexelSize[1] = 1.0f / float(m_pAoRT->getHeight());
-    // Fog parameters for the composite's AO fade. These must match the scene's
-    // setupFog (ShaderObject::setupFog): fogScale = 1/(fogEnd - fogStart). The
-    // composite recomputes the same linear fog factor from the scene depth and
-    // fades the AO term out where fog has taken over, so fully-fogged pixels are
-    // not darkened by AO.
-    const double fogStart = pdc->getFogStart();
-    const double fogEnd = pdc->getFogEnd();
-    aoc.fogEnd = float(fogEnd);
-    aoc.fogScale = (fogEnd > fogStart) ? float(1.0 / (fogEnd - fogStart)) : 0.0f;
-    gfx::AoConstants aocAO = aoc;
-    aocAO.viewportPixelSize[0] = aoc.aoTexelSize[0];
-    aocAO.viewportPixelSize[1] = aoc.aoTexelSize[1];
-    // Keep the horizon-radius cap at a fixed full-res-equivalent value so half
-    // res yields the same occlusion as full res.
-    aocAO.maxScreenspaceRadius =
-        256.0f * (aoc.viewportPixelSize[0] / aoc.aoTexelSize[0]);
+    if (aoActive) {
+        aoc.effectRadius = float(pScene->getAORadius());
+        aoc.finalValuePower = float(pScene->getAOIntensity());
+        aoc.sliceCount = pScene->getAOSlices();
+        aoc.stepsPerSlice = pScene->getAOSteps();
+        aoc.aoNoiseOffset = params.aoNoiseOffset;
+        // AO buffer texel size (= full res, or 2x coarser at half res). The GTAO /
+        // denoise passes run at this resolution, so they use it as their pixel size;
+        // the composite reads both to know whether (and how) to upsample.
+        aoc.aoTexelSize[0] = 1.0f / float(m_pAoRT->getWidth());
+        aoc.aoTexelSize[1] = 1.0f / float(m_pAoRT->getHeight());
+        // Fog parameters for the composite's AO fade. These must match the scene's
+        // setupFog (ShaderObject::setupFog): fogScale = 1/(fogEnd - fogStart). The
+        // composite recomputes the same linear fog factor from the scene depth and
+        // fades the AO term out where fog has taken over, so fully-fogged pixels are
+        // not darkened by AO.
+        const double fogStart = pdc->getFogStart();
+        const double fogEnd = pdc->getFogEnd();
+        aoc.fogEnd = float(fogEnd);
+        aoc.fogScale = (fogEnd > fogStart) ? float(1.0 / (fogEnd - fogStart)) : 0.0f;
+        gfx::AoConstants aocAO = aoc;
+        aocAO.viewportPixelSize[0] = aoc.aoTexelSize[0];
+        aocAO.viewportPixelSize[1] = aoc.aoTexelSize[1];
+        // Keep the horizon-radius cap at a fixed full-res-equivalent value so half
+        // res yields the same occlusion as full res.
+        aocAO.maxScreenspaceRadius =
+            256.0f * (aoc.viewportPixelSize[0] / aoc.aoTexelSize[0]);
 
-    // 3. GTAO pass: read the scene depth, write AO + packed edges.
-    m_pAoRT->bind();
-    m_pAoRT->clear(1.0f, 1.0f, 1.0f, 1.0f);
-    m_pAOPostProc->drawGtao(pdc, m_pAOSceneRT, aocAO, /*debugMode=*/0);
-    m_pAoRT->unbind();
+        // 3. GTAO pass: read the scene depth, write AO + packed edges.
+        m_pAoRT->bind();
+        m_pAoRT->clear(1.0f, 1.0f, 1.0f, 1.0f);
+        m_pAOPostProc->drawGtao(pdc, m_pAOSceneRT, aocAO, /*debugMode=*/0);
+        m_pAoRT->unbind();
 
-    // 4. Edge-aware denoise of the AO term (single pass).
-    m_pAoDenRT->bind();
-    m_pAOPostProc->drawDenoise(pdc, m_pAoRT, aocAO);
-    m_pAoDenRT->unbind();
+        // 4. Edge-aware denoise of the AO term (single pass).
+        m_pAoDenRT->bind();
+        m_pAOPostProc->drawDenoise(pdc, m_pAoRT, aocAO);
+        m_pAoDenRT->unbind();
+    } else {
+        // AA-only: keep the AO texel size equal to the viewport so the
+        // composite's upsample check stays off. The composite shader reads no
+        // other AO uniforms when u_hasAO == 0 (plain copy).
+        aoc.aoTexelSize[0] = aoc.viewportPixelSize[0];
+        aoc.aoTexelSize[1] = aoc.viewportPixelSize[1];
+    }
 
     gfx::RenderTarget *outRT = selectOutRT(params);
+    // The composite multiplies the denoised AO term, or plain-copies the scene
+    // color when the AO passes did not run (nullptr -> u_hasAO == 0).
+    gfx::RenderTarget *pAoDen = aoActive ? m_pAoDenRT : nullptr;
 
     if (params.enablePostAA) {
         // ---- Live path: composite scene color * denoised AO, then the selected
@@ -232,7 +249,7 @@ bool FrameRenderPipeline::render(gfx::DisplayContext *pdc, const ScenePtr &pScen
             pdc->setBlendEnabled(false);
 
             m_pCompRT->bind();
-            m_pAOPostProc->drawComposite(pdc, m_pAOSceneRT, m_pAoDenRT, aoc);
+            m_pAOPostProc->drawComposite(pdc, m_pAOSceneRT, pAoDen, aoc);
             m_pCompRT->unbind();
 
             if (aaMethod == Scene::AA_SMAA && m_pSmaaEdgeRT != nullptr &&
@@ -260,7 +277,7 @@ bool FrameRenderPipeline::render(gfx::DisplayContext *pdc, const ScenePtr &pScen
             pdc->setBlendEnabled(true);
         } else {
             if (outRT != nullptr) outRT->bind();
-            m_pAOPostProc->drawComposite(pdc, m_pAOSceneRT, m_pAoDenRT, aoc);
+            m_pAOPostProc->drawComposite(pdc, m_pAOSceneRT, pAoDen, aoc);
             if (outRT != nullptr) outRT->unbind();
         }
 
@@ -300,7 +317,7 @@ bool FrameRenderPipeline::render(gfx::DisplayContext *pdc, const ScenePtr &pScen
         pdc->setDepthTestEnabled(false);
         pdc->setBlendEnabled(false);
         if (outRT != nullptr) outRT->bind();
-        m_pAOPostProc->drawComposite(pdc, m_pAOSceneRT, m_pAoDenRT, aoc);
+        m_pAOPostProc->drawComposite(pdc, m_pAOSceneRT, pAoDen, aoc);
         if (outRT != nullptr) outRT->unbind();
         pdc->setBlendEnabled(true);
         pdc->setDepthTestEnabled(true);

--- a/src/qsys/FrameRenderPipeline.cpp
+++ b/src/qsys/FrameRenderPipeline.cpp
@@ -20,37 +20,57 @@ FrameRenderPipeline::~FrameRenderPipeline()
     dispose();
 }
 
-void FrameRenderPipeline::setSize(gfx::DisplayContext *pdc, int w, int h, bool halfRes)
+void FrameRenderPipeline::setSize(gfx::DisplayContext *pdc, int w, int h, bool halfRes,
+                                  bool aoEnabled)
 {
     if (pdc == nullptr) return;
 
+    // The normal attachment (MRT) lets the GTAO pass use real geometry
+    // normals instead of depth-reconstructed ones; it exists only for the AO
+    // passes. Attachment flags are fixed at creation, so recreate the scene
+    // target when the AO requirement changes.
+    if (m_pAOSceneRT != nullptr && m_pAOSceneRT->hasNormal() != aoEnabled) {
+        delete m_pAOSceneRT;
+        m_pAOSceneRT = nullptr;
+    }
     if (m_pAOSceneRT == nullptr) {
-        // The normal attachment (MRT) lets the GTAO pass use real geometry
-        // normals instead of depth-reconstructed ones.
-        m_pAOSceneRT = pdc->createRenderTarget(
-            w, h, gfx::RT_COLOR_RGBA8 | gfx::RT_DEPTH_TEX | gfx::RT_NORMAL_RGBA16F);
+        int flags = gfx::RT_COLOR_RGBA8 | gfx::RT_DEPTH_TEX;
+        if (aoEnabled) flags |= gfx::RT_NORMAL_RGBA16F;
+        m_pAOSceneRT = pdc->createRenderTarget(w, h, flags);
     } else {
         m_pAOSceneRT->resize(w, h);
     }
 
-    // AO term targets (GTAO + denoise). Half resolution when requested; the
-    // composite edge-aware upsamples them back to full res. resize() is a no-op
-    // when unchanged, so toggling halfRes at runtime re-allocates them.
-    const int aoW = halfRes ? (w + 1) / 2 : w;
-    const int aoH = halfRes ? (h + 1) / 2 : h;
+    // AO term targets (GTAO + denoise), allocated only while AO is on. Half
+    // resolution when requested; the composite edge-aware upsamples them back
+    // to full res. resize() is a no-op when unchanged, so toggling halfRes at
+    // runtime re-allocates them.
+    if (aoEnabled) {
+        const int aoW = halfRes ? (w + 1) / 2 : w;
+        const int aoH = halfRes ? (h + 1) / 2 : h;
 
-    // AO targets hold packed data (AO + edges) and must use NEAREST filtering.
-    const int aoFlags = gfx::RT_COLOR_RGBA8 | gfx::RT_COLOR_NEAREST;
-    if (m_pAoRT == nullptr) {
-        m_pAoRT = pdc->createRenderTarget(aoW, aoH, aoFlags);
-    } else {
-        m_pAoRT->resize(aoW, aoH);
-    }
+        // AO targets hold packed data (AO + edges) and must use NEAREST filtering.
+        const int aoFlags = gfx::RT_COLOR_RGBA8 | gfx::RT_COLOR_NEAREST;
+        if (m_pAoRT == nullptr) {
+            m_pAoRT = pdc->createRenderTarget(aoW, aoH, aoFlags);
+        } else {
+            m_pAoRT->resize(aoW, aoH);
+        }
 
-    if (m_pAoDenRT == nullptr) {
-        m_pAoDenRT = pdc->createRenderTarget(aoW, aoH, aoFlags);
+        if (m_pAoDenRT == nullptr) {
+            m_pAoDenRT = pdc->createRenderTarget(aoW, aoH, aoFlags);
+        } else {
+            m_pAoDenRT->resize(aoW, aoH);
+        }
     } else {
-        m_pAoDenRT->resize(aoW, aoH);
+        if (m_pAoRT != nullptr) {
+            delete m_pAoRT;
+            m_pAoRT = nullptr;
+        }
+        if (m_pAoDenRT != nullptr) {
+            delete m_pAoDenRT;
+            m_pAoDenRT = nullptr;
+        }
     }
 
     // Composite target for the post-process AA stage. LINEAR filtering (no
@@ -144,8 +164,9 @@ void FrameRenderPipeline::dispose()
 
 bool FrameRenderPipeline::isReady() const
 {
-    return m_pAOSceneRT != nullptr && m_pAoRT != nullptr && m_pAoDenRT != nullptr &&
-           m_pAOPostProc != nullptr;
+    // The AO term targets are optional (absent in AA-only mode); render()
+    // falls back to the no-AO composite when they are missing.
+    return m_pAOSceneRT != nullptr && m_pAOPostProc != nullptr;
 }
 
 gfx::RenderTarget *FrameRenderPipeline::selectOutRT(const FrameRenderParams &params) const

--- a/src/qsys/FrameRenderPipeline.cpp
+++ b/src/qsys/FrameRenderPipeline.cpp
@@ -204,6 +204,8 @@ bool FrameRenderPipeline::render(gfx::DisplayContext *pdc, const ScenePtr &pScen
 
     // 2. AO constants: camera part from params, AO tuning read from the Scene.
     gfx::AoConstants aoc = params.camAoc;
+    // SMAA tuning (used by the post-AA stage, independent of AO).
+    aoc.smaaThreshold = float(pScene->getAASmaaThreshold());
     if (aoActive) {
         aoc.effectRadius = float(pScene->getAORadius());
         aoc.finalValuePower = float(pScene->getAOIntensity());

--- a/src/qsys/FrameRenderPipeline.hpp
+++ b/src/qsys/FrameRenderPipeline.hpp
@@ -1,7 +1,9 @@
 // -*-Mode: C++;-*-
 //
-// FrameRenderPipeline: off-screen multi-pass orchestration for the GTAO AO path
-// (scene -> GTAO -> denoise -> composite -> [FXAA/SMAA] -> [temporal jitter]).
+// FrameRenderPipeline: off-screen multi-pass orchestration for the GTAO AO and
+// post-process AA paths (scene -> [GTAO -> denoise] -> composite ->
+// [FXAA/SMAA] -> [temporal jitter]). AO and AA are independent: either one
+// routes the frame through this pipeline.
 //
 // Extracted from GUIView::drawScene so the same pass chain serves both the live
 // view and the off-screen exporter, and so the future tritium (WebGL2) port
@@ -40,6 +42,11 @@ struct FrameRenderParams
 
     /// GTAO noise rotation [0,1) for temporal supersampling (0 = single frame).
     float aoNoiseOffset = 0.0f;
+
+    /// Run the GTAO + denoise passes and multiply the AO term in the composite.
+    /// false = the pipeline serves AA only: the scene color passes through the
+    /// composite unchanged (u_hasAO == 0 plain copy).
+    bool enableAO = true;
 
     /// Clear the scene target's background alpha to 0 (transparent export).
     bool bgTransparent = false;
@@ -90,12 +97,13 @@ public:
     /// True once the core targets and post-process primitive exist (setSize ran).
     bool isReady() const;
 
-    /// Run the pass chain: scene(via sceneRenderFn) -> GTAO -> denoise ->
-    /// composite -> [post-AA] -> [jitter accumulate/display] -> [depth blit].
-    /// pScene supplies AO/AA/background settings. sceneRenderFn sets the model
-    /// matrix and calls pScene->display(pdc); the pipeline binds/clears the scene
-    /// target around it. Returns true when the AO chain ran (always true once
-    /// isReady()); the caller handles the plain-scene fallback when not ready.
+    /// Run the pass chain: scene(via sceneRenderFn) -> [GTAO -> denoise (when
+    /// params.enableAO)] -> composite -> [post-AA] -> [jitter
+    /// accumulate/display] -> [depth blit]. pScene supplies AO/AA/background
+    /// settings. sceneRenderFn sets the model matrix and calls
+    /// pScene->display(pdc); the pipeline binds/clears the scene target around
+    /// it. Returns true when the chain ran (always true once isReady()); the
+    /// caller handles the plain-scene fallback when not ready.
     bool render(gfx::DisplayContext *pdc, const ScenePtr &pScene,
                 const FrameRenderParams &params,
                 const std::function<void()> &sceneRenderFn);

--- a/src/qsys/FrameRenderPipeline.hpp
+++ b/src/qsys/FrameRenderPipeline.hpp
@@ -85,8 +85,12 @@ public:
     /// (Re)create the render targets at the given backing-pixel size. Idempotent:
     /// existing targets are resized, not reallocated. When halfRes is true the
     /// GTAO term targets (AO / denoise) are allocated at half resolution; the
-    /// scene and composite targets stay full resolution.
-    void setSize(gfx::DisplayContext *pdc, int w, int h, bool halfRes);
+    /// scene and composite targets stay full resolution. When aoEnabled is false
+    /// the AO term targets and the scene target's MRT normal attachment are not
+    /// allocated (released if present) to save VRAM and scene-pass bandwidth;
+    /// toggling AO recreates the scene target with the matching attachments.
+    void setSize(gfx::DisplayContext *pdc, int w, int h, bool halfRes,
+                 bool aoEnabled);
 
     /// Release all render targets and the post-process primitive. Does NOT touch
     /// the display context (the targets self-guard the GL context via their parent

--- a/src/qsys/GUIView.cpp
+++ b/src/qsys/GUIView.cpp
@@ -250,7 +250,7 @@ void GUIView::drawScene()
                 aoOn && pScene->isAOHalfRes() && getUpdateFlag();
             if (usePipeline) {
                 ensurePipeline(convToBackingX(getWidth()),
-                               convToBackingY(getHeight()), aoHalfRes);
+                               convToBackingY(getHeight()), aoHalfRes, aoOn);
             }
             // Owe a full-resolution follow-up frame after a half-res one, so the
             // idle loop keeps running until the still image is rendered at full
@@ -856,7 +856,7 @@ void GUIView::setFogColorImpl(DisplayContext *pdc)
 //////////
 // Screen-space ambient occlusion (GTAO) live path
 
-void GUIView::ensurePipeline(int w, int h, bool halfRes)
+void GUIView::ensurePipeline(int w, int h, bool halfRes, bool aoEnabled)
 {
     DisplayContext *pdc = getDisplayContext();
     if (pdc == nullptr) return;
@@ -864,7 +864,7 @@ void GUIView::ensurePipeline(int w, int h, bool halfRes)
     // Lazily create the pipeline (the display context is not valid in the GUIView
     // constructor, so this cannot be done there).
     if (m_pPipeline == nullptr) m_pPipeline = MB_NEW FrameRenderPipeline();
-    m_pPipeline->setSize(pdc, w, h, halfRes);
+    m_pPipeline->setSize(pdc, w, h, halfRes, aoEnabled);
 }
 
 gfx::AoConstants GUIView::computeAoConstants() const
@@ -893,8 +893,11 @@ bool GUIView::renderAOColorFrame(DisplayContext *pdc, const ScenePtr &pScene,
     const bool useAO = pScene->isAOEnabled() && hasFBO();
     // The off-screen export always renders the AO term at full resolution: the
     // half-res mode is a live-interaction optimization (see drawScene), not a
-    // quality setting, so an exported still must not inherit it.
-    if (useAO) ensurePipeline(bw, bh, /*halfRes=*/false);
+    // quality setting, so an exported still must not inherit it. The AO-off
+    // plain-scene fallback below is equivalent to an AA-only pipeline composite
+    // (this path never applies spatial post-AA), so the pipeline is only set up
+    // for AO here; pass params.enableAO when export post-AA is added.
+    if (useAO) ensurePipeline(bw, bh, /*halfRes=*/false, /*aoEnabled=*/true);
 
     if (useAO && m_pPipeline != nullptr && m_pPipeline->isReady()) {
         // Composite-only chain (no spatial post-AA, no jitter, no UI depth blit),

--- a/src/qsys/GUIView.cpp
+++ b/src/qsys/GUIView.cpp
@@ -215,9 +215,10 @@ void GUIView::drawScene()
 
     ////////////////////////////////////////////////
 
-    // Temporal-jitter: assume no further accumulation this frame unless the AO
-    // path re-arms it below; keep the projection un-jittered for the default
-    // setUpProjMat call (the AO path re-applies the per-sample offset).
+    // Temporal-jitter: assume no further accumulation this frame unless the
+    // pipeline path re-arms it below; keep the projection un-jittered for the
+    // default setUpProjMat call (the pipeline path re-applies the per-sample
+    // offset).
     m_jitterMoreSamples = false;
     m_jitterPxX = m_jitterPxY = 0.0;
     m_aoHalfPending = false;
@@ -227,11 +228,17 @@ void GUIView::drawScene()
     switch (getStereoMode()) {
         default:
         case Camera::CSM_NONE: {
-            // Screen-space ambient occlusion (GTAO) renders the 3D scene into
-            // an off-screen target so depth/color are available to a fullscreen
-            // pass, then composites the result onto the default framebuffer.
-            const bool useAO = pScene->isAOEnabled() && hasFBO() &&
-                               getStereoMode() == Camera::CSM_NONE;
+            // The off-screen frame pipeline serves AO (GTAO) and/or AA
+            // (FXAA/SMAA/temporal jitter): the 3D scene is rendered into an
+            // off-screen target so depth/color are available to the fullscreen
+            // passes, then composited onto the default framebuffer. AO and AA
+            // are independent: any of them routes the frame through the
+            // pipeline; none of them = legacy direct rendering (hardware MSAA
+            // on the default framebuffer).
+            const bool pipeAvail = hasFBO();
+            const bool aoOn = pScene->isAOEnabled() && pipeAvail;
+            const bool usePipeline =
+                pipeAvail && pScene->requiresFramePipeline();
 
             // Adaptive half-resolution AO: when aoHalfRes is enabled, the GTAO
             // term is computed at half resolution only while the camera is
@@ -240,8 +247,8 @@ void GUIView::drawScene()
             // for camera/scene-driven redraws and false for the idle continuous
             // redraws, so it distinguishes "moving" from "still".
             const bool aoHalfRes =
-                useAO && pScene->isAOHalfRes() && getUpdateFlag();
-            if (useAO) {
+                aoOn && pScene->isAOHalfRes() && getUpdateFlag();
+            if (usePipeline) {
                 ensurePipeline(convToBackingX(getWidth()),
                                convToBackingY(getHeight()), aoHalfRes);
             }
@@ -251,7 +258,8 @@ void GUIView::drawScene()
             // otherwise re-arm the redraw).
             m_aoHalfPending = aoHalfRes;
 
-            if (useAO && m_pPipeline != nullptr && m_pPipeline->isReady()) {
+            if (usePipeline && m_pPipeline != nullptr &&
+                m_pPipeline->isReady()) {
                 // Temporal-jitter supersampling (camera still): the pipeline
                 // renders each jittered sample's final color, sums it into the
                 // float accumulation buffer, and displays the running average.
@@ -285,6 +293,7 @@ void GUIView::drawScene()
                 // by the pipeline; the scene geometry is rendered via the callback.
                 FrameRenderParams params;
                 params.camAoc = computeAoConstants();
+                params.enableAO = aoOn;
                 // Rotate the GTAO noise per accumulated jitter sample (R1
                 // sequence) so the grain averages out; 0 when not jittering.
                 if (jitterActive) {

--- a/src/qsys/GUIView.hpp
+++ b/src/qsys/GUIView.hpp
@@ -165,8 +165,10 @@ private:
 
     /// Lazily create the off-screen pipeline (needs a valid display context) and
     /// (re)size its render targets to the given backing-pixel size. When halfRes
-    /// is true the GTAO term targets are allocated at half resolution.
-    void ensurePipeline(int w, int h, bool halfRes);
+    /// is true the GTAO term targets are allocated at half resolution; when
+    /// aoEnabled is false the AO-specific targets are not allocated at all
+    /// (AA-only pipeline).
+    void ensurePipeline(int w, int h, bool halfRes, bool aoEnabled);
 
     /// Compute the view-space reconstruction constants for the GTAO passes from
     /// the current camera (perspective). Mirrors setUpProjMat's slab derivation.

--- a/src/qsys/Scene.cpp
+++ b/src/qsys/Scene.cpp
@@ -127,6 +127,7 @@ Scene::Scene()
   m_bAOHalfRes = false;
   m_nAAMethod = AA_SMAA;
   m_nAAJitterLevel = 0;
+  m_fAASmaaThreshold = 0.05;
 
   MB_DPRINTLN("Scene (%d) created.", (int)m_nUID);
 }

--- a/src/qsys/Scene.cpp
+++ b/src/qsys/Scene.cpp
@@ -125,7 +125,7 @@ Scene::Scene()
   m_nAOSlices = 9;
   m_nAOSteps = 3;
   m_bAOHalfRes = false;
-  m_nAAMethod = AA_FXAA;
+  m_nAAMethod = AA_SMAA;
   m_nAAJitterLevel = 0;
 
   MB_DPRINTLN("Scene (%d) created.", (int)m_nUID);

--- a/src/qsys/Scene.cpp
+++ b/src/qsys/Scene.cpp
@@ -125,7 +125,7 @@ Scene::Scene()
   m_nAOSlices = 9;
   m_nAOSteps = 3;
   m_bAOHalfRes = false;
-  m_nAAMethod = AA_SMAA;
+  m_nAAMethod = AA_FXAA;
   m_nAAJitterLevel = 0;
   m_fAASmaaThreshold = 0.05;
 

--- a/src/qsys/Scene.hpp
+++ b/src/qsys/Scene.hpp
@@ -243,7 +243,8 @@ namespace qsys {
       AA_SMAA = 2,
     };
 
-    /// Post-process anti-aliasing method applied after the AO composite.
+    /// Post-process anti-aliasing method applied after the composite stage of
+    /// the frame pipeline (independent of the AO setting).
     int getAAMethod() const { return m_nAAMethod; }
     void setAAMethod(int v) {
       setUpdateFlag();
@@ -255,6 +256,15 @@ namespace qsys {
     void setAAJitterLevel(int v) {
       setUpdateFlag();
       m_nAAJitterLevel = v;
+    }
+
+    /// True when the scene's render settings require the off-screen frame
+    /// pipeline (AO, spatial post-AA, or temporal jitter); false = legacy
+    /// direct rendering (hardware MSAA on the default framebuffer) suffices.
+    /// AO and AA are independent: any one of them routes the frame through
+    /// the pipeline.
+    bool requiresFramePipeline() const {
+      return m_bAOEnabled || m_nAAMethod != AA_NONE || m_nAAJitterLevel > 0;
     }
 
     /// get source path of this scene

--- a/src/qsys/Scene.hpp
+++ b/src/qsys/Scene.hpp
@@ -123,6 +123,9 @@ namespace qsys {
     /// Temporal jitter supersampling level (0 = off, 1..5 = 2/4/8/16/32 samples)
     int m_nAAJitterLevel;
 
+    /// SMAA edge-detection threshold (max RGB delta between neighbor pixels)
+    double m_fAASmaaThreshold;
+
     /// UID of this scene
     qlib::uid_t m_nUID;
 
@@ -256,6 +259,13 @@ namespace qsys {
     void setAAJitterLevel(int v) {
       setUpdateFlag();
       m_nAAJitterLevel = v;
+    }
+
+    /// SMAA edge-detection threshold. Lower = more edges antialiased.
+    double getAASmaaThreshold() const { return m_fAASmaaThreshold; }
+    void setAASmaaThreshold(double v) {
+      setUpdateFlag();
+      m_fAASmaaThreshold = v;
     }
 
     /// True when the scene's render settings require the off-screen frame

--- a/src/qsys/Scene.qif
+++ b/src/qsys/Scene.qif
@@ -83,6 +83,13 @@ runtime_class Scene
   property integer aaJitterLevel => redirect(getAAJitterLevel, setAAJitterLevel);
   default aaJitterLevel = 0;
 
+  /// SMAA edge-detection threshold (max RGB delta between neighbors). Lower =
+  /// more edges antialiased; higher = only strong edges. 0.05 matches the SMAA
+  /// "Ultra" preset (0.1 = Medium/High) -- molecular scenes need the lower
+  /// value so object-object silhouettes with modest color contrast are caught.
+  property real aaSmaaThreshold => redirect(getAASmaaThreshold, setAASmaaThreshold);
+  default aaSmaaThreshold = 0.05;
+
   property string onload => m_scrOnLoadEvent;
   default onload = "";
 

--- a/src/qsys/Scene.qif
+++ b/src/qsys/Scene.qif
@@ -67,18 +67,19 @@ runtime_class Scene
   property boolean aoHalfRes => redirect(isAOHalfRes, setAOHalfRes);
   default aoHalfRes = false;
 
-  /// Post-process anti-aliasing method applied after the AO composite.
-  /// none = no post-AA (legacy behavior), fxaa = FXAA, smaa = SMAA (reserved).
+  /// Post-process anti-aliasing method, independent of the AO setting (either
+  /// one routes the frame through the off-screen pipeline).
+  /// none = direct rendering with hardware MSAA, fxaa = FXAA, smaa = SMAA.
   enumdef aa_method {
     none = 0;
     fxaa = 1;
     smaa = 2;
   }
   property enum aa_method => redirect(getAAMethod, setAAMethod);
-  default aa_method = "fxaa";
+  default aa_method = "smaa";
 
   /// Temporal jitter supersampling level (0 = off, 1..5 = 2/4/8/16/32 samples).
-  /// Accumulated only while the camera is still (AO path); resets on change.
+  /// Accumulated only while the camera is still; resets on change.
   property integer aaJitterLevel => redirect(getAAJitterLevel, setAAJitterLevel);
   default aaJitterLevel = 0;
 

--- a/src/qsys/Scene.qif
+++ b/src/qsys/Scene.qif
@@ -76,7 +76,7 @@ runtime_class Scene
     smaa = 2;
   }
   property enum aa_method => redirect(getAAMethod, setAAMethod);
-  default aa_method = "smaa";
+  default aa_method = "fxaa";
 
   /// Temporal jitter supersampling level (0 = off, 1..5 = 2/4/8/16/32 samples).
   /// Accumulated only while the camera is still; resets on change.

--- a/src/sysdep/ogl_core/smaa_edges_frag.glsl
+++ b/src/sysdep/ogl_core/smaa_edges_frag.glsl
@@ -8,16 +8,17 @@
 
 uniform sampler2D u_colorTex;
 uniform vec2 u_rcpFrame;  // (1/width, 1/height), == SMAA uTexSizeInv
+// Edge-detection threshold (max RGB delta), Scene.aaSmaaThreshold.
+// 0.1 = SMAA Medium/High preset, 0.05 = Ultra.
+uniform float u_threshold;
 
 in vec2 v_uv;
 
 out vec4 o_FragColor;
 
-const float SMAA_THRESHOLD = 0.1;
-
 vec4 SMAAColorEdgeDetectionPS(vec2 texcoord, vec4 offset[3], sampler2D colorTex)
 {
-    vec2 threshold = vec2(SMAA_THRESHOLD, SMAA_THRESHOLD);
+    vec2 threshold = vec2(u_threshold, u_threshold);
 
     // Calculate color deltas:
     vec4 delta;

--- a/src/tests/qsys/test_scene.cpp
+++ b/src/tests/qsys/test_scene.cpp
@@ -418,10 +418,10 @@ TEST_F(SceneTest, AAPropsAreIndependentOfAO)
 // require it on their own; all off = legacy direct (MSAA) rendering.
 TEST_F(SceneTest, RequiresFramePipelineContract)
 {
-    // Default scene: AO off, aa_method smaa, jitter 0 -> pipeline required
+    // Default scene: AO off, aa_method fxaa, jitter 0 -> pipeline required
     // (the default AA is deliberately active without AO).
     EXPECT_FALSE(m_pScene->isAOEnabled());
-    EXPECT_EQ(m_pScene->getAAMethod(), qsys::Scene::AA_SMAA);
+    EXPECT_EQ(m_pScene->getAAMethod(), qsys::Scene::AA_FXAA);
     EXPECT_EQ(m_pScene->getAAJitterLevel(), 0);
     EXPECT_TRUE(m_pScene->requiresFramePipeline());
 
@@ -436,7 +436,7 @@ TEST_F(SceneTest, RequiresFramePipelineContract)
     EXPECT_TRUE(m_pScene->requiresFramePipeline());
 
     m_pScene->setAOEnabled(false);
-    m_pScene->setAAMethod(qsys::Scene::AA_FXAA);
+    m_pScene->setAAMethod(qsys::Scene::AA_SMAA);
     EXPECT_TRUE(m_pScene->requiresFramePipeline());
 }
 

--- a/src/tests/qsys/test_scene.cpp
+++ b/src/tests/qsys/test_scene.cpp
@@ -439,3 +439,13 @@ TEST_F(SceneTest, RequiresFramePipelineContract)
     m_pScene->setAAMethod(qsys::Scene::AA_FXAA);
     EXPECT_TRUE(m_pScene->requiresFramePipeline());
 }
+
+// The SMAA edge-detection threshold is a tunable scene property; 0.05 (the
+// SMAA "Ultra" preset) is the deliberate default so object-object silhouettes
+// with modest color contrast are still antialiased.
+TEST_F(SceneTest, SmaaThresholdDefaultAndSetGet)
+{
+    EXPECT_DOUBLE_EQ(m_pScene->getAASmaaThreshold(), 0.05);
+    m_pScene->setAASmaaThreshold(0.12);
+    EXPECT_DOUBLE_EQ(m_pScene->getAASmaaThreshold(), 0.12);
+}

--- a/src/tests/qsys/test_scene.cpp
+++ b/src/tests/qsys/test_scene.cpp
@@ -397,3 +397,45 @@ TEST_F(SceneTest, CreateViewSetsSceneID)
     ASSERT_FALSE(pView.isnull());
     EXPECT_EQ(pView->getSceneID(), m_pScene->getUID());
 }
+
+// AA (aa_method / aaJitterLevel) is independent of AO: the settings hold
+// their values regardless of the AO flag, and toggling AO does not touch them.
+TEST_F(SceneTest, AAPropsAreIndependentOfAO)
+{
+    m_pScene->setAOEnabled(false);
+    m_pScene->setAAMethod(qsys::Scene::AA_SMAA);
+    m_pScene->setAAJitterLevel(3);
+    EXPECT_EQ(m_pScene->getAAMethod(), qsys::Scene::AA_SMAA);
+    EXPECT_EQ(m_pScene->getAAJitterLevel(), 3);
+
+    m_pScene->setAOEnabled(true);
+    EXPECT_EQ(m_pScene->getAAMethod(), qsys::Scene::AA_SMAA);
+    EXPECT_EQ(m_pScene->getAAJitterLevel(), 3);
+}
+
+// requiresFramePipeline() decides whether drawScene routes the frame through
+// the off-screen pipeline: AO, spatial post-AA, or temporal jitter each
+// require it on their own; all off = legacy direct (MSAA) rendering.
+TEST_F(SceneTest, RequiresFramePipelineContract)
+{
+    // Default scene: AO off, aa_method smaa, jitter 0 -> pipeline required
+    // (the default AA is deliberately active without AO).
+    EXPECT_FALSE(m_pScene->isAOEnabled());
+    EXPECT_EQ(m_pScene->getAAMethod(), qsys::Scene::AA_SMAA);
+    EXPECT_EQ(m_pScene->getAAJitterLevel(), 0);
+    EXPECT_TRUE(m_pScene->requiresFramePipeline());
+
+    m_pScene->setAAMethod(qsys::Scene::AA_NONE);
+    EXPECT_FALSE(m_pScene->requiresFramePipeline());
+
+    m_pScene->setAAJitterLevel(2);
+    EXPECT_TRUE(m_pScene->requiresFramePipeline());
+
+    m_pScene->setAAJitterLevel(0);
+    m_pScene->setAOEnabled(true);
+    EXPECT_TRUE(m_pScene->requiresFramePipeline());
+
+    m_pScene->setAOEnabled(false);
+    m_pScene->setAAMethod(qsys::Scene::AA_FXAA);
+    EXPECT_TRUE(m_pScene->requiresFramePipeline());
+}

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -12,6 +12,10 @@
  *   - the AA controls (method / jitter) are never gated on the AO flag (AA is
  *     independent of AO in the C++ frame pipeline);
  *   - the `aaSmaaThreshold` entry renders no row (deliberately not surfaced);
+ *   - the AO Preset / AA Quality dropdowns derive their step from the live
+ *     values (default entries read Low / Standard, never Custom), apply a
+ *     step as ONE `onSetMany` multi-write, offer Custom only while true, and
+ *     ignore props outside their patch (aoSlices);
  *   - enabling colour proofing with no profile seeds the default ICC profile in
  *     one multi-write (`onSetMany`); with a profile it is a plain toggle;
  *   - PropertiesTab shows the four scene sections (no placeholder) for `scene`.
@@ -46,6 +50,11 @@ import {
   SceneBackgroundSection,
   SceneColorProofingSection,
 } from '../components/inspector/SceneRenderingSection'
+import {
+  SCENE_AO_PRESET_AXIS,
+  SCENE_AA_QUALITY_AXIS,
+  sceneStepOf,
+} from '../data/sceneQualityPresets'
 import { getRendererPropSections } from '../components/inspector/rendererPropSections'
 import { PropertiesTab } from '../components/inspector/PropertiesTab'
 
@@ -227,7 +236,8 @@ describe('SceneAntialiasingSection', () => {
       />,
     )
     expect(rowByLabel(container, 'SMAA threshold')).toBeNull()
-    expect(container.querySelectorAll('.h3-form-prop-row').length).toBe(2)
+    // Quality + Method + Jitter SS -- and nothing else.
+    expect(container.querySelectorAll('.h3-form-prop-row').length).toBe(3)
     unmount()
   })
 
@@ -254,6 +264,177 @@ describe('SceneAntialiasingSection', () => {
       sel.dispatchEvent(new Event('change', { bubbles: true }))
     })
     expect(onSet).toHaveBeenCalledWith('aaJitterLevel', 'integer', 3)
+    unmount()
+  })
+})
+
+describe('Scene quality presets', () => {
+  const read = (entries: GenericPropEntry[]) => (k: string) =>
+    entries.find((e) => e.key === k)?.value
+
+  it('every step of an axis writes the same key set', () => {
+    for (const axis of [SCENE_AO_PRESET_AXIS, SCENE_AA_QUALITY_AXIS]) {
+      const keys = Object.keys(axis.steps[0].patch).sort()
+      for (const step of axis.steps) {
+        expect(Object.keys(step.patch).sort()).toEqual(keys)
+      }
+    }
+  })
+
+  it('the default steps match the C++ defaults (a fresh scene is not Custom)', () => {
+    expect(sceneStepOf(SCENE_AO_PRESET_AXIS, read(fullEntries()))).toBe('low')
+    expect(sceneStepOf(SCENE_AA_QUALITY_AXIS, read(fullEntries()))).toBe('standard')
+  })
+
+  it('sceneStepOf tolerates float round-trip noise (epsilon compare)', () => {
+    const entries = fullEntries().map((e) =>
+      e.key === 'aoIntensity'
+        ? entry({ key: 'aoIntensity', type: 'real', value: 2.2000000001 })
+        : e,
+    )
+    expect(sceneStepOf(SCENE_AO_PRESET_AXIS, read(entries))).toBe('low')
+  })
+
+  it('editing a prop outside the patch (aoSlices) keeps the AO preset step', () => {
+    const entries = fullEntries().map((e) =>
+      e.key === 'aoSlices' ? entry({ key: 'aoSlices', type: 'integer', value: 12 }) : e,
+    )
+    expect(sceneStepOf(SCENE_AO_PRESET_AXIS, read(entries))).toBe('low')
+  })
+
+  it('AO Preset reads "low" on defaults and applies a step as one multi-write', () => {
+    const onSet = vi.fn()
+    const onSetMany = vi.fn()
+    const { container, unmount } = mountTree(
+      <SceneAmbientOcclusionSection
+        entries={fullEntries()}
+        onSet={onSet}
+        onSetMany={onSetMany}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    const sel = rowByLabel(container, 'Preset')!.querySelector('select') as HTMLSelectElement
+    expect(sel.value).toBe('low')
+    // Custom is only offered while it is the truth -- not on a step.
+    expect(Array.from(sel.options).map((o) => o.value)).toEqual(['low', 'medium', 'high'])
+    act(() => {
+      sel.value = 'medium'
+      sel.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(onSetMany).toHaveBeenCalledTimes(1)
+    expect(onSetMany).toHaveBeenCalledWith([
+      { key: 'aoRadius', valueType: 'real', value: 8 },
+      { key: 'aoSteps', valueType: 'integer', value: 4 },
+      { key: 'aoIntensity', valueType: 'real', value: 1.9 },
+    ])
+    expect(onSet).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('AO Preset reads Custom (offered only then) after a patched prop was edited', () => {
+    const entries = fullEntries().map((e) =>
+      e.key === 'aoRadius' ? entry({ key: 'aoRadius', type: 'real', value: 6.0 }) : e,
+    )
+    const onSetMany = vi.fn()
+    const { container, unmount } = mountTree(
+      <SceneAmbientOcclusionSection
+        entries={entries}
+        onSet={vi.fn()}
+        onSetMany={onSetMany}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    const sel = rowByLabel(container, 'Preset')!.querySelector('select') as HTMLSelectElement
+    expect(sel.value).toBe('custom')
+    expect(Array.from(sel.options).map((o) => o.value)).toEqual([
+      'low', 'medium', 'high', 'custom',
+    ])
+    // Re-picking "custom" is a read-back state, not an applicable choice.
+    act(() => {
+      sel.value = 'custom'
+      sel.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(onSetMany).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('disables the AO Preset while AO is off; the AA Quality stays enabled', () => {
+    const ao = mountTree(
+      <SceneAmbientOcclusionSection
+        entries={fullEntries(false)}
+        onSet={vi.fn()}
+        onSetMany={vi.fn()}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    expect(
+      (rowByLabel(ao.container, 'Preset')!.querySelector('select') as HTMLSelectElement).disabled,
+    ).toBe(true)
+    ao.unmount()
+
+    const aa = mountTree(
+      <SceneAntialiasingSection
+        entries={fullEntries(false)}
+        onSet={vi.fn()}
+        onSetMany={vi.fn()}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    expect(
+      (rowByLabel(aa.container, 'Quality')!.querySelector('select') as HTMLSelectElement).disabled,
+    ).toBe(false)
+    aa.unmount()
+  })
+
+  it('AA Quality reads "standard" on defaults and applies a step as one multi-write', () => {
+    const onSet = vi.fn()
+    const onSetMany = vi.fn()
+    const { container, unmount } = mountTree(
+      <SceneAntialiasingSection
+        entries={fullEntries()}
+        onSet={onSet}
+        onSetMany={onSetMany}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    const sel = rowByLabel(container, 'Quality')!.querySelector('select') as HTMLSelectElement
+    expect(sel.value).toBe('standard')
+    act(() => {
+      sel.value = 'ultra'
+      sel.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    expect(onSetMany).toHaveBeenCalledTimes(1)
+    expect(onSetMany).toHaveBeenCalledWith([
+      { key: 'aa_method', valueType: 'enum', value: 'fxaa' },
+      { key: 'aaJitterLevel', valueType: 'integer', value: 5 },
+    ])
+    expect(onSet).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('AA Quality reads Custom when SMAA is picked in the Method row', () => {
+    const entries = fullEntries().map((e) =>
+      e.key === 'aa_method'
+        ? entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['fxaa', 'none', 'smaa'] })
+        : e,
+    )
+    const { container, unmount } = mountTree(
+      <SceneAntialiasingSection
+        entries={entries}
+        onSet={vi.fn()}
+        onSetMany={vi.fn()}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    expect(
+      (rowByLabel(container, 'Quality')!.querySelector('select') as HTMLSelectElement).value,
+    ).toBe('custom')
     unmount()
   })
 })

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -11,6 +11,7 @@
  *   - the AA method shows friendly labels and commits the raw enum id;
  *   - the AA controls (method / jitter) are never gated on the AO flag (AA is
  *     independent of AO in the C++ frame pipeline);
+ *   - the SMAA threshold row is active for smaa and disabled for other methods;
  *   - enabling colour proofing with no profile seeds the default ICC profile in
  *     one multi-write (`onSetMany`); with a profile it is a plain toggle;
  *   - PropertiesTab shows the four scene sections (no placeholder) for `scene`.
@@ -81,6 +82,7 @@ function fullEntries(aoOn = true): GenericPropEntry[] {
     // enumdef arrives from C++ getPropsJSON in alphabetical order; the section
     // must impose the natural None/FXAA/SMAA display order itself.
     entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['fxaa', 'none', 'smaa'] }),
+    entry({ key: 'aaSmaaThreshold', type: 'real', value: 0.05 }),
     entry({ key: 'aaJitterLevel', type: 'integer', value: 0 }),
     entry({ key: 'bgcolor', type: 'object', value: '#000000' }),
     entry({ key: 'use_colproof', type: 'boolean', value: false }),
@@ -211,6 +213,40 @@ describe('SceneAntialiasingSection', () => {
     expect(method.disabled).toBe(false)
     expect(jitter.disabled).toBe(false)
     unmount()
+  })
+
+  it('enables the SMAA threshold row for smaa and disables it for other methods', () => {
+    const { container, unmount } = mountTree(
+      <SceneAntialiasingSection
+        entries={fullEntries()}
+        onSet={vi.fn()}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    // aa_method is smaa in fullEntries -> threshold active (drag row not dimmed).
+    expect(
+      rowByLabel(container, 'SMAA threshold')!.querySelector('.h3-form-drag-disabled'),
+    ).toBeNull()
+    unmount()
+
+    const withFxaa = fullEntries().map((e) =>
+      e.key === 'aa_method'
+        ? entry({ key: 'aa_method', type: 'enum', value: 'fxaa', enumdef: ['fxaa', 'none', 'smaa'] })
+        : e,
+    )
+    const second = mountTree(
+      <SceneAntialiasingSection
+        entries={withFxaa}
+        onSet={vi.fn()}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    expect(
+      rowByLabel(second.container, 'SMAA threshold')!.querySelector('.h3-form-drag-disabled'),
+    ).not.toBeNull()
+    second.unmount()
   })
 
   it('Jitter SS is a 0-5 dropdown (not a numeric stepper) and commits a number', () => {

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -9,6 +9,8 @@
  *   - AO sub-controls are disabled while `aoEnabled` is off;
  *   - a numeric AO row commits a realtime single-step `onSet`;
  *   - the AA method shows friendly labels and commits the raw enum id;
+ *   - the AA controls (method / jitter) are never gated on the AO flag (AA is
+ *     independent of AO in the C++ frame pipeline);
  *   - enabling colour proofing with no profile seeds the default ICC profile in
  *     one multi-write (`onSetMany`); with a profile it is a plain toggle;
  *   - PropertiesTab shows the four scene sections (no placeholder) for `scene`.
@@ -76,7 +78,7 @@ function fullEntries(aoOn = true): GenericPropEntry[] {
     entry({ key: 'aoSlices', type: 'integer', value: 9 }),
     entry({ key: 'aoSteps', type: 'integer', value: 3 }),
     entry({ key: 'aoHalfRes', type: 'boolean', value: false }),
-    entry({ key: 'aa_method', type: 'enum', value: 'fxaa', enumdef: ['none', 'fxaa', 'smaa'] }),
+    entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['none', 'fxaa', 'smaa'] }),
     entry({ key: 'aaJitterLevel', type: 'integer', value: 0 }),
     entry({ key: 'bgcolor', type: 'object', value: '#000000' }),
     entry({ key: 'use_colproof', type: 'boolean', value: false }),
@@ -186,10 +188,26 @@ describe('SceneAntialiasingSection', () => {
     const sel = rowByLabel(container, 'Method')!.querySelector('select') as HTMLSelectElement
     expect(Array.from(sel.options).map((o) => o.textContent)).toEqual(['None', 'FXAA', 'SMAA'])
     act(() => {
-      sel.value = 'smaa'
+      sel.value = 'fxaa'
       sel.dispatchEvent(new Event('change', { bubbles: true }))
     })
-    expect(onSet).toHaveBeenCalledWith('aa_method', 'enum', 'smaa')
+    expect(onSet).toHaveBeenCalledWith('aa_method', 'enum', 'fxaa')
+    unmount()
+  })
+
+  it('keeps the AA controls enabled while AO is off (AA is independent of AO)', () => {
+    const { container, unmount } = mountTree(
+      <SceneAntialiasingSection
+        entries={fullEntries(false)}
+        onSet={vi.fn()}
+        onReset={vi.fn()}
+        sceneId={1}
+      />,
+    )
+    const method = rowByLabel(container, 'Method')!.querySelector('select') as HTMLSelectElement
+    const jitter = rowByLabel(container, 'Jitter SS')!.querySelector('select') as HTMLSelectElement
+    expect(method.disabled).toBe(false)
+    expect(jitter.disabled).toBe(false)
     unmount()
   })
 

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -81,7 +81,7 @@ function fullEntries(aoOn = true): GenericPropEntry[] {
     entry({ key: 'aoHalfRes', type: 'boolean', value: false }),
     // enumdef arrives from C++ getPropsJSON in alphabetical order; the section
     // must impose the natural None/FXAA/SMAA display order itself.
-    entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['fxaa', 'none', 'smaa'] }),
+    entry({ key: 'aa_method', type: 'enum', value: 'fxaa', enumdef: ['fxaa', 'none', 'smaa'] }),
     entry({ key: 'aaSmaaThreshold', type: 'real', value: 0.05 }),
     entry({ key: 'aaJitterLevel', type: 'integer', value: 0 }),
     entry({ key: 'bgcolor', type: 'object', value: '#000000' }),
@@ -192,10 +192,10 @@ describe('SceneAntialiasingSection', () => {
     const sel = rowByLabel(container, 'Method')!.querySelector('select') as HTMLSelectElement
     expect(Array.from(sel.options).map((o) => o.textContent)).toEqual(['None', 'FXAA', 'SMAA'])
     act(() => {
-      sel.value = 'fxaa'
+      sel.value = 'smaa'
       sel.dispatchEvent(new Event('change', { bubbles: true }))
     })
-    expect(onSet).toHaveBeenCalledWith('aa_method', 'enum', 'fxaa')
+    expect(onSet).toHaveBeenCalledWith('aa_method', 'enum', 'smaa')
     unmount()
   })
 
@@ -216,6 +216,7 @@ describe('SceneAntialiasingSection', () => {
   })
 
   it('enables the SMAA threshold row for smaa and disables it for other methods', () => {
+    // aa_method is fxaa (the C++ default) in fullEntries -> threshold dimmed.
     const { container, unmount } = mountTree(
       <SceneAntialiasingSection
         entries={fullEntries()}
@@ -224,20 +225,19 @@ describe('SceneAntialiasingSection', () => {
         sceneId={1}
       />,
     )
-    // aa_method is smaa in fullEntries -> threshold active (drag row not dimmed).
     expect(
       rowByLabel(container, 'SMAA threshold')!.querySelector('.h3-form-drag-disabled'),
-    ).toBeNull()
+    ).not.toBeNull()
     unmount()
 
-    const withFxaa = fullEntries().map((e) =>
+    const withSmaa = fullEntries().map((e) =>
       e.key === 'aa_method'
-        ? entry({ key: 'aa_method', type: 'enum', value: 'fxaa', enumdef: ['fxaa', 'none', 'smaa'] })
+        ? entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['fxaa', 'none', 'smaa'] })
         : e,
     )
     const second = mountTree(
       <SceneAntialiasingSection
-        entries={withFxaa}
+        entries={withSmaa}
         onSet={vi.fn()}
         onReset={vi.fn()}
         sceneId={1}
@@ -245,7 +245,7 @@ describe('SceneAntialiasingSection', () => {
     )
     expect(
       rowByLabel(second.container, 'SMAA threshold')!.querySelector('.h3-form-drag-disabled'),
-    ).not.toBeNull()
+    ).toBeNull()
     second.unmount()
   })
 

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -11,7 +11,7 @@
  *   - the AA method shows friendly labels and commits the raw enum id;
  *   - the AA controls (method / jitter) are never gated on the AO flag (AA is
  *     independent of AO in the C++ frame pipeline);
- *   - the SMAA threshold row is active for smaa and disabled for other methods;
+ *   - the `aaSmaaThreshold` entry renders no row (deliberately not surfaced);
  *   - enabling colour proofing with no profile seeds the default ICC profile in
  *     one multi-write (`onSetMany`); with a profile it is a plain toggle;
  *   - PropertiesTab shows the four scene sections (no placeholder) for `scene`.
@@ -215,8 +215,9 @@ describe('SceneAntialiasingSection', () => {
     unmount()
   })
 
-  it('enables the SMAA threshold row for smaa and disables it for other methods', () => {
-    // aa_method is fxaa (the C++ default) in fullEntries -> threshold dimmed.
+  it('does not surface the aaSmaaThreshold property as a row', () => {
+    // The C++ scene exposes aaSmaaThreshold, but its visual effect is too
+    // subtle for a GUI row; the section must ignore the entry.
     const { container, unmount } = mountTree(
       <SceneAntialiasingSection
         entries={fullEntries()}
@@ -225,28 +226,9 @@ describe('SceneAntialiasingSection', () => {
         sceneId={1}
       />,
     )
-    expect(
-      rowByLabel(container, 'SMAA threshold')!.querySelector('.h3-form-drag-disabled'),
-    ).not.toBeNull()
+    expect(rowByLabel(container, 'SMAA threshold')).toBeNull()
+    expect(container.querySelectorAll('.h3-form-prop-row').length).toBe(2)
     unmount()
-
-    const withSmaa = fullEntries().map((e) =>
-      e.key === 'aa_method'
-        ? entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['fxaa', 'none', 'smaa'] })
-        : e,
-    )
-    const second = mountTree(
-      <SceneAntialiasingSection
-        entries={withSmaa}
-        onSet={vi.fn()}
-        onReset={vi.fn()}
-        sceneId={1}
-      />,
-    )
-    expect(
-      rowByLabel(second.container, 'SMAA threshold')!.querySelector('.h3-form-drag-disabled'),
-    ).toBeNull()
-    second.unmount()
   })
 
   it('Jitter SS is a 0-5 dropdown (not a numeric stepper) and commits a number', () => {

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -78,7 +78,9 @@ function fullEntries(aoOn = true): GenericPropEntry[] {
     entry({ key: 'aoSlices', type: 'integer', value: 9 }),
     entry({ key: 'aoSteps', type: 'integer', value: 3 }),
     entry({ key: 'aoHalfRes', type: 'boolean', value: false }),
-    entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['none', 'fxaa', 'smaa'] }),
+    // enumdef arrives from C++ getPropsJSON in alphabetical order; the section
+    // must impose the natural None/FXAA/SMAA display order itself.
+    entry({ key: 'aa_method', type: 'enum', value: 'smaa', enumdef: ['fxaa', 'none', 'smaa'] }),
     entry({ key: 'aaJitterLevel', type: 'integer', value: 0 }),
     entry({ key: 'bgcolor', type: 'object', value: '#000000' }),
     entry({ key: 'use_colproof', type: 'boolean', value: false }),
@@ -175,7 +177,7 @@ describe('SceneAmbientOcclusionSection', () => {
 })
 
 describe('SceneAntialiasingSection', () => {
-  it('shows friendly method labels and commits the raw enum id', () => {
+  it('shows friendly method labels in None/FXAA/SMAA order and commits the raw enum id', () => {
     const onSet = vi.fn()
     const { container, unmount } = mountTree(
       <SceneAntialiasingSection

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -5,17 +5,16 @@
  * Pins:
  *   - the registry resolves `type_name === "scene"` to the four curated
  *     sections (Ambient occlusion / Anti-aliasing / Background / Color proofing);
- *   - each row renders only when its property exists;
- *   - AO sub-controls are disabled while `aoEnabled` is off;
- *   - a numeric AO row commits a realtime single-step `onSet`;
- *   - the AA method shows friendly labels and commits the raw enum id;
- *   - the AA controls (method / jitter) are never gated on the AO flag (AA is
- *     independent of AO in the C++ frame pipeline);
- *   - the `aaSmaaThreshold` entry renders no row (deliberately not surfaced);
+ *   - the AO/AA sections are preset-only: AO renders Enabled + Preset, AA
+ *     renders Quality, and none of the individual tuning knobs (radius /
+ *     intensity / slices / steps / half-res / method / jitter /
+ *     aaSmaaThreshold) gets a row (they live in the generic property tree);
  *   - the AO Preset / AA Quality dropdowns derive their step from the live
  *     values (default entries read Low / Standard, never Custom), apply a
  *     step as ONE `onSetMany` multi-write, offer Custom only while true, and
  *     ignore props outside their patch (aoSlices);
+ *   - the AO Preset is disabled while AO is off; the AA Quality is not (AA is
+ *     independent of AO in the C++ frame pipeline);
  *   - enabling colour proofing with no profile seeds the default ICC profile in
  *     one multi-write (`onSetMany`); with a profile it is a plain toggle;
  *   - PropertiesTab shows the four scene sections (no placeholder) for `scene`.
@@ -24,7 +23,7 @@
 import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { act } from 'react'
-import { mountTree, pressStepArrow } from './helpers/testHarness'
+import { mountTree } from './helpers/testHarness'
 import type { GenericPropEntry } from '../worker/server/services/genericProps.service'
 
 void React
@@ -121,149 +120,59 @@ describe('Scene section registry', () => {
 })
 
 describe('SceneAmbientOcclusionSection', () => {
-  it('renders the AO rows; Radius carries the Angstrom unit', () => {
+  it('renders Enabled + Preset only; the tuning knobs have no rows', () => {
     const { container, unmount } = mountTree(
       <SceneAmbientOcclusionSection
         entries={fullEntries()}
         onSet={vi.fn()}
+        onSetMany={vi.fn()}
         onReset={vi.fn()}
         sceneId={1}
       />,
     )
-    for (const label of ['Enabled', 'Radius', 'Intensity', 'Slices', 'Steps', 'Half resolution']) {
-      expect(rowByLabel(container, label)).not.toBeNull()
+    expect(rowByLabel(container, 'Enabled')).not.toBeNull()
+    expect(rowByLabel(container, 'Preset')).not.toBeNull()
+    // The individual knobs live in the generic property tree, not here.
+    for (const label of ['Radius', 'Intensity', 'Slices', 'Steps', 'Half resolution']) {
+      expect(rowByLabel(container, label)).toBeNull()
     }
-    expect(
-      rowByLabel(container, 'Radius')!.querySelector('.h3-form-drag-unit')!.textContent,
-    ).toBe('Å')
+    expect(container.querySelectorAll('.h3-form-prop-row').length).toBe(2)
     unmount()
   })
 
-  it('disables the AO sub-controls while aoEnabled is off', () => {
+  it('keeps the Enabled toggle active while AO is off', () => {
     const { container, unmount } = mountTree(
       <SceneAmbientOcclusionSection
         entries={fullEntries(false)}
         onSet={vi.fn()}
+        onSetMany={vi.fn()}
         onReset={vi.fn()}
         sceneId={1}
       />,
     )
-    // Radius (DragNumericField) dimmed, Half resolution (switch) input disabled.
-    expect(
-      rowByLabel(container, 'Radius')!.querySelector('.h3-form-drag-disabled'),
-    ).not.toBeNull()
-    expect(
-      (rowByLabel(container, 'Half resolution')!.querySelector('input') as HTMLInputElement)
-        .disabled,
-    ).toBe(true)
-    // The Enabled toggle itself stays enabled.
     expect(
       (rowByLabel(container, 'Enabled')!.querySelector('input') as HTMLInputElement).disabled,
     ).toBe(false)
     unmount()
   })
-
-  it('commits a realtime single-step change of Radius on the step arrow', () => {
-    const onSet = vi.fn()
-    const { container, unmount } = mountTree(
-      <SceneAmbientOcclusionSection
-        entries={fullEntries()}
-        onSet={onSet}
-        onReset={vi.fn()}
-        sceneId={1}
-      />,
-    )
-    const incr = rowByLabel(container, 'Radius')!.querySelector(
-      '.h3-form-drag-arrow-right',
-    ) as HTMLButtonElement
-    pressStepArrow(incr)
-    // step 0.1 from 4.0 -> 4.1, committed live (preview restored to original first).
-    expect(onSet).toHaveBeenCalledWith('aoRadius', 'real', 4.1, {
-      mode: 'commit',
-      originalValue: 4.0,
-      originalWasDefault: false,
-    })
-    unmount()
-  })
 })
 
 describe('SceneAntialiasingSection', () => {
-  it('shows friendly method labels in None/FXAA/SMAA order and commits the raw enum id', () => {
-    const onSet = vi.fn()
-    const { container, unmount } = mountTree(
-      <SceneAntialiasingSection
-        entries={fullEntries()}
-        onSet={onSet}
-        onReset={vi.fn()}
-        sceneId={1}
-      />,
-    )
-    const sel = rowByLabel(container, 'Method')!.querySelector('select') as HTMLSelectElement
-    expect(Array.from(sel.options).map((o) => o.textContent)).toEqual(['None', 'FXAA', 'SMAA'])
-    act(() => {
-      sel.value = 'smaa'
-      sel.dispatchEvent(new Event('change', { bubbles: true }))
-    })
-    expect(onSet).toHaveBeenCalledWith('aa_method', 'enum', 'smaa')
-    unmount()
-  })
-
-  it('keeps the AA controls enabled while AO is off (AA is independent of AO)', () => {
-    const { container, unmount } = mountTree(
-      <SceneAntialiasingSection
-        entries={fullEntries(false)}
-        onSet={vi.fn()}
-        onReset={vi.fn()}
-        sceneId={1}
-      />,
-    )
-    const method = rowByLabel(container, 'Method')!.querySelector('select') as HTMLSelectElement
-    const jitter = rowByLabel(container, 'Jitter SS')!.querySelector('select') as HTMLSelectElement
-    expect(method.disabled).toBe(false)
-    expect(jitter.disabled).toBe(false)
-    unmount()
-  })
-
-  it('does not surface the aaSmaaThreshold property as a row', () => {
-    // The C++ scene exposes aaSmaaThreshold, but its visual effect is too
-    // subtle for a GUI row; the section must ignore the entry.
+  it('renders the Quality dropdown only; method / jitter / threshold have no rows', () => {
     const { container, unmount } = mountTree(
       <SceneAntialiasingSection
         entries={fullEntries()}
         onSet={vi.fn()}
+        onSetMany={vi.fn()}
         onReset={vi.fn()}
         sceneId={1}
       />,
     )
-    expect(rowByLabel(container, 'SMAA threshold')).toBeNull()
-    // Quality + Method + Jitter SS -- and nothing else.
-    expect(container.querySelectorAll('.h3-form-prop-row').length).toBe(3)
-    unmount()
-  })
-
-  it('Jitter SS is a 0-5 dropdown (not a numeric stepper) and commits a number', () => {
-    const onSet = vi.fn()
-    const { container, unmount } = mountTree(
-      <SceneAntialiasingSection
-        entries={fullEntries()}
-        onSet={onSet}
-        onReset={vi.fn()}
-        sceneId={1}
-      />,
-    )
-    const row = rowByLabel(container, 'Jitter SS')!
-    // A dropdown (SelectField), not the NumericField/DragNumericField stepper.
-    const sel = row.querySelector('select') as HTMLSelectElement
-    expect(sel).not.toBeNull()
-    expect(row.querySelector('.h3-form-numeric, .h3-form-drag')).toBeNull()
-    expect(Array.from(sel.options).map((o) => [o.value, o.textContent])).toEqual([
-      ['0', 'Off'], ['1', '1'], ['2', '2'], ['3', '3'], ['4', '4'], ['5', '5'],
-    ])
-    act(() => {
-      sel.value = '3'
-      sel.dispatchEvent(new Event('change', { bubbles: true }))
-    })
-    expect(onSet).toHaveBeenCalledWith('aaJitterLevel', 'integer', 3)
+    expect(rowByLabel(container, 'Quality')).not.toBeNull()
+    for (const label of ['Method', 'Jitter SS', 'SMAA threshold']) {
+      expect(rowByLabel(container, label)).toBeNull()
+    }
+    expect(container.querySelectorAll('.h3-form-prop-row').length).toBe(1)
     unmount()
   })
 })

--- a/tritium/react-gui/src/renderer/components/inspector/RendererCommonSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/RendererCommonSection.tsx
@@ -302,10 +302,12 @@ export interface MappedEnumRowProps extends RowProps {
   /** Display text per raw enum ID (value stays the raw C++ string ID). */
   labels: Record<string, string>;
   /**
-   * Restrict the offered options to this subset of the property's `enumdef`
-   * (in this order). Use when the UXP dialog exposes fewer choices than the C++
-   * enum (e.g. the cartoon cylinder-helix / sheet / coil section type omits
-   * "fancy1"). Defaults to the full `enumdef`.
+   * Offer these options, in this order. Entries not present in the property's
+   * `enumdef` are dropped, so this both restricts the choices (e.g. the
+   * cartoon cylinder-helix / sheet / coil section type omits "fancy1") and
+   * fixes the display order (the `enumdef` from C++ getPropsJSON is
+   * alphabetical, which is rarely the natural order). Defaults to the full
+   * `enumdef`.
    */
   options?: string[];
   disabled?: boolean;
@@ -330,8 +332,10 @@ export const MappedEnumRow: React.FC<MappedEnumRowProps> = ({
   disabled,
 }) => {
   const allOptions = entry.enumdef ?? [String(entry.value)];
+  // options controls the display order (enumdef is alphabetical); keep only
+  // the entries the live enumdef actually offers.
   const shownOptions = options
-    ? allOptions.filter((o) => options.includes(o))
+    ? options.filter((o) => allOptions.includes(o))
     : allOptions;
   return (
     <PropertyField label={label} {...resetProps(entry, onReset)}>

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -136,6 +136,9 @@ const AA_METHOD_LABELS: Record<string, string> = {
   fxaa: "FXAA",
   smaa: "SMAA",
 };
+// Display order (off first, then by quality); the enumdef from C++ is
+// alphabetical (fxaa/none/smaa).
+const AA_METHOD_ORDER = ["none", "fxaa", "smaa"];
 
 // aaJitterLevel only takes 0-5 (GUIView.cpp clamps to this range: levels
 // above 5 have no jitter table). 0 disables temporal jitter; 1-5 select the
@@ -165,6 +168,7 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
           entry={aaMethod}
           label="Method"
           labels={AA_METHOD_LABELS}
+          options={AA_METHOD_ORDER}
           onSet={onSet}
           onReset={onReset}
         />

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -138,15 +138,16 @@ const AA_METHOD_LABELS: Record<string, string> = {
 };
 
 // aaJitterLevel only takes 0-5 (GUIView.cpp clamps to this range: levels
-// above 5 have no jitter table). 0 disables temporal jitter while AO stays
-// on; 1-5 select the jitter sample-count table (1<<level samples).
+// above 5 have no jitter table). 0 disables temporal jitter; 1-5 select the
+// jitter sample-count table (1<<level samples).
 const JITTER_LEVELS = [0, 1, 2, 3, 4, 5];
 const JITTER_LEVEL_LABELS: Record<number, string> = { 0: "Off" };
 
 /**
  * Post-process anti-aliasing: method (none / FXAA / SMAA) and temporal jitter
- * supersampling level. Jitter only accumulates on the AO path, so it is
- * disabled while AO is off. The level is a dropdown (`NumEnumRow`), not a
+ * supersampling level. AA is independent of AO: method and jitter each route
+ * the frame through the off-screen pipeline on their own, so neither control
+ * is gated on the AO flag. The level is a dropdown (`NumEnumRow`), not a
  * numeric stepper: it only takes the six values in `JITTER_LEVELS`.
  */
 export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
@@ -157,8 +158,6 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   const get = finder(entries);
   const aaMethod = get("aa_method");
   const aaJitter = get("aaJitterLevel");
-  const aoEnabled = get("aoEnabled");
-  const jitterOff = aoEnabled ? !Boolean(aoEnabled.value) : true;
   return (
     <>
       {aaMethod && (
@@ -178,7 +177,6 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
           labels={JITTER_LEVEL_LABELS}
           onSet={onSet}
           onReset={onReset}
-          disabled={jitterOff}
         />
       )}
     </>

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -147,13 +147,14 @@ const JITTER_LEVELS = [0, 1, 2, 3, 4, 5];
 const JITTER_LEVEL_LABELS: Record<number, string> = { 0: "Off" };
 
 /**
- * Post-process anti-aliasing: method (none / FXAA / SMAA), the SMAA
- * edge-detection threshold, and the temporal jitter supersampling level. AA is
- * independent of AO: method and jitter each route the frame through the
- * off-screen pipeline on their own, so neither control is gated on the AO
- * flag. The threshold row only applies to SMAA and is disabled for the other
- * methods. The level is a dropdown (`NumEnumRow`), not a numeric stepper: it
- * only takes the six values in `JITTER_LEVELS`.
+ * Post-process anti-aliasing: method (none / FXAA / SMAA) and the temporal
+ * jitter supersampling level. AA is independent of AO: method and jitter each
+ * route the frame through the off-screen pipeline on their own, so neither
+ * control is gated on the AO flag. The C++ scene also has an
+ * `aaSmaaThreshold` property (SMAA edge-detection tuning); it is deliberately
+ * not surfaced here -- its visual effect proved too subtle to justify a row,
+ * so it stays script/.qsc-only. The level is a dropdown (`NumEnumRow`), not a
+ * numeric stepper: it only takes the six values in `JITTER_LEVELS`.
  */
 export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   entries,
@@ -163,8 +164,6 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   const get = finder(entries);
   const aaMethod = get("aa_method");
   const aaJitter = get("aaJitterLevel");
-  const smaaThreshold = get("aaSmaaThreshold");
-  const smaaOff = aaMethod ? String(aaMethod.value) !== "smaa" : true;
   return (
     <>
       {aaMethod && (
@@ -175,20 +174,6 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
           options={AA_METHOD_ORDER}
           onSet={onSet}
           onReset={onReset}
-        />
-      )}
-      {smaaThreshold && (
-        <NumRow
-          entry={smaaThreshold}
-          label="SMAA threshold"
-          onSet={onSet}
-          onReset={onReset}
-          min={0.01}
-          max={0.2}
-          step={0.01}
-          decimals={2}
-          realtime
-          disabled={smaaOff}
         />
       )}
       {aaJitter && (

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -147,11 +147,13 @@ const JITTER_LEVELS = [0, 1, 2, 3, 4, 5];
 const JITTER_LEVEL_LABELS: Record<number, string> = { 0: "Off" };
 
 /**
- * Post-process anti-aliasing: method (none / FXAA / SMAA) and temporal jitter
- * supersampling level. AA is independent of AO: method and jitter each route
- * the frame through the off-screen pipeline on their own, so neither control
- * is gated on the AO flag. The level is a dropdown (`NumEnumRow`), not a
- * numeric stepper: it only takes the six values in `JITTER_LEVELS`.
+ * Post-process anti-aliasing: method (none / FXAA / SMAA), the SMAA
+ * edge-detection threshold, and the temporal jitter supersampling level. AA is
+ * independent of AO: method and jitter each route the frame through the
+ * off-screen pipeline on their own, so neither control is gated on the AO
+ * flag. The threshold row only applies to SMAA and is disabled for the other
+ * methods. The level is a dropdown (`NumEnumRow`), not a numeric stepper: it
+ * only takes the six values in `JITTER_LEVELS`.
  */
 export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   entries,
@@ -161,6 +163,8 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   const get = finder(entries);
   const aaMethod = get("aa_method");
   const aaJitter = get("aaJitterLevel");
+  const smaaThreshold = get("aaSmaaThreshold");
+  const smaaOff = aaMethod ? String(aaMethod.value) !== "smaa" : true;
   return (
     <>
       {aaMethod && (
@@ -171,6 +175,20 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
           options={AA_METHOD_ORDER}
           onSet={onSet}
           onReset={onReset}
+        />
+      )}
+      {smaaThreshold && (
+        <NumRow
+          entry={smaaThreshold}
+          label="SMAA threshold"
+          onSet={onSet}
+          onReset={onReset}
+          min={0.01}
+          max={0.2}
+          step={0.01}
+          decimals={2}
+          realtime
+          disabled={smaaOff}
         />
       )}
       {aaJitter && (

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -29,8 +29,16 @@ import {
   ColorRow,
   TextRow,
 } from "./RendererCommonSection";
+import { PropertyField, SelectField } from "../../h3-kit/form";
+import { RENDER_QUALITY_CUSTOM, stepPatch } from "../../data/renderSettings";
+import type { RenderQualityAxis } from "../../data/renderSettings";
+import {
+  SCENE_AO_PRESET_AXIS,
+  SCENE_AA_QUALITY_AXIS,
+  sceneStepOf,
+} from "../../data/sceneQualityPresets";
 import type { GenericPropEntry } from "../../worker/server/services/genericProps.service";
-import type { RendererPropSectionProps } from "./rendererPropSections";
+import type { PropMultiWrite, RendererPropSectionProps } from "./rendererPropSections";
 
 /** Find a live property entry by key. */
 function finder(entries: GenericPropEntry[]) {
@@ -39,13 +47,61 @@ function finder(entries: GenericPropEntry[]) {
 }
 
 /**
- * Ambient occlusion (GTAO): enable toggle plus radius / intensity / slices /
- * steps and adaptive half-resolution. The numeric and half-res rows are
- * disabled while AO is off (they have no effect without the AO path).
+ * Composite preset dropdown (umbreon quality-axis pattern): its step is
+ * DERIVED from the live property values (`sceneStepOf`; reads "Custom" when
+ * they match no step -- the Custom option is only offered while that is the
+ * truth), and selecting a step applies its patch as ONE undo step via
+ * `onSetMany`. Editing an individual row needs no bookkeeping: the dropdown
+ * reads back from the values, so it drops to Custom -- or lands on another
+ * step -- by itself. Carries no modified/reset decorations: no single
+ * property backs it (same rationale as the atomintr Dashed toggle).
+ */
+const QualityRow: React.FC<{
+  axis: RenderQualityAxis;
+  entries: GenericPropEntry[];
+  onSetMany?: RendererPropSectionProps["onSetMany"];
+  disabled?: boolean;
+}> = ({ axis, entries, onSetMany, disabled }) => {
+  const get = finder(entries);
+  // Render only when every property the axis writes is present.
+  if (Object.keys(axis.steps[0].patch).some((k) => !get(k))) return null;
+
+  const step = sceneStepOf(axis, (k) => get(k)?.value);
+  const apply = (stepId: string) => {
+    // "Custom" is a read-back state, not an applicable choice.
+    if (stepId === RENDER_QUALITY_CUSTOM || !onSetMany) return;
+    const writes: PropMultiWrite[] = Object.entries(stepPatch(axis, stepId)).map(
+      ([key, value]) => ({ key, valueType: get(key)!.type, value }),
+    );
+    onSetMany(writes);
+  };
+  return (
+    <PropertyField label={axis.label}>
+      <SelectField value={step} disabled={disabled} onChange={apply}>
+        {axis.steps.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.label}
+          </option>
+        ))}
+        {step === RENDER_QUALITY_CUSTOM && (
+          <option value={RENDER_QUALITY_CUSTOM}>Custom</option>
+        )}
+      </SelectField>
+    </PropertyField>
+  );
+};
+
+/**
+ * Ambient occlusion (GTAO): enable toggle, a look-preset dropdown (radius /
+ * steps / intensity as one tuned set, see `SCENE_AO_PRESET_AXIS`), plus the
+ * individual radius / intensity / slices / steps / half-resolution tuning
+ * rows. Everything below the toggle is disabled while AO is off (no effect
+ * without the AO path).
  */
 export const SceneAmbientOcclusionSection: React.FC<RendererPropSectionProps> = ({
   entries,
   onSet,
+  onSetMany,
   onReset,
 }) => {
   const get = finder(entries);
@@ -61,6 +117,12 @@ export const SceneAmbientOcclusionSection: React.FC<RendererPropSectionProps> = 
       {aoEnabled && (
         <BoolRow entry={aoEnabled} label="Enabled" onSet={onSet} onReset={onReset} />
       )}
+      <QualityRow
+        axis={SCENE_AO_PRESET_AXIS}
+        entries={entries}
+        onSetMany={onSetMany}
+        disabled={off}
+      />
       {aoRadius && (
         <NumRow
           entry={aoRadius}
@@ -147,18 +209,21 @@ const JITTER_LEVELS = [0, 1, 2, 3, 4, 5];
 const JITTER_LEVEL_LABELS: Record<number, string> = { 0: "Off" };
 
 /**
- * Post-process anti-aliasing: method (none / FXAA / SMAA) and the temporal
- * jitter supersampling level. AA is independent of AO: method and jitter each
- * route the frame through the off-screen pipeline on their own, so neither
- * control is gated on the AO flag. The C++ scene also has an
- * `aaSmaaThreshold` property (SMAA edge-detection tuning); it is deliberately
- * not surfaced here -- its visual effect proved too subtle to justify a row,
- * so it stays script/.qsc-only. The level is a dropdown (`NumEnumRow`), not a
- * numeric stepper: it only takes the six values in `JITTER_LEVELS`.
+ * Post-process anti-aliasing: a quality-preset dropdown (method + jitter as
+ * one ladder, see `SCENE_AA_QUALITY_AXIS`), the method (none / FXAA / SMAA)
+ * and the temporal jitter supersampling level. AA is independent of AO:
+ * method and jitter each route the frame through the off-screen pipeline on
+ * their own, so no control here is gated on the AO flag. The C++ scene also
+ * has an `aaSmaaThreshold` property (SMAA edge-detection tuning); it is
+ * deliberately not surfaced here -- its visual effect proved too subtle to
+ * justify a row, so it stays script/.qsc-only. The level is a dropdown
+ * (`NumEnumRow`), not a numeric stepper: it only takes the six values in
+ * `JITTER_LEVELS`.
  */
 export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   entries,
   onSet,
+  onSetMany,
   onReset,
 }) => {
   const get = finder(entries);
@@ -166,6 +231,11 @@ export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   const aaJitter = get("aaJitterLevel");
   return (
     <>
+      <QualityRow
+        axis={SCENE_AA_QUALITY_AXIS}
+        entries={entries}
+        onSetMany={onSetMany}
+      />
       {aaMethod && (
         <MappedEnumRow
           entry={aaMethod}

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -6,14 +6,15 @@
  * The Scene has no dedicated UXP property dialog -- its rendering/display
  * settings were only editable through the generic property tree. These curated
  * sections surface the meaningful subset (ambient occlusion / GTAO,
- * post-process anti-aliasing, background colour, CMYK colour proofing) with
- * purpose-built rows, mirroring how the renderer-type sections (cpk / cartoon /
- * ...) are built.
+ * post-process anti-aliasing, background colour, CMYK colour proofing),
+ * mirroring how the renderer-type sections (cpk / cartoon / ...) are built.
+ * The AO/AA sections are deliberately preset-only (one dropdown each): the
+ * individual tuning knobs stay in the generic property tree, and hand edits
+ * there reflect back into the dropdowns as "Custom".
  *
  * Backed by the same live getGenericProps / setGenericProp bridge as every other
  * Properties-tab section: each property is looked up by key in the live entry
- * list and its row renders nothing when absent. The numeric AO controls use the
- * shared `NumRow` (realtime drag preview + single undo). Every C++ setter calls
+ * list and its row renders nothing when absent. Every C++ setter calls
  * `setUpdateFlag()`, so edits preview live in the 3D view.
  *
  * Registered under the `scene` key in `RENDERER_SECTION_REGISTRY`; the section
@@ -23,8 +24,6 @@
 import React from "react";
 import {
   BoolRow,
-  NumRow,
-  NumEnumRow,
   MappedEnumRow,
   ColorRow,
   TextRow,
@@ -93,10 +92,11 @@ const QualityRow: React.FC<{
 
 /**
  * Ambient occlusion (GTAO): enable toggle, a look-preset dropdown (radius /
- * steps / intensity as one tuned set, see `SCENE_AO_PRESET_AXIS`), plus the
- * individual radius / intensity / slices / steps / half-resolution tuning
- * rows. Everything below the toggle is disabled while AO is off (no effect
- * without the AO path).
+ * steps / intensity as one tuned set, see `SCENE_AO_PRESET_AXIS`). The
+ * individual tuning knobs (aoRadius / aoIntensity / aoSlices / aoSteps /
+ * aoHalfRes) are deliberately NOT surfaced here -- they remain editable in
+ * the generic property tree, where edits reflect back into this dropdown as
+ * "Custom". The preset is disabled while AO is off.
  */
 export const SceneAmbientOcclusionSection: React.FC<RendererPropSectionProps> = ({
   entries,
@@ -106,11 +106,6 @@ export const SceneAmbientOcclusionSection: React.FC<RendererPropSectionProps> = 
 }) => {
   const get = finder(entries);
   const aoEnabled = get("aoEnabled");
-  const aoRadius = get("aoRadius");
-  const aoIntensity = get("aoIntensity");
-  const aoSlices = get("aoSlices");
-  const aoSteps = get("aoSteps");
-  const aoHalfRes = get("aoHalfRes");
   const off = aoEnabled ? !Boolean(aoEnabled.value) : true;
   return (
     <>
@@ -123,140 +118,28 @@ export const SceneAmbientOcclusionSection: React.FC<RendererPropSectionProps> = 
         onSetMany={onSetMany}
         disabled={off}
       />
-      {aoRadius && (
-        <NumRow
-          entry={aoRadius}
-          label="Radius"
-          onSet={onSet}
-          onReset={onReset}
-          min={0}
-          max={50}
-          step={0.1}
-          decimals={1}
-          unit="Å"
-          realtime
-          disabled={off}
-        />
-      )}
-      {aoIntensity && (
-        <NumRow
-          entry={aoIntensity}
-          label="Intensity"
-          onSet={onSet}
-          onReset={onReset}
-          min={0}
-          max={10}
-          step={0.1}
-          decimals={1}
-          realtime
-          disabled={off}
-        />
-      )}
-      {aoSlices && (
-        <NumRow
-          entry={aoSlices}
-          label="Slices"
-          onSet={onSet}
-          onReset={onReset}
-          min={1}
-          max={32}
-          step={1}
-          decimals={0}
-          realtime
-          disabled={off}
-        />
-      )}
-      {aoSteps && (
-        <NumRow
-          entry={aoSteps}
-          label="Steps"
-          onSet={onSet}
-          onReset={onReset}
-          min={1}
-          max={16}
-          step={1}
-          decimals={0}
-          realtime
-          disabled={off}
-        />
-      )}
-      {aoHalfRes && (
-        <BoolRow
-          entry={aoHalfRes}
-          label="Half resolution"
-          onSet={onSet}
-          onReset={onReset}
-          disabled={off}
-        />
-      )}
     </>
   );
 };
 
-const AA_METHOD_LABELS: Record<string, string> = {
-  none: "None",
-  fxaa: "FXAA",
-  smaa: "SMAA",
-};
-// Display order (off first, then by quality); the enumdef from C++ is
-// alphabetical (fxaa/none/smaa).
-const AA_METHOD_ORDER = ["none", "fxaa", "smaa"];
-
-// aaJitterLevel only takes 0-5 (GUIView.cpp clamps to this range: levels
-// above 5 have no jitter table). 0 disables temporal jitter; 1-5 select the
-// jitter sample-count table (1<<level samples).
-const JITTER_LEVELS = [0, 1, 2, 3, 4, 5];
-const JITTER_LEVEL_LABELS: Record<number, string> = { 0: "Off" };
-
 /**
- * Post-process anti-aliasing: a quality-preset dropdown (method + jitter as
- * one ladder, see `SCENE_AA_QUALITY_AXIS`), the method (none / FXAA / SMAA)
- * and the temporal jitter supersampling level. AA is independent of AO:
- * method and jitter each route the frame through the off-screen pipeline on
- * their own, so no control here is gated on the AO flag. The C++ scene also
- * has an `aaSmaaThreshold` property (SMAA edge-detection tuning); it is
- * deliberately not surfaced here -- its visual effect proved too subtle to
- * justify a row, so it stays script/.qsc-only. The level is a dropdown
- * (`NumEnumRow`), not a numeric stepper: it only takes the six values in
- * `JITTER_LEVELS`.
+ * Post-process anti-aliasing: one quality-preset dropdown (method + jitter as
+ * one ladder, see `SCENE_AA_QUALITY_AXIS`). AA is independent of AO, so the
+ * control is not gated on the AO flag. The individual knobs (aa_method /
+ * aaJitterLevel / aaSmaaThreshold) are deliberately NOT surfaced here -- they
+ * remain editable in the generic property tree, where edits (e.g. picking
+ * SMAA) reflect back into this dropdown as "Custom".
  */
 export const SceneAntialiasingSection: React.FC<RendererPropSectionProps> = ({
   entries,
-  onSet,
   onSetMany,
-  onReset,
 }) => {
-  const get = finder(entries);
-  const aaMethod = get("aa_method");
-  const aaJitter = get("aaJitterLevel");
   return (
-    <>
-      <QualityRow
-        axis={SCENE_AA_QUALITY_AXIS}
-        entries={entries}
-        onSetMany={onSetMany}
-      />
-      {aaMethod && (
-        <MappedEnumRow
-          entry={aaMethod}
-          label="Method"
-          labels={AA_METHOD_LABELS}
-          options={AA_METHOD_ORDER}
-          onSet={onSet}
-          onReset={onReset}
-        />
-      )}
-      {aaJitter && (
-        <NumEnumRow
-          entry={aaJitter}
-          label="Jitter SS"
-          options={JITTER_LEVELS}
-          labels={JITTER_LEVEL_LABELS}
-          onSet={onSet}
-          onReset={onReset}
-        />
-      )}
-    </>
+    <QualityRow
+      axis={SCENE_AA_QUALITY_AXIS}
+      entries={entries}
+      onSetMany={onSetMany}
+    />
   );
 };
 

--- a/tritium/react-gui/src/renderer/data/sceneQualityPresets.ts
+++ b/tritium/react-gui/src/renderer/data/sceneQualityPresets.ts
@@ -1,0 +1,72 @@
+/**
+ * @file data/sceneQualityPresets.ts
+ * @description Preset ladders for the Scene inspector's live-view GTAO /
+ * post-AA sections, in the shape of the umbreon render-quality axes
+ * (`RenderQualityAxis`): each axis is one dropdown whose step is DERIVED from
+ * the live property values (never stored) and whose selection applies its
+ * patch as one undo step.
+ *
+ * Contracts (mirroring renderSettings.ts / renderBackends.ts):
+ * - Every step of an axis writes the same keys.
+ * - The default step's patch must exactly match the C++ property defaults
+ *   (Scene.qif), so a fresh scene reads as that step and not as Custom.
+ * - The AO axis is a tuned LOOK set, not a pure quality ladder: aoRadius is
+ *   the depth-reach knob the user actually changes, aoSteps rises with it so
+ *   the wider radius is not undersampled (cost is slices*steps, linear), and
+ *   aoIntensity falls to keep large radii from crushing the image to black.
+ *   aoSlices is deliberately absent: it barely changes the denoised image
+ *   (and gtao_frag.glsl clamps it to 16).
+ */
+import { RENDER_QUALITY_CUSTOM } from "./renderSettings";
+import type { RenderQualityAxis } from "./renderSettings";
+
+/** AO look preset: depth reach + sampling to match + darkness compensation. */
+export const SCENE_AO_PRESET_AXIS: RenderQualityAxis = {
+  key: "sceneAoPreset",
+  label: "Preset",
+  defaultStep: "low",
+  steps: [
+    // = C++ defaults (Scene.qif)
+    { id: "low", label: "Low", patch: { aoRadius: 4, aoSteps: 3, aoIntensity: 2.2 } },
+    { id: "medium", label: "Medium", patch: { aoRadius: 8, aoSteps: 4, aoIntensity: 1.9 } },
+    { id: "high", label: "High", patch: { aoRadius: 12, aoSteps: 5, aoIntensity: 1.7 } },
+  ],
+};
+
+/**
+ * AA quality: spatial method plus temporal jitter supersampling. Jitter only
+ * accumulates while the camera is still (idle-driven), so High/Ultra cost
+ * convergence time after the view settles, not interactivity. Picking SMAA in
+ * the Method row reads as Custom here (a tuning choice outside the ladder).
+ */
+export const SCENE_AA_QUALITY_AXIS: RenderQualityAxis = {
+  key: "sceneAaQuality",
+  label: "Quality",
+  defaultStep: "standard",
+  steps: [
+    { id: "off", label: "Off", patch: { aa_method: "none", aaJitterLevel: 0 } },
+    // = C++ defaults (Scene.qif)
+    { id: "standard", label: "Standard (FXAA)", patch: { aa_method: "fxaa", aaJitterLevel: 0 } },
+    { id: "high", label: "High (FXAA + 8x SS)", patch: { aa_method: "fxaa", aaJitterLevel: 3 } },
+    { id: "ultra", label: "Ultra (FXAA + 32x SS)", patch: { aa_method: "fxaa", aaJitterLevel: 5 } },
+  ],
+};
+
+/**
+ * `stepOf` variant with epsilon comparison for numbers. The AO patch holds
+ * reals (aoIntensity 2.2/1.9/1.7) whose C++ double -> JSON -> JS number round
+ * trip must not break the strict === used by renderSettings.stepOf.
+ */
+export function sceneStepOf(
+  axis: RenderQualityAxis,
+  read: (key: string) => string | number | boolean | undefined,
+): string {
+  const eq = (a: unknown, b: unknown) =>
+    typeof a === "number" && typeof b === "number" ? Math.abs(a - b) < 1e-6 : a === b;
+  for (const step of axis.steps) {
+    if (Object.entries(step.patch).every(([key, value]) => eq(read(key), value))) {
+      return step.id;
+    }
+  }
+  return RENDER_QUALITY_CUSTOM;
+}

--- a/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
@@ -105,7 +105,7 @@ export class GfxManager {
         this._canvas = canvas;
         // antialias: false -- the off-screen frame pipeline owns antialiasing
         // (post-process FXAA/SMAA and/or temporal jitter; default aa_method is
-        // smaa), so the multisampled default framebuffer added no visible
+        // fxaa), so the multisampled default framebuffer added no visible
         // benefit while it blocked blitDepthToDefault (a single-sample FBO
         // cannot blit into a multisampled default fb), degrading on-screen
         // overlay depth occlusion. With a single-sample default framebuffer the

--- a/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
@@ -103,27 +103,26 @@ export class GfxManager {
             throw Error('already bound to canvas');
         }
         this._canvas = canvas;
-        // antialias: true is the WebGL2 default, but request it explicitly so the
-        // dependency is obvious. The scene is drawn straight to the DEFAULT
-        // framebuffer only when AO, aa_method, and jitter are all off (legacy
-        // direct path); there the multisampled default framebuffer is the only
-        // geometry antialiasing -- forcing false makes that mode visibly jaggy.
-        // With the default settings (aa_method smaa) the frame goes through the
-        // off-screen pipeline and the MSAA is redundant, but the context
-        // attribute is fixed at creation and cannot be toggled per aa_method, so
-        // it stays on. The tradeoff is that blitDepthToDefault is skipped (a
-        // single-sample FBO cannot blit into a multisampled default fb),
-        // degrading on-screen overlay depth occlusion whenever the pipeline is
-        // active -- i.e. in the default configuration.
-        this._context = wrapGL(canvas.getContext('webgl2', { antialias: true }));
+        // antialias: false -- the off-screen frame pipeline owns antialiasing
+        // (post-process FXAA/SMAA and/or temporal jitter; default aa_method is
+        // smaa), so the multisampled default framebuffer added no visible
+        // benefit while it blocked blitDepthToDefault (a single-sample FBO
+        // cannot blit into a multisampled default fb), degrading on-screen
+        // overlay depth occlusion. With a single-sample default framebuffer the
+        // depth blit works in every pipeline mode. The context attribute is
+        // fixed at creation and cannot follow aa_method, so the legacy direct
+        // path (AO / aa_method / jitter all off) is left without any geometry
+        // AA -- pick a post-AA method instead of relying on MSAA.
+        this._context = wrapGL(canvas.getContext('webgl2', { antialias: false }));
         const gl = this._context;
         // Required for rendering to RGBA16F color/normal attachments (GTAO MRT
         // normal buffer, float jitter accumulator). Acquire once; without it the
         // off-screen AO float framebuffers are incomplete.
         const floatColorExt = gl.getExtension('EXT_color_buffer_float');
         console.log('EXT_color_buffer_float =', floatColorExt !== null);
-        // antialias defaults to true; a multisampled default fb cannot be a blit
-        // destination from a single-sample fbo (see blitDepthToDefault).
+        // Read the actual attribute back (the browser may override the request);
+        // a multisampled default fb cannot be a blit destination from a
+        // single-sample fbo (see blitDepthToDefault).
         const defaultFbMultisampled = gl.getContextAttributes()?.antialias ?? false;
         console.log('default framebuffer multisampled =', defaultFbMultisampled);
 

--- a/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
@@ -104,15 +104,17 @@ export class GfxManager {
         }
         this._canvas = canvas;
         // antialias: true is the WebGL2 default, but request it explicitly so the
-        // dependency is obvious. With the default aa_method (none) the scene is
-        // drawn straight to the DEFAULT framebuffer, so the multisampled default
-        // framebuffer IS the only geometry antialiasing -- forcing false makes
-        // the view visibly jaggy. (When aa_method is a post-process pass like
-        // SMAA the MSAA becomes redundant, but the context attribute is fixed at
-        // creation and cannot be toggled per aa_method, so it stays on.) The
-        // tradeoff is that blitDepthToDefault is skipped (a single-sample FBO
-        // cannot blit into a multisampled default fb), degrading only on-screen
-        // overlay depth occlusion.
+        // dependency is obvious. The scene is drawn straight to the DEFAULT
+        // framebuffer only when AO, aa_method, and jitter are all off (legacy
+        // direct path); there the multisampled default framebuffer is the only
+        // geometry antialiasing -- forcing false makes that mode visibly jaggy.
+        // With the default settings (aa_method smaa) the frame goes through the
+        // off-screen pipeline and the MSAA is redundant, but the context
+        // attribute is fixed at creation and cannot be toggled per aa_method, so
+        // it stays on. The tradeoff is that blitDepthToDefault is skipped (a
+        // single-sample FBO cannot blit into a multisampled default fb),
+        // degrading on-screen overlay depth occlusion whenever the pipeline is
+        // active -- i.e. in the default configuration.
         this._context = wrapGL(canvas.getContext('webgl2', { antialias: true }));
         const gl = this._context;
         // Required for rendering to RGBA16F color/normal attachments (GTAO MRT

--- a/tritium/react-gui/src/renderer/worker/server/services/devRenderOpts.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/devRenderOpts.service.ts
@@ -17,10 +17,11 @@
  *   await window.__cm.invokeService('devRenderOpts', { viewId: <id> })  // toggles AO
  *
  * Temporal-jitter supersampling (jitterLevel 0=off, 1..5 = 2/4/8/16/32 samples)
- * accumulates only while the camera is still and requires the AO path to be on.
- * Adaptive half-res AO (aoHalfRes) computes the GTAO term at half resolution
- * while the camera is moving and re-renders at full resolution once still;
- * requires the AO path to be on.
+ * accumulates only while the camera is still. AA (aaMethod / jitterLevel) is
+ * independent of AO: any of them routes the frame through the off-screen
+ * pipeline on its own. Adaptive half-res AO (aoHalfRes) computes the GTAO term
+ * at half resolution while the camera is moving and re-renders at full
+ * resolution once still; it only has an effect while AO is on.
  *
  * Remove this file (and its ServiceMap row + the window.__cm hook) once the
  * pipeline ships with real UI controls.


### PR DESCRIPTION
## Summary

The post-process AA settings (`aa_method`, `aaJitterLevel`) only took effect while AO was enabled, because the off-screen `FrameRenderPipeline` that implements them was gated on the AO flag in `GUIView::drawScene`. This PR makes AA fully independent of AO, and then simplifies how both are set from the tritium inspector.

### C++ (qsys/gfx)

- **Decouple AA from AO**: the frame pipeline now starts whenever any of AO, spatial post-AA, or temporal jitter is enabled (`Scene::requiresFramePipeline()`); with AO off the GTAO/denoise passes are skipped and the composite plain-copies the scene color (existing `u_hasAO == 0` shader path). With everything off, the legacy direct (hardware MSAA) path is unchanged. Stereo remains pipeline-less (AA, like AO, does not apply there).
- **AA-only memory/bandwidth**: the AO term targets and the scene target's MRT normal attachment (RGBA16F) are only allocated while AO is on; toggling AO recreates the scene target with matching attachments.
- **Default AA actually runs now**: `aa_method` stays `fxaa` by default (visual comparison on molecular scenes favored FXAA over SMAA -- thin lines and sub-pixel silhouette detail respond better to FXAA's sub-pixel blending). SMAA remains selectable; its edge-detection threshold is now a scene property (`aaSmaaThreshold`, default 0.05 = SMAA Ultra) instead of a shader constant, script/.qsc-tunable.
- Off-screen export (`renderAOColorFrame`) keeps its plain-scene fallback; the export jitter loop was already AO-independent.

### tritium (react-gui)

- **Preset-only scene sections** (umbreon quality-axis pattern): the AO section is an Enabled toggle plus a Preset dropdown (Low / Medium / High), the AA section is a single Quality dropdown (Off / Standard (FXAA) / High (FXAA + 8x SS) / Ultra (FXAA + 32x SS)). The step is *derived* from the live property values -- hand edits in the generic property tree read back as "Custom" (offered only while true) -- and selecting a step applies its patch as one undo step via `onSetMany`.
- **AO presets are tuned look sets, not pure quality ladders**: `aoRadius` (4/8/12) is the depth-reach knob, `aoSteps` (3/4/5) rises with it so the wider radius is not undersampled (cost is slices×steps), and `aoIntensity` (2.2/1.9/1.7) falls so large radii do not crush the image to black. `aoSlices` is deliberately absent (barely changes the denoised image; the shader clamps it to 16).
- **WebGL MSAA dropped** (`antialias: false`): the pipeline owns antialiasing now, and a single-sample default framebuffer lets `blitDepthToDefault` work in every mode (overlay depth occlusion). `MappedEnumRow`'s `options` prop now controls display order as its doc promised (enumdef arrives alphabetical from C++).

## Tests

- gtest: contract pins for AA/AO property independence, `requiresFramePipeline()`, and the threshold default (1253 tests pass)
- Vitest: preset derivation / Custom transitions / one-undo multi-writes / patch-outside props not affecting the step / preset-only section shape (2505 tests pass)
- `tsc` clean (no new errors), production build + app launch verified (AA-only pipeline active by default: SMAA/FXAA shaders load, GTAO shaders do not)

## Notes

- **Stacked on #465** (`fix/numeric-field-clear-and-preset-dropdowns`) -- the preset dropdown work builds on the `NumEnumRow` added there. Merge #465 first; GitHub will retarget this PR to `develop`.
- Behavior change to call out in release notes: post-AA now runs without AO, so default scenes render through the off-screen pipeline (FXAA) instead of direct MSAA. Saved `.qsc` files keep their meaning (no property additions/removals; only the `aa_method` default's *effect* changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)