### PR TITLE
fix(tritium,rendering): FBO depth blit, umbreon debug log, and scene/style exception-safety leaks

### DIFF
--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -46,4 +46,11 @@ modules and that are not obvious from any single header.
   恒久対策 (umbreon を別プロセス化し Scene を mmap file で zero-copy 渡し /
   Boost.Interprocess `managed_mapped_file` + Boost.Process) の設計方針と次ステップ。
   macOS の shm 上限が低いため mapped file 必須。renderer worker 内の大確保一般に共通する制約。
+- [umbreon レンダリングが renderer プロセスの darwinbg 降格で数倍遅くなる](umbreon-render-qos-throttling.md)
+  (日本語) -- 「一旦遅くなると設定を変えても遅いまま、再起動で直る」報告の原因調査。
+  macOS の task policy 実験で、renderer プロセスが darwinbg (background task
+  policy) に落ちたまま解除されないケースが 6 倍級の遅化を再現・維持できると特定
+  (umbreon 側のスレッド/TBB バグではない)。renderer プロセス内からの自己修復は
+  原理的に不可能なため、対策は Electron main プロセス側 (renderer backgrounding
+  の無効化、powerSaveBlocker、外部からの taskpolicy 解除) に限られる。
 

--- a/docs/architecture/umbreon-render-qos-throttling.md
+++ b/docs/architecture/umbreon-render-qos-throttling.md
@@ -1,0 +1,84 @@
+# umbreon レンダリングが renderer プロセスの darwinbg 降格で数倍遅くなる (macOS)
+
+tritium で「GI + soft shadow でレンダリングした後、一旦異常に遅くなると設定を
+変えても遅いまま。アプリを再起動すると直る」という報告の調査記録。**umbreon 側の
+バグではなく**、Electron の renderer プロセスが macOS の背景タスクポリシー
+(darwinbg)に落とされたまま戻らないことが原因と特定した。umbreon 側で見つかった
+無関係のバグは `~/proj64/umbreon/docs/plans/known-issues-render-perf-and-leaks.md`
+(umbreon リポジトリ側)を参照。
+
+## 症状
+
+- レンダラ種別 (isosurf/cartoon 等) に依存しない。
+- GI なしの通常 ray tracing でも発生する。
+- 遅くなった状態でも出力画像は正しく、画質も通常のレイトレース品質と変わらない
+  (同じ計算をただ何倍も遅く実行しているだけの挙動)。
+- 発生中も GUI 操作 (回転などの OpenGL 表示) は通常速度。
+- 再現性が低い。意図的な再現操作 (animation 操作、multi-gradient 操作の再実行)
+  では再現しなかった。
+
+レンダリング本体は Electron のメインウィンドウ renderer プロセス内で、umbreon が
+起こす `std::thread` + TBB `parallel_for` で実行される (`renderJob.service.ts`
+→ `UmbreonBackend.beginInProcess` → C++ `beginRender`)。
+
+## 原因の特定 (2026-08-11, macOS / Apple Silicon 8 threads)
+
+TBB の合成ワークロード (`parallel_for` を繰り返すだけの CPU バウンドなプローブ)
+と `taskpolicy` コマンドを使った制御実験:
+
+| 実験 | 結果 |
+|---|---|
+| 通常状態のプロセスを `taskpolicy -b -p` で darwinbg 化 | **約 6 倍遅化** (460ms -> 2800ms、全スレッド PRI が `31T` -> `4T`)。報告された遅さと同スケール |
+| darwinbg を `taskpolicy -B -p` で解除 | **即座に回復**。TBB ワーカーが darwinbg 中に生成された場合でも同じく回復 (スレッド生成タイミングは無関係) |
+| darwinbg 状態で**起動**したプロセス (`taskpolicy -b <cmd>`) | `-B` でも回復しない (起動時 clamp)。ただし tritium は通常起動なので該当しない |
+| メインスレッドだけ `QOS_CLASS_BACKGROUND` にして TBB ワーカープールを生成 | **遅くならない**。oneTBB ワーカーは親スレッドの pthread QoS を継承しない (PRI `31T` で生成される) |
+| プロセス自身が `setpriority(PRIO_DARWIN_PROCESS, 0, 0)` で自己解除 | **効かない** (呼び出しは成功を返すが速度・PRI とも無変化) |
+
+結論: 「スレッド生成時に QoS が継承されて固着する」という説は否定される。
+6 倍級の遅化を発生・維持できるのは**プロセスレベルの darwinbg が掛かりっぱなしに
+なるケースのみ**。macOS の task policy は external (他プロセスから適用) /
+internal (自己申告) の 2 スロットを持ち、外部から掛けられた darwinbg は
+自プロセス内から打ち消せない (renderer プロセス自身の対策は原理的に不可能)。
+
+Chromium は renderer プロセスの task policy を occlusion / App Nap と連動して
+上下させる。「何らかのきっかけで darwinbg に落ち、解除ロジックが働かないまま
+残る」と仮定すると、症状 (プロセス内で固着・レンダラ/設定に無関係・再起動で
+回復・再現条件が絞り込めない低頻度) と完全に一致する。
+
+## 次回発生時の確認・その場での回復 (sudo 不要)
+
+```sh
+# 1. レンダリング中に CPU を使っている renderer プロセスの PID を特定
+#    (Activity Monitor で "Electron Helper (Renderer)" のうち CPU を食っているもの)
+
+# 2. スレッド優先度を確認: PRI が 4T なら darwinbg 確定 (正常は 31T)
+ps -M <pid> | head -5
+
+# 3. 外部から task policy を解除 -- 速度が戻れば原因確定、かつその場で回復できる
+taskpolicy -B -p <pid>
+
+# 4. 戻らなければ原因は darwinbg ではない (メモリ圧/スワップ側を疑う: footprint <pid> / vm_stat)
+```
+
+## 対策 (未実装。優先度順)
+
+renderer プロセス内 (libcuemol2/umbreon) からの自己修復は上記の通り原理的に
+不可能なので、対策は Electron の **main プロセス側**に置く。
+
+1. **予防 (最有力)**: main の起動時に Chromium の renderer 降格そのものを止める。
+   ```ts
+   app.commandLine.appendSwitch('disable-renderer-backgrounding')
+   app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
+   ```
+   VSCode や Slack など、renderer で重い処理を行う Electron アプリの定番設定。
+2. **予防 (補助)**: レンダリングジョブの実行中だけ
+   `powerSaveBlocker.start('prevent-app-suspension')` で App Nap を抑止し、
+   ジョブ終了時に `stop()` する。
+3. **回復 (保険)**: main プロセスがレンダリング開始時に
+   `taskpolicy -B -p <renderer pid>` を実行する。pid は
+   `webContents.getOSProcessId()`。main は renderer とは別プロセスなので
+   external スロットを解除できる (上記実験で実証済み)。darwinbg 検知ログを
+   兼ねられる。
+
+1 の効果を実機 (Electron renderer, 実際の umbreon レンダリング) で検証していない
+点に注意。次に着手する場合はまずここから。

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -368,6 +368,11 @@ struct LogCollector
   LString text;
 };
 
