### PR TITLE
feat: implement MOLFANC nearest-atom coloring for isosurf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,14 +120,17 @@ core (@cuemol/core): C++ addon + auto-generated TypeScript wrappers
 - 境界 (main↔preload↔renderer / renderer↔worker / コマンド) をまたぐ追加は **型契約マップ** に行追加が起点 — `shared/ipcContract.ts` (`InvokeChannels`/`PushChannels`)、`worker/shared/WorkerCalls.ts` (`ServiceMap`/`MethodMap`/`RpcMap`)、`commands/CommandMap.ts`。マップ行を足すと callsite 側が compile error で誘導される。詳細は `tritium/CLAUDE.md`
 - LSP の警告 (`Cannot find module '@cuemol/core/...'`、`electronAPI does not exist on Window` など) は project-references 解決の noise が多い。検証は `npx tsc -p tsconfig.<project>.json --noEmit` と production build (`task build_tritium`) を真とする
 
-**End-to-end 検証チェーン**
+**検証チェーン (実装 → ユーザー目視確認 → test/lint の順)**
 
-`npm test` は worker や main を mock するので、実 IPC 経路や bundle 整合性は捕捉できない。リファクタや境界変更の最終確認は次の順で:
+実装が終わったら、**まず動くものをユーザーに見せる**。テストや lint の整備は目視確認で仕様・挙動が確定した後に行う (先に書くと修正時に手戻りで無駄になる):
 
-1. `cd tritium/react-gui && npm test` (Vitest, ~200+ tests)
-2. `cd tritium/react-gui && npx tsc -p tsconfig.web.json --noEmit` (renderer 型) と `tsconfig.node.json` (main + preload 型)
-3. `cd build_scripts && task build_tritium` (electron-vite production bundle — bundler レベルの依存解決を catch)
-4. `cd build_scripts && task run_tritium` で起動し、`launch worker OK` → `CueMol2 nodejs add-on : INITIALIZED` → `bindCanvas` → `shader program created OK` まで進むか確認
+1. `cd build_scripts && task build_tritium` (electron-vite production bundle — bundler レベルの依存解決を catch。既存テストの修正もこの段階ではしない)
+2. `cd build_scripts && task run_tritium` で起動し、`launch worker OK` → `CueMol2 nodejs add-on : INITIALIZED` → `bindCanvas` → `shader program created OK` まで進むか確認
+3. **ユーザーによる目視確認 (E2E) を依頼し、フィードバックを反映する。挙動が確定するまで 1-3 を繰り返す**
+4. 確定後に: `cd tritium/react-gui && npm test` (Vitest) — 既存テストの追随修正と新規テストの追加
+5. `cd tritium/react-gui && npx tsc -p tsconfig.web.json --noEmit` (renderer 型) と `tsconfig.node.json` (main + preload 型)、`task lint_tritium_style`
+
+`npm test` は worker や main を mock するので、実 IPC 経路や bundle 整合性は捕捉できない。ビルドと起動の確認だけを先に行い、テスト整備は目視確認後にまとめて行う。
 
 **Refactoring 前の degrade 検出テスト**
 

--- a/src/modules/xtal/MapSurfRenderer.cpp
+++ b/src/modules/xtal/MapSurfRenderer.cpp
@@ -17,13 +17,19 @@
 #include <qsys/ViewEvent.hpp>
 #include <qsys/View.hpp>
 #include <qsys/Scene.hpp>
+#include <qsys/SceneManager.hpp>
 #include <modules/molstr/AtomIterator.hpp>
+#include <modules/molstr/AtomPosMap2.hpp>
+#include <modules/molstr/MolAtom.hpp>
+#include <modules/molstr/MolCoord.hpp>
 
 using namespace xtal;
 using qlib::Matrix4D;
 using qlib::Matrix3D;
 using qsys::ScrEventManager;
+using qsys::SceneManager;
 using molstr::AtomIterator;
+using molstr::MolAtomPtr;
 
 // default constructor
 MapSurfRenderer::MapSurfRenderer()
@@ -35,6 +41,9 @@ MapSurfRenderer::MapSurfRenderer()
   m_nDrawMode = MSRDRAW_FILL;
   m_lw = 1.2;
   m_pCMap = NULL;
+
+  m_nTgtMolID = qlib::invalid_uid;
+  m_pAtomPosMap = NULL;
 
   m_nBinFac = 1;
   m_nMaxGrid = 100;
@@ -67,6 +76,18 @@ MapSurfRenderer::~MapSurfRenderer()
   // for safety, remove from event manager is needed here...
   ScrEventManager *pSEM = ScrEventManager::getInstance();
   pSEM->removeViewListener(this);
+
+  if (m_pAtomPosMap!=NULL)
+    delete m_pAtomPosMap;
+
+  // detach from the coloring target mol
+  if (m_nTgtMolID!=qlib::invalid_uid) {
+    qsys::ObjectPtr pObj = SceneManager::getObjectS(m_nTgtMolID);
+    if (!pObj.isnull()) {
+      pObj->removeListener(this);
+    }
+    m_nTgtMolID = qlib::invalid_uid;
+  }
 
 // #if (GUI_ARCH!=MB_GUI_ARCH_CLI)
 //   if (m_pVBO!=NULL)
@@ -416,6 +437,7 @@ void MapSurfRenderer::renderImpl(DisplayContext *pdl)
 
   m_pColMapObj = NULL;
   m_pGrad = NULL;
+  m_pColMol = MolCoordPtr();
 
   if (getColorMode()==MapRenderer::MAPREND_MULTIGRAD) {
     m_pGrad = getMultiGrad().get();
@@ -428,6 +450,31 @@ void MapSurfRenderer::renderImpl(DisplayContext *pdl)
       LOG_DPRINTLN("MapSurfRend> \"%s\" is not a scalar object.", nm.c_str());
     }
     setupXformMat();
+  }
+  else if (!m_bGenSurfMode &&
+           getColorMode()==MapRenderer::MAPREND_MOLFANC) {
+    if (m_nTgtMolID!=qlib::invalid_uid) {
+      qsys::ObjectPtr pobj = SceneManager::getObjectS(m_nTgtMolID);
+      m_pColMol = MolCoordPtr(pobj, qlib::no_throw_tag());
+    }
+    if (!m_pColMol.isnull()) {
+      // TO DO: re-generate atom-map only when Mol is changed.
+      makeAtomPosMap();
+
+      // Sync the ColoringScheme fallback color with the solid color prop
+      molstr::ColSchmHolder::setDefaultColor(MapRenderer::getColor());
+
+      // initialize the coloring scheme (with the target mol)
+      molstr::ColoringSchemePtr pCS = getColSchm();
+      if (!pCS.isnull())
+        pCS->start(m_pColMol, this);
+
+      setupXformMat();
+    }
+    else {
+      LOG_DPRINTLN("MapSurfRend> MOLFANC target mol \"%d\" is not found.",
+                   int(m_nTgtMolID));
+    }
   }
 
   /////////////////////
@@ -494,6 +541,18 @@ void MapSurfRenderer::renderImpl(DisplayContext *pdl)
         pdl->end();*/
       }
         
+
+  // cleanup for MOLFANC mode
+  if (!m_pColMol.isnull()) {
+    molstr::ColoringSchemePtr pCS = getColSchm();
+    if (!pCS.isnull())
+      pCS->end();
+  }
+  if (m_pAtomPosMap!=NULL) {
+    delete m_pAtomPosMap;
+    m_pAtomPosMap = NULL;
+  }
+  m_pColMol = MolCoordPtr();
 
   m_pColMapObj = NULL;
   m_pGrad = NULL;
@@ -931,13 +990,17 @@ void MapSurfRenderer::setupXformMat()
   ScalarObject *pMap = m_pCMap;
   DensityMap *pXtal = dynamic_cast<DensityMap *>(pMap);
 
+  // Apply the object's xform matrix first, to be consistent with
+  // setupXformMat(pdl) used in the display-list path.
+  m_xform = pMap->getXformMatrix();
+
   //  setup frac-->orth matrix
   if (pXtal==NULL) {
-    m_xform = Matrix4D::makeTransMat(pMap->getOrigin());
+    m_xform.matprod( Matrix4D::makeTransMat(pMap->getOrigin()) );
   }
   else {
     Matrix3D orthmat = pXtal->getXtalInfo().getOrthMat();
-    m_xform = Matrix4D(orthmat);
+    m_xform.matprod( Matrix4D(orthmat) );
   }
 
   {  
@@ -995,15 +1058,179 @@ void MapSurfRenderer::setVertexColor(DisplayContext *pdl, const Vector4D &pos)
   if (m_bGenSurfMode)
     return;
 
-  if (m_pColMapObj==NULL)
-    return;
-
   Vector4D vv(pos);
   vv.w() = 1.0;
   m_xform.xform4D(vv);
 
+  if (getColorMode()==MapRenderer::MAPREND_MOLFANC) {
+    ColorPtr pcol;
+    if (getColorMol(vv, pcol))
+      pdl->color(pcol);
+    // on failure, the solid color baked in render() remains in effect
+    return;
+  }
+
+  // MULTIGRAD mode
+  if (m_pColMapObj==NULL)
+    return;
+
   double par = m_pColMapObj->getValueAt(vv);
   ColorPtr pcol = m_pGrad->getColor(par);
   pdl->color(pcol);
+}
+
+bool MapSurfRenderer::getColorMol(const Vector4D &v, gfx::ColorPtr &rcol)
+{
+  if (m_pColMol.isnull())
+    return false;
+  if (m_pAtomPosMap==NULL)
+    return false;
+
+  int aid = m_pAtomPosMap->searchNearestAtom(v);
+  if (aid<0) {
+    MB_DPRINTLN("nearest atom is not found at (%f,%f,%f)", v.x(), v.y(), v.z());
+    return false;
+  }
+
+  MolAtomPtr pa = m_pColMol->getAtom(aid);
+  if (pa.isnull())
+    return false;
+
+  rcol = molstr::ColSchmHolder::getColor(pa);
+  return true;
+}
+
+void MapSurfRenderer::makeAtomPosMap()
+{
+  if (m_pColMol.isnull())
+    return;
+
+  if (m_pAtomPosMap!=NULL)
+    delete m_pAtomPosMap;
+
+  m_pAtomPosMap = MB_NEW molstr::AtomPosMap2();
+  m_pAtomPosMap->setTarget(m_pColMol);
+  m_pAtomPosMap->generate(m_pMolSel);
+}
+
+/// Resolve mol name, set m_nTgtMolID, listen the MolCoord events,
+/// and return the MolCoord object
+MolCoordPtr MapSurfRenderer::resolveMolIDImpl(const qlib::LString &name)
+{
+  qsys::ScenePtr pScene = getScene();
+  if (pScene.isnull())
+    return MolCoordPtr();
+
+  qsys::ObjectPtr pobj = pScene->getObjectByName(name);
+  MolCoordPtr pMol = MolCoordPtr(pobj, qlib::no_throw_tag());
+  if (pMol.isnull()) {
+    return pMol;
+  }
+
+  m_nTgtMolID = pMol->getUID();
+
+  // event handling: attach to the new object
+  pMol->addListener(this);
+
+  MB_DPRINTLN("MapSurfRend.resolveMolID> resolved (%s), OK.", name.c_str());
+  return pMol;
+}
+
+void MapSurfRenderer::setTgtObjName(const qlib::LString &name)
+{
+  // detach from oldobj
+  if (m_nTgtMolID!=qlib::invalid_uid) {
+    qsys::ObjectPtr pObj = SceneManager::getObjectS(m_nTgtMolID);
+    if (!pObj.isnull()) {
+      pObj->removeListener(this);
+    }
+    m_nTgtMolID = qlib::invalid_uid;
+  }
+
+  // get object by name
+  if (name.isEmpty())
+    return;
+
+  m_sTgtMolName = name;
+
+  if (getScene().isnull())
+    return; // Scene is not loaded (when called in the scene-file loading)
+
+  MolCoordPtr pMol = resolveMolIDImpl(name);
+  if (pMol.isnull()) {
+    LOG_DPRINTLN("MapSurfRend> \"%s\" is not a MolCoord object.", name.c_str());
+    return;
+  }
+
+  invalidateDisplayCache();
+}
+
+qlib::LString MapSurfRenderer::getTgtObjName() const
+{
+  if (m_nTgtMolID==qlib::invalid_uid)
+    return LString();
+  qsys::ObjectPtr pObj = SceneManager::getObjectS(m_nTgtMolID);
+  if (pObj.isnull())
+    return LString();
+  return pObj->getName();
+}
+
+void MapSurfRenderer::propChanged(qlib::LPropEvent &ev)
+{
+  LString name = ev.getName();
+  LString pname = ev.getParentName();
+
+  if (name.equals("coloring")||
+      pname.equals("coloring")||
+      pname.startsWith("coloring.")) {
+    invalidateDisplayCache();
+  }
+  else if (name.equals("target")||
+           name.equals("sel")) {
+    invalidateDisplayCache();
+  }
+
+  super_t::propChanged(ev);
+}
+
+void MapSurfRenderer::objectChanged(qsys::ObjectEvent &ev)
+{
+  if (getColorMode()==MapRenderer::MAPREND_MOLFANC &&
+      ev.getType()==qsys::ObjectEvent::OBE_PROPCHG) {
+    qlib::LPropEvent *pPE = ev.getPropEvent();
+    if (pPE) {
+      if (pPE->getName().equals("defaultcolor")||
+          pPE->getName().equals("coloring")||
+          pPE->getParentName().equals("coloring")||
+          pPE->getParentName().startsWith("coloring.")) {
+        invalidateDisplayCache();
+      }
+    }
+  }
+
+  super_t::objectChanged(ev);
+}
+
+void MapSurfRenderer::sceneChanged(qsys::SceneEvent &ev)
+{
+  if (ev.getType()==qsys::SceneEvent::SCE_SCENE_ONLOADED) {
+    // resolve target mol name, if required
+    if (!m_sTgtMolName.isEmpty())
+      resolveMolIDImpl(m_sTgtMolName);
+  }
+  else if (ev.getType()==qsys::SceneEvent::SCE_OBJ_ADDED &&
+           ev.getTarget()==getClientObjID()) {
+    // resolve target mol name, if required
+    if (!m_sTgtMolName.isEmpty())
+      resolveMolIDImpl(m_sTgtMolName);
+  }
+  else if (ev.getType()==qsys::SceneEvent::SCE_REND_ADDED &&
+           ev.getTarget()==getUID()) {
+    // resolve target mol name, if required
+    if (!m_sTgtMolName.isEmpty())
+      resolveMolIDImpl(m_sTgtMolName);
+  }
+
+  super_t::sceneChanged(ev);
 }
 

