### PR TITLE
feat(tritium): gate the Component Catalog view on a dev-only build flag

### DIFF
--- a/docs/migration/ui-style-guide.md
+++ b/docs/migration/ui-style-guide.md
@@ -23,6 +23,8 @@ label+control の UI (フォーム行・テキスト入力・select・numeric・
 - **2 桁の裸 cell** = `NumberCell`。
 真にカタログに無い時のみ、`_form-kit.css` にサイズを 1 定義して**先にカタログへ追加**する。カタログ調査を飛ばして Blueprint 直叩き/独自 CSS で作ると、既存の verified 実装とサイズ・デザインが食い違い手戻りする (このガイドが防ぎたい再発そのもの)。
 
+> **Component Catalog は開発ビルド専用**: activity bar の "Component Catalog" view は `__DEV_UI__` (compile-time flag) で gate されており、`electron-vite dev` / 通常の `electron-vite build` (= `task build_tritium` + `task run_tritium`) でのみ表示される。release packaging (`tritium/packaging/package.sh`) は `CUEMOL_RELEASE=1` を立てるので、CatalogPane1-3 は tree-shaking で bundle ごと落ちる。カタログに component を追加しても製品ビルドには入らない。
+
 | コンポーネント | 用途 | canonical サイズ (source) |
 |---|---|---|
 | `FieldSection` | **pane 内の最上位グループ** (`title` = グループ見出し + 任意の中身) | title は `.type-group-label` role, section 間 gap は親 container の `gap: --form-section-gap` |

--- a/tritium/packaging/package.sh
+++ b/tritium/packaging/package.sh
@@ -25,8 +25,11 @@ REACT_GUI="$REPO_ROOT/react-gui"
 bash "$SCRIPT_DIR/collect-cuemol2-runtime.sh"
 
 # --- 2. electron-vite build -------------------------------------------------
+# CUEMOL_RELEASE=1 flips the __DEV_UI__ compile-time flag off (see
+# react-gui/electron.vite.config.ts), so developer-only UI -- currently the
+# Component Catalog sidebar view -- is not built into a shipped bundle.
 cd "$REACT_GUI"
-pnpm exec electron-vite build
+CUEMOL_RELEASE=1 pnpm exec electron-vite build
 
 # --- 3. electron-builder ----------------------------------------------------
 # Derive the bundle version from the master QM_VERSION (single source of truth:

--- a/tritium/react-gui/electron.vite.config.ts
+++ b/tritium/react-gui/electron.vite.config.ts
@@ -46,6 +46,22 @@ const workerExternal = [
   'path',
 ]
 
+// ---------------------------------------------------------------------------
+// Developer-only UI flag (__DEV_UI__)
+// ---------------------------------------------------------------------------
+// Some sidebar UI exists only for development / design review -- currently the
+// "Component Catalog" activity-bar view (CatalogPane1-3). It is gated on the
+// compile-time constant __DEV_UI__ so that a release build drops the branches
+// and, by tree-shaking, the CatalogPane modules themselves.
+//
+// Release packaging (packaging/package.sh, and the package:dir script) sets
+// CUEMOL_RELEASE=1 before running electron-vite build. A plain
+// `electron-vite build` / `electron-vite dev` -- i.e. every developer run,
+// including `electron-vite preview` of that build -- keeps the dev UI. Note
+// that import.meta.env.DEV cannot be used for this: `preview` runs a
+// production bundle, so DEV is already false in a normal debug run.
+const devUi = process.env.CUEMOL_RELEASE !== '1'
+
 const workerGlobals: Record<string, string> = {
   // Map the external to a require() call executed at IIFE init time.
   // Electron's nodeIntegrationInWorker injects the global require.
@@ -64,6 +80,9 @@ export default defineConfig({
   },
   renderer: {
     plugins: [react(), tsconfigPaths()],
+    define: {
+      __DEV_UI__: JSON.stringify(devUi),
+    },
     build: {
       rollupOptions: {
         // Two HTML entries: the main window (index.html) and the modeless

--- a/tritium/react-gui/package.json
+++ b/tritium/react-gui/package.json
@@ -16,7 +16,7 @@
     "lint:comments": "node scripts/check-comment-ascii.mjs",
     "package:mac": "bash ../packaging/package-mac.sh",
     "package:win": "bash ../packaging/package.sh --win --x64",
-    "package:dir": "electron-vite build && electron-builder --dir --arm64"
+    "package:dir": "CUEMOL_RELEASE=1 electron-vite build && electron-builder --dir --arm64"
   },
   "dependencies": {
     "@blueprintjs/core": "^5.13.0",

--- a/tritium/react-gui/src/renderer/@types/electron.d.ts
+++ b/tritium/react-gui/src/renderer/@types/electron.d.ts
@@ -8,6 +8,12 @@ declare module '*.png' {
   export default src
 }
 
+// Compile-time flag for developer-only UI (currently the Component Catalog
+// activity-bar view). Substituted by the `define` entry in
+// electron.vite.config.ts / vitest.config.ts: true for developer builds and
+// tests, false when packaging/package.sh builds a release (CUEMOL_RELEASE=1).
+declare const __DEV_UI__: boolean
+
 // Shared IPC types exposed as globals using TypeScript import() type syntax.
 // This works in script-mode .d.ts files without requiring export {} or declare global.
 type PaneCollapseState  = import('../../shared/ipcTypes').PaneCollapseState

--- a/tritium/react-gui/src/renderer/__test__/activityBarDevUi.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/activityBarDevUi.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @file activityBarDevUi.test.ts
+ * @description Degrade-detection test for the developer-only gating of the
+ * Component Catalog activity-bar view.
+ *
+ * The catalog is a design-review showcase and must not reach a shipped build:
+ * release packaging (packaging/package.sh) sets CUEMOL_RELEASE=1, which turns
+ * the `__DEV_UI__` compile-time flag off. This test pins the observable
+ * contract of the gate -- which buttons the bar offers for each flag value --
+ * so removing the gate fails here rather than silently shipping the catalog.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildActivityItems } from "../components/ActivityBar";
+
+describe("activity-bar dev-only views", () => {
+  it("offers the Component Catalog in developer builds", () => {
+    const ids = buildActivityItems(true).map((i) => i.id);
+    expect(ids).toEqual(["explorer", "selection", "crystal", "catalog"]);
+  });
+
+  it("drops the Component Catalog from release builds", () => {
+    const ids = buildActivityItems(false).map((i) => i.id);
+    expect(ids).toEqual(["explorer", "selection", "crystal"]);
+  });
+});

--- a/tritium/react-gui/src/renderer/components/ActivityBar.tsx
+++ b/tritium/react-gui/src/renderer/components/ActivityBar.tsx
@@ -30,13 +30,25 @@ interface ActivityItemDef {
   label: string;
 }
 
-/** Ordered list of activity-bar buttons rendered top-to-bottom. */
-const ITEMS: ActivityItemDef[] = [
+/**
+ * Build the ordered list of activity-bar buttons rendered top-to-bottom.
+ *
+ * @param devUi - Whether developer-only views are part of this build. The
+ *   Component Catalog is a design-review showcase, so it is present in
+ *   developer builds only; see `__DEV_UI__` in electron.vite.config.ts.
+ * @returns The buttons in top-to-bottom order.
+ */
+export const buildActivityItems = (devUi: boolean): ActivityItemDef[] => [
   { id: "explorer", icon: "activity.explorer", label: "Explorer" },
   { id: "selection", icon: "activity.selection", label: "Selection" },
   { id: "crystal", icon: "activity.crystal", label: "Crystal" },
-  { id: "catalog", icon: "activity.catalog", label: "Component Catalog" },
+  ...(devUi
+    ? [{ id: "catalog", icon: "activity.catalog", label: "Component Catalog" } as ActivityItemDef]
+    : []),
 ];
+
+/** Ordered list of activity-bar buttons rendered top-to-bottom. */
+const ITEMS: ActivityItemDef[] = buildActivityItems(__DEV_UI__);
 
 // ------------------------------------------------------------
 // Component

--- a/tritium/react-gui/src/renderer/components/panels/SidePanel.tsx
+++ b/tritium/react-gui/src/renderer/components/panels/SidePanel.tsx
@@ -386,7 +386,11 @@ export const SidePanel: React.FC<SidePanelProps> = ({
         ),
       },
     ],
-    catalog: [
+    /* Developer-only view: the whole entry (and, by tree-shaking, the
+     * CatalogPane modules) is dropped from a release build. `__DEV_UI__` is
+     * referenced inline rather than through a shared const so the bundler can
+     * fold the branch away -- see electron.vite.config.ts. */
+    ...(__DEV_UI__ ? { catalog: [
       {
         id: "catalog1",
         defaultSize: 280,
@@ -416,7 +420,7 @@ export const SidePanel: React.FC<SidePanelProps> = ({
           />
         ),
       },
-    ],
+    ] } : {}),
   }), [
     cm, activeSceneId, activeMolViewId,
     viewProjection, viewCenterMark,

--- a/tritium/react-gui/vitest.config.ts
+++ b/tritium/react-gui/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Developer-only UI flag, mirroring electron.vite.config.ts. Tests always
+  // run with the dev UI present; the release-build behaviour is covered by
+  // passing the flag explicitly to the gated builders.
+  define: {
+    __DEV_UI__: "true",
+  },
   test: {
     environment: "jsdom",
     include: ["src/renderer/__test__/**/*.test.{ts,tsx}"],


### PR DESCRIPTION
## Summary

Active bar の **Component Catalog** view (`CatalogPane1-3`) は design review 用の showcase なので、debug run でのみ表示し、packaged release build には含めないようにした。

compile-time flag `__DEV_UI__` を導入し、release packaging の入口 (`tritium/packaging/package.sh` — mac/win/linux の CI もすべてここ経由) で `CUEMOL_RELEASE=1` を立てて off にする。branch が畳まれることで `CatalogPane1-3` は tree-shaking で bundle ごと落ちる。

`import.meta.env.DEV` は使えない: `task run_tritium` は `electron-vite preview` (= production bundle の起動) なので、debug run でも `DEV` は既に `false` になる。

## Changes

| File | 変更 |
|---|---|
| `react-gui/electron.vite.config.ts` | `CUEMOL_RELEASE=1` のとき renderer に `define: { __DEV_UI__: false }` |
| `packaging/package.sh` | `CUEMOL_RELEASE=1 pnpm exec electron-vite build` |
| `react-gui/package.json` | `package:dir` にも同じ env (packaged 成果物は常に除外) |
| `components/ActivityBar.tsx` | `buildActivityItems(devUi)` に切り出し、catalog ボタンを gate |
| `components/panels/SidePanel.tsx` | `...(__DEV_UI__ ? { catalog: [...] } : {})` — inline 参照にして bundler が branch ごと畳めるようにする |
| `@types/electron.d.ts` / `vitest.config.ts` | `__DEV_UI__` の型宣言と、テスト側 define (`true`) |
| `__test__/activityBarDevUi.test.ts` | gate の degrade 検出テスト (新規) |
| `docs/migration/ui-style-guide.md` | 「Component Catalog は開発ビルド専用」の注記 |

開発フロー (`task build_tritium` -> `task run_tritium`, `electron-vite dev`) はこれまで通りカタログが出る。

## Test plan

- 実バンドル (`out/renderer/assets/index-*.js`) を比較して確認:
  - 通常ビルド: `Segmented control` / `catalog-note` / `Component Catalog` あり、1,025.98 kB
  - `CUEMOL_RELEASE=1` ビルド: CatalogPane1-3 由来の文字列は **全て 0 件**、1,004.26 kB (-22 kB)
  - 残るのは `SidePanel` の `VIEW_TITLES.catalog` 文字列のみ (`ActivityView` union に `"catalog"` が残るため `Record` のキーとして必要な、到達不能な定数)
- `npx vitest run`: 298 files / 2742 tests pass
- `npx tsc -p tsconfig.web.json --noEmit`: 触ったファイルに新規エラーなし

Note: `npm run lint:comments` は `src/shared/menuAccel.ts` の glyph で失敗するが、本 PR とは無関係な既存の失敗。