### PR TITLE
fix(docs): correct a stray non-English word in the v2.3.8.494 release note

### DIFF
--- a/docs/release_notes/v2.3.8.494.md
+++ b/docs/release_notes/v2.3.8.494.md
@@ -42,7 +42,7 @@ sessions.
 log occupying the bottom pane. Umbreon quality is set per axis — Supersampling
 1x–4x, AO or GI quality Low/Medium/High, Shadows Off/Hard/Soft/Very soft — and
 Lighting is a single choice of Raytrace only, Ambient Occlusion or Global
-Illumination. GI offers a Denoise选択 of OIDN (default), A-trous or None. The
+Illumination. GI offers a Denoise choice of OIDN (default), A-trous or None. The
 last 50 renders are kept as history: Back / Forward in the result pane recalls
 each image together with the settings that produced it. Save and Copy are back
 in the result toolbar, and trackpad pinch zooms around the pointer.


### PR DESCRIPTION
One-character-class fix in the release note merged in #485.

The Denoise sentence read `Denoise选択` instead of `Denoise choice`. The release note is published verbatim as the GitHub release body, so this would have appeared on the release page for v2.3.8.494.

Found by scanning the note for non-ASCII characters. The remaining non-ASCII in the file is intentional: em/en dashes in prose, and `▲▼↑↓` where the text describes the actual stepper and arrow-key behaviour. No doubled words, and the product-name and version spellings are consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)