--- a/src/modules/xtal/MapSurfRenderer.hpp
+++ b/src/modules/xtal/MapSurfRenderer.hpp
@@ -15,11 +15,14 @@
 #include <modules/molstr/molstr.hpp>
 #include <modules/molstr/BSPTree.hpp>
 
+#include <modules/molstr/ColoringScheme.hpp>
 #include <modules/surface/MolSurfObj.hpp>
 #include <gfx/DrawAttrArray.hpp>
 #include <gfx/ShaderObject.hpp>
 
 class MapSurfRenderer_wrap;
+
+namespace molstr { class AtomPosMap2; }
 
 namespace xtal {
 
@@ -31,6 +34,7 @@ namespace xtal {
   class DensityMap;
 
   class MapSurfRenderer : public MapRenderer,
+                          public molstr::ColSchmHolder,
                           public qsys::ViewEventListener
   {
     MC_SCRIPTABLE;
@@ -40,6 +44,15 @@ namespace xtal {
     typedef MapRenderer super_t;
     friend class ::MapSurfRenderer_wrap;
 
+  public:
+    // Both MapRenderer::getColor() (solid color property) and
+    // ColSchmHolder::getColor(MolAtomPtr/MolResiduePtr) are inherited from
+    // different bases; bring both overload sets into the same scope so that
+    // unqualified calls resolve by argument instead of being ambiguous.
+    using MapRenderer::getColor;
+    using molstr::ColSchmHolder::getColor;
+
+  private:
     ///////////////////////////////////////////
     // properties
 
@@ -153,6 +166,42 @@ namespace xtal {
     }
 
   private:
+    /// Molecule object ID by which painting color is determined
+    /// (used in MOLFANC mode)
+    qlib::uid_t m_nTgtMolID;
+
+    /// Molecule object name by which painting color is determined.
+    /// Used if MolID cannot be resolved (when deserialized from qsc file)
+    qlib::LString m_sTgtMolName;
+
+    /// Selection for atompos-map (used in MOLFANC mode)
+    SelectionPtr m_pMolSel;
+
+  public:
+    /// Get reference molecule target (used in MOLFANC mode)
+    qlib::LString getTgtObjName() const;
+
+    /// Set reference molecule target (used in MOLFANC mode)
+    void setTgtObjName(const qlib::LString &n);
+
+    SelectionPtr getMolSel() const { return m_pMolSel; }
+
+    void setMolSel(SelectionPtr pNewSel) {
+      m_pMolSel = pNewSel;
+      invalidateDisplayCache();
+    }
+
+    ////
+
+    void propChanged(qlib::LPropEvent &ev) override;
+
+    /// object-changed event handler (for target mol changes in MOLFANC mode)
+    void objectChanged(qsys::ObjectEvent &ev) override;
+
+    /// scene-changed event handler (for target mol name resolution)
+    void sceneChanged(qsys::SceneEvent &ev) override;
+
+  private:
 
     ///////////////////////////////////////////
     // work area
@@ -228,6 +277,21 @@ namespace xtal {
     qsys::ScalarObject *m_pColMapObj;
 
     qsys::MultiGradient *m_pGrad;
+
+    /// Coloring target mol (for MOLFANC mode; only valid during rendering)
+    MolCoordPtr m_pColMol;
+
+    /// Nearest-atom map for MOLFANC coloring (only valid during rendering)
+    molstr::AtomPosMap2 *m_pAtomPosMap;
+
+    /// Resolve mol name, set m_nTgtMolID, listen the MolCoord events,
+    /// and return the MolCoord object
+    MolCoordPtr resolveMolIDImpl(const qlib::LString &name);
+
+    void makeAtomPosMap();
+
+    /// Get color of the nearest atom (v is in the orthogonal coordinates)
+    bool getColorMol(const Vector4D &v, gfx::ColorPtr &rcol);
 
     void setVertexColor(DisplayContext *pdl, const Vector4D &rfPosition);
 

--- a/src/modules/xtal/MapSurfRenderer.qif
+++ b/src/modules/xtal/MapSurfRenderer.qif
@@ -7,6 +7,7 @@
 
 #include "MapRenderer.qif"
 #include <modules/molstr/SelCommand.qif>
+#include <modules/molstr/ColoringScheme.qif>
 
 runtime_class MapSurfRenderer extends MapRenderer
 {
@@ -54,6 +55,22 @@ runtime_class MapSurfRenderer extends MapRenderer
 
   /// Convert to MolSurfObj
   object<Object$> generateSurfObj();
+
+  //////////
+  // for "molecule" colormode
+
+  /// reference molecule target (used in molecule mode)
+  property string target => redirect(getTgtObjName, setTgtObjName);
+  default target = "";
+
+  property object<ColoringScheme$> coloring => redirect(getColSchm, setColSchm);
+  default coloring = molstr::ColoringScheme::createDefaultS();
+
+  using SelCommand;
+
+  /// Selection for atom mapping (used in molecule mode)
+  property object<MolSelection$> sel => redirect(getMolSel, setMolSel);
+  default sel = molstr::SelectionPtr(new molstr::SelCommand());
 
   //////////
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -179,6 +179,7 @@ gtest_discover_tests(test_surface PROPERTIES LABELS "test_surface")
 add_executable(test_xtal
   modules/xtal/test_main.cpp
   modules/xtal/test_maprenderer_color.cpp
+  modules/xtal/test_mapsurf_molfanc.cpp
   modules/xtal/test_multigrad_undo.cpp
   modules/xtal/test_quant_step.cpp
 )

--- a/src/tests/modules/xtal/test_mapsurf_molfanc.cpp
+++ b/src/tests/modules/xtal/test_mapsurf_molfanc.cpp
@@ -1,0 +1,120 @@
+// -*-Mode: C++;-*-
+//
+// Tests for MapSurfRenderer MOLFANC (colormode=molecule) support.
+//
+// GenerateSurfObjAppliesXformMatrix pins the CPU-side transform
+// (setupXformMat with no args): it must apply the object's xform matrix
+// consistently with the display-list path, since both the MULTIGRAD /
+// MOLFANC color lookups and generateSurfObj() vertices depend on it.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/Matrix4D.hpp>
+#include <qlib/Vector4D.hpp>
+#include <qsys/Scene.hpp>
+#include <qsys/SceneManager.hpp>
+#include <vector>
+#include "molstr/MolCoord.hpp"
+#include "surface/MolSurfObj.hpp"
+#include "xtal/DensityMap.hpp"
+#include "xtal/MapSurfRenderer.hpp"
+
+using qlib::Matrix4D;
+using qlib::Vector4D;
+
+namespace {
+
+class MapSurfXformTest : public ::testing::Test {
+protected:
+    qsys::ScenePtr m_pScene;
+    qsys::ObjectPtr m_pObj;
+    qsys::RendererPtr m_pRend;
+    xtal::MapSurfRenderer *m_pMSR;
+
+    void SetUp() override
+    {
+        m_pScene = qsys::SceneManager::getInstance()->createScene();
+
+        xtal::DensityMap *pMap = MB_NEW xtal::DensityMap();
+        // 4x4x4 ramp covering [0, 63]; the default iso-level
+        // (rmsd * siglevel 1.1, about 20) cuts through the cell
+        std::vector<float> data(64);
+        for (int i = 0; i < 64; ++i) data[i] = float(i);
+        pMap->setMapFloatArray(data.data(), 4, 4, 4, 0, 1, 2);
+        pMap->setMapParams(0, 0, 0, 4, 4, 4);
+        pMap->setXtalParams(4.0, 4.0, 4.0, 90.0, 90.0, 90.0);
+
+        m_pObj = qsys::ObjectPtr(pMap);
+        m_pObj->setName("testmap");
+        m_pScene->addObject(m_pObj);
+
+        m_pRend = m_pObj->createRenderer("isosurf");
+        m_pMSR = dynamic_cast<xtal::MapSurfRenderer *>(m_pRend.get());
+        ASSERT_NE(m_pMSR, nullptr);
+        // The 4x4x4 map covers the whole cell, which would enable PBC and
+        // extend the marching range far beyond the cell; keep it bounded.
+        m_pMSR->setUsePBC(false);
+    }
+
+    void TearDown() override
+    {
+        qsys::SceneManager::getInstance()->destroyScene(m_pScene->getUID());
+    }
+
+    /// Generate the surface and return its vertex count; centroid in rval.
+    int calcSurfCentroid(Vector4D &rval)
+    {
+        qsys::ObjectPtr pSurfObj = m_pMSR->generateSurfObj();
+        surface::MolSurfObj *pSurf =
+            dynamic_cast<surface::MolSurfObj *>(pSurfObj.get());
+        if (pSurf == nullptr)
+            return -1;
+        const int nvert = pSurf->getVertSize();
+        Vector4D sum;
+        for (int i = 0; i < nvert; ++i)
+            sum += pSurf->getVertAt(i).v3d();
+        if (nvert > 0)
+            rval = sum.divide(double(nvert));
+        return nvert;
+    }
+};
+
+}  // namespace
+
+TEST_F(MapSurfXformTest, GenerateSurfObjAppliesXformMatrix)
+{
+    Vector4D c0;
+    const int nvert0 = calcSurfCentroid(c0);
+    ASSERT_GT(nvert0, 0);
+
+    const Vector4D tr(10.0, -5.0, 3.0);
+    m_pObj->setXformMatrix(Matrix4D::makeTransMat(tr));
+
+    Vector4D c1;
+    const int nvert1 = calcSurfCentroid(c1);
+    ASSERT_EQ(nvert1, nvert0);
+
+    // Vertices are stored as float32; keep the tolerance above that noise.
+    EXPECT_NEAR(c1.x() - c0.x(), tr.x(), 1e-4);
+    EXPECT_NEAR(c1.y() - c0.y(), tr.y(), 1e-4);
+    EXPECT_NEAR(c1.z() - c0.z(), tr.z(), 1e-4);
+}
+
+// The target property (MOLFANC coloring mol) resolves a scene object by
+// name, keeps it across get, and stays unresolved for unknown names.
+TEST_F(MapSurfXformTest, TargetNameResolution)
+{
+    qsys::ObjectPtr pMol = qsys::ObjectPtr(MB_NEW molstr::MolCoord());
+    pMol->setName("testmol");
+    m_pScene->addObject(pMol);
+
+    EXPECT_TRUE(m_pMSR->getTgtObjName().isEmpty());
+
+    m_pMSR->setTgtObjName("testmol");
+    EXPECT_EQ(m_pMSR->getTgtObjName(), qlib::LString("testmol"));
+
+    // unknown names detach the previous target and stay unresolved
+    m_pMSR->setTgtObjName("no_such_mol");
+    EXPECT_TRUE(m_pMSR->getTgtObjName().isEmpty());
+}

--- a/tritium/react-gui/src/main/index.ts
+++ b/tritium/react-gui/src/main/index.ts
@@ -9,6 +9,11 @@ import { isAppQuitting, isForceQuit, setAppQuitting } from './quitState'
 import { clearRenderHistory } from './renderHistory'
 import { sweepMovieOutputs } from './movieOutput'
 import { APP_PRODUCT_NAME } from '../shared/appInfo'
+import { installMainCrashHandlers } from './installMainCrashHandlers'
+
+// Before anything else, so a throw during the setup below is still reported
+// to the terminal and a closed stdout pipe cannot masquerade as a crash.
+installMainCrashHandlers()
 
 app.setName(APP_PRODUCT_NAME)
 

--- a/tritium/react-gui/src/main/installMainCrashHandlers.ts
+++ b/tritium/react-gui/src/main/installMainCrashHandlers.ts
@@ -1,0 +1,62 @@
+/**
+ * @file main/installMainCrashHandlers.ts
+ * @description Main-process crash funnel. Mirrors uncaught exceptions and
+ * unhandled rejections to the terminal, and keeps a broken stdio pipe from
+ * surfacing as a crash.
+ *
+ * Electron's built-in handler only pops a modal "A JavaScript error occurred
+ * in the main process" dialog, whose text cannot be copied and which never
+ * reaches the log a headless / piped run captures. These listeners are added
+ * alongside it (Node runs every `uncaughtException` listener), so the dialog
+ * still appears while the same report also lands on stderr.
+ *
+ * The renderer has its own funnel in `renderer/crash/`; this covers the main
+ * process only.
+ */
+
+/** stdio write errors that mean "nobody is reading" rather than a real fault. */
+const PIPE_ERROR_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED', 'ERR_STREAM_WRITE_AFTER_END']);
+
+/** Set once a stdio stream reports a pipe error, to stop writing into it. */
+let stdioBroken = false;
+
+/**
+ * Write a crash report without ever throwing.
+ *
+ * @remarks Must not use `console.*` unguarded: a dead stdout is exactly the
+ *   case this file exists for, and re-entering the failing path would loop.
+ */
+function report(kind: string, err: unknown): void {
+    if (stdioBroken) return;
+    const detail = err instanceof Error ? (err.stack ?? `${err.name}: ${err.message}`) : String(err);
+    try {
+        process.stderr.write(`[Main] ${kind}: ${detail}\n`);
+    } catch {
+        // stderr is gone too -- nothing left to report through.
+        stdioBroken = true;
+    }
+}
+
+/**
+ * Install the main-process crash handlers. Call once, as early as possible in
+ * `main/index.ts` (before any window or store access).
+ */
+export function installMainCrashHandlers(): void {
+    // Launching through a pipe that closes early (`npm start | head`) leaves
+    // stdout writable but unread; the next console.log fails asynchronously in
+    // the stream's write callback. Without an 'error' listener that becomes an
+    // uncaught exception and pops the Electron dialog, so the app looks
+    // crashed when only the log sink went away.
+    for (const stream of [process.stdout, process.stderr] as const) {
+        stream.on('error', (err: NodeJS.ErrnoException) => {
+            if (PIPE_ERROR_CODES.has(err.code ?? '')) {
+                stdioBroken = true;
+                return;
+            }
+            report('stdio error', err);
+        });
+    }
+
+    process.on('uncaughtException', (err) => report('uncaughtException', err));
+    process.on('unhandledRejection', (reason) => report('unhandledRejection', reason));
+}

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -50,6 +50,7 @@ import { CmdId } from "./commands/ids";
 import type { ViewCenterMark } from "../shared/ipcTypes";
 import { IPC } from "../shared/ipcChannels";
 import { useCueMolBusy } from "./hooks/useCueMolBusy";
+import { useBusyCursor } from "./hooks/useBusyCursor";
 import { useShowConfirmCloseTabDialog } from "./components/dialogs/ConfirmCloseTabDialogProvider";
 import { useRenderConfig } from "./contexts/RenderConfigContext";
 import { useWindowCloseHandler } from "./hooks/useWindowCloseHandler";
@@ -402,6 +403,10 @@ const App: React.FC = () => {
   });
 
   const cueMolBusy = useCueMolBusy();
+
+  // Same flag also drives a global wait cursor, so the busy state is visible
+  // wherever the pointer is -- not only in the status bar.
+  useBusyCursor(cueMolBusy);
 
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 

--- a/tritium/react-gui/src/renderer/__test__/colorPaneMolFancWire.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/colorPaneMolFancWire.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Wire tests for the ColorPane MOLFANC (colormode="molecule") support on the
+ * isosurf map renderer. Pins the observable renderer-side wire only:
+ *
+ *   - Coloring dropdown: isosurf (has `coloring`) offers the full paint set
+ *     (Paint/Solid/CPK/Bfac/Rainbow) + Multi-gradient + Reset, but NOT the
+ *     Electrostatic-potential item (surface renderers only); clicking Paint
+ *     fires setRendererColoring with 'paint-type-paint'.
+ *   - "Coloring mol" selector: shown above the class deck in molecule
+ *     colormode, lists the scene's MolCoord objects, and commits a change
+ *     through setRendererColoringTarget; hidden outside molecule mode.
+ *
+ * The worker-side protocol (colormode forcing, target auto-pick, resetdef)
+ * is pinned in rendererColoringService.test.ts.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act } from 'react'
+
+void React
+
+vi.mock('@cuemol/core/src/wrappers/wrapper-loader', () => ({ wrapper_map: {} }))
+vi.mock('@cuemol/core/src/BaseWrapper', () => ({ BaseWrapper: class {} }))
+
+vi.mock('../hooks/useCueMolEventListener', () => ({
+    useCueMolEventListener: () => undefined,
+}))
+
+vi.mock('../h3-kit/colorpicker/CueColorField', () => ({
+    CueColorField: ({ value }: { value: string }) => (
+        <button type="button" data-testid="color-commit" data-value={value} />
+    ),
+}))
+
+vi.mock('../h3-kit/colorpicker/ColorPickerContext', () => ({
+    ColorPickerProvider: ({ children }: { children: React.ReactNode }) => (
+        <>{children}</>
+    ),
+    useColorPickerCtx: () => ({ cm: null, sceneId: undefined }),
+}))
+
+vi.mock('../components/panes/PaintSelCell', () => ({
+    PaintSelCell: () => <input data-testid="paint-sel-cell" readOnly />,
+}))
+
+import { ColorPane } from '../components/panes/ColorPane'
+import { mountTree, flushPromises } from './helpers/testHarness'
+
+const SCENE_ID = 7
+const REND_ID = 100
+
+/** isosurf coloring state in solid colormode (default after creation). */
+const ISOSURF_SOLID = {
+    ok: true,
+    className: 'SolidColoring',
+    defaultColor: '#0000FF',
+    paintEntries: [],
+    surfaceType: 'isosurf',
+    colormode: 'solid',
+    multiGradCapable: true,
+    hasColoring: true,
+    molFancTarget: '',
+}
+
+/** isosurf in molecule colormode with a Paint coloring and a target mol. */
+const ISOSURF_MOLECULE_PAINT = {
+    ...ISOSURF_SOLID,
+    className: 'PaintColoring',
+    colormode: 'molecule',
+    molFancTarget: 'mol1',
+}
+
+interface MockCm {
+    invokeService: ReturnType<typeof vi.fn>
+}
+
+function makeCm(coloringState: Record<string, unknown>): MockCm {
+    return {
+        invokeService: vi.fn((name: string) => {
+            if (name === 'listPaintCapableRenderers') {
+                return Promise.resolve({
+                    ok: true,
+                    renderers: [
+                        {
+                            objId: 11,
+                            objName: 'mtz1',
+                            rendId: REND_ID,
+                            targetKind: 'renderer',
+                            name: 'isosurf1',
+                            typeName: 'isosurf',
+                        },
+                    ],
+                })
+            }
+            if (name === 'getRendererColoringState') {
+                return Promise.resolve(coloringState)
+            }
+            if (name === 'listSceneObjects') {
+                return Promise.resolve({
+                    objects: [
+                        { uid: 21, name: 'mol1', className: 'MolCoord' },
+                        { uid: 22, name: 'mol2', className: 'MolCoord' },
+                        { uid: 23, name: 'map1', className: 'DensityMap' },
+                    ],
+                })
+            }
+            if (name === 'listElePotMapObjects') {
+                return Promise.resolve({ ok: true, objects: [] })
+            }
+            return Promise.resolve({ ok: true })
+        }),
+    }
+}
+
+async function mountWith(coloringState: Record<string, unknown>) {
+    const cm = makeCm(coloringState)
+    const handle = mountTree(<ColorPane cm={cm as never} sceneId={SCENE_ID} />)
+    await flushPromises()
+    return { cm, ...handle }
+}
+
+/** The select that offers the scene's molecules (the Coloring mol selector). */
+function findMolSelector(container: HTMLElement): HTMLSelectElement | null {
+    return (
+        (Array.from(container.querySelectorAll('select')).find((s) =>
+            s.querySelector('option[value="mol2"]'),
+        ) as HTMLSelectElement | undefined) ?? null
+    )
+}
+
+describe('ColorPane MOLFANC wire (isosurf)', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('isosurf dropdown offers the paint set + Multi-gradient but no Elepot', async () => {
+        const { cm, container, unmount } = await mountWith(ISOSURF_SOLID)
+        const trigger = Array.from(
+            container.querySelectorAll('button'),
+        ).find((b) => b.textContent?.includes('Coloring')) as HTMLButtonElement
+        await act(async () => { trigger.click() })
+        await flushPromises()
+        const items = Array.from(document.querySelectorAll('.bp5-menu-item'))
+        expect(items.map((i) => i.textContent)).toEqual([
+            'Paint coloring',
+            'Solid coloring',
+            'CPK coloring',
+            'Bfac/Occ coloring',
+            'Rainbow coloring',
+            'Multi-gradient coloring',
+            'Reset to default style',
+        ])
+        const paint = items.find((i) => i.textContent === 'Paint coloring')!
+        await act(async () => { (paint as HTMLElement).click() })
+        await flushPromises()
+        expect(cm.invokeService).toHaveBeenCalledWith('setRendererColoring', {
+            sceneId: SCENE_ID,
+            rendId: REND_ID,
+            targetKind: 'renderer',
+            coloringId: 'paint-type-paint',
+        })
+        unmount()
+    })
+
+    it('molecule mode shows the Coloring mol selector and commits through setRendererColoringTarget', async () => {
+        const { cm, container, unmount } = await mountWith(ISOSURF_MOLECULE_PAINT)
+        const select = findMolSelector(container)
+        expect(select).not.toBeNull()
+        expect(select!.value).toBe('mol1')
+        // The DensityMap must not be offered.
+        expect(select!.querySelector('option[value="map1"]')).toBeNull()
+        await act(async () => {
+            const setter = Object.getOwnPropertyDescriptor(
+                HTMLSelectElement.prototype, 'value',
+            )!.set!
+            setter.call(select!, 'mol2')
+            select!.dispatchEvent(new Event('change', { bubbles: true }))
+        })
+        await flushPromises()
+        expect(cm.invokeService).toHaveBeenCalledWith('setRendererColoringTarget', {
+            sceneId: SCENE_ID,
+            rendId: REND_ID,
+            targetKind: 'renderer',
+            targetName: 'mol2',
+        })
+        unmount()
+    })
+
+    it('the Coloring mol selector is hidden outside molecule mode', async () => {
+        const { container, unmount } = await mountWith(ISOSURF_SOLID)
+        expect(findMolSelector(container)).toBeNull()
+        unmount()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/colorPaneMultiGradWire.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/colorPaneMultiGradWire.test.tsx
@@ -2,10 +2,13 @@
  * Wire tests for the ColorPane Multi-gradient deck (UXP multigrad editor
  * port). Pins the observable renderer-side wire only:
  *
- *   - deck routing: multigrad colormode -> MultiGradSection; map renderer
- *     outside multigrad mode -> guidance note.
- *   - Coloring dropdown: map renderers offer only the Multi-gradient item;
- *     clicking it fires setRendererColoring with 'paint-type-multigrad'.
+ *   - deck routing: multigrad colormode -> MultiGradSection; a map renderer
+ *     without a `coloring` property (contour) outside multigrad mode ->
+ *     guidance note.
+ *   - Coloring dropdown: map renderers without `coloring` offer only the
+ *     Multi-gradient item; clicking it fires setRendererColoring with
+ *     'paint-type-multigrad'. (isosurf has `coloring` and offers the full
+ *     paint set -- pinned in colorPaneMolFancWire.test.tsx.)
  *   - toolbar: Add / Delete all / Preset fire setMultiGradNodes commits
  *     with the expected node payloads + labels.
  *   - Color map selector fires setMultiGradColorMap.
@@ -112,8 +115,8 @@ function makeCm(opts: {
                             objName: 'mtz1',
                             rendId: REND_ID,
                             targetKind: 'renderer',
-                            name: 'isosurf1',
-                            typeName: opts.surfaceTypeName ?? 'isosurf',
+                            name: 'contour1',
+                            typeName: opts.surfaceTypeName ?? 'contour',
                         },
                     ],
                 })
@@ -141,9 +144,10 @@ const MAP_REND_MULTIGRAD = {
     className: '',
     defaultColor: '',
     paintEntries: [],
-    surfaceType: 'isosurf',
+    surfaceType: 'contour',
     colormode: 'multigrad',
     multiGradCapable: true,
+    hasColoring: false,
 }
 
 async function mountWith(coloringState: Record<string, unknown>) {

--- a/tritium/react-gui/src/renderer/__test__/colorPaneWire.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/colorPaneWire.test.tsx
@@ -114,6 +114,8 @@ interface ColoringState {
     paintEntries?: Array<{ idx: number; selStr: string; colorValue: string }>
     surfaceType?: string
     colormode?: string
+    hasColoring?: boolean
+    molFancTarget?: string
     cpkColors?: Record<string, string>
     rainbowParams?: Record<string, unknown>
     bfacParams?: Record<string, unknown>
@@ -421,6 +423,8 @@ describe('ColorPane wire', () => {
             ok: true,
             className: 'SolidColoring',
             defaultColor: '#000000',
+            // The paint items are gated on the renderer exposing `coloring`.
+            hasColoring: true,
         })
         // Open the "Coloring" dropdown.
         const caret = container.querySelector(

--- a/tritium/react-gui/src/renderer/__test__/installMainCrashHandlers.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/installMainCrashHandlers.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pins the two behaviours the main-process crash funnel exists for:
+ *
+ *   1. A closed stdout pipe (`npm start | head`) must be swallowed, not turned
+ *      into an uncaught exception -- that is what popped the untranslatable
+ *      "A JavaScript error occurred in the main process" dialog.
+ *   2. An uncaught exception must also reach stderr, so a piped / headless run
+ *      keeps a copy of what the modal dialog shows.
+ *
+ * The module keeps a "stdio is dead" flag, so each test loads a fresh copy.
+ * Listeners are added to the real `process`, so each test removes exactly the
+ * ones it added and leaves the runner's own handlers untouched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// installMainCrashHandlers lives in src/main (tsconfig.node project). A
+// string-variable dynamic import keeps tsc's cross-project check (TS6307) off
+// this file while Vitest still resolves it at runtime -- same trick as
+// quitState.test.ts.
+const crashHandlersEntry = '../../main/installMainCrashHandlers'
+
+interface CrashHandlersModule {
+    installMainCrashHandlers(): void
+}
+
+type Listener = (...args: unknown[]) => void
+
+const TARGETS: Array<[NodeJS.EventEmitter, string]> = [
+    [process, 'uncaughtException'],
+    [process, 'unhandledRejection'],
+    [process.stdout, 'error'],
+    [process.stderr, 'error'],
+]
+
+/** Capture the listener sets that must be restored after each test. */
+function snapshot(): Listener[][] {
+    return TARGETS.map(([emitter, event]) => emitter.listeners(event) as Listener[])
+}
+
+function restore(before: Listener[][]): void {
+    TARGETS.forEach(([emitter, event], i) => {
+        const kept = new Set(before[i])
+        for (const fn of emitter.listeners(event) as Listener[]) {
+            if (!kept.has(fn)) emitter.removeListener(event, fn)
+        }
+    })
+}
+
+/** Load and run a pristine copy of the module (module-level flag reset). */
+async function install(): Promise<void> {
+    vi.resetModules()
+    const mod = (await import(crashHandlersEntry)) as CrashHandlersModule
+    mod.installMainCrashHandlers()
+}
+
+/** The single listener `install()` added for TARGETS[index]. */
+function addedListener(before: Listener[][], index: number): Listener {
+    const [emitter, event] = TARGETS[index]
+    const kept = new Set(before[index])
+    const added = (emitter.listeners(event) as Listener[]).filter((fn) => !kept.has(fn))
+    expect(added).toHaveLength(1)
+    return added[0]
+}
+
+const UNCAUGHT = 0
+
+function pipeError(): NodeJS.ErrnoException {
+    const err: NodeJS.ErrnoException = new Error('write EPIPE')
+    err.code = 'EPIPE'
+    return err
+}
+
+function spyStderrWrite() {
+    return vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+}
+
+describe('installMainCrashHandlers', () => {
+    let before: Listener[][]
+    let writeSpy: ReturnType<typeof spyStderrWrite>
+
+    beforeEach(() => {
+        before = snapshot()
+        writeSpy = spyStderrWrite()
+    })
+
+    afterEach(() => {
+        writeSpy.mockRestore()
+        restore(before)
+    })
+
+    it('swallows an EPIPE on stdout instead of letting it throw', async () => {
+        await install()
+
+        // Without a listener, emitting 'error' on an EventEmitter throws.
+        expect(() => process.stdout.emit('error', pipeError())).not.toThrow()
+        expect(writeSpy).not.toHaveBeenCalled()
+    })
+
+    it('reports an uncaught exception to stderr', async () => {
+        await install()
+
+        addedListener(before, UNCAUGHT)(new Error('boom'))
+
+        expect(writeSpy).toHaveBeenCalledTimes(1)
+        const line = String(writeSpy.mock.calls[0][0])
+        expect(line).toContain('uncaughtException')
+        expect(line).toContain('boom')
+    })
+
+    it('stops writing to stderr once the pipe is known to be broken', async () => {
+        await install()
+
+        process.stdout.emit('error', pipeError())
+        addedListener(before, UNCAUGHT)(new Error('boom'))
+
+        expect(writeSpy).not.toHaveBeenCalled()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/isosurfRendererSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/isosurfRendererSection.test.tsx
@@ -9,8 +9,8 @@
  *     section (default-expanded);
  *   - the curated rows render (Center update / Drawing mode / Line-Point size /
  *     Max grid size / Back-face culling / Use periodic boundary / Limit display
- *     by / Target / Selection / Distance) and unrelated props (coloring) are
- *     ignored;
+ *     by / Target / Selection / Distance) and unrelated props (colormode /
+ *     target / sel -- owned by the Coloring panel -- and siglevel) are ignored;
  *   - "Drawing mode" writes `drawmode`; Line/Point size is disabled while the
  *     mode is "fill" and enabled for line / point (UXP updateDisabledState);
  *   - "Max grid size" commits a single-step `max_grids`; "Back-face culling"
@@ -129,7 +129,10 @@ describe('IsosurfMainSection', () => {
   it('renders the curated rows and ignores unrelated (coloring) props', () => {
     const entries = [
       ...isosurfEntries(),
-      entry({ key: 'colormode', type: 'enum', value: 'solid', enumdef: ['solid'] }),
+      // Coloring props are owned by the Coloring panel, not this section.
+      entry({ key: 'colormode', type: 'enum', value: 'solid', enumdef: ['molecule', 'multigrad', 'solid'] }),
+      entry({ key: 'target', type: 'string', value: '' }),
+      entry({ key: 'sel', type: 'object<MolSelection>', value: '' }),
       entry({ key: 'siglevel', type: 'real', value: 1.1 }),
     ]
     const { container, unmount } = mountTree(

--- a/tritium/react-gui/src/renderer/__test__/rendererColoringService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/rendererColoringService.test.ts
@@ -14,6 +14,14 @@ interface MakeFixtureOpts {
     rendExists?: boolean
     /** Mock JSON returned by styleMgr.getStyleNamesJSON, keyed by sceneId. */
     styleNamesJSON?: Record<number, string>
+    /**
+     * When set, the renderer exposes a `target` property (MOLFANC reference
+     * mol) with this initial value; when omitted, reads yield undefined
+     * (renderer without the property).
+     */
+    initialTarget?: string
+    /** Top-level scene objects returned by scene.getSceneDataJSON. */
+    sceneObjects?: Array<{ type: string; name: string }>
 }
 
 function makeFixture(opts: MakeFixtureOpts = {}) {
@@ -28,11 +36,17 @@ function makeFixture(opts: MakeFixtureOpts = {}) {
     const resetProp = vi.fn()
     const setColoring = vi.fn()
     const setColormode = vi.fn()
+    const setTarget = vi.fn()
 
     let styleValue = initialStyle
     let colormodeValue = ''
+    let targetValue = opts.initialTarget ?? ''
 
-    const rend = {
+    const setProp = vi.fn((name: string, value: unknown) => {
+        if (name === 'target') { targetValue = String(value); setTarget(value) }
+    })
+
+    const rend: Record<string, unknown> = {
         // Plain accessors so the service can read/write style and properties.
         get style() { return styleValue },
         set style(v: string) { styleValue = v },
@@ -43,6 +57,13 @@ function makeFixture(opts: MakeFixtureOpts = {}) {
         get coloring() { return undefined },
         applyStyles,
         resetProp,
+        setProp,
+    }
+    if (opts.initialTarget !== undefined) {
+        Object.defineProperty(rend, 'target', {
+            get: () => targetValue,
+            set: (v: string) => { targetValue = v; setTarget(v) },
+        })
     }
 
     const startUndoTxn = vi.fn()
@@ -52,6 +73,12 @@ function makeFixture(opts: MakeFixtureOpts = {}) {
     const scene = {
         uid: 7,
         getRenderer: vi.fn(() => (rendExists ? rend : null)),
+        getSceneDataJSON: vi.fn(() => JSON.stringify([
+            { type: '', ID: 1, name: 'scene' },
+            ...(opts.sceneObjects ?? []).map((o, i) => ({
+                type: o.type, ID: 10 + i, name: o.name,
+            })),
+        ])),
         startUndoTxn,
         commitUndoTxn,
         rollbackUndoTxn,
@@ -70,6 +97,7 @@ function makeFixture(opts: MakeFixtureOpts = {}) {
 
     return {
         ctx, scene, rend, applyStyles, resetProp, setColoring, setColormode,
+        setTarget, setProp,
         createObj, getStyleNamesJSON, startUndoTxn, commitUndoTxn, rollbackUndoTxn,
         getStyle: () => styleValue,
     }
@@ -321,6 +349,97 @@ describe('setRendererColoring — Phase 1 new cases', () => {
     })
 })
 
+describe('setRendererColoring — isosurf (MOLFANC) cases', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('paint-type-paint forces colormode="molecule" and auto-picks the first MolCoord as target', () => {
+        const { ctx, setColormode, setTarget } = makeFixture({
+            typeName: 'isosurf',
+            initialTarget: '',
+            sceneObjects: [
+                { type: 'DensityMap', name: 'map1' },
+                { type: 'MolCoord', name: 'mol1' },
+                { type: 'MolCoord', name: 'mol2' },
+            ],
+        })
+        const res = services.setRendererColoring(ctx, baseArgs('paint-type-paint'))
+        expect(res).toEqual({ ok: true })
+        expect(setColormode).toHaveBeenCalledWith('molecule')
+        expect(setTarget).toHaveBeenCalledWith('mol1')
+    })
+
+    it('does not overwrite an already-set target', () => {
+        const { ctx, setColormode, setTarget } = makeFixture({
+            typeName: 'isosurf',
+            initialTarget: 'molX',
+            sceneObjects: [{ type: 'MolCoord', name: 'mol1' }],
+        })
+        services.setRendererColoring(ctx, baseArgs('paint-type-cpk'))
+        expect(setColormode).toHaveBeenCalledWith('molecule')
+        expect(setTarget).not.toHaveBeenCalled()
+    })
+
+    it('paint-type-solid resets coloring and switches colormode back to "solid"', () => {
+        const { ctx, resetProp, setColormode } = makeFixture({
+            typeName: 'isosurf',
+            initialTarget: '',
+        })
+        const res = services.setRendererColoring(ctx, baseArgs('paint-type-solid'))
+        expect(res).toEqual({ ok: true })
+        expect(resetProp).toHaveBeenCalledWith('coloring')
+        expect(setColormode).toHaveBeenCalledWith('solid')
+    })
+
+    it('paint-type-solid on molsurf does not touch colormode (unchanged behavior)', () => {
+        const { ctx, resetProp, setColormode } = makeFixture({ typeName: 'molsurf' })
+        services.setRendererColoring(ctx, baseArgs('paint-type-solid'))
+        expect(resetProp).toHaveBeenCalledWith('coloring')
+        expect(setColormode).not.toHaveBeenCalled()
+    })
+
+    it('paint-type-resetdef resets both coloring and colormode', () => {
+        const { ctx, resetProp } = makeFixture({
+            typeName: 'isosurf',
+            initialTarget: '',
+        })
+        services.setRendererColoring(ctx, baseArgs('paint-type-resetdef'))
+        expect(resetProp).toHaveBeenCalledWith('coloring')
+        expect(resetProp).toHaveBeenCalledWith('colormode')
+    })
+})
+
+describe('setRendererColoringTarget', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('writes the target name via setProp inside an undo txn', () => {
+        const { ctx, setProp, startUndoTxn, commitUndoTxn } = makeFixture({
+            typeName: 'isosurf',
+            initialTarget: '',
+        })
+        const res = services.setRendererColoringTarget(ctx, {
+            sceneId: 1,
+            rendId: 100,
+            targetKind: 'renderer',
+            targetName: 'mol2',
+        })
+        expect(res).toEqual({ ok: true })
+        expect(setProp).toHaveBeenCalledWith('target', 'mol2')
+        expect(startUndoTxn).toHaveBeenCalledWith('Change coloring target')
+        expect(commitUndoTxn).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses renderers without a target property', () => {
+        const { ctx, setProp } = makeFixture({ typeName: 'cartoon' })
+        const res = services.setRendererColoringTarget(ctx, {
+            sceneId: 1,
+            rendId: 100,
+            targetName: 'mol2',
+        })
+        expect(res).toEqual({ ok: false })
+        expect(setProp).not.toHaveBeenCalled()
+    })
+})
+
 // Helper to build a richer fixture: scene with getSceneDataJSON + per-renderer
 // coloring objects. Used by listPaintCapableRenderers and getRendererColoringState.
 interface PaintEntry { sel: string; color: string }
@@ -333,6 +452,12 @@ interface RendSpec {
     paintEntries?: PaintEntry[]
     /** Initial scalar properties on the coloring (CPK col_C, Rainbow mode, ...). */
     coloringProps?: Record<string, unknown>
+    /** When set, the renderer exposes a `colormode` property with this value. */
+    colormode?: string
+    /** When set, the renderer exposes a `target` property with this value. */
+    target?: string
+    /** When true, the renderer exposes a `multi_grad` property. */
+    multiGrad?: boolean
 }
 
 interface ObjectSpec {
@@ -449,7 +574,7 @@ function makeRichFixture(opts: MakeRichOpts) {
 
         const typeName =
             (spec as RendSpec).typeName ?? (spec as ObjectSpec).name ?? ''
-        const rend = {
+        const rend: Record<string, unknown> = {
             type_name: typeName,
             get coloring() {
                 return coloring
@@ -469,6 +594,11 @@ function makeRichFixture(opts: MakeRichOpts) {
             applyStyles,
             hasPropDefault,
         }
+        // Optional renderer-level props (MOLFANC / multigrad probes).
+        const rspec = spec as RendSpec
+        if (rspec.colormode !== undefined) rend.colormode = rspec.colormode
+        if (rspec.target !== undefined) rend.target = rspec.target
+        if (rspec.multiGrad) rend.multi_grad = { __mg: true }
 
         return {
             rend,
@@ -642,6 +772,54 @@ describe('getRendererColoringState', () => {
         expect(res.className).toBe('CPKColoring')
         expect(res.paintEntries).toEqual([])
         expect(rendWrappers.get(100)!.spies.getSelAt).not.toHaveBeenCalled()
+    })
+
+    it('reports hasColoring and the MOLFANC target for isosurf', () => {
+        const { ctx } = makeRichFixture({
+            objects: [{
+                id: 10, name: 'mtz1', rends: [{
+                    id: 100, name: 'iso1', typeName: 'isosurf',
+                    coloringClass: 'SolidColoring',
+                    colormode: 'molecule', target: 'mol1', multiGrad: true,
+                }],
+            }],
+        })
+        const res = services.getRendererColoringState(ctx, { sceneId: 1, rendId: 100 })
+        expect(res.ok).toBe(true)
+        expect(res.hasColoring).toBe(true)
+        expect(res.molFancTarget).toBe('mol1')
+    })
+
+    it('reports hasColoring:false and no molFancTarget for a plain map renderer', () => {
+        const { ctx } = makeRichFixture({
+            objects: [{
+                id: 10, name: 'mtz1', rends: [{
+                    id: 100, name: 'ctr1', typeName: 'contour',
+                    coloringClass: null,
+                    colormode: 'solid', multiGrad: true,
+                }],
+            }],
+        })
+        const res = services.getRendererColoringState(ctx, { sceneId: 1, rendId: 100 })
+        expect(res.hasColoring).toBe(false)
+        expect(res.molFancTarget).toBeUndefined()
+    })
+
+    it('does not expose an unrelated target prop as molFancTarget (no colormode)', () => {
+        // DisoRenderer-like: has coloring + a `target` that names a renderer,
+        // but no colormode -- the colormode gate must keep it out.
+        const { ctx } = makeRichFixture({
+            objects: [{
+                id: 10, name: 'mol1', rends: [{
+                    id: 100, name: 'diso1', typeName: 'disorder',
+                    coloringClass: 'SolidColoring',
+                    target: 'cartoon1',
+                }],
+            }],
+        })
+        const res = services.getRendererColoringState(ctx, { sceneId: 1, rendId: 100 })
+        expect(res.hasColoring).toBe(true)
+        expect(res.molFancTarget).toBeUndefined()
     })
 })
 

--- a/tritium/react-gui/src/renderer/__test__/useBusyCursor.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/useBusyCursor.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * Pins the observable contract of useBusyCursor: the busy flag shows up on the
+ * document root as `data-busy="true"`, which is what the global wait-cursor
+ * rule in styles/_base.css keys off. The attribute name and value are the wire
+ * format between the hook and the stylesheet, so they are what is asserted.
+ */
+
+import React from 'react'
+import { describe, it, expect, afterEach } from 'vitest'
+import { act } from 'react'
+import { mountTree } from './helpers/testHarness'
+import { useBusyCursor } from '../hooks/useBusyCursor'
+void React
+
+const Probe: React.FC<{ busy: boolean }> = ({ busy }) => {
+    useBusyCursor(busy)
+    return null
+}
+
+function busyAttr(): string | null {
+    return document.documentElement.getAttribute('data-busy')
+}
+
+describe('useBusyCursor', () => {
+    afterEach(() => {
+        document.documentElement.removeAttribute('data-busy')
+    })
+
+    it('sets data-busy on the document root while busy and clears it when idle', () => {
+        const { root, unmount } = mountTree(<Probe busy={false} />)
+        expect(busyAttr()).toBeNull()
+
+        act(() => root.render(<Probe busy={true} />))
+        expect(busyAttr()).toBe('true')
+
+        act(() => root.render(<Probe busy={false} />))
+        expect(busyAttr()).toBeNull()
+
+        unmount()
+    })
+
+    it('clears data-busy when unmounted while still busy', () => {
+        const { unmount } = mountTree(<Probe busy={true} />)
+        expect(busyAttr()).toBe('true')
+
+        unmount()
+        expect(busyAttr()).toBeNull()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/useRendererColoringState.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/useRendererColoringState.test.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 import { useRendererColoringState } from '../hooks/useRendererColoringState'
-import { SEM_OBJECT, SEM_RENDERER, SEM_ANY } from '../event'
+import { SEM_OBJECT, SEM_RENDERER, SEM_SCENE, SEM_ANY } from '../event'
 
 void React
 
@@ -117,13 +117,15 @@ describe('useRendererColoringState', () => {
         h.unmount()
     })
 
-    it('subscribes with SEM_OBJECT|SEM_RENDERER source mask scoped to the scene', async () => {
+    it('subscribes with SEM_OBJECT|SEM_RENDERER|SEM_SCENE source mask scoped to the scene', async () => {
+        // SEM_SCENE covers the bulk-load path: after a slow qsc load only the
+        // scene-level sceneLoaded event fires, and the deck must refetch on it.
         const cm = makeCm()
         const h = mountHook(cm)
         await flush()
         expect(cm.addEventListener).toHaveBeenCalledWith(
             '',
-            SEM_OBJECT | SEM_RENDERER,
+            SEM_OBJECT | SEM_RENDERER | SEM_SCENE,
             SEM_ANY,
             SCENE_ID,
             expect.any(Function),

--- a/tritium/react-gui/src/renderer/components/inspector/IsosurfRendererSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/IsosurfRendererSection.tsx
@@ -18,8 +18,14 @@
  * is disabled while the drawing mode is "fill" (it only matters for line/point
  * rendering). "Center update" and the "Limit display by" block are identical to
  * the contour renderer (both extend C++ `MapRenderer`) and come from
- * `MapRendererCommon`. Coloring and tuning props (`binning` / `glrender_mode` /
- * ...) are not on the UXP Map tab and stay out.
+ * `MapRendererCommon`. Tuning props (`binning` / `glrender_mode` / ...) are not
+ * on the UXP Map tab and stay out.
+ *
+ * @remarks Coloring is deliberately NOT on this section: the MOLFANC
+ * (colormode="molecule") coloring -- mode switch, reference molecule
+ * (`target`) and coloring scheme -- is edited in the Coloring panel
+ * (`ColorPane`), same as molsurf. The raw `colormode` / `target` / `sel`
+ * properties stay editable through the generic Properties tab.
  *
  * Backed by the same live getGenericProps / setGenericProp bridge as the common
  * page; each property is looked up by key and its row renders nothing when the

--- a/tritium/react-gui/src/renderer/components/inspector/MapRendererCommon.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/MapRendererCommon.tsx
@@ -135,31 +135,36 @@ export const CenterUpdateRow: React.FC<CenterUpdateRowProps> = ({
   );
 };
 
-interface LimitTargetRowProps {
+export interface MolTargetRowProps {
   entry: GenericPropEntry;
+  /** Row label (e.g. "Target", "Selection mol", "Coloring mol"). */
+  label: string;
+  /** Scene molecule (MolCoord) object names to offer. */
   names: string[];
-  disabled: boolean;
+  disabled?: boolean;
   onSet: SetFn;
   onReset: ResetFn;
 }
 
 /**
- * "Target" selector for the display-limit feature: lists the scene's molecule
- * objects (MolCoord interface) by name, committing the raw object-name string
- * into `bndry_molname`. The current value stays selectable even when the fetch
- * is empty or excludes it; an empty value shows a blank placeholder option (the
- * row is disabled while limiting is off).
+ * Molecule-target selector shared by the MapRenderer display-limit block and
+ * the reference-molecule (`target`) rows of surface-style renderers: lists the
+ * scene's molecule objects (MolCoord interface) by name, committing the raw
+ * object-name string into the given property. The current value stays
+ * selectable even when the fetch is empty or excludes it; an empty value shows
+ * a blank placeholder option.
  */
-const LimitTargetRow: React.FC<LimitTargetRowProps> = ({
+export const MolTargetRow: React.FC<MolTargetRowProps> = ({
   entry,
+  label,
   names,
-  disabled,
+  disabled = false,
   onSet,
   onReset,
 }) => {
   const current = String(entry.value ?? "");
   return (
-    <PropertyField label="Target" {...resetProps(entry, onReset)}>
+    <PropertyField label={label} {...resetProps(entry, onReset)}>
       <SelectField
         value={current}
         disabled={disabled || entry.readonly}
@@ -245,8 +250,9 @@ export const LimitDisplayRows: React.FC<LimitDisplayRowsProps> = ({
       <PropertyField label="Limit display by" inline>
         <SwitchField checked={limitOn} onChange={toggleLimit} />
       </PropertyField>
-      <LimitTargetRow
+      <MolTargetRow
         entry={bndryMol}
+        label="Target"
         names={molNames}
         disabled={!limitOn}
         onSet={onSet}

--- a/tritium/react-gui/src/renderer/components/inspector/MolSurfRendererSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/MolSurfRendererSection.tsx
@@ -29,14 +29,10 @@
  */
 
 import React from "react";
-import { NumRow, SelRow, MappedEnumRow, resetProps } from "./RendererCommonSection";
-import { useMolObjectNames } from "./MapRendererCommon";
-import { PropertyField, SelectField } from "../../h3-kit/form";
+import { NumRow, SelRow, MappedEnumRow } from "./RendererCommonSection";
+import { MolTargetRow, useMolObjectNames } from "./MapRendererCommon";
 import type { GenericPropEntry } from "../../worker/server/services/genericProps.service";
 import type { RendererPropSectionProps } from "./rendererPropSections";
-
-type SetFn = RendererPropSectionProps["onSet"];
-type ResetFn = RendererPropSectionProps["onReset"];
 
 /** Drawing-mode labels, shared with the dsurface surface section. */
 const DRAWMODE_LABELS: Record<string, string> = {
@@ -52,44 +48,6 @@ const COLORMODE_LABELS: Record<string, string> = {
   multigrad: "Multi-gradient",
 };
 
-interface TargetRowProps {
-  entry: GenericPropEntry;
-  sceneId: number | undefined;
-  onSet: SetFn;
-  onReset: ResetFn;
-}
-
-/**
- * "Selection mol" selector: lists the scene's molecule (MolCoord) objects by
- * name, committing the raw object-name string into `target` (the reference
- * molecule for the surface). The current value stays selectable even when the
- * fetch is empty or excludes it; an empty value shows a blank placeholder.
- */
-const TargetRow: React.FC<TargetRowProps> = ({ entry, sceneId, onSet, onReset }) => {
-  const names = useMolObjectNames(sceneId);
-  const current = String(entry.value ?? "");
-  return (
-    <PropertyField label="Selection mol" {...resetProps(entry, onReset)}>
-      <SelectField
-        value={current}
-        disabled={entry.readonly}
-        onChange={(v) => onSet(entry.key, entry.type, v)}
-      >
-        {current === "" && <option value="" />}
-        {/* Keep the current value selectable even if it is not in the list. */}
-        {current !== "" && !names.includes(current) && (
-          <option value={current}>{current}</option>
-        )}
-        {names.map((n) => (
-          <option key={n} value={n}>
-            {n}
-          </option>
-        ))}
-      </SelectField>
-    </PropertyField>
-  );
-};
-
 /**
  * "MolSurf" section: drawing mode, line/point size, the reference-molecule
  * target, the shown selection and the coloring mode.
@@ -101,6 +59,7 @@ export const MolSurfMainSection: React.FC<RendererPropSectionProps> = ({
   sceneId,
 }) => {
   const get = (key: string) => entries.find((e: GenericPropEntry) => e.key === key);
+  const molNames = useMolObjectNames(sceneId);
 
   const drawmode = get("drawmode");
   const width = get("width");
@@ -138,7 +97,13 @@ export const MolSurfMainSection: React.FC<RendererPropSectionProps> = ({
         />
       )}
       {target && (
-        <TargetRow entry={target} sceneId={sceneId} onSet={onSet} onReset={onReset} />
+        <MolTargetRow
+          entry={target}
+          label="Selection mol"
+          names={molNames}
+          onSet={onSet}
+          onReset={onReset}
+        />
       )}
       {showsel && (
         <SelRow

--- a/tritium/react-gui/src/renderer/components/inspector/rendererPropSections.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/rendererPropSections.tsx
@@ -318,7 +318,9 @@ export const RENDERER_SECTION_REGISTRY: Record<string, RendererPropSectionDef[]>
   // MapSurfRenderer ("isosurf"): UXP isosurf-propdlg "Map" tab. One section --
   // drawing mode, line/point size (off for fill), max grid size, back-face
   // culling, plus the Center update / Limit display block shared with contour
-  // (both extend MapRenderer). Coloring / tuning props stay out.
+  // (both extend MapRenderer). Coloring (colormode / target / MOLFANC scheme)
+  // is owned by the Coloring panel (ColorPane), same as molsurf; tuning props
+  // stay out.
   isosurf: [
     {
       key: "isosurf-main",

--- a/tritium/react-gui/src/renderer/components/panes/ColorPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/ColorPane.tsx
@@ -57,12 +57,14 @@ import type {
     PaintEntryDto,
     RainbowParams,
 } from '../../worker/server/services/rendererColoring.service'
+import type { SceneObjectEntry } from '../../worker/server/services/listSceneObjects.service'
 import { CueColorField } from '../../h3-kit/colorpicker/CueColorField'
 import { ColorPickerProvider } from '../../h3-kit/colorpicker/ColorPickerContext'
 import { MultiGradSection } from '../multigrad/MultiGradSection'
 import { usePaintCapableRenderers } from '../../hooks/usePaintCapableRenderers'
 import { useRendererColoringState } from '../../hooks/useRendererColoringState'
 import { useElePotMapObjects } from '../../hooks/useElePotMapObjects'
+import { useMolCoordObjects } from '../../hooks/useMolCoordObjects'
 import { PaintSelCell } from './PaintSelCell'
 import { fireService } from '../../utils/fireService'
 
@@ -683,9 +685,18 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
     const isElepotActive = isSurface && state?.colormode === 'potential'
     const multiGradCapable = state?.multiGradCapable === true
     const isMultiGradActive = multiGradCapable && state?.colormode === 'multigrad'
-    // Map renderers (contour / isosurf / gpu_*) carry a multi_grad gradient
-    // but no `coloring` property, so none of the coloring-class decks apply.
-    const isMapRenderer = multiGradCapable && !isSurface
+    // UXP `'coloring' in rend`: gates the Paint/CPK/Bfac/Rainbow/Reset items.
+    const hasColoring = state?.hasColoring === true
+    // Map renderers without a `coloring` property (contour / gpu_*) carry a
+    // multi_grad gradient only, so none of the coloring-class decks apply.
+    // The isosurf map renderer has `coloring` (MOLFANC) and is NOT in this
+    // group -- it routes through the coloring-class decks like molsurf.
+    const isMapRenderer = multiGradCapable && !hasColoring
+    // MOLFANC (molecule colormode): the renderer colors by its reference
+    // molecule (`target` property); show the "Coloring mol" selector.
+    const molFancTarget = state?.molFancTarget
+    const isMolFancActive =
+        molFancTarget !== undefined && state?.colormode === 'molecule'
 
     // Fetch the ElePotMap object list only while the Elepot deck is active;
     // outside of that the dropdown is hidden and the listener would burn
@@ -694,6 +705,14 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
         cm,
         sceneId,
         enabled: isElepotActive,
+    })
+
+    // Molecule list for the "Coloring mol" selector; fetched only while a
+    // molecule-colormode renderer is selected (same gating as Elepot).
+    const { objects: molObjects } = useMolCoordObjects({
+        cm,
+        sceneId,
+        enabled: isMolFancActive,
     })
 
     // -- Mutation handlers --
@@ -836,6 +855,22 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
         [cm, requireTarget],
     )
 
+    /**
+     * "Coloring mol" selector commit: write the MOLFANC reference-molecule
+     * name into the renderer's `target` property.
+     */
+    const onSetColoringTarget = useCallback(
+        (targetName: string) => {
+            const t = requireTarget()
+            if (!t || !cm) return
+            fireService(cm, 'setRendererColoringTarget', {
+                ...t,
+                targetName,
+            })
+        },
+        [cm, requireTarget],
+    )
+
     // -- Deck routing --
     const renderDeck = (): React.ReactNode => {
         if (sceneId === undefined || target === null) {
@@ -873,9 +908,10 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
                 </div>
             )
         }
-        // A map renderer outside multigrad mode has no editable coloring
-        // here (its solid color lives in the Density map panel), so guide
-        // the user to the mode switch instead of showing a wrong deck.
+        // A map renderer without a `coloring` property (contour / gpu_*) has
+        // no editable coloring outside multigrad mode (its solid color lives
+        // in the Density map panel), so guide the user to the mode switch
+        // instead of showing a wrong deck.
         if (isMapRenderer) {
             return (
                 <div className="color-deck-scroll">
@@ -900,44 +936,78 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
                 />
             )
         }
-        if (className === PAINT_DECK_CLASS) {
-            return (
-                <PaintTable
-                    entries={entries}
-                    selectedIdx={selectedRow}
-                    onSelect={setSelectedRow}
-                    onAdd={onAddRow}
-                    onRemove={onRemoveRow}
-                    onMoveUp={() => onMoveRow('up')}
-                    onMoveDown={() => onMoveRow('down')}
-                    onUpdate={onUpdateCell}
-                    sceneId={sceneId}
-                    molId={parentMolId}
-                />
-            )
+        // MOLFANC (molecule colormode): the coloring-class decks below color
+        // by the nearest atom of the reference molecule; show a selector for
+        // it above the deck. Same sentinel-option shape as the Elepot
+        // "Potential" selector so a stale / removed target stays visible.
+        const molFancSelector = isMolFancActive ? (
+            <Field label="Coloring mol" inline>
+                <SelectField
+                    value={molFancTarget}
+                    disabled={molObjects.length === 0}
+                    onChange={onSetColoringTarget}
+                >
+                    {molObjects.find((o) => o.name === molFancTarget) === undefined && (
+                        <option value={molFancTarget}>
+                            {molFancTarget || '(no molecule selected)'}
+                        </option>
+                    )}
+                    {molObjects.map((o: SceneObjectEntry) => (
+                        <option key={o.uid} value={o.name}>
+                            {o.name}
+                        </option>
+                    ))}
+                </SelectField>
+            </Field>
+        ) : null
+        const renderClassDeck = (): React.ReactNode => {
+            if (className === PAINT_DECK_CLASS) {
+                return (
+                    <PaintTable
+                        entries={entries}
+                        selectedIdx={selectedRow}
+                        onSelect={setSelectedRow}
+                        onAdd={onAddRow}
+                        onRemove={onRemoveRow}
+                        onMoveUp={() => onMoveRow('up')}
+                        onMoveDown={() => onMoveRow('down')}
+                        onUpdate={onUpdateCell}
+                        sceneId={sceneId}
+                        molId={parentMolId}
+                    />
+                )
+            }
+            if (SOLID_DECK_CLASSES.has(className)) {
+                return (
+                    <SolidDeck
+                        className={className}
+                        defaultColor={defaultColor}
+                        onCommit={onDefaultColorCommit}
+                    />
+                )
+            }
+            if (className === 'CPKColoring' && state.cpkColors) {
+                return <CpkDeck colors={state.cpkColors} onCommit={onSetColoringProp} />
+            }
+            if (className === 'RainbowColoring' && state.rainbowParams) {
+                return <RainbowDeck params={state.rainbowParams} onCommit={onSetColoringProp} />
+            }
+            if (className === 'BfacColoring' && state.bfacParams) {
+                return <BfacDeck params={state.bfacParams} onCommit={onSetColoringProp} />
+            }
+            return <DeferredDeck className={className} />
         }
-        if (SOLID_DECK_CLASSES.has(className)) {
-            return (
-                <SolidDeck
-                    className={className}
-                    defaultColor={defaultColor}
-                    onCommit={onDefaultColorCommit}
-                />
-            )
-        }
-        if (className === 'CPKColoring' && state.cpkColors) {
-            return <CpkDeck colors={state.cpkColors} onCommit={onSetColoringProp} />
-        }
-        if (className === 'RainbowColoring' && state.rainbowParams) {
-            return <RainbowDeck params={state.rainbowParams} onCommit={onSetColoringProp} />
-        }
-        if (className === 'BfacColoring' && state.bfacParams) {
-            return <BfacDeck params={state.bfacParams} onCommit={onSetColoringProp} />
-        }
-        return <DeferredDeck className={className} />
+        return (
+            <>
+                {molFancSelector}
+                {renderClassDeck()}
+            </>
+        )
     }
 
-    const dropdownDisabled = target === null
+    // Also disabled while the first coloring-state fetch is in flight, so
+    // the dropdown never opens with capability flags still unknown.
+    const dropdownDisabled = target === null || state === null
 
     return (
         <ColorPickerProvider cm={cm} sceneId={sceneId}>
@@ -963,19 +1033,24 @@ export const ColorPane: React.FC<ColorPaneProps> = ({
                             content={
                                 <Menu>
                                     {COLORING_MODE_ITEMS
-                                        // UXP `setupColoringSelector` hides
-                                        // the Electrostatic-potential item on
-                                        // non-surface renderers; do the same
-                                        // here so the dropdown matches the
-                                        // active target's capabilities. Map
-                                        // renderers have no `coloring` prop,
-                                        // so only the Multi-gradient item
-                                        // applies to them.
+                                        // UXP `setupColoringSelector` gates:
+                                        // the Paint/CPK/Bfac/Rainbow/Solid/
+                                        // Reset items require a `coloring`
+                                        // property ('coloring' in rend), the
+                                        // Multi-gradient item a `multi_grad`
+                                        // property, and Electrostatic
+                                        // potential additionally a surface
+                                        // renderer. Map renderers without
+                                        // `coloring` (contour / gpu_*) offer
+                                        // only Multi-gradient; isosurf has
+                                        // `coloring` (MOLFANC) and offers
+                                        // the full paint set.
                                         .filter((it) =>
-                                            isMapRenderer
-                                                ? it.multigradOnly
-                                                : (!it.surfaceOnly || isSurface) &&
-                                                  (!it.multigradOnly || multiGradCapable))
+                                            it.multigradOnly
+                                                ? multiGradCapable
+                                                : it.surfaceOnly
+                                                  ? hasColoring && isSurface
+                                                  : hasColoring)
                                         .map((it, i) => (
                                             <MenuItem
                                                 key={i}

--- a/tritium/react-gui/src/renderer/hooks/useBusyCursor.ts
+++ b/tritium/react-gui/src/renderer/hooks/useBusyCursor.ts
@@ -1,0 +1,38 @@
+/**
+ * @file renderer/hooks/useBusyCursor.ts
+ * @description Reflects the CueMol busy state onto the document root as a
+ * `data-busy` attribute, which `styles/_base.css` turns into a global wait
+ * cursor.
+ *
+ * The status bar sits at the very bottom of the window, far from where the
+ * user is looking (3D viewport, side panels), so the "Busy" label alone is
+ * easy to miss. Changing the pointer itself signals the wait regardless of
+ * where the cursor is.
+ *
+ * The hook takes `busy` as a parameter instead of calling `useCueMolBusy()`
+ * itself: every `useCueMolBusy()` call opens its own worker subscription and
+ * its own debounce timer, so App passes down the single value it already has.
+ */
+
+import { useEffect } from 'react';
+
+/** Attribute set on `<html>` while the worker is busy. */
+const BUSY_ATTR = 'data-busy';
+
+/**
+ * Apply/remove the global busy cursor.
+ *
+ * @param busy - Debounced busy flag, normally from `useCueMolBusy()`.
+ */
+export function useBusyCursor(busy: boolean): void {
+    useEffect(() => {
+        if (!busy) return;
+        const root = document.documentElement;
+        root.setAttribute(BUSY_ATTR, 'true');
+        // Runs both when busy falls back to false and on unmount, so the
+        // attribute can never be left stuck on.
+        return () => {
+            root.removeAttribute(BUSY_ATTR);
+        };
+    }, [busy]);
+}

--- a/tritium/react-gui/src/renderer/hooks/useMolCoordObjects.ts
+++ b/tritium/react-gui/src/renderer/hooks/useMolCoordObjects.ts
@@ -1,0 +1,84 @@
+/**
+ * @file hooks/useMolCoordObjects.ts
+ * @description Live list of molecule (MolCoord) objects in the active scene,
+ * used by the Coloring panel's "Coloring mol" selector shown in molecule
+ * colormode (MOLFANC nearest-atom coloring).
+ *
+ * Fetches via `listSceneObjects` + the client-side `objectFilters.molCoord`
+ * filter and refetches on SEM_OBJECT events so the dropdown stays in sync
+ * when a molecule is added, renamed or removed.
+ */
+
+import { useRef } from 'react'
+import type { AsyncCueMol } from '../worker/client/AsyncCueMol'
+import type { SceneObjectEntry } from '../worker/server/services/listSceneObjects.service'
+import { objectFilters } from '../h3-kit/ObjectSelect'
+import { SEM_OBJECT, SEM_ANY } from '../event'
+import { useLiveFetch } from './useLiveFetch'
+
+const EMPTY: SceneObjectEntry[] = []
+
+const REFETCH_DEBOUNCE_MS = 30
+
+export interface UseMolCoordObjectsOptions {
+    cm: AsyncCueMol | null
+    sceneId: number | undefined
+    /** Skip the subscription + fetch entirely when false (selector hidden). */
+    enabled: boolean
+}
+
+export interface UseMolCoordObjectsResult {
+    objects: SceneObjectEntry[]
+    refetch: () => void
+}
+
+/**
+ * Fetch + auto-refresh MolCoord objects in the active scene.
+ *
+ * Returns an empty array until the first fetch resolves or when `enabled`
+ * is false. The list is recomputed on a 30ms debounce after object events
+ * to coalesce bursts.
+ */
+export function useMolCoordObjects({
+    cm,
+    sceneId,
+    enabled,
+}: UseMolCoordObjectsOptions): UseMolCoordObjectsResult {
+    const sceneIdRef = useRef<number | undefined>(sceneId)
+    sceneIdRef.current = sceneId
+    const enabledRef = useRef(enabled)
+    enabledRef.current = enabled
+
+    const { state: objects, refetch } = useLiveFetch<SceneObjectEntry[]>({
+        cm,
+        initial: EMPTY,
+        fallback: EMPTY,
+        fetch: () => {
+            const sid = sceneIdRef.current
+            if (!cm || sid === undefined || !enabledRef.current) return null
+            return cm
+                .invokeService('listSceneObjects', { sceneId: sid })
+                .then((res) =>
+                    (res?.objects ?? EMPTY).filter((o: SceneObjectEntry) =>
+                        objectFilters.molCoord(o),
+                    ),
+                )
+                .catch((err: unknown) => {
+                    console.warn('listSceneObjects failed:', err)
+                    return EMPTY
+                })
+        },
+        fetchDeps: [sceneId, enabled],
+        listeners: [
+            {
+                enabled: enabled && sceneId !== undefined,
+                srcMask: SEM_OBJECT,
+                evtMask: SEM_ANY,
+                scopeId: sceneId ?? -1,
+                debounceMs: REFETCH_DEBOUNCE_MS,
+            },
+        ],
+    })
+
+    return { objects, refetch }
+}

--- a/tritium/react-gui/src/renderer/hooks/usePaintCapableRenderers.ts
+++ b/tritium/react-gui/src/renderer/hooks/usePaintCapableRenderers.ts
@@ -14,10 +14,14 @@
 import { useRef } from 'react'
 import type { AsyncCueMol } from '../worker/client/AsyncCueMol'
 import type { PaintCapableRendererEntry } from '../worker/server/services/rendererColoring.service'
-import { SEM_OBJECT, SEM_RENDERER, SEM_ANY } from '../event'
+import { SEM_OBJECT, SEM_RENDERER, SEM_SCENE, SEM_ANY } from '../event'
 import { useLiveFetch } from './useLiveFetch'
 
-const SCENE_EVENT_MASK = SEM_OBJECT | SEM_RENDERER
+// SEM_SCENE is included for the bulk-load path: a slow qsc load fires no
+// per-object ADDED events the pane can use (the first fetch resolves before
+// the backend finishes), so the scene-level sceneLoaded event is the only
+// signal to refetch the list.
+const SCENE_EVENT_MASK = SEM_OBJECT | SEM_RENDERER | SEM_SCENE
 const REFETCH_DEBOUNCE_MS = 30
 const EMPTY: PaintCapableRendererEntry[] = []
 

--- a/tritium/react-gui/src/renderer/hooks/useRendererColoringState.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRendererColoringState.ts
@@ -15,14 +15,17 @@ import type {
     ColoringTargetKind,
     GetRendererColoringStateResult,
 } from '../worker/server/services/rendererColoring.service'
-import { SEM_OBJECT, SEM_RENDERER, SEM_ANY } from '../event'
+import { SEM_OBJECT, SEM_RENDERER, SEM_SCENE, SEM_ANY } from '../event'
 import { useLiveFetch } from './useLiveFetch'
 
 const REFETCH_DEBOUNCE_MS = 30
 // Listen for renderer events when editing a renderer's coloring and for
 // object events when editing an object's coloring. Combining the masks
 // keeps the subscription wire identical regardless of target kind.
-const COLORING_EVENT_MASK = SEM_OBJECT | SEM_RENDERER
+// SEM_SCENE covers the bulk-load path (sceneLoaded after a slow qsc load,
+// which fires no per-renderer events) -- scene events carry no propname so
+// they pass the refetch filter below.
+const COLORING_EVENT_MASK = SEM_OBJECT | SEM_RENDERER | SEM_SCENE
 
 /**
  * Renderer-level props that the Elepot / Multi-gradient decks read.
@@ -40,6 +43,9 @@ const DECK_REFETCH_PROPS = new Set<string>([
     // Multi-gradient deck: gradient nodes + color-map binding
     'multi_grad',
     'color_mapname',
+    // MOLFANC (molecule colormode): reference mol + atom-map selection
+    'target',
+    'sel',
 ])
 
 export interface UseRendererColoringStateOptions {
@@ -63,6 +69,7 @@ const EMPTY_STATE: GetRendererColoringStateResult = {
     surfaceType: '',
     colormode: '',
     multiGradCapable: false,
+    hasColoring: false,
 }
 
 /**

--- a/tritium/react-gui/src/renderer/styles/_base.css
+++ b/tritium/react-gui/src/renderer/styles/_base.css
@@ -35,6 +35,17 @@ body {
   height: 100%;
 }
 
+/* --- Busy cursor --- */
+/* The CueMol worker is single-threaded: while a tracked RPC is in flight the
+   whole UI is stale, so signal it on the pointer as well as in the status bar.
+   The universal selector and !important are required because nearly every
+   interactive element declares its own cursor (buttons, tree rows, the render
+   image viewer's grab, the rect-select overlay's crosshair, ...). */
+:root[data-busy="true"],
+:root[data-busy="true"] * {
+  cursor: wait !important;
+}
+
 /* ─── Scrollbars ─── */
 ::-webkit-scrollbar {
   width: 8px;

--- a/tritium/react-gui/src/renderer/worker/server/services/coloring/applyColoring.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/coloring/applyColoring.ts
@@ -11,6 +11,7 @@ import type { Renderer } from '@cuemol/core/src/wrappers/Renderer';
 import type { MolRenderer } from '@cuemol/core/src/wrappers/MolRenderer';
 import type { ColoringScheme } from '@cuemol/core/src/wrappers/ColoringScheme';
 import type { AbstractColor } from '@cuemol/core/src/wrappers/AbstractColor';
+import type { Scene } from '@cuemol/core/src/wrappers/Scene';
 import type { WorkerContext } from '../../types/WorkerContext';
 import { withUndoTxn } from '../withUndoTxn';
 import { getSceneOrNull } from '../helpers/sceneResolver';
@@ -19,11 +20,14 @@ import { makeColor } from '../helpers/makeColor';
 import {
     resolveColoringTarget,
     isMolSurf,
+    isMapSurf,
     isElepotCapable,
     isMultiGradCapable,
     getMultiGradOrNull,
     getColoringClassName,
     materializeColoringIfDefault,
+    readMolFancTargetOrNull,
+    findFirstMolCoordName,
 } from './colorTargets';
 import { findFirstElePotMapName } from './elepotWriter';
 import {
@@ -39,7 +43,29 @@ import type {
     SetRendererDefaultColorResult,
     SetColoringPropArgs,
     SetColoringPropResult,
+    SetRendererColoringTargetArgs,
+    SetRendererColoringTargetResult,
 } from './types';
+
+/**
+ * Force `colormode = "molecule"` on renderers whose coloring only applies
+ * in molecule mode (molsurf's MOLFANC, and the isosurf map renderer's
+ * nearest-atom coloring). On these renderers the MOLFANC path also needs a
+ * reference molecule, so when `target` is still empty the scene's first
+ * MolCoord is picked as a sensible default (mirrors the elepot default in
+ * `paint-type-elepot`). No-op for every other renderer.
+ */
+function forceMoleculeColormode(scene: Scene, rend: Renderer): void {
+    if (!isMolSurf(rend) && !isMapSurf(rend)) return;
+    (rend as unknown as { colormode: string }).colormode = 'molecule';
+    const target = readMolFancTargetOrNull(rend);
+    if (target === '') {
+        const name = findFirstMolCoordName(scene);
+        if (name) {
+            (rend as unknown as { target: string }).target = name;
+        }
+    }
+}
 
 /**
  * Apply a `style-XXX` coloring style.
@@ -47,36 +73,33 @@ import type {
  * Steps mirror UXP:
  *   1. strip existing `*Paint$` entries from rend.style,
  *   2. push the new style name,
- *   3. on molsurf, force colormode = "molecule" (the surface ignores
- *      coloring when colormode != "molecule"),
+ *   3. on molsurf / isosurf, force colormode = "molecule" (the surface
+ *      ignores coloring when colormode != "molecule"),
  *   4. resetProp("coloring") so the new style's coloring takes effect,
  *   5. applyStyles(newStyle).
  */
-function applyStyleColoring(rend: Renderer, styleName: string): void {
+function applyStyleColoring(scene: Scene, rend: Renderer, styleName: string): void {
     const curStyle = rend.style ?? '';
     const stripped = styleRemove(curStyle, /Paint$/);
     const newStyle = stylePush(stripped, styleName);
 
-    if (isMolSurf(rend)) {
-        (rend as unknown as { colormode: string }).colormode = 'molecule';
-    }
+    forceMoleculeColormode(scene, rend);
     rend.resetProp('coloring');
     rend.applyStyles(newStyle);
 }
 
 /**
  * Apply a `paint-type-XXX` coloring by instantiating a fresh coloring object
- * and assigning it. On molsurf, also force colormode = "molecule".
+ * and assigning it. On molsurf / isosurf, also force colormode = "molecule".
  */
 function applyObjColoring(
     ctx: WorkerContext,
+    scene: Scene,
     rend: Renderer,
     coloringClassName: string,
 ): void {
     const coloring = ctx.svc.createObj(coloringClassName) as ColoringScheme;
-    if (isMolSurf(rend)) {
-        (rend as unknown as { colormode: string }).colormode = 'molecule';
-    }
+    forceMoleculeColormode(scene, rend);
     (rend as unknown as MolRenderer).coloring = coloring;
 }
 
@@ -150,7 +173,7 @@ export function setRendererColoring(
         const styleName = args.coloringId.substring('style-'.length);
         if (!styleName) return { ok: false };
         withUndoTxn(scene, 'Change coloring style', () => {
-            applyStyleColoring(rend, styleName);
+            applyStyleColoring(scene, rend, styleName);
         });
         return { ok: true };
     }
@@ -158,31 +181,47 @@ export function setRendererColoring(
     switch (args.coloringId) {
         case 'paint-type-bfac':
             withUndoTxn(scene, 'Change coloring', () => {
-                applyObjColoring(ctx, rend, 'BfacColoring');
+                applyObjColoring(ctx, scene, rend, 'BfacColoring');
             });
             return { ok: true };
         case 'paint-type-rainbow':
             withUndoTxn(scene, 'Change coloring', () => {
-                applyObjColoring(ctx, rend, 'RainbowColoring');
+                applyObjColoring(ctx, scene, rend, 'RainbowColoring');
             });
             return { ok: true };
         case 'paint-type-paint':
             withUndoTxn(scene, 'Change coloring', () => {
-                applyObjColoring(ctx, rend, 'PaintColoring');
+                applyObjColoring(ctx, scene, rend, 'PaintColoring');
             });
             return { ok: true };
         case 'paint-type-cpk':
             withUndoTxn(scene, 'Change coloring', () => {
-                applyObjColoring(ctx, rend, 'CPKColoring');
+                applyObjColoring(ctx, scene, rend, 'CPKColoring');
             });
             return { ok: true };
         case 'paint-type-solid':
-        case 'paint-type-resetdef':
-            // UXP `setRendColoring`: both Solid and "Reset to default" route
-            // through `resetProp("coloring")`. The unknown deck then shows
-            // the renderer's defaultcolor picker.
+            // UXP `setRendColoring`: Solid routes through
+            // `resetProp("coloring")`; the unknown deck then shows the
+            // renderer's defaultcolor picker. On the isosurf map renderer
+            // the mesh color is governed by colormode, so also switch it
+            // back to "solid" -- otherwise the MOLFANC nearest-atom path
+            // keeps overriding the solid color.
             withUndoTxn(scene, 'Reset coloring', () => {
                 rend.resetProp('coloring');
+                if (isMapSurf(rend)) {
+                    (rend as unknown as { colormode: string }).colormode = 'solid';
+                }
+            });
+            return { ok: true };
+        case 'paint-type-resetdef':
+            // "Reset to default style": restore the style-inherited coloring.
+            // On isosurf also reset colormode to its default ("solid") so the
+            // renderer returns to its true default state.
+            withUndoTxn(scene, 'Reset coloring', () => {
+                rend.resetProp('coloring');
+                if (isMapSurf(rend)) {
+                    rend.resetProp('colormode');
+                }
             });
             return { ok: true };
         case 'paint-type-multigrad':
@@ -298,6 +337,30 @@ export function setColoringProp(
         const live = (rend as unknown as MolRenderer).coloring;
         if (!live) return;
         live.setProp(args.propName, value);
+    });
+    return { ok: true };
+}
+
+/**
+ * Write the MOLFANC reference-molecule name (`target` property) on a
+ * renderer. Drives the Coloring panel's "Coloring mol" selector shown in
+ * molecule colormode. Refuses on renderers without the `target` property.
+ */
+export function setRendererColoringTarget(
+    ctx: WorkerContext,
+    args: SetRendererColoringTargetArgs,
+): SetRendererColoringTargetResult {
+    const scene = getSceneOrNull(ctx, args.sceneId);
+    if (!scene) return { ok: false };
+    const rend = resolveColoringTarget(scene, args.targetKind, args.rendId);
+    if (!rend) return { ok: false };
+    if (readMolFancTargetOrNull(rend) === null) return { ok: false };
+
+    withUndoTxn(scene, 'Change coloring target', () => {
+        // `target` lives directly on the renderer's native wrapper; use the
+        // setProp escape hatch (same shape as setRendererElepotProp).
+        (rend as unknown as { setProp: (n: string, v: unknown) => void })
+            .setProp('target', args.targetName);
     });
     return { ok: true };
 }

--- a/tritium/react-gui/src/renderer/worker/server/services/coloring/colorTargets.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/coloring/colorTargets.ts
@@ -43,6 +43,70 @@ export function isMolSurf(rend: Renderer): boolean {
 }
 
 /**
+ * The isosurf map renderer (C++ `xtal::MapSurfRenderer`). It is the only
+ * map renderer with the MOLFANC (`colormode="molecule"`) nearest-atom
+ * coloring: it carries `coloring` / `target` / `sel` and a colormode
+ * enumdef that includes "solid". Keep this a type_name check -- duck-typing
+ * on `target` would misfire on renderers where the property means something
+ * else (e.g. DisoRenderer), and dsurface's colormode has no "solid" entry.
+ */
+export function isMapSurf(rend: Renderer): boolean {
+    return readTypeName(rend) === 'isosurf';
+}
+
+/**
+ * Duck-typed probe for the `coloring` (ColoringScheme) property on a
+ * renderer or object wrapper. Mirrors UXP `'coloring' in rend`, which
+ * gates the Paint/CPK/Bfac/Rainbow/Reset items and decks.
+ */
+export function hasColoringProp(t: unknown): boolean {
+    try {
+        const c = (t as { coloring?: unknown })?.coloring;
+        return c !== undefined;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Read the renderer's MOLFANC reference-molecule name (`target` property).
+ * Returns null when the renderer does not expose the property (the wrapper
+ * getter throws or yields a non-string).
+ */
+export function readMolFancTargetOrNull(rend: Renderer): string | null {
+    try {
+        const t = (rend as unknown as { target?: unknown }).target;
+        return typeof t === 'string' ? t : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Walk the scene's top-level objects and return the first MolCoord's name.
+ * Returns "" when the scene has none. Same shape as
+ * `elepotWriter.findFirstElePotMapName`; the class test matches the
+ * client-side `objectFilters.molCoord` (h3-kit/ObjectSelect).
+ */
+export function findFirstMolCoordName(scene: Scene): string {
+    try {
+        const parsed = JSON.parse(scene.getSceneDataJSON()) as unknown;
+        if (!Array.isArray(parsed)) return '';
+        for (let i = 1; i < parsed.length; i++) {
+            const obj = parsed[i] as { type?: string; name?: string };
+            const cls = obj?.type;
+            if (typeof cls !== 'string') continue;
+            if (cls === 'MolCoord' || cls.endsWith('Mol')) {
+                if (typeof obj.name === 'string') return obj.name;
+            }
+        }
+    } catch {
+        // Fall through to empty.
+    }
+    return '';
+}
+
+/**
  * Read `type_name` from a renderer; returns "" for wrappers that don't expose
  * the field (e.g. some renderer groups, or non-renderer objects).
  */

--- a/tritium/react-gui/src/renderer/worker/server/services/coloring/deckState.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/coloring/deckState.ts
@@ -22,6 +22,8 @@ import {
     isElepotCapable,
     isMultiGradCapable,
     getColoringClassName,
+    hasColoringProp,
+    readMolFancTargetOrNull,
 } from './colorTargets';
 import type {
     GetRendererColoringStateArgs,
@@ -216,7 +218,7 @@ export function getRendererColoringState(
         return {
             ok: false, className: '', defaultColor: '',
             paintEntries: [], surfaceType: '', colormode: '',
-            multiGradCapable: false,
+            multiGradCapable: false, hasColoring: false,
         };
     }
     const rend = resolveColoringTarget(scene, args.targetKind, args.rendId);
@@ -224,7 +226,7 @@ export function getRendererColoringState(
         return {
             ok: false, className: '', defaultColor: '',
             paintEntries: [], surfaceType: '', colormode: '',
-            multiGradCapable: false,
+            multiGradCapable: false, hasColoring: false,
         };
     }
 
@@ -239,6 +241,7 @@ export function getRendererColoringState(
     const colormode = isElepotCapable(rend) || multiGradCapable
         ? safeReadString(rend, 'colormode')
         : '';
+    const hasColoring = hasColoringProp(rend);
 
     const result: GetRendererColoringStateResult = {
         ok: true,
@@ -248,7 +251,17 @@ export function getRendererColoringState(
         surfaceType,
         colormode,
         multiGradCapable,
+        hasColoring,
     };
+
+    // MOLFANC reference-molecule name; the colormode gate keeps unrelated
+    // `target` properties (e.g. DisoRenderer's target renderer name) out.
+    if (colormode !== '') {
+        const molFancTarget = readMolFancTargetOrNull(rend);
+        if (molFancTarget !== null) {
+            result.molFancTarget = molFancTarget;
+        }
+    }
 
     // Elepot deck takes priority over the coloring class on surface renderers
     // (mirrors UXP `_setupData` which checks colormode === "potential" before

--- a/tritium/react-gui/src/renderer/worker/server/services/coloring/panelList.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/coloring/panelList.ts
@@ -8,7 +8,6 @@
  * Runs in the Web Worker thread; C++ wrappers are called synchronously.
  */
 import type { Renderer } from '@cuemol/core/src/wrappers/Renderer';
-import type { MolRenderer } from '@cuemol/core/src/wrappers/MolRenderer';
 import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
 import type { WorkerContext } from '../../types/WorkerContext';
 import { getSceneOrNull } from '../helpers/sceneResolver';
@@ -19,6 +18,7 @@ import {
     isSelEmpty,
     getColoringClassName,
     isMultiGradCapable,
+    hasColoringProp,
 } from './colorTargets';
 import type {
     GetPaintColoringStylesArgs,
@@ -116,18 +116,6 @@ interface RawSceneRendItem {
     childNodes?: RawSceneRendItem[];
 }
 
-function rendererHasColoringProp(rend: Renderer): boolean {
-    // The `paint_coloring_filter` UXP gate checks that the renderer exposes a
-    // `coloring` property. Wrapper getters throw for missing properties, so
-    // probe via the proxy and discard read-only errors.
-    try {
-        const c = (rend as unknown as MolRenderer).coloring;
-        return c !== undefined;
-    } catch {
-        return false;
-    }
-}
-
 function collectRendsRecursive(
     items: RawSceneRendItem[] | undefined,
     out: { id: number; name: string; typeName: string }[],
@@ -144,15 +132,6 @@ function collectRendsRecursive(
         if (Array.isArray(it.childNodes)) {
             collectRendsRecursive(it.childNodes, out);
         }
-    }
-}
-
-function objectHasColoringProp(obj: unknown): boolean {
-    try {
-        const c = (obj as { coloring?: unknown })?.coloring;
-        return c !== undefined;
-    } catch {
-        return false;
     }
 }
 
@@ -191,7 +170,7 @@ export function listPaintCapableRenderers(
         const obj = parsed[i] as RawSceneObjItem;
         if (typeof obj?.ID !== 'number') continue;
         const objWrap = scene.getObject(obj.ID);
-        if (objWrap && objectHasColoringProp(objWrap)) {
+        if (objWrap && hasColoringProp(objWrap)) {
             out.push({
                 targetKind: 'object',
                 rendId: obj.ID,
@@ -213,7 +192,7 @@ export function listPaintCapableRenderers(
             // Map renderers (contour / isosurf / gpu_*) have no `coloring`
             // property but are colorable via their `multi_grad` gradient, so
             // they qualify for the panel too.
-            if (!rendererHasColoringProp(rend) && !isMultiGradCapable(rend)) {
+            if (!hasColoringProp(rend) && !isMultiGradCapable(rend)) {
                 continue;
             }
             out.push({

--- a/tritium/react-gui/src/renderer/worker/server/services/coloring/types.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/coloring/types.ts
@@ -226,6 +226,18 @@ export interface GetRendererColoringStateResult {
     elepotParams?: ElepotParams;
     /** True iff the renderer exposes a `multi_grad` property. */
     multiGradCapable: boolean;
+    /**
+     * True iff the target exposes a `coloring` (ColoringScheme) property.
+     * Mirrors UXP `'coloring' in rend`; gates the Paint/CPK/Bfac/Rainbow/
+     * Reset dropdown items (map renderers without it offer only multigrad).
+     */
+    hasColoring: boolean;
+    /**
+     * MOLFANC reference-molecule name (renderer `target` property). Present
+     * only for renderers that expose both a colormode and the property
+     * (molsurf / dsurface / isosurf); drives the "Coloring mol" selector.
+     */
+    molFancTarget?: string;
 }
 
 export interface AddPaintEntryArgs {
@@ -332,6 +344,18 @@ export interface SetRendererElepotPropArgs {
 }
 
 export interface SetRendererElepotPropResult {
+    ok: boolean;
+}
+
+export interface SetRendererColoringTargetArgs {
+    sceneId: number;
+    rendId: number;
+    targetKind?: ColoringTargetKind;
+    /** MolCoord object name to write into the renderer's `target` property. */
+    targetName: string;
+}
+
+export interface SetRendererColoringTargetResult {
     ok: boolean;
 }
 

--- a/tritium/react-gui/src/renderer/worker/server/services/rendererColoring.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/rendererColoring.service.ts
@@ -28,6 +28,7 @@ import {
     setRendererColoring,
     setRendererDefaultColor,
     setColoringProp,
+    setRendererColoringTarget,
 } from './coloring/applyColoring';
 import {
     paintRendererSelection,
@@ -96,6 +97,8 @@ export type {
     ListElePotMapObjectsResult,
     SetRendererElepotPropArgs,
     SetRendererElepotPropResult,
+    SetRendererColoringTargetArgs,
+    SetRendererColoringTargetResult,
     MultiGradNodeDto,
     MultiGradWriteNode,
     MultiGradMapObjectEntry,
@@ -128,6 +131,7 @@ export const services = {
     setColoringProp,
     listElePotMapObjects,
     setRendererElepotProp,
+    setRendererColoringTarget,
     getMultiGradState,
     getMultiGradHistogram,
     setMultiGradNodes,

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -235,6 +235,8 @@ import type {
   ListElePotMapObjectsResult,
   SetRendererElepotPropArgs,
   SetRendererElepotPropResult,
+  SetRendererColoringTargetArgs,
+  SetRendererColoringTargetResult,
   GetMultiGradStateArgs,
   GetMultiGradStateResult,
   GetMultiGradHistogramArgs,
@@ -594,6 +596,7 @@ export interface ServiceMap {
   setColoringProp:            { args: SetColoringPropArgs;             result: SetColoringPropResult }
   listElePotMapObjects:       { args: ListElePotMapObjectsArgs;        result: ListElePotMapObjectsResult }
   setRendererElepotProp:      { args: SetRendererElepotPropArgs;       result: SetRendererElepotPropResult }
+  setRendererColoringTarget:  { args: SetRendererColoringTargetArgs;   result: SetRendererColoringTargetResult }
   getMultiGradState:          { args: GetMultiGradStateArgs;           result: GetMultiGradStateResult }
   getMultiGradHistogram:      { args: GetMultiGradHistogramArgs;       result: GetMultiGradHistogramResult }
   setMultiGradNodes:          { args: SetMultiGradNodesArgs;           result: SetMultiGradNodesResult }


### PR DESCRIPTION
## Summary
- Implement the isosurf (MapSurfRenderer) colormode="molecule" (MOLFANC) mode, previously declared in the enum/qif but never implemented: mesh vertices are colored by the nearest atom of a reference MolCoord, mirroring `surface::MolSurfRenderer`'s MOLFANC mode.
- Fix a latent bug where `setupXformMat()` (no-arg overload) skipped the map object's xform matrix, causing MULTIGRAD/MOLFANC color lookups (and `generateSurfObj()` output) to sample the wrong position on maps with a non-identity xform.
- Route isosurf's coloring editing through the Coloring panel (matching molsurf), instead of the Inspector — the Inspector only switches render options, while coloring schemes (Paint/CPK/Bfac/Rainbow/Solid) and the reference molecule live in `ColorPane`. An earlier Inspector-only pass left MOLFANC practically unusable since there was no way to pick a coloring scheme.
- Fix the Coloring panel getting stuck uninitialized after a slow qsc scene load (missing `SEM_SCENE` subscription meant no refetch after the bulk load finished).

## Test plan
- [x] `task run_gtest` — 1267/1267 passing (incl. new `test_mapsurf_molfanc.cpp`: xform-matrix regression + target-name resolution)
- [x] `cd tritium/react-gui && npm test` — 2735/2735 passing
- [x] `npx tsc -p tsconfig.web.json --noEmit` / `tsconfig.node.json --noEmit` — no new errors vs. baseline
- [x] `npm run lint:style` — no new errors vs. baseline
- [x] `task build_tritium` + `task run_tritium` — manual E2E verification by the user (Paint/CPK/Rainbow coloring on isosurf, Coloring mol selector, Solid/Multi-gradient round-trip, qsc load with a slow backend)