### PR TITLE
ci(windows): fetch win_flex_bison from GitHub releases instead of Chocolatey

### DIFF
--- a/build_scripts/build_libcuemol2_posix/action.yml
+++ b/build_scripts/build_libcuemol2_posix/action.yml
@@ -29,7 +29,43 @@ runs:
     if: runner.os == 'Windows'
     shell: powershell
     run: |
-      choco install -y -r winflexbison3
+      # win_flex/win_bison: fetched straight from the upstream GitHub release
+      # rather than via Chocolatey. The community feed rate-limits/rejects CI
+      # runners (499/503 responses), which broke this step repeatedly; GitHub
+      # is the same host the workflow already runs on. Pinned by version and
+      # SHA256 so the toolchain is reproducible.
+      # CMake's FindBISON/FindFLEX search for win_bison/win_flex by name, and
+      # win_bison locates its data/ skeletons relative to the executable, so
+      # extracting the archive and adding that one directory to PATH is all
+      # that is needed.
+      $wfbVersion = "2.5.25"
+      $wfbSha256 = "8D324B62BE33604B2C45AD1DD34AB93D722534448F55A16CA7292DE32B6AC135"
+      $wfbUrl = "https://github.com/lexxmark/winflexbison/releases/download/v$wfbVersion/win_flex_bison-$wfbVersion.zip"
+      $wfbZip = Join-Path $env:RUNNER_TEMP "win_flex_bison.zip"
+      $wfbDir = Join-Path $env:RUNNER_TEMP "winflexbison"
+
+      $ok = $false
+      foreach ($attempt in 1..3) {
+        try {
+          Invoke-WebRequest -Uri $wfbUrl -OutFile $wfbZip -UseBasicParsing
+          $ok = $true
+          break
+        } catch {
+          Write-Host "win_flex_bison download attempt $attempt failed: $($_.Exception.Message)"
+          Start-Sleep -Seconds (5 * $attempt)
+        }
+      }
+      if (-not $ok) { throw "failed to download $wfbUrl" }
+
+      $actual = (Get-FileHash -Path $wfbZip -Algorithm SHA256).Hash
+      if ($actual -ne $wfbSha256) {
+        throw "win_flex_bison checksum mismatch: expected $wfbSha256, got $actual"
+      }
+
+      Expand-Archive -Path $wfbZip -DestinationPath $wfbDir -Force
+      $wfbDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      & (Join-Path $wfbDir "win_bison.exe") --version
+      & (Join-Path $wfbDir "win_flex.exe") --version
 
       $mozilladir = "c:\mozilla-build"
       $src_url = "https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-3.4.exe"


### PR DESCRIPTION
## Summary

The Windows CI leg installed flex/bison with `choco install -y -r winflexbison3`. The Chocolatey community feed repeatedly refused the GitHub Actions runners — first `499`, then `503 Service Unavailable` — which failed the job before the build started, since `BISON_TARGET`/`FLEX_TARGET` in `src/modules/molstr` and `src/gfx` need them. Re-running did not converge (the feed answered `200` from a developer machine while continuing to reject the runners).

Replace it with a direct download of the upstream release archive:

- **Same host as the workflow** — GitHub, rather than a third-party feed that rate-limits CI ranges.
- **Reproducible** — pinned to `v2.5.25` and verified against a SHA256, where `choco` resolved "latest" on every run.
- **No package manager needed** — CMake's `FindBISON`/`FindFLEX` already search for `win_bison`/`win_flex` by name, and `win_bison` locates its `data/` skeletons relative to the executable, so extracting the archive and putting that one directory on `PATH` is sufficient.
- Downloads retry three times with backoff for ordinary network blips.

This removes the **last Chocolatey dependency in the repository** (verified by grep across workflows, composite actions, and build scripts). The rest of the Windows tooling comes from the runner image (MSVC via `ilammy/msvc-dev-cmd`), GitHub-hosted actions (`sccache-action`, `setup-node`), the project's own `curl`-based deplibs download, and the cached MozillaBuild install — which is also where `wget` comes from for the full-build UXP steps, not Chocolatey.

## Test plan

- [x] Confirmed `choco` appears nowhere else in the repo (workflows, composite actions, `.bat`/`.sh`/`.ps1`)
- [x] Verified the pinned archive's layout: `win_bison.exe` / `win_flex.exe` plus `data/` at the archive root, matching the names CMake searches for
- [x] Verified the published SHA256 by downloading the asset
- [ ] **This PR's own Windows CI run is the real verification** — it exercises the new step end-to-end (download, checksum, PATH, then the flex/bison-dependent build and gtest suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)