### PR TITLE
fix(ci): stop the release-notes checkout from deleting the build artifacts

### DIFF
--- a/.github/workflows/build2.yml
+++ b/.github/workflows/build2.yml
@@ -453,11 +453,18 @@ jobs:
 
     # Only the release-notes file is needed from the tree; a full checkout here
     # would drag in the whole uxp_gui tree for one markdown file.
+    #
+    # Checked out into its own directory, NOT the workspace root: actions/checkout
+    # defaults to clean: true, which runs `git clean -ffdx` and would delete the
+    # untracked artifacts/ directory downloaded above. v2.3.8.494 was published
+    # with its notes but no assets that way ("Pattern 'artifacts/*' does not match
+    # any files").
     - name: Checkout release notes
       if: startsWith(github.ref, 'refs/tags/') && env.BUILD_MODE == 'full'
       uses: actions/checkout@v4
       with:
         sparse-checkout: docs/release_notes
+        path: _release_notes
 
     # Resolve the release body before publishing. Without a body the release is
     # created empty: action-gh-release writes no body of its own and does not
@@ -483,7 +490,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
-        NOTES="docs/release_notes/${GITHUB_REF_NAME}.md"
+        NOTES="_release_notes/docs/release_notes/${GITHUB_REF_NAME}.md"
         if [ -f "$NOTES" ]; then
           echo "using hand-written notes: $NOTES"
           cp "$NOTES" release_notes.md
@@ -497,6 +504,21 @@ jobs:
         fi
         echo "--- release body ---"
         cat release_notes.md
+
+    # action-gh-release only warns ("Pattern ... does not match any files") and
+    # still succeeds when its glob is empty, so an assetless release publishes
+    # silently -- which is how v2.3.8.494 first went out. Fail loudly instead.
+    - name: Check artifacts are present
+      if: startsWith(github.ref, 'refs/tags/') && env.BUILD_MODE == 'full'
+      run: |
+        set -euo pipefail
+        count=$(find artifacts -type f | wc -l)
+        echo "artifacts to attach: $count"
+        find artifacts -type f -printf '  %p\n'
+        if [ "$count" -eq 0 ]; then
+          echo "::error::No artifacts to attach -- refusing to publish an empty release."
+          exit 1
+        fi
 
     - name: Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Regression from #485, found while releasing v2.3.8.494.

## What happened

`v2.3.8.494` published with a correct release body (16,668 chars — the notes fix worked) and **zero assets**.

`actions/checkout` defaults to `clean: true`, which runs `git clean -ffdx`. The notes checkout I added lands in the workspace root, so it deleted the untracked `artifacts/` directory that `download-artifact` had just filled with all six build artifacts:

```
Download All Artifacts   Found 6 artifact(s)
                         Starting download of artifact to: /home/runner/work/cuemol2/cuemol2/artifacts
Checkout release notes   clean: true
                         Deleting the contents of '/home/runner/work/cuemol2/cuemol2'
Release                  🤔 Pattern 'artifacts/*' does not match any files.
```

## Fix

The checkout now goes to its own `_release_notes/` directory, where cleaning cannot reach the artifacts, and the notes path is read from there.

`action-gh-release` only *warns* on an empty glob and still succeeds, which is exactly why this shipped unnoticed. The job now counts the artifacts and fails before publishing if there are none, so this cannot silently recur.

## Verification

- `build2.yml` parses; `release_build` resolves to: Download All Artifacts → Checkout release notes → Resolve release notes → Check artifacts are present → Release
- The v2.3.8.494 run confirms both halves independently: the body was set correctly (so the notes mechanism works), and the assets were missing (so the cleaning is the sole cause)

Once this merges, v2.3.8.494's assets can be attached by re-running the release build for the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)