### PR TITLE
feat(render): add the Umbreon (NPR) tone-hatching backend

### DIFF
--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -17,6 +17,7 @@
 #ifdef HAVE_UMBREON
 #  include <umbreon/umbreon.hpp>
 #  include <umbreon/log.hpp>
+#  include <umbreon/npr/hatch_shade.hpp>
 #  include <cmath>
 #  include <cstdint>
 #  include <map>
@@ -920,7 +921,11 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   // albedo multiply -- direct lighting and albedo stay noise-free -- which needs
   // umbreon built with UMBREON_WITH_OIDN (linked from the deplibs OIDN bundle;
   // see src/cmake/umbreon.cmake).
-  if (prm.giEnabled) {
+  // Hatch ink mode discards the shaded color, so umbreon force-disables GI
+  // with a warning when both are on. Decide it here instead (same policy as
+  // the aaMode fallback above), so the render never plans GI work it will
+  // then drop.
+  if (prm.giEnabled && !prm.hatchEnable) {
     opt.gi = true;
     opt.giIntegrator = 2;
     opt.pt1Spp = (prm.giSamples > 0) ? prm.giSamples : 32;
@@ -934,12 +939,95 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   // a no-op at 0, so it is set unconditionally.
   opt.denoiser = prm.denoiser;
 
+  // NPR tone hatching: the image becomes an ink drawing whose hatch marks
+  // carry the shading tone on a paper base.
+  if (prm.hatchEnable) {
+    opt.hatch.enable = true;
+    // The style name is either a look (paper/ink model + tone recipe +
+    // layers) or a layer preset. Try the look first -- looks are the
+    // recognizable drawing styles and the two namespaces do not overlap.
+    // An unknown name warns into the render log and falls back to
+    // richardson, so a typo degrades to a valid drawing instead of the
+    // built-in defaults silently changing the look.
+    const std::string style = prm.hatchStyle.c_str();
+    if (!umbreon::applyHatchLook(opt.hatch, style) &&
+        !umbreon::applyHatchPreset(opt.hatch, style)) {
+      umbreon::logMessage(umbreon::LogLevel::Warning,
+                          "unknown hatch style '%s'; using richardson",
+                          style.c_str());
+      umbreon::applyHatchLook(opt.hatch, "richardson");
+    }
+    // Density / width are MULTIPLIERS over the style's per-layer values
+    // (density divides every lattice pitch: 2 = twice as many lines/dots).
+    // Scaling instead of overwriting preserves the relative pitches of a
+    // multi-layer look, which one absolute pitch would collapse.
+    const float density =
+        (prm.hatchDensity > 0.0) ? float(prm.hatchDensity) : 1.0f;
+    const float widthScale =
+        (prm.hatchWidthScale > 0.0) ? float(prm.hatchWidthScale) : 1.0f;
+    for (umbreon::HatchLayer &l : opt.hatch.layers) {
+      l.spacingPx /= density;
+      l.widthPx *= widthScale;
+    }
+    // Base / ink model overrides (the manual's four coloring patterns).
+    // Applied after the style so a coloring pick works on top of ANY style:
+    // e.g. stipple + "albedo" base = stippled comic fill. Empty keeps the
+    // style's own model (richardson stays a colored-pencil drawing).
+    if (prm.hatchBase.equalsIgnoreCase("paper"))
+      opt.hatch.base = umbreon::HatchBase::Paper;
+    else if (prm.hatchBase.equalsIgnoreCase("albedo"))
+      opt.hatch.base = umbreon::HatchBase::Albedo;
+    bool inkModeSet = true;
+    if (prm.hatchInk.equalsIgnoreCase("fixed"))
+      opt.hatch.ink = umbreon::HatchInk::Fixed;
+    else if (prm.hatchInk.equalsIgnoreCase("albedo"))
+      opt.hatch.ink = umbreon::HatchInk::FromAlbedo;
+    else
+      inkModeSet = false;
+    // Ink / paper overrides, only when the exporter parsed an explicit
+    // color: the styles carry their own (richardson's warm paper, its
+    // albedo-derived ink), which an unconditional default would destroy.
+    if (prm.hatchInkColorSet) {
+      // Absent an explicit ink model, a fixed override color implies
+      // fixed-ink mode; leaving FromAlbedo would silently ignore the
+      // user's pick under richardson. An explicit "albedo" ink wins (the
+      // fixed color is then simply unused).
+      if (!inkModeSet)
+        opt.hatch.ink = umbreon::HatchInk::Fixed;
+      for (int k = 0; k < 3; ++k)
+        opt.hatch.inkColor[k] = prm.hatchInkColor[k];
+    }
+    if (prm.hatchPaperColorSet) {
+      for (int k = 0; k < 3; ++k)
+        opt.hatch.paperColor[k] = prm.hatchPaperColor[k];
+    }
+    // umbreon paints the paper over SURFACE pixels only; the pixels around
+    // the drawing keep the scene background (the manual: "the paper color
+    // only fills the object interior, not the background"). For a drawing
+    // the sheet IS the paper, and a mismatched background both breaks that
+    // illusion and makes a paper-color pick look inert -- so point the
+    // background, and the fog that fades into it, at the resolved paper.
+    // The two meet exactly: with CueMol's assumedGamma = 1 both the painted
+    // paper and the background reach the PNG as these display values.
+    scene.background = umbreon::Vec3(
+        opt.hatch.paperColor[0], opt.hatch.paperColor[1],
+        opt.hatch.paperColor[2]);
+    scene.fog.color = scene.background;
+  }
+
   // Native screen-space (Freestyle-style) edge lines. Enabled when any section
   // requested edge lines; each section's natures + edge color live in
   // scene.groupEdgeStyle (captured in appendIntData). The analytic silhouettes
   // of spheres/cylinders are outlined too (strokeEdges.analytic defaults on), so
   // ball-and-stick is edged without folding it into the mesh.
-  if (m_pImpl->anyEdges) {
+  //
+  // Under NPR hatching the manual pairs the tone pass with contour edges, so
+  // hatchDefaultEdges additionally runs the pass even when NO section asked
+  // for edge lines: sections whose renderer configured edges keep their
+  // captured per-section style, and only the all-disabled entries get the
+  // default contour filled in below.
+  const bool defaultContours = prm.hatchEnable && prm.hatchDefaultEdges;
+  if (m_pImpl->anyEdges || defaultContours) {
     opt.strokeEdges.enable = true;
     opt.strokeEdges.silhouette = true;
     opt.strokeEdges.border = true;
@@ -981,6 +1069,39 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     if (m_pImpl->groupEdgeStyle.size() < std::size_t(m_pImpl->nextGroup))
       m_pImpl->groupEdgeStyle.resize(std::size_t(m_pImpl->nextGroup));
     scene.groupEdgeStyle = m_pImpl->groupEdgeStyle;
+
+    // NPR default contours: give each section whose renderer requested no
+    // edge lines (its EdgeStyle is all-disabled) a silhouette + border
+    // contour in the ink color, mirroring what a bare "--edges on" seeds in
+    // the umbreon CLI. Sections WITH renderer-side settings were styled in
+    // appendIntData and are left untouched, so per-renderer edge color /
+    // width / mode still win.
+    if (defaultContours) {
+      float er = 0.0f, eg = 0.0f, eb = 0.0f;
+      if (prm.hatchInkColorSet) {
+        er = prm.hatchInkColor[0];
+        eg = prm.hatchInkColor[1];
+        eb = prm.hatchInkColor[2];
+      }
+      for (umbreon::EdgeStyle &es : scene.groupEdgeStyle) {
+        bool anyCls = false;
+        for (const umbreon::EdgeClassStyle &cs : es.cls)
+          anyCls = anyCls || cs.enabled;
+        if (anyCls)
+          continue;
+        const int slots[2] = {int(umbreon::EdgeClass::Silhouette),
+                              int(umbreon::EdgeClass::Object)};
+        for (int k = 0; k < 2; ++k) {
+          umbreon::EdgeClassStyle &cs = es.cls[slots[k]];
+          cs.enabled = true;
+          cs.color[0] = er;
+          cs.color[1] = eg;
+          cs.color[2] = eb;
+          cs.opacity = 1.0f;
+          cs.width = float(EDGE_THICKNESS_PX);
+        }
+      }
+    }
   }
 
   // %g: aoDistance defaults to the 1e20 "unlimited" sentinel, which %f would

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -86,6 +86,44 @@ namespace render {
     /// components) with alpha = coverage (0 where no geometry is hit), so the
     /// PNG can be composited over another image (POV "_transpbg").
     bool transparentBackground = false;
+    /// NPR tone-hatching pass (umbreon RenderOptions::hatch). When on, the
+    /// image is an ink drawing: hatch marks carry the shading tone on a paper
+    /// base, and GI is not used (umbreon force-disables it under the default
+    /// ink mode, so it is decided here instead of relying on the warning).
+    bool hatchEnable = false;
+    /// Hatch style: an umbreon look (richardson / ink-cross / manga) or layer
+    /// preset (pen-cross / pencil / engraving / stipple / screentone-60 /
+    /// manga-square). An unknown name warns and falls back to richardson.
+    qlib::LString hatchStyle = "richardson";
+    /// Mark density multiplier: every layer's lattice pitch is DIVIDED by it,
+    /// so 2 doubles the number of hatch lines / halftone dots. A multiplier
+    /// (not an absolute pitch) so the relative pitches of a multi-layer look
+    /// are preserved.
+    double hatchDensity = 1.0;
+    /// Mark width multiplier over the style's per-layer widths.
+    double hatchWidthScale = 1.0;
+    /// Base / ink model overrides (umbreon --hatch-base / --hatch-ink). The
+    /// four combinations are the manual's coloring patterns: paper+fixed =
+    /// pen figure, paper+albedo = colored pencil (richardson), albedo+fixed =
+    /// comic (flat fill under black ink), albedo+albedo = print-like. Empty =
+    /// keep the style's own model. hatchBase: "paper" | "albedo"; hatchInk:
+    /// "fixed" | "albedo".
+    qlib::LString hatchBase;
+    qlib::LString hatchInk;
+    /// Ink / paper color overrides, display-encoded RGB in [0, 1] (the hatch
+    /// composite runs on the display-encoded frame; see umbreon HatchOptions).
+    /// Applied only when the matching *Set flag is true; otherwise the style's
+    /// own colors are kept (richardson, for one, carries a warm paper color
+    /// that a fixed white default would silently destroy).
+    bool hatchInkColorSet = false;
+    bool hatchPaperColorSet = false;
+    float hatchInkColor[3] = {0.0f, 0.0f, 0.0f};
+    float hatchPaperColor[3] = {1.0f, 1.0f, 1.0f};
+    /// Give sections whose renderer requests no edge lines a default contour
+    /// (silhouette outline in the ink color), so an unconfigured scene still
+    /// reads as a drawing. Sections WITH renderer-side edge settings keep
+    /// their captured per-section style.
+    bool hatchDefaultEdges = true;
   };
 
   /// DisplayContext backend that renders a scene with umbreon (Embree).

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -103,6 +103,34 @@ namespace {
     png_destroy_write_struct(&pPNG, &pInfo);
   }
 
+  /// Parse a "#RRGGBB" hex string into display-encoded RGB floats in [0, 1].
+  /// Returns false (leaving rgb untouched) for an empty or malformed string,
+  /// so an unset color degrades to "keep the hatch style's own color" instead
+  /// of throwing.
+  bool parseHexColor(const LString &str, float rgb[3])
+  {
+    LString s = str.trim();
+    if (s.startsWith("#"))
+      s = s.substr(1);
+    if (s.length() != 6)
+      return false;
+    int v[6];
+    for (int i = 0; i < 6; ++i) {
+      const char c = s[i];
+      if (c >= '0' && c <= '9')
+        v[i] = c - '0';
+      else if (c >= 'a' && c <= 'f')
+        v[i] = c - 'a' + 10;
+      else if (c >= 'A' && c <= 'F')
+        v[i] = c - 'A' + 10;
+      else
+        return false;
+    }
+    for (int k = 0; k < 3; ++k)
+      rgb[k] = float(v[k * 2] * 16 + v[k * 2 + 1]) / 255.0f;
+    return true;
+  }
+
 }  // anonymous namespace
 
 UmbreonSceneExporter::UmbreonSceneExporter()
@@ -117,6 +145,11 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_bTransparentBackground(false),
        m_bGI(false), m_nGiSamples(32), m_dGiIntensity(1.0),
        m_dGiEnvIntensity(1.0), m_bGiDenoise(true), m_nDenoiser(0),
+       m_bHatchEnable(false), m_sHatchStyle("richardson"),
+       m_dHatchDensity(1.0), m_dHatchWidthScale(1.0),
+       m_sHatchBase(""), m_sHatchInk(""),
+       m_sHatchInkColor(""), m_sHatchPaperColor(""),
+       m_bHatchDefaultEdges(true),
        m_bWasCancelled(false)
 {
 }
@@ -205,6 +238,16 @@ void UmbreonSceneExporter::setupContext(UmbreonDisplayContext &ctx,
   prm.giEnvIntensity = m_dGiEnvIntensity;
   prm.giDenoise = m_bGiDenoise;
   prm.denoiser = m_nDenoiser;
+  prm.hatchEnable = m_bHatchEnable;
+  prm.hatchStyle = m_sHatchStyle;
+  prm.hatchDensity = m_dHatchDensity;
+  prm.hatchWidthScale = m_dHatchWidthScale;
+  prm.hatchBase = m_sHatchBase;
+  prm.hatchInk = m_sHatchInk;
+  prm.hatchInkColorSet = parseHexColor(m_sHatchInkColor, prm.hatchInkColor);
+  prm.hatchPaperColorSet =
+      parseHexColor(m_sHatchPaperColor, prm.hatchPaperColor);
+  prm.hatchDefaultEdges = m_bHatchDefaultEdges;
 }
 
 void UmbreonSceneExporter::write()

--- a/src/modules/rendering/UmbreonSceneExporter.hpp
+++ b/src/modules/rendering/UmbreonSceneExporter.hpp
@@ -122,6 +122,32 @@ namespace render {
     /// full-frame post-pass denoiser (0 = None, 1 = AtrousBilateral, 2 = OIDN)
     int m_nDenoiser;
 
+    /// NPR tone-hatching pass (ink drawing); default off
+    bool m_bHatchEnable;
+
+    /// hatch style: an umbreon look or layer-preset name; unknown names fall
+    /// back to richardson with a warning in the render log
+    LString m_sHatchStyle;
+
+    /// mark density multiplier (2 = twice as many lines / dots)
+    double m_dHatchDensity;
+
+    /// mark width multiplier over the style's per-layer widths
+    double m_dHatchWidthScale;
+
+    /// base / ink model overrides ("paper"/"albedo", "fixed"/"albedo");
+    /// empty = keep the hatch style's own model
+    LString m_sHatchBase;
+    LString m_sHatchInk;
+
+    /// ink / paper color overrides as "#RRGGBB" hex strings (display-encoded);
+    /// empty = keep the hatch style's own colors
+    LString m_sHatchInkColor;
+    LString m_sHatchPaperColor;
+
+    /// give sections without renderer-side edge lines a default contour
+    bool m_bHatchDefaultEdges;
+
     /// Asynchronous render context, created by beginRender() and released by
     /// endRender(). Held across the poll phase so the scene walk + background
     /// ray trace outlive a single scriptable call. Null when no render is in

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -124,6 +124,52 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   /// full-frame post-pass denoiser (0 = None, 1 = AtrousBilateral, 2 = OIDN)
   property integer denoiser => m_nDenoiser;
 
+  //////////
+  // NPR tone-hatching pass (umbreon --hatch): the image becomes an ink
+  // drawing where hatch marks carry the shading tone on a paper base. GI is
+  // not used while this is on (umbreon force-disables it under the default
+  // ink mode), so drive it with raytracing or AO lighting only.
+
+  /// enable the NPR tone-hatching pass
+  property boolean hatchEnable => m_bHatchEnable;
+
+  /// hatch style: an umbreon look (richardson / ink-cross / manga) or layer
+  /// preset (pen-cross / pencil / engraving / stipple / screentone-60 /
+  /// manga-square). Unknown names fall back to richardson with a warning in
+  /// the render log.
+  property string hatchStyle => m_sHatchStyle;
+
+  /// mark density multiplier: every layer's lattice pitch is divided by it,
+  /// so 2 doubles the number of hatch lines / halftone dots
+  property real hatchDensity => m_dHatchDensity;
+
+  /// mark width multiplier over the style's per-layer stroke widths
+  property real hatchWidthScale => m_dHatchWidthScale;
+
+  /// base (fill) model override: "paper" (bare paper between the marks) or
+  /// "albedo" (flat unshaded fill of each section's own color); empty (the
+  /// default) keeps the style's own base
+  property string hatchBase => m_sHatchBase;
+
+  /// ink model override: "fixed" (one ink color) or "albedo" (each section
+  /// draws in its own color); empty (the default) keeps the style's own ink
+  property string hatchInk => m_sHatchInk;
+
+  /// ink color override as a "#RRGGBB" hex string (display-encoded); empty
+  /// (the default) keeps the style's own ink model, e.g. richardson draws
+  /// each section in its own color
+  property string hatchInkColor => m_sHatchInkColor;
+
+  /// paper (background) color override as a "#RRGGBB" hex string
+  /// (display-encoded); empty (the default) keeps the style's own paper,
+  /// e.g. richardson's warm drawing paper
+  property string hatchPaperColor => m_sHatchPaperColor;
+
+  /// give sections whose renderer requests no edge lines a default silhouette
+  /// contour in the ink color; sections with renderer-side edge settings keep
+  /// their own style
+  property boolean hatchDefaultEdges => m_bHatchDefaultEdges;
+
   ////////////////////
   // Asynchronous render (non-blocking, with progress + cancel).
   //

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -1595,3 +1595,155 @@ TEST(UmbreonExport, ContactEdgesInkTheCrossSectionIntersection)
     EXPECT_EQ(runsOn, 3);
     EXPECT_GT(inkOn, inkOff + 30);
 }
+
+namespace {
+
+const int kHatchDim = 64;
+
+/// Render one sphere with the NPR tone-hatching pass. `edgeLines` gives the
+/// section renderer-side edge lines (red, so its ink is distinguishable from
+/// the black default contour); `paperHex` empty keeps the style's own paper.
+void renderHatchedSphere(bool edgeLines, bool defaultEdges,
+                         const char *style, float paperR, float paperG,
+                         float paperB, bool paperSet,
+                         std::vector<unsigned char> &outPix)
+{
+    const double kViewH = 6.0;
+
+    UmbreonDisplayContext ctx;
+    ctx.init();
+
+    ctx.setPerspective(false);
+    ctx.setViewDist(100.0);
+    ctx.setZoom(kViewH);
+    ctx.setLineScale(kViewH / kHatchDim);
+    // A blue scene background, so a paper-colored background is unmistakably
+    // the hatch pass' doing and not the scene's.
+    ctx.setBgColor(gfx::SolidColor::createRGB(0.0, 0.0, 1.0));
+    ctx.loadIdent();
+
+    ctx.enableEdgeLines(edgeLines);
+    if (edgeLines) {
+        ctx.setEdgeLineType(gfx::DisplayContext::ELT_SILHOUETTE);
+        ctx.setEdgeLineWidth(2.0 * kViewH / kHatchDim);
+        ctx.setEdgeLineColor(gfx::SolidColor::createRGB(1.0, 0.0, 0.0));
+    }
+
+    ctx.startRender();
+    ctx.startSection("mol");
+    ctx.color(gfx::SolidColor::createRGB(0.2, 0.8, 0.2));
+    ctx.sphere(1.8, Vector4D(0.0, 0.0, 0.0));
+    ctx.endSection();
+
+    UmbreonRenderParams prm;
+    prm.width = kHatchDim;
+    prm.height = kHatchDim;
+    prm.supersample = 2;
+    prm.hatchEnable = true;
+    prm.hatchStyle = style;
+    prm.hatchDefaultEdges = defaultEdges;
+    prm.hatchPaperColorSet = paperSet;
+    prm.hatchPaperColor[0] = paperR;
+    prm.hatchPaperColor[1] = paperG;
+    prm.hatchPaperColor[2] = paperB;
+
+    int ow = 0, oh = 0, ncomp = 0;
+    ctx.render(prm, ow, oh, ncomp, outPix);
+    ASSERT_EQ(outPix.size(),
+              static_cast<std::size_t>(kHatchDim * kHatchDim * 3));
+}
+
+/// Pixel at (x, y) of an RGB frame.
+void pixelAt(const std::vector<unsigned char> &pix, int x, int y, int rgb[3])
+{
+    const std::size_t i = (static_cast<std::size_t>(y) * kHatchDim + x) * 3;
+    for (int k = 0; k < 3; ++k) rgb[k] = pix[i + k];
+}
+
+}  // namespace
+
+// The NPR pass repaints the picture as an ink drawing: the surface is no
+// longer the shaded object color but the paper base with ink marks on it, and
+// the paper reaches the BACKGROUND too. umbreon paints its paper over surface
+// pixels only ("the paper color only fills the object interior"), which left a
+// custom paper color looking inert against the scene background -- the display
+// context therefore points the background (and the fog fading into it) at the
+// resolved paper.
+TEST(UmbreonExport, HatchInkModePaintsThePaperOverTheBackgroundToo)
+{
+    std::vector<unsigned char> pix;
+    // A saturated magenta paper: no shading path could produce it by accident.
+    renderHatchedSphere(false, true, "ink-cross", 1.0f, 0.0f, 1.0f, true, pix);
+
+    int corner[3];
+    pixelAt(pix, 1, 1, corner);
+    EXPECT_GT(corner[0], 200);
+    EXPECT_LT(corner[1], 60);
+    EXPECT_GT(corner[2], 200);
+
+    // The sphere's interior is drawn on that paper rather than left green:
+    // paper between the marks, ink on them, so no pixel keeps the object hue.
+    std::size_t nGreen = 0;
+    for (std::size_t i = 0; i + 2 < pix.size(); i += 3) {
+        if (pix[i + 1] > pix[i] + 20 && pix[i + 1] > pix[i + 2] + 20) ++nGreen;
+    }
+    EXPECT_EQ(nGreen, 0u);
+}
+
+// Contour edges under NPR: the manual pairs the tone pass with contour lines,
+// so a section whose renderer asks for none still gets a default contour in
+// the ink color. A section that DOES configure edge lines keeps its own style
+// -- the default must not overwrite the renderer's color or width.
+TEST(UmbreonExport, HatchDefaultEdgesRespectTheRendererEdgeStyle)
+{
+    // Count strongly-red pixels: only the renderer's own red edge color can
+    // produce them (the default contour is black, the paper white).
+    auto countRedInk = [](const std::vector<unsigned char> &pix) {
+        std::size_t n = 0;
+        for (std::size_t i = 0; i + 2 < pix.size(); i += 3) {
+            if (pix[i] > 150 && pix[i + 1] < 90 && pix[i + 2] < 90) ++n;
+        }
+        return n;
+    };
+    // ... and near-black pixels for the default contour.
+    auto countDarkInk = [](const std::vector<unsigned char> &pix) {
+        std::size_t n = 0;
+        for (std::size_t i = 0; i + 2 < pix.size(); i += 3) {
+            if (pix[i] < 60 && pix[i + 1] < 60 && pix[i + 2] < 60) ++n;
+        }
+        return n;
+    };
+
+    // No renderer-side edges: the default contour supplies the outline.
+    std::vector<unsigned char> pixDefault;
+    renderHatchedSphere(false, true, "ink-cross", 1.0f, 1.0f, 1.0f, true,
+                        pixDefault);
+    EXPECT_GT(countDarkInk(pixDefault), 40u);
+    EXPECT_EQ(countRedInk(pixDefault), 0u);
+
+    // Renderer-side red edges: its color survives the default-contour pass.
+    std::vector<unsigned char> pixRenderer;
+    renderHatchedSphere(true, true, "ink-cross", 1.0f, 1.0f, 1.0f, true,
+                        pixRenderer);
+    EXPECT_GT(countRedInk(pixRenderer), 40u);
+
+    // Turning the default off leaves an unconfigured section without a
+    // contour, so the outline ink disappears (the hatch marks stay).
+    std::vector<unsigned char> pixOff;
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true,
+                        pixOff);
+    EXPECT_LT(countDarkInk(pixOff), countDarkInk(pixDefault));
+}
+
+// An unknown style name must not silently fall back to umbreon's built-in
+// defaults (a different picture from any style the UI offers): the context
+// warns and renders richardson, so the frame matches an explicit richardson.
+TEST(UmbreonExport, UnknownHatchStyleFallsBackToRichardson)
+{
+    std::vector<unsigned char> pixBogus, pixRichardson;
+    renderHatchedSphere(false, true, "no-such-style", 0.0f, 0.0f, 0.0f, false,
+                        pixBogus);
+    renderHatchedSphere(false, true, "richardson", 0.0f, 0.0f, 0.0f, false,
+                        pixRichardson);
+    EXPECT_EQ(pixBogus, pixRichardson);
+}

--- a/tritium/react-gui/src/renderer/__test__/renderBackendsRegistry.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/renderBackendsRegistry.test.ts
@@ -10,11 +10,52 @@ import { RENDER_BACKENDS, RENDER_BACKEND_IDS } from '../data/renderBackends'
 import { RENDER_COMMON_PROPS } from '../data/renderSettings'
 
 describe('render backends registry', () => {
-    it('registers both the povray and umbreon backends', () => {
+    it('registers the povray, umbreon and umbreon NPR backends', () => {
         expect(RENDER_BACKEND_IDS).toContain('povray')
         expect(RENDER_BACKEND_IDS).toContain('umbreon')
+        expect(RENDER_BACKEND_IDS).toContain('umbreon_npr')
         expect(RENDER_BACKENDS.umbreon.id).toBe('umbreon')
         expect(RENDER_BACKENDS.umbreon.label).toBe('Umbreon')
+        expect(RENDER_BACKENDS.umbreon_npr.id).toBe('umbreon_npr')
+        expect(RENDER_BACKENDS.umbreon_npr.label).toBe('Umbreon (NPR)')
+    })
+
+    // NPR renders through umbreon's hatch ink mode, which discards the shaded
+    // color -- umbreon force-disables GI there. Offering a GI lighting or a GI
+    // quality ladder would be a dead control, so the backend must carry
+    // neither, and its default must be plain raytracing.
+    it('offers the NPR backend raytracing and AO only, defaulting to raytracing', () => {
+        const quality = RENDER_BACKENDS.umbreon_npr.quality
+        expect(quality?.lightings.map((l) => l.id)).toEqual(['none', 'ao'])
+        expect(quality?.defaultLighting).toBe('none')
+        expect(quality?.axes.map((a) => a.key)).not.toContain('gi')
+        const groupKeys = RENDER_BACKENDS.umbreon_npr.groups.map((g) => g.key)
+        expect(groupKeys).not.toContain('Global Illumination')
+        expect(groupKeys).toContain('Hatching')
+        const giProps = RENDER_BACKENDS.umbreon_npr.props.filter(
+            (p) => p.group === 'Global Illumination',
+        )
+        expect(giProps).toEqual([])
+    })
+
+    // Every key a lighting option's enable patch writes must exist as a prop of
+    // that backend: the settings hook drops patch keys with no matching PropDef,
+    // and `lightingOf` then never matches the option, so the selector would
+    // silently snap back to "none".
+    it('every lighting enable patch key exists as a prop of its backend', () => {
+        for (const id of RENDER_BACKEND_IDS) {
+            const backend = RENDER_BACKENDS[id]
+            if (!backend.quality) continue
+            const propKeys = new Set(backend.props.map((p) => p.key))
+            for (const lighting of backend.quality.lightings) {
+                for (const key of Object.keys(lighting.enable)) {
+                    expect(
+                        propKeys.has(key),
+                        `${id}: lighting "${lighting.id}" patches unknown prop "${key}"`,
+                    ).toBe(true)
+                }
+            }
+        }
     })
 
     it('every backend prop belongs to one of its declared groups', () => {

--- a/tritium/react-gui/src/renderer/__test__/renderSettingsEditor.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/renderSettingsEditor.test.tsx
@@ -33,7 +33,7 @@ import {
 import { RENDER_BACKENDS } from '../data/renderBackends';
 
 function mountFor(
-  backend: 'povray' | 'umbreon',
+  backend: 'povray' | 'umbreon' | 'umbreon_npr',
   opts: { lighting?: RenderLightingMode } = {},
 ) {
   return mountTree(
@@ -248,6 +248,26 @@ describe('RenderSettingsEditor quality section', () => {
   it('has no quality section for a backend without a preset table', () => {
     const { container, unmount } = mountFor('povray');
     expect(container.querySelector('.insp-render-quality')).toBeNull();
+    unmount();
+  });
+
+  it('offers the NPR backend raytracing and AO only, with the Hatching group', () => {
+    const { container, unmount } = mountFor('umbreon_npr', { lighting: 'none' });
+    const [lightingSel] = qualitySelects(container);
+    // GI is absent: hatch ink mode discards the shaded color, so umbreon
+    // force-disables it and the option would be dead.
+    expect(Array.from(lightingSel.options).map((o) => o.value)).toEqual([
+      'none',
+      'ao',
+    ]);
+    expect(qualityLabels(container)).toEqual([
+      'Lighting',
+      'Supersampling',
+      'Shadows',
+    ]);
+    const groups = groupHeaders(container);
+    expect(groups).toContain('Hatching');
+    expect(groups).not.toContain('Global Illumination');
     unmount();
   });
 });

--- a/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
@@ -12,7 +12,10 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { umbreonBackend } from '../worker/server/services/renderBackends/UmbreonBackend'
+import {
+    umbreonBackend,
+    umbreonNprBackend,
+} from '../worker/server/services/renderBackends/UmbreonBackend'
 import type { WorkerContext } from '../worker/server/types/WorkerContext'
 import type { RenderSettingsSnapshot } from '../data/renderResult'
 import type { PropDef } from '../data/rendererProperties'
@@ -413,5 +416,104 @@ describe('umbreonBackend.beginInProcessAnimFrame', () => {
             umbreonBackend.beginInProcessAnimFrame!(ctx, animMgr as never, snapshot, '/o.png'),
         ).toThrow(/no frame left/)
         expect(exporter.beginRender).not.toHaveBeenCalled()
+    })
+})
+
+// The NPR backend shares the whole in-process cycle with the plain one and
+// differs only in the exporter block it writes: the hatch pass instead of GI.
+describe('umbreonNprBackend.beginInProcess', () => {
+    const nprSnapshot = (extra: PropDef[] = []): RenderSettingsSnapshot => ({
+        mode: 'still',
+        backend: 'umbreon_npr',
+        commonProps: [p('width', 640), p('height', 480), p('unit', 'px'), p('dpi', 600)],
+        backendProps: [
+            p('supersample', 4),
+            p('hatchStyle', 'manga'),
+            p('hatchDensity', 2),
+            p('hatchWidthScale', 0.5),
+            p('hatchColoring', 'Ink on color fill'),
+            p('hatchDefaultEdges', false),
+            ...extra,
+        ],
+    })
+
+    const beginNpr = (snapshot: RenderSettingsSnapshot) => {
+        const exporter = makeExporter()
+        const createHandler = vi.fn(() => exporter)
+        const ctx = { strMgr: { createHandler } } as unknown as WorkerContext
+        umbreonNprBackend.beginInProcess!(ctx, {} as never, snapshot, '/o.png')
+        return { exporter, createHandler }
+    }
+
+    it('writes the hatch block and no GI, reusing the umbreon exporter', () => {
+        const { exporter, createHandler } = beginNpr(nprSnapshot())
+
+        // Same C++ exporter: NPR is a mode of it, not a separate handler.
+        expect(createHandler).toHaveBeenCalledWith('umbreon', 2)
+        expect(exporter.supersample).toBe(4)
+
+        expect(exporter.hatchEnable).toBe(true)
+        expect(exporter.hatchStyle).toBe('manga')
+        expect(exporter.hatchDensity).toBe(2)
+        expect(exporter.hatchWidthScale).toBe(0.5)
+        expect(exporter.hatchDefaultEdges).toBe(false)
+        // "Ink on color fill" = a flat unshaded fill of each renderer's own
+        // color under a fixed ink (the manual's comic pattern).
+        expect(exporter.hatchBase).toBe('albedo')
+        expect(exporter.hatchInk).toBe('fixed')
+
+        // GI is never sent: hatch ink mode discards the shaded color, so
+        // umbreon force-disables it and a sent value would only mislead.
+        expect(exporter.useGI).toBeUndefined()
+        expect(exporter.giSamples).toBeUndefined()
+        expect(exporter.denoiser).toBeUndefined()
+    })
+
+    it('sends a color only while its Custom switch is on', () => {
+        // Off: empty strings tell the exporter to keep the style's own colors
+        // (richardson's warm paper and per-section ink would be destroyed by
+        // an unconditional black-on-white default).
+        const off = beginNpr(
+            nprSnapshot([p('hatchInkColor', '#123456'), p('hatchPaperColor', '#abcdef')]),
+        )
+        expect(off.exporter.hatchInkColor).toBe('')
+        expect(off.exporter.hatchPaperColor).toBe('')
+
+        const on = beginNpr(
+            nprSnapshot([
+                p('hatchCustomInk', true),
+                p('hatchInkColor', '#123456'),
+                p('hatchCustomPaper', true),
+                p('hatchPaperColor', '#abcdef'),
+            ]),
+        )
+        expect(on.exporter.hatchInkColor).toBe('#123456')
+        expect(on.exporter.hatchPaperColor).toBe('#abcdef')
+    })
+
+    it('keeps the style\'s own base/ink model on "Style default"', () => {
+        const snapshot = nprSnapshot()
+        snapshot.backendProps = snapshot.backendProps.map((prop) =>
+            prop.key === 'hatchColoring' ? p('hatchColoring', 'Style default') : prop,
+        )
+        const { exporter } = beginNpr(snapshot)
+        expect(exporter.hatchBase).toBe('')
+        expect(exporter.hatchInk).toBe('')
+    })
+
+    it('the plain umbreon backend never enables hatching', () => {
+        const exporter = makeExporter()
+        const ctx = {
+            strMgr: { createHandler: vi.fn(() => exporter) },
+        } as unknown as WorkerContext
+        const snapshot: RenderSettingsSnapshot = {
+            mode: 'still',
+            backend: 'umbreon',
+            commonProps: [p('width', 640), p('height', 480), p('unit', 'px'), p('dpi', 600)],
+            backendProps: [p('useGI', true)],
+        }
+        umbreonBackend.beginInProcess!(ctx, {} as never, snapshot, '/o.png')
+        expect(exporter.hatchEnable).toBeUndefined()
+        expect(exporter.useGI).toBe(true)
     })
 })

--- a/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
@@ -378,3 +378,42 @@ describe('useRenderSettings quality axes', () => {
         h.unmount();
     });
 });
+
+// The NPR backend restricts the same machinery: hatch ink mode discards the
+// shaded color (umbreon force-disables GI there), so it offers raytracing and
+// AO only and starts on plain raytracing.
+describe('useRenderSettings NPR backend', () => {
+    const nprHook = () => {
+        const h = makeRenderHook(() => useRenderSettings());
+        act(() => h.result.setBackend('umbreon_npr'));
+        return h;
+    };
+
+    it('starts on raytracing with no GI axis', () => {
+        const h = nprHook();
+        expect(h.result.lighting).toBe('none');
+        expect(h.result.qualitySteps).toEqual({
+            aa: 'high',
+            ao: 'medium',
+            shadows: 'off',
+        });
+        expect(valueOf(h.result.backendProps, 'aoEnabled')).toBe(false);
+        // The hatch pass is the point of the backend, so its style and the
+        // density multiplier are present from the start.
+        expect(valueOf(h.result.backendProps, 'hatchStyle')).toBe('richardson');
+        expect(valueOf(h.result.backendProps, 'hatchDensity')).toBe(1.0);
+        h.unmount();
+    });
+
+    it('setLighting("ao") is reported back (the enable patch reaches a real prop)', () => {
+        const h = nprHook();
+        act(() => h.result.setLighting('ao'));
+        // A patch key with no matching PropDef would be dropped, leaving
+        // `lighting` stuck on "none" -- this pins that it is not.
+        expect(h.result.lighting).toBe('ao');
+        expect(valueOf(h.result.backendProps, 'aoEnabled')).toBe(true);
+        act(() => h.result.setLighting('none'));
+        expect(h.result.lighting).toBe('none');
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/components/inspector/RenderSettingsEditor.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/RenderSettingsEditor.tsx
@@ -39,6 +39,7 @@ import { RENDER_BACKENDS } from "../../data/renderBackends";
  */
 const GROUP_ORDER = [
   "Camera",
+  "Hatching",
   "Antialiasing",
   "Quality",
   "Edges",

--- a/tritium/react-gui/src/renderer/components/renderwindow/RenderWindowApp.tsx
+++ b/tritium/react-gui/src/renderer/components/renderwindow/RenderWindowApp.tsx
@@ -43,9 +43,11 @@ export const RenderWindowApp: React.FC = () => {
   // Default the movie output to the app-managed folder and remember the
   // settings across window closes (see hooks/useMovieOutputPrefs.ts).
   const movieOutput = useMovieOutputPrefs(settings.movie, settings.updateMovie);
+  // Both umbreon-based backends (plain and NPR) ride the same in-process
+  // exporter, so one availability flag gates them together.
   const backendIds = umbreonAvailable
     ? RENDER_BACKEND_IDS
-    : RENDER_BACKEND_IDS.filter((id) => id !== "umbreon");
+    : RENDER_BACKEND_IDS.filter((id) => id !== "umbreon" && id !== "umbreon_npr");
 
   // Rendering > Image / Movie rendering both open this window and pin its
   // output mode. The request is a state object with a seq, so re-picking the

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -235,6 +235,90 @@ const UMBREON_QUALITY: RenderQualityConfig = {
   ],
 };
 
+/**
+ * Umbreon (NPR) backend: the same in-process ray tracer with umbreon's NPR
+ * tone-hatching pass on top -- the image becomes an ink drawing whose hatch
+ * marks carry the shading tone. Shares every umbreon prop except the GI
+ * group: hatch ink mode discards the shaded color, so umbreon force-disables
+ * GI, and offering it would be a dead control.
+ */
+const UMBREON_NPR_PROPS: PropDef[] = [
+  // --- Hatching (the pass that defines this backend) ---
+  // Styles are umbreon's looks (paper/ink model + tone recipe + layers:
+  // richardson / ink-cross / manga) followed by its layer presets (marks
+  // only); the C++ side resolves the name through applyHatchLook first,
+  // then applyHatchPreset.
+  { key: "hatchStyle",   label: "Style", type: "enum", value: "richardson", group: "Hatching",
+    options: ["richardson", "ink-cross", "manga", "pen-cross", "pencil",
+              "engraving", "stipple", "screentone-60", "manga-square"] },
+  // The manual's four base/ink coloring patterns, applied over any style:
+  // ink on paper (pen figure), colored ink on paper (colored pencil --
+  // richardson's own mode), ink on a flat fill of each renderer's color
+  // (comic), colored ink on that fill (print-like). "Style default" keeps
+  // the style's model -- without it every mark preset is fixed black on
+  // white paper. Mapped to the exporter's hatchBase/hatchInk pair by
+  // HATCH_COLORING in UmbreonBackend.
+  { key: "hatchColoring", label: "Coloring", type: "enum", value: "Style default", group: "Hatching",
+    options: ["Style default", "Ink on paper", "Colored ink on paper",
+              "Ink on color fill", "Colored ink on color fill"] },
+  // Multipliers over the style's own layer values, so the relative pitches
+  // of a multi-layer look survive: density divides every lattice pitch
+  // (2 = twice as many lines / halftone dots), width scales the marks.
+  { key: "hatchDensity",    label: "Mark density", type: "real", value: 1.0, group: "Hatching", min: 0.25, max: 4, step: 0.05 },
+  { key: "hatchWidthScale", label: "Mark width",   type: "real", value: 1.0, group: "Hatching", min: 0.25, max: 4, step: 0.05 },
+  // Ink/paper overrides are gated by the Custom switches: the styles carry
+  // their own colors (richardson's warm paper, its per-section ink), which
+  // an always-on black/white default would silently destroy. The backend
+  // sends the color only while the switch is on.
+  { key: "hatchCustomInk",   label: "Custom ink color",   type: "boolean", value: false, group: "Hatching" },
+  { key: "hatchInkColor",    label: "Ink color",          type: "color", value: "#000000", group: "Hatching" },
+  { key: "hatchCustomPaper", label: "Custom paper color", type: "boolean", value: false, group: "Hatching" },
+  { key: "hatchPaperColor",  label: "Paper color",        type: "color", value: "#ffffff", group: "Hatching" },
+  // Give renderers WITHOUT edge-line settings a default contour (the manual
+  // pairs hatching with contour edges); renderers with their own edge lines
+  // keep their configured color / width / mode either way.
+  { key: "hatchDefaultEdges", label: "Default contour edges", type: "boolean", value: true, group: "Hatching" },
+  ...UMBREON_PROPS.filter((p) => p.group !== "Global Illumination"),
+];
+
+/**
+ * NPR quality axes: umbreon's minus everything GI. The lighting selector
+ * keeps only Raytrace / AO (defaulting to plain raytracing -- the manual's
+ * own art direction: AO darkening muddies the hatch tone, so it is an
+ * opt-in), matching the C++ side, which skips GI whenever hatching is on.
+ *
+ * The enable patches reference only `aoEnabled`: this backend has no useGI
+ * prop, and a patch key without a matching PropDef is dropped by the settings
+ * hook, which would leave `lightingOf` unable to ever match the AO option.
+ */
+const UMBREON_NPR_QUALITY: RenderQualityConfig = {
+  lightings: [
+    { id: "none", label: "Raytrace only", enable: { aoEnabled: false } },
+    {
+      id: "ao",
+      label: "Ambient Occlusion",
+      enable: { aoEnabled: true },
+      group: "Ambient Occlusion",
+    },
+  ],
+  defaultLighting: "none",
+  lightingKeys: ["aoEnabled"],
+  axes: UMBREON_QUALITY.axes.filter((a) => a.key !== "gi"),
+};
+
+/**
+ * Common props the umbreon backends do not read (POV-Ray-only): stereo is
+ * unsupported, blendpng post-blend is POV-Ray's layer compositing, umbreon
+ * renders in-process (no CPU-thread knob), and pixel labels are POV-only.
+ */
+const UMBREON_UNSUPPORTED_COMMON_KEYS = [
+  "stereoMode",
+  "stereoDepth",
+  "numThreads",
+  "postBlend",
+  "pixelLabels",
+];
+
 /** All registered rendering backends, keyed by id. */
 export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> = {
   povray: {
@@ -255,16 +339,23 @@ export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> =
     ],
     props: UMBREON_PROPS,
     quality: UMBREON_QUALITY,
-    // Common props the umbreon backend does not read (POV-Ray-only): stereo is
-    // unsupported, blendpng post-blend is POV-Ray's layer compositing, umbreon
-    // renders in-process (no CPU-thread knob), and pixel labels are POV-only.
-    unsupportedCommonKeys: [
-      "stereoMode",
-      "stereoDepth",
-      "numThreads",
-      "postBlend",
-      "pixelLabels",
+    unsupportedCommonKeys: UMBREON_UNSUPPORTED_COMMON_KEYS,
+  },
+  umbreon_npr: {
+    id: "umbreon_npr",
+    label: "Umbreon (NPR)",
+    groups: [
+      // Hatching first and expanded: the style select is what this backend
+      // is about; everything below it is shared umbreon tuning.
+      { key: "Hatching", defaultExpanded: true },
+      { key: "Antialiasing", defaultExpanded: false },
+      { key: "Ambient Occlusion", defaultExpanded: false },
+      { key: "Shadows", defaultExpanded: false },
+      { key: "Edges", defaultExpanded: false },
     ],
+    props: UMBREON_NPR_PROPS,
+    quality: UMBREON_NPR_QUALITY,
+    unsupportedCommonKeys: UMBREON_UNSUPPORTED_COMMON_KEYS,
   },
 };
 

--- a/tritium/react-gui/src/renderer/data/renderSettings.ts
+++ b/tritium/react-gui/src/renderer/data/renderSettings.ts
@@ -12,7 +12,7 @@ import { DEFAULT_MOVIE_BASE_NAME } from "../../shared/movieFrames";
 import type { PropDef } from "./rendererProperties";
 
 /** Identifier of a rendering backend. Extended as backends are added. */
-export type RenderBackendId = "povray" | "umbreon";
+export type RenderBackendId = "povray" | "umbreon" | "umbreon_npr";
 
 /**
  * What a render job produces: a single image, or the frame sequence (and

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/UmbreonBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/UmbreonBackend.ts
@@ -57,6 +57,17 @@ const AO_GATHER: Record<string, number> = {
   "Per shading hit": 0,
 };
 
+// NPR coloring pattern (renderBackends.ts "hatchColoring" enum) -> the
+// exporter's hatchBase/hatchInk pair (umbreon --hatch-base / --hatch-ink).
+// Empty strings keep the style's own base/ink model.
+const HATCH_COLORING: Record<string, { base: string; ink: string }> = {
+  "Style default": { base: "", ink: "" },
+  "Ink on paper": { base: "paper", ink: "fixed" },
+  "Colored ink on paper": { base: "paper", ink: "albedo" },
+  "Ink on color fill": { base: "albedo", ink: "fixed" },
+  "Colored ink on color fill": { base: "albedo", ink: "albedo" },
+};
+
 
 /**
  * Create the umbreon exporter and apply every setting from `snapshot`.
@@ -65,10 +76,16 @@ const AO_GATHER: Record<string, number> = {
  * camera is chosen: the still path names it (`camera = "__current"`), while an
  * animation frame gets the animation's own camera object from
  * `AnimMgr.beginFrame()` (an explicit camera object overrides the name).
+ *
+ * @param npr - Umbreon (NPR) backend: write the hatch block instead of the GI
+ *   one. The two are exclusive by design -- hatch ink mode discards the shaded
+ *   color, so the C++ side skips GI whenever hatching is on, and the NPR
+ *   backend's props carry no GI keys to send anyway.
  */
 function makeExporter(
   ctx: WorkerContext,
   snapshot: RenderSettingsSnapshot,
+  npr: boolean,
 ): UmbreonSceneExporter {
   const exporter = ctx.strMgr.createHandler("umbreon", 2) as UmbreonSceneExporter;
   if (!exporter) throw new Error("cannot create umbreon exporter");
@@ -129,14 +146,36 @@ function makeExporter(
   // there unless this is asked for.
   exporter.contactEdges = boolVal(ub, "contactEdges", false);
 
-  // Diffuse global illumination (pt1 path-traced integrator).
-  exporter.useGI = boolVal(ub, "useGI", false);
-  exporter.giSamples = numVal(ub, "giSamples", 32);
-  exporter.giIntensity = numVal(ub, "giIntensity", 1.0);
-  exporter.giEnvIntensity = numVal(ub, "giEnvIntensity", 1.0);
-  const denoise = DENOISE_MODE[strVal(ub, "denoise", "OIDN")] ?? DENOISE_MODE.OIDN;
-  exporter.giDenoise = denoise.giDenoise; // pt1Denoise: OIDN on the indirect buffer
-  exporter.denoiser = denoise.denoiser; // full-frame post-pass (0 = None, 1 = a-trous)
+  if (npr) {
+    // NPR tone hatching. Colors are sent only while their Custom switch is
+    // on; an empty string tells the exporter to keep the style's own colors
+    // (richardson's warm paper, its per-section ink).
+    exporter.hatchEnable = true;
+    exporter.hatchStyle = strVal(ub, "hatchStyle", "richardson");
+    exporter.hatchDensity = numVal(ub, "hatchDensity", 1.0);
+    exporter.hatchWidthScale = numVal(ub, "hatchWidthScale", 1.0);
+    const coloring =
+      HATCH_COLORING[strVal(ub, "hatchColoring", "Style default")] ??
+      HATCH_COLORING["Style default"];
+    exporter.hatchBase = coloring.base;
+    exporter.hatchInk = coloring.ink;
+    exporter.hatchInkColor = boolVal(ub, "hatchCustomInk", false)
+      ? strVal(ub, "hatchInkColor", "#000000")
+      : "";
+    exporter.hatchPaperColor = boolVal(ub, "hatchCustomPaper", false)
+      ? strVal(ub, "hatchPaperColor", "#ffffff")
+      : "";
+    exporter.hatchDefaultEdges = boolVal(ub, "hatchDefaultEdges", true);
+  } else {
+    // Diffuse global illumination (pt1 path-traced integrator).
+    exporter.useGI = boolVal(ub, "useGI", false);
+    exporter.giSamples = numVal(ub, "giSamples", 32);
+    exporter.giIntensity = numVal(ub, "giIntensity", 1.0);
+    exporter.giEnvIntensity = numVal(ub, "giEnvIntensity", 1.0);
+    const denoise = DENOISE_MODE[strVal(ub, "denoise", "OIDN")] ?? DENOISE_MODE.OIDN;
+    exporter.giDenoise = denoise.giDenoise; // pt1Denoise: OIDN on the indirect buffer
+    exporter.denoiser = denoise.denoiser; // full-frame post-pass (0 = None, 1 = a-trous)
+  }
 
   return exporter;
 }
@@ -179,79 +218,96 @@ function makeHandle(
   };
 }
 
-export const umbreonBackend: RenderBackend = {
-  id: "umbreon",
+/**
+ * Build one umbreon-based backend. The plain and the NPR backend share the
+ * whole in-process render cycle and differ only in the exporter block
+ * `makeExporter` writes (GI vs hatch), so a single factory keeps them from
+ * drifting apart.
+ */
+function createUmbreonBackend(id: string, npr: boolean): RenderBackend {
+  return {
+    id,
 
-  // No input file to write: umbreon renders straight to the output PNG in
-  // `beginInProcess`. Carry only the workdir so `outputImagePath` can derive
-  // the target path (the shared `exportScene -> outputImagePath` convention).
-  exportScene(_ctx, _scene, _snapshot, workDir): ExportedScene {
-    return { inputPath: "", workDir, blendTable: {} };
-  },
+    // No input file to write: umbreon renders straight to the output PNG in
+    // `beginInProcess`. Carry only the workdir so `outputImagePath` can derive
+    // the target path (the shared `exportScene -> outputImagePath` convention).
+    exportScene(_ctx, _scene, _snapshot, workDir): ExportedScene {
+      return { inputPath: "", workDir, blendTable: {} };
+    },
 
-  outputImagePath(exported: ExportedScene): string {
-    return path.join(exported.workDir, "render.png");
-  },
+    outputImagePath(exported: ExportedScene): string {
+      return path.join(exported.workDir, "render.png");
+    },
 
-  beginInProcess(
-    ctx: WorkerContext,
-    scene: Scene,
-    snapshot: RenderSettingsSnapshot,
-    outputPath: string,
-  ): InProcessRender {
-    const exporter = makeExporter(ctx, snapshot);
-    exporter.camera = "__current";
+    beginInProcess(
+      ctx: WorkerContext,
+      scene: Scene,
+      snapshot: RenderSettingsSnapshot,
+      outputPath: string,
+    ): InProcessRender {
+      const exporter = makeExporter(ctx, snapshot, npr);
+      exporter.camera = "__current";
 
-    exporter.attach(scene);
-    try {
+      exporter.attach(scene);
+      try {
+        exporter.setPath(outputPath);
+        // Build the scene (this call) and start the ray trace on a background
+        // C++ thread; returns immediately so the pipeline can poll for
+        // progress.
+        exporter.beginRender();
+      } catch (e) {
+        // A failed start must not leave the scene attached: the exporter would
+        // keep holding the C++ scene reference until it is garbage-collected.
+        exporter.detach();
+        throw e;
+      }
+
+      return makeHandle(exporter, () => exporter.detach());
+    },
+
+    beginInProcessAnimFrame(
+      ctx: WorkerContext,
+      animMgr: AnimMgr,
+      snapshot: RenderSettingsSnapshot,
+      outputPath: string,
+    ): InProcessRender {
+      const exporter = makeExporter(ctx, snapshot, npr);
       exporter.setPath(outputPath);
-      // Build the scene (this call) and start the ray trace on a background C++
-      // thread; returns immediately so the pipeline can poll for progress.
-      exporter.beginRender();
-    } catch (e) {
-      // A failed start must not leave the scene attached: the exporter would
-      // keep holding the C++ scene reference until it is garbage-collected.
-      exporter.detach();
-      throw e;
-    }
 
-    return makeHandle(exporter, () => exporter.detach());
-  },
+      // beginFrame() attaches the scene, applies this frame's animation state
+      // and hands over the animation's own camera -- so no attach() and no
+      // `camera` name here (an explicit camera object wins over the name
+      // anyway). The frame stays applied until endFrame(), which is what lets
+      // the ray trace run asynchronously in between.
+      if (!animMgr.beginFrame(exporter)) {
+        throw new Error("the animation has no frame left to render");
+      }
+      try {
+        exporter.beginRender();
+      } catch (e) {
+        animMgr.endFrame(exporter);
+        throw e;
+      }
 
-  beginInProcessAnimFrame(
-    ctx: WorkerContext,
-    animMgr: AnimMgr,
-    snapshot: RenderSettingsSnapshot,
-    outputPath: string,
-  ): InProcessRender {
-    const exporter = makeExporter(ctx, snapshot);
-    exporter.setPath(outputPath);
+      return makeHandle(exporter, () => animMgr.endFrame(exporter));
+    },
 
-    // beginFrame() attaches the scene, applies this frame's animation state and
-    // hands over the animation's own camera -- so no attach() and no `camera`
-    // name here (an explicit camera object wins over the name anyway). The
-    // frame stays applied until endFrame(), which is what lets the ray trace
-    // run asynchronously in between.
-    if (!animMgr.beginFrame(exporter)) {
-      throw new Error("the animation has no frame left to render");
-    }
-    try {
-      exporter.beginRender();
-    } catch (e) {
-      animMgr.endFrame(exporter);
-      throw e;
-    }
+    // Never invoked for an in-process backend (renderJob branches on
+    // `beginInProcess` before touching these); defensive stubs.
+    buildTasks(_exported, _snapshot, _binaries: RenderBinaries): RenderTaskSpec[] {
+      throw new Error("umbreon renders in-process; buildTasks is unused");
+    },
 
-    return makeHandle(exporter, () => animMgr.endFrame(exporter));
-  },
+    parseProgress(_stdout: string): number | null {
+      return null;
+    },
+  };
+}
 
-  // Never invoked for an in-process backend (renderJob branches on
-  // `beginInProcess` before touching these); defensive stubs.
-  buildTasks(_exported, _snapshot, _binaries: RenderBinaries): RenderTaskSpec[] {
-    throw new Error("umbreon renders in-process; buildTasks is unused");
-  },
+export const umbreonBackend: RenderBackend = createUmbreonBackend("umbreon", false);
 
-  parseProgress(_stdout: string): number | null {
-    return null;
-  },
-};
+/** Umbreon with the NPR tone-hatching pass (ink-drawing output). */
+export const umbreonNprBackend: RenderBackend = createUmbreonBackend(
+  "umbreon_npr",
+  true,
+);

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/index.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/index.ts
@@ -7,13 +7,14 @@
 
 import type { RenderBackend } from "./RenderBackend";
 import { povrayBackend } from "./PovrayBackend";
-import { umbreonBackend } from "./UmbreonBackend";
+import { umbreonBackend, umbreonNprBackend } from "./UmbreonBackend";
 
 export type { RenderBackend } from "./RenderBackend";
 
 const BACKENDS: Record<string, RenderBackend> = {
   [povrayBackend.id]: povrayBackend,
   [umbreonBackend.id]: umbreonBackend,
+  [umbreonNprBackend.id]: umbreonNprBackend,
 };
 
 /** Look up a backend by id; null when the id is unknown. */


### PR DESCRIPTION
## Summary

Adds **Umbreon (NPR)** as a third rendering-window backend alongside POV-Ray and Umbreon. It drives umbreon's NPR tone-hatching pass (`RenderOptions::hatch`), so a scene renders as an ink drawing — hatch marks carry the shading tone on a paper base — instead of a photorealistic ray trace.

Because hatch ink mode discards the shaded color, umbreon force-disables GI there. The backend therefore restricts the integrator (Lighting) selector to **Raytrace only (default)** and **Ambient Occlusion**, and drops the GI group and GI quality axis entirely.

## libcuemol2

- `UmbreonSceneExporter` gains hatch properties: `hatchEnable`, `hatchStyle`, `hatchDensity`, `hatchWidthScale`, `hatchBase`, `hatchInk`, `hatchInkColor`, `hatchPaperColor`, `hatchDefaultEdges`. Colors are `#RRGGBB` strings and the base/ink model names are strings, so an empty value means "keep the style's own model/color" — richardson's warm paper and its per-section ink survive.
- The style name resolves through `applyHatchLook` first, then `applyHatchPreset`; an unknown name warns into the render log and falls back to richardson rather than silently landing on umbreon's built-in defaults.
- Density and width are **multipliers** over the style's per-layer values, so the relative pitches of a multi-layer look are preserved (one absolute pitch would collapse them).
- GI is skipped whenever hatching is on, decided here rather than relying on umbreon's warning path.
- **Contour edges**: `hatchDefaultEdges` runs the stroke pass even when no section asked for edge lines, filling in a silhouette + border contour **only** for sections whose `EdgeStyle` is all-disabled. Sections whose renderer configured edge lines keep their captured color, width and silhouette mode.
- The resolved paper color also drives the scene background and the fog fading into it. umbreon paints paper over surface pixels only ("the paper color only fills the object interior, not the background"), which made a custom paper look inert; for a drawing the whole sheet is the paper.

## tritium

- New `umbreon_npr` backend labelled **Umbreon (NPR)**, sharing the umbreon prop set minus the GI group, plus a **Hatching** group: style, mark density, mark width, coloring pattern, optional custom ink / paper colors, and the default-contour toggle.
- The **Coloring** selector exposes the manual's four base/ink combinations — ink on paper (pen figure), colored ink on paper (colored pencil), ink on color fill (comic), colored ink on color fill (print-like) — plus "Style default". Without it every mark preset rendered as fixed black on white; now any style can use the renderer's colors.
- `UmbreonBackend` is built by `createUmbreonBackend(id, npr)` so the plain and NPR backends cannot drift apart; only the exporter block differs (hatch vs GI).
- Both umbreon-based backends are gated together by the existing `umbreonAvailable` flag.

## Test plan

- `task run_gtest` — green (test_umbreon 25 -> 28). New gtests pin the paper-over-background repaint, the "renderer edge style wins over the default contour" rule, and the unknown-style fallback.
- `cd tritium/react-gui && npm test` — green (2756 -> 2765). Covers the registry restrictions (no GI lighting/axis/props for NPR, every lighting patch key exists as a prop), the NPR lighting defaults, the editor's Lighting options and Hatching group, and the exporter prop mapping including the Custom-switch color gating.
- `npx tsc -p tsconfig.web.json --noEmit` / `tsconfig.node.json` — clean; `task lint_tritium_style` baseline unchanged (no CSS touched).
- Manual E2E in the app: verified the backend appears, renders each style, and that mark density, custom colors, the coloring patterns and renderer-side edge lines behave as described.

> [!NOTE]
> Requires an umbreon build with the NPR pass (`task install_umbreon` against current `main`) and `ENABLE_UMBREON=ON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)