+/// Cap on the collected text. The GUI polls drainLog() so the buffer stays
+/// small there, but the synchronous write() path (python, scripts) never
+/// drains it; without a cap it grows for the process lifetime.
+constexpr int MAX_LOG_LENGTH = 1 << 20;
+
 LogCollector &logCollector()
 {
   static LogCollector collector;
@@ -387,6 +392,9 @@ void ensureLogSink()
       if (level == umbreon::LogLevel::Warning) c.text += "warning: ";
       c.text += text;
       c.text += "\n";
+      // Keep the newest half so the cap is not re-hit on every append.
+      if (c.text.length() > MAX_LOG_LENGTH)
+        c.text = c.text.right(MAX_LOG_LENGTH / 2);
     });
   });
 }

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -975,7 +975,9 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     scene.groupEdgeStyle = m_pImpl->groupEdgeStyle;
   }
 
-  MB_DPRINTLN("Umbreon> render %dx%d ss=%d aa=%d ao=%d aodist=%f tris=%d",
+  // %g: aoDistance defaults to the 1e20 "unlimited" sentinel, which %f would
+  // print as a 21-digit integer and read as a corrupted value.
+  MB_DPRINTLN("Umbreon> render %dx%d ss=%d aa=%d ao=%d aodist=%g tris=%d",
               opt.width, opt.height, opt.supersample, opt.aaMode, opt.aoSamples,
               opt.aoDistance, int(scene.mesh.triangleCount()));
 #endif

--- a/src/qsys/Scene.cpp
+++ b/src/qsys/Scene.cpp
@@ -620,8 +620,9 @@ void Scene::display(DisplayContext *pdc)
 {
   qlib::AutoPerfMeas apm(PM_RENDER_SCENE);
 
-  // StyleMgr is held in the member variable (at the ctor)
-  m_pStyleMgr->pushContextID(getUID());
+  // Scoped push of this scene's style context: a renderer throwing mid-display
+  // must not leave the scene ID on the StyleMgr context stack.
+  AutoStyleCtxt style_ctxt(getUID());
   pdc->startRender();
 
   std::vector<RendererPtr> transps;
@@ -708,7 +709,6 @@ void Scene::display(DisplayContext *pdc)
   }
 
   pdc->endRender();
-  m_pStyleMgr->popContextID();
 }
 
 void Scene::displayRendImpl(DisplayContext *pdc, ObjectPtr pObj, RendererPtr pRend)
@@ -755,7 +755,9 @@ void Scene::displayRendImpl(DisplayContext *pdc, ObjectPtr pObj, RendererPtr pRe
 
 void Scene::processHit(DisplayContext *pdc)
 {
-  m_pStyleMgr->pushContextID(getUID());
+  // Scoped push, matching display(): keep the StyleMgr context stack balanced
+  // on every exit path.
+  AutoStyleCtxt style_ctxt(getUID());
   pdc->startRender();
 
   rendtab_t::const_iterator i = m_rendtab.begin();
@@ -770,7 +772,6 @@ void Scene::processHit(DisplayContext *pdc)
   }
 
   pdc->endRender();
-  m_pStyleMgr->popContextID();
 }
 
 //////////////////////////////

--- a/tritium/react-gui/src/renderer/__test__/fboStore.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/fboStore.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { FboStore } from '../worker/server/gfx/FboStore'
+
+/**
+ * Degrade-detection tests for FboStore's depth attachment format and the
+ * depth blit.
+ *
+ * blitDepthToDefault requires the read and draw depth/stencil formats to
+ * match, and the default framebuffer's depth is a packed depth/stencil
+ * allocation on ANGLE/Metal even though the context reports STENCIL_BITS 0.
+ * A depth-only (DEPTH_COMPONENT24) attachment therefore made every depth
+ * blit fail with GL_INVALID_OPERATION -- once per rendered frame -- and UI
+ * overlays lost scene-depth occlusion. These tests pin the packed
+ * DEPTH24_STENCIL8 allocation and the blit call shape so a refactor cannot
+ * silently reintroduce the per-frame failure.
+ */
+
+// Real GL constant values, so a wrong constant in the implementation is
+// caught by value.
+const GL = {
+    TEXTURE_2D: 0x0de1,
+    TEXTURE_MIN_FILTER: 0x2801,
+    TEXTURE_MAG_FILTER: 0x2800,
+    TEXTURE_WRAP_S: 0x2802,
+    TEXTURE_WRAP_T: 0x2803,
+    NEAREST: 0x2600,
+    LINEAR: 0x2601,
+    CLAMP_TO_EDGE: 0x812f,
+    RGBA: 0x1908,
+    RGBA8: 0x8058,
+    RGBA16F: 0x881a,
+    UNSIGNED_BYTE: 0x1401,
+    FLOAT: 0x1406,
+    DEPTH_COMPONENT24: 0x81a6,
+    DEPTH_COMPONENT: 0x1902,
+    UNSIGNED_INT: 0x1405,
+    DEPTH24_STENCIL8: 0x88f0,
+    DEPTH_STENCIL: 0x84f9,
+    UNSIGNED_INT_24_8: 0x84fa,
+    DEPTH_ATTACHMENT: 0x8d00,
+    DEPTH_STENCIL_ATTACHMENT: 0x821a,
+    COLOR_ATTACHMENT0: 0x8ce0,
+    COLOR_ATTACHMENT1: 0x8ce1,
+    FRAMEBUFFER: 0x8d40,
+    READ_FRAMEBUFFER: 0x8ca8,
+    DRAW_FRAMEBUFFER: 0x8ca9,
+    FRAMEBUFFER_COMPLETE: 0x8cd5,
+    DEPTH_BUFFER_BIT: 0x100,
+    COLOR_BUFFER_BIT: 0x4000,
+    TEXTURE0: 0x84c0,
+}
+
+const RT_DEPTH_TEX = 0x02
+
+function makeGl() {
+    let texSeq = 0
+    return {
+        ...GL,
+        createFramebuffer: vi.fn(() => ({ fb: true })),
+        bindFramebuffer: vi.fn(),
+        createTexture: vi.fn(() => ({ tex: ++texSeq })),
+        bindTexture: vi.fn(),
+        texImage2D: vi.fn(),
+        texParameteri: vi.fn(),
+        framebufferTexture2D: vi.fn(),
+        drawBuffers: vi.fn(),
+        checkFramebufferStatus: vi.fn(() => GL.FRAMEBUFFER_COMPLETE),
+        blitFramebuffer: vi.fn(),
+        viewport: vi.fn(),
+        deleteTexture: vi.fn(),
+        deleteFramebuffer: vi.fn(),
+    }
+}
+
+describe('FboStore depth attachment format', () => {
+    let gl: ReturnType<typeof makeGl>
+    let store: FboStore
+
+    beforeEach(() => {
+        gl = makeGl()
+        store = new FboStore()
+        store.setContext(gl as never, { width: 800, height: 600 }, true, false)
+    })
+
+    it('allocates the depth texture as packed DEPTH24_STENCIL8', () => {
+        expect(store.createFramebuffer('f', 320, 240, RT_DEPTH_TEX)).toBe(true)
+
+        const depthAlloc = gl.texImage2D.mock.calls.find(
+            (c) => c[2] === GL.DEPTH24_STENCIL8)
+        expect(depthAlloc).toBeDefined()
+        expect(depthAlloc).toEqual([
+            GL.TEXTURE_2D, 0, GL.DEPTH24_STENCIL8, 320, 240, 0,
+            GL.DEPTH_STENCIL, GL.UNSIGNED_INT_24_8, null,
+        ])
+        // The depth-only format is what breaks the depth blit against the
+        // packed default framebuffer -- it must not come back.
+        expect(gl.texImage2D.mock.calls.some(
+            (c) => c[2] === GL.DEPTH_COMPONENT24)).toBe(false)
+    })
+
+    it('attaches the depth texture at DEPTH_STENCIL_ATTACHMENT', () => {
+        store.createFramebuffer('f', 320, 240, RT_DEPTH_TEX)
+
+        const attachPoints = gl.framebufferTexture2D.mock.calls.map((c) => c[1])
+        expect(attachPoints).toContain(GL.DEPTH_STENCIL_ATTACHMENT)
+        expect(attachPoints).not.toContain(GL.DEPTH_ATTACHMENT)
+    })
+
+    it('creates no depth texture without RT_DEPTH_TEX', () => {
+        store.createFramebuffer('f', 320, 240, 0)
+        expect(gl.texImage2D.mock.calls.some(
+            (c) => c[2] === GL.DEPTH24_STENCIL8 || c[2] === GL.DEPTH_COMPONENT24,
+        )).toBe(false)
+    })
+})
+
+describe('FboStore.blitDepthToDefault', () => {
+    let gl: ReturnType<typeof makeGl>
+
+    function makeStore(defaultFbMultisampled: boolean): FboStore {
+        gl = makeGl()
+        const store = new FboStore()
+        store.setContext(gl as never, { width: 800, height: 600 }, true,
+                         defaultFbMultisampled)
+        store.createFramebuffer('scene', 320, 240, RT_DEPTH_TEX)
+        return store
+    }
+
+    it('blits DEPTH_BUFFER_BIT from the fbo into the default framebuffer', () => {
+        const store = makeStore(false)
+        store.blitDepthToDefault('scene')
+
+        expect(gl.blitFramebuffer).toHaveBeenCalledTimes(1)
+        expect(gl.blitFramebuffer).toHaveBeenCalledWith(
+            0, 0, 320, 240, 0, 0, 800, 600, GL.DEPTH_BUFFER_BIT, GL.NEAREST)
+        // read = the fbo, draw = null (default framebuffer)
+        expect(gl.bindFramebuffer.mock.calls).toEqual(expect.arrayContaining([
+            [GL.READ_FRAMEBUFFER, expect.objectContaining({ fb: true })],
+            [GL.DRAW_FRAMEBUFFER, null],
+        ]))
+    })
+
+    it('is skipped when the default framebuffer is multisampled', () => {
+        const store = makeStore(true)
+        store.blitDepthToDefault('scene')
+        expect(gl.blitFramebuffer).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op for an unknown fbo name', () => {
+        const store = makeStore(false)
+        store.blitDepthToDefault('nope')
+        expect(gl.blitFramebuffer).not.toHaveBeenCalled()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
@@ -198,6 +198,30 @@ describe('umbreonBackend.beginInProcess', () => {
         expect(exporter.detach).toHaveBeenCalledTimes(1)
     })
 
+    it('detaches the scene when the render fails to start', () => {
+        const exporter = makeExporter()
+        exporter.beginRender = vi.fn(() => {
+            throw new Error('umbreon backend not compiled in')
+        })
+        const ctx = {
+            strMgr: { createHandler: vi.fn(() => exporter) },
+        } as unknown as WorkerContext
+        const snapshot: RenderSettingsSnapshot = {
+            mode: 'still',
+            backend: 'umbreon',
+            commonProps: [p('width', 640), p('height', 480), p('unit', 'px'), p('dpi', 600)],
+            backendProps: [],
+        }
+
+        expect(() =>
+            umbreonBackend.beginInProcess!(ctx, {} as never, snapshot, '/o.png'),
+        ).toThrow(/not compiled in/)
+
+        // attach() already ran, so the scene must be released -- otherwise the
+        // exporter keeps the C++ scene reference alive until GC.
+        expect(exporter.detach).toHaveBeenCalledTimes(1)
+    })
+
     it('falls back to the C++ ctor defaults when umbreon props are absent', () => {
         const exporter = makeExporter()
         const ctx = {

--- a/tritium/react-gui/src/renderer/worker/server/gfx/FboStore.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx/FboStore.ts
@@ -85,7 +85,7 @@ export class FboStore {
      * Create an off-screen FBO. `flags` is a gfx::RTFlags bitmask:
      *   RT_COLOR_RGBA16F (0x10) -> RGBA16F color attachment 0 (else RGBA8)
      *   RT_COLOR_NEAREST (0x04) -> NEAREST color filtering (else LINEAR)
-     *   RT_DEPTH_TEX     (0x02) -> sampleable DEPTH_COMPONENT24 depth texture
+     *   RT_DEPTH_TEX     (0x02) -> sampleable DEPTH24_STENCIL8 depth texture
      *   RT_NORMAL_RGBA16F(0x08) -> RGBA16F MRT normal at color attachment 1
      * Float (RGBA16F) attachments require EXT_color_buffer_float. Returns
      * false if the framebuffer is incomplete.
@@ -147,17 +147,26 @@ export class FboStore {
         }
 
         // Depth attachment (sampleable), only when RT_DEPTH_TEX is set.
+        //
+        // DEPTH24_STENCIL8, not DEPTH_COMPONENT24: blitDepthToDefault requires
+        // the read and draw depth/stencil formats to match, and the default
+        // framebuffer's depth is a packed depth/stencil allocation on ANGLE/
+        // Metal even when the context reports STENCIL_BITS 0. A depth-only
+        // attachment made every depth blit fail with GL_INVALID_OPERATION
+        // (once per frame), leaving UI overlays without scene depth. Sampling
+        // is unaffected: DEPTH_STENCIL_TEXTURE_MODE defaults to
+        // DEPTH_COMPONENT, so the GTAO passes read the same depth in .r.
         let depthTex: WebGLTexture | null = null;
         if (wantDepth) {
             depthTex = gl.createTexture()!;
             gl.bindTexture(gl.TEXTURE_2D, depthTex);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT24, width, height, 0,
-                          gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null);
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH24_STENCIL8, width, height, 0,
+                          gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, null);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT,
+            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT,
                                     gl.TEXTURE_2D, depthTex, 0);
         }
 

--- a/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
+++ b/tritium/react-gui/src/renderer/worker/server/gfx_manager.ts
@@ -108,11 +108,14 @@ export class GfxManager {
         // fxaa), so the multisampled default framebuffer added no visible
         // benefit while it blocked blitDepthToDefault (a single-sample FBO
         // cannot blit into a multisampled default fb), degrading on-screen
-        // overlay depth occlusion. With a single-sample default framebuffer the
-        // depth blit works in every pipeline mode. The context attribute is
-        // fixed at creation and cannot follow aa_method, so the legacy direct
-        // path (AO / aa_method / jitter all off) is left without any geometry
-        // AA -- pick a post-AA method instead of relying on MSAA.
+        // overlay depth occlusion. A single-sample default framebuffer is
+        // necessary for the depth blit but not sufficient: the formats must
+        // also match, which is why FboStore allocates depth attachments as
+        // DEPTH24_STENCIL8 (the default fb's depth is packed on ANGLE/Metal).
+        // The context attribute is fixed at creation and cannot follow
+        // aa_method, so the legacy direct path (AO / aa_method / jitter all
+        // off) is left without any geometry AA -- pick a post-AA method
+        // instead of relying on MSAA.
         this._context = wrapGL(canvas.getContext('webgl2', { antialias: false }));
         const gl = this._context;
         // Required for rendering to RGBA16F color/normal attachments (GTAO MRT
@@ -475,7 +478,7 @@ export class GfxManager {
     /// API: create an off-screen FBO. `flags` is a gfx::RTFlags bitmask:
     ///   RT_COLOR_RGBA16F (0x10) -> RGBA16F color attachment 0 (else RGBA8)
     ///   RT_COLOR_NEAREST (0x04) -> NEAREST color filtering (else LINEAR)
-    ///   RT_DEPTH_TEX     (0x02) -> sampleable DEPTH_COMPONENT24 depth texture
+    ///   RT_DEPTH_TEX     (0x02) -> sampleable DEPTH24_STENCIL8 depth texture
     ///   RT_NORMAL_RGBA16F(0x08) -> RGBA16F MRT normal at color attachment 1
     /// Float (RGBA16F) attachments require EXT_color_buffer_float. Returns false
     /// if the framebuffer is incomplete.

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/UmbreonBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/UmbreonBackend.ts
@@ -203,10 +203,17 @@ export const umbreonBackend: RenderBackend = {
     exporter.camera = "__current";
 
     exporter.attach(scene);
-    exporter.setPath(outputPath);
-    // Build the scene (this call) and start the ray trace on a background C++
-    // thread; returns immediately so the pipeline can poll for progress.
-    exporter.beginRender();
+    try {
+      exporter.setPath(outputPath);
+      // Build the scene (this call) and start the ray trace on a background C++
+      // thread; returns immediately so the pipeline can poll for progress.
+      exporter.beginRender();
+    } catch (e) {
+      // A failed start must not leave the scene attached: the exporter would
+      // keep holding the C++ scene reference until it is garbage-collected.
+      exporter.detach();
+      throw e;
+    }
 
     return makeHandle(exporter, () => exporter.detach());
   },


### PR DESCRIPTION
## Summary
- Allocate off-screen FBO depth attachments as packed `DEPTH24_STENCIL8` instead of `DEPTH_COMPONENT24` -- on ANGLE/Metal the default framebuffer's depth is packed even when `STENCIL_BITS` reports 0, so a depth-only attachment made `blitDepthToDefault` fail with `GL_INVALID_OPERATION` every frame, dropping scene-depth occlusion from UI overlays.
- Print `aoDistance` with `%g` (not `%f`) in the umbreon debug log -- the "unlimited" sentinel (`1e20`) printed as a 21-digit integer that read as corrupted data.
- Detach the scene when umbreon's still-mode render fails to start (`beginInProcess`), matching the animation path's existing guard -- an exception during `beginRender()` previously left the exporter holding the C++ scene reference until GC.
- Cap the process-lifetime umbreon log collector at 1 MiB -- callers that never poll `drainLog()` (the synchronous `write()` path, scripts) let it grow unbounded for the process's life.
- Make the `StyleMgr` context push in `Scene::display()` / `Scene::processHit()` exception-safe via the existing `AutoStyleCtxt` RAII guard -- a renderer throwing mid-display previously left its scene ID on the context stack permanently.

These came out of investigating an intermittent "umbreon rendering gets permanently slow until app restart" report; none of them fully explain that symptom (the leading suspect is QoS-class stickiness in the render thread pool, tracked separately), but each is a real, independently-reproducible bug found along the way.

## Test plan
- [x] `task build_libcuemol2` -- clean build, no errors
- [x] `task run_gtest` -- 1265/1265 passed
- [x] `cd tritium/react-gui && npm test` -- 2722/2722 passed (294 files), including new `fboStore.test.ts` and the added `umbreonBackend.test.ts` detach-on-failure case
- [x] `npx tsc -p tsconfig.web.json --noEmit` -- no new errors from changed files