### PR TITLE
feat(uxp): mirror the CueMol clipboard payload as text

### DIFF
--- a/uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/qsc-copipe.js
+++ b/uxp_gui/cuemol2/components/jsmods/cuemol2ui-lib/qsc-copipe.js
@@ -54,6 +54,176 @@ let clipboardService = Cc["@mozilla.org/widget/clipboard;1"].
 let clipboardHelper = Cc["@mozilla.org/widget/clipboardhelper;1"].
                       getService(Ci.nsIClipboardHelper);
 
+/////////////////////////////////////////////////////////////////
+// CueMol clipboard text envelope (cross-application interchange)
+//
+// On macOS Gecko never exports our custom flavors: nsClipboard's
+// PasteboardDictFromTransferable writes only text / RTF / HTML / images /
+// files / x-moz-custom-clipdata and drops everything else, so the flavors
+// below live purely in the in-process transferable cache. text/unicode IS
+// exported on every platform, so mirroring the payload there is the only
+// way another application -- CueMol3 -- can see a copy made here, and the
+// only way we can see one made there.
+//
+// Format (line 1 magic, line 2 metadata, the rest base64):
+//
+//   CueMolClipboard/1
+//   {"kind":"renderer","form":"rendArray","name":"grp1"}
+//   <base64 of the raw payload bytes>
+//
+// Base64 because an object payload is not well-formed XML: the writer
+// appends an end-of-XML sentinel plus compressed data chunks after the
+// document, and that must survive as bytes.
+
+const kEnvelopeMagic = "CueMolClipboard/1";
+
+const AppShellService = Cc["@mozilla.org/appshell/appShellService;1"].
+                        getService(Ci.nsIAppShellService);
+
+/** base64 of a byte string (one char per byte, as convBAryToStr yields). */
+function b64encode(aByteStr) {
+  return AppShellService.hiddenDOMWindow.btoa(String(aByteStr));
+}
+
+/** Inverse of b64encode; throws on malformed input. */
+function b64decode(aText) {
+  return AppShellService.hiddenDOMWindow.atob(String(aText));
+}
+
+/**
+ * Metadata a flavor maps to. `form` distinguishes the two renderer
+ * payload shapes (UXP qscrend vs qscrendary), which the reader needs
+ * because they deserialize through different entry points.
+ */
+function envelopeMetaFor(aFlavor) {
+  switch (aFlavor) {
+  case "application/x-cuemol2-scenexml-rend":
+    return {kind: "renderer", form: "single"};
+  case "application/x-cuemol2-scenexml-rend-array":
+    return {kind: "renderer", form: "rendArray"};
+  case "application/x-cuemol2-scenexml-obj":
+    return {kind: "object", form: "single"};
+  case "application/x-cuemol2-scenexml-cam":
+    return {kind: "camera", form: "single"};
+  case "application/x-cuemol2-scenexml-style":
+    return {kind: "style", form: "single"};
+  case "application/x-cuemol2-json-paint":
+    return {kind: "paint", form: "single"};
+  default:
+    return null;
+  }
+}
+
+/**
+ * Build the envelope text for a payload.
+ *
+ * aByteStr is one JS char per payload byte: for scenexml that is what
+ * convBAryToStr returns, and for the paint JSON we widen the UTF-16 text
+ * to UTF-8 bytes first so the base64 is byte-defined either way.
+ */
+function makeEnvelope(aFlavor, aByteStr) {
+  let meta = envelopeMetaFor(aFlavor);
+  if (!meta) return null;
+  return kEnvelopeMagic + "\n" +
+         JSON.stringify(meta) + "\n" +
+         b64encode(aByteStr) + "\n";
+}
+
+/** A UTF-8 unicode converter. */
+function utf8Converter() {
+  let conv = Cc["@mozilla.org/intl/scriptableunicodeconverter"].
+             createInstance(Ci.nsIScriptableUnicodeConverter);
+  conv.charset = "UTF-8";
+  return conv;
+}
+
+/** UTF-16 JS string -> a byte string holding its UTF-8 encoding. */
+function toUtf8ByteStr(aStr) {
+  let conv = utf8Converter();
+  return conv.ConvertFromUnicode(aStr) + conv.Finish();
+}
+
+/** Inverse of toUtf8ByteStr. */
+function fromUtf8ByteStr(aByteStr) {
+  return utf8Converter().ConvertToUnicode(aByteStr);
+}
+
+/**
+ * Parse an envelope. Returns {kind, form, bytes} or null for anything that
+ * is not an intact CueMol envelope -- ordinary copied text lands here on
+ * every Paste check, so this must be quiet and total.
+ *
+ * Everything after line 2 is the payload with all whitespace stripped, so
+ * a body wrapped or CRLF-normalised on its way through the clipboard still
+ * decodes.
+ */
+function parseEnvelope(aText) {
+  if (typeof aText != "string" || aText.length == 0) return null;
+  let nl1 = aText.indexOf("\n");
+  if (nl1 < 0) return null;
+  if (aText.substring(0, nl1).replace(/\r$/, "").trim() != kEnvelopeMagic)
+    return null;
+  let nl2 = aText.indexOf("\n", nl1 + 1);
+  if (nl2 < 0) return null;
+
+  let meta;
+  try {
+    meta = JSON.parse(aText.substring(nl1 + 1, nl2).replace(/\r$/, "").trim());
+  }
+  catch (e) { return null; }
+  if (!meta || typeof meta.kind != "string") return null;
+
+  let b64 = aText.substring(nl2 + 1).replace(/\s+/g, "");
+  if (b64.length % 4 != 0 || !/^[A-Za-z0-9+\/]*={0,2}$/.test(b64)) return null;
+
+  let bytes;
+  try { bytes = b64decode(b64); }
+  catch (e) { return null; }
+
+  return {kind: meta.kind,
+          form: (meta.form == "rendArray") ? "rendArray" : "single",
+          bytes: bytes};
+}
+
+/**
+ * Add the text/unicode mirror of a payload to a transferable that already
+ * carries the native flavor. One setData call publishes both, so on
+ * Windows / Linux nothing about the existing exchange changes and on
+ * macOS the text is the only thing that actually leaves the process.
+ */
+function addEnvelopeFlavor(aXferable, aFlavor, aByteStr) {
+  try {
+    let text = makeEnvelope(aFlavor, aByteStr);
+    if (!text) return;
+    let str = Cc["@mozilla.org/supports-string;1"].
+      createInstance(Ci.nsISupportsString);
+    str.data = text;
+    aXferable.addDataFlavor("text/unicode");
+    aXferable.setTransferData("text/unicode", str, text.length * 2);
+  }
+  catch (e) {
+    // The native flavor is already on the transferable; losing the mirror
+    // costs cross-application paste, not this app's own copy/paste.
+    dd("Copipe> envelope mirror failed: " + e);
+  }
+}
+
+/** Read the envelope off the clipboard, filtered to one flavor. */
+function getEnvelopeFor(aFlavor) {
+  let want = envelopeMetaFor(aFlavor);
+  if (!want) return null;
+  let text = null;
+  try { text = exports.get("text"); }
+  catch (e) { return null; }
+  let env = parseEnvelope(text);
+  if (!env) return null;
+  if (env.kind != want.kind) return null;
+  // A single-renderer read must not accept an array payload (and vice
+  // versa): the caller picks its deserializer by flavor.
+  if (want.kind == "renderer" && env.form != want.form) return null;
+  return env;
+}
+
 
 exports.set = function(aData, aDataType) {
   let options = {
@@ -143,6 +313,10 @@ exports.set = function(aData, aDataType) {
     xferable.addDataFlavor(flavor);
     xferable.setTransferData(flavor, str, xmlstr.length * 2);
 
+    // xmlstr is already one char per XML byte (convBAryToStr does not
+    // transcode), so it goes into the envelope as-is.
+    addEnvelopeFlavor(xferable, flavor, xmlstr);
+
     break;
   }
 
@@ -154,6 +328,10 @@ exports.set = function(aData, aDataType) {
     str.data = options.data;
     xferable.addDataFlavor(flavor);
     xferable.setTransferData(flavor, str, options.data.length * 2);
+
+    // Real text here, unlike the scenexml case: widen to UTF-8 bytes so
+    // the envelope payload is byte-defined for both kinds.
+    addEnvelopeFlavor(xferable, flavor, toUtf8ByteStr(options.data));
 
     break;
   }
@@ -213,17 +391,28 @@ exports.get = function(aDataType)
 
   var data = {};
   var dataLen = {};
+  let bHasNative = true;
   try {
     xferable.getTransferData(flavor, data, dataLen);
   }
   catch (e) {
-    // Clipboard doesn't contain data in flavor, return null.
-    return null;
+    // Clipboard doesn't contain data in this flavor.
+    bHasNative = false;
   }
 
-  // There's no data available, return.
-  if (data.value === null)
-    return null;
+  if (bHasNative && data.value === null)
+    bHasNative = false;
+
+  if (!bHasNative) {
+    // Fall back to the text envelope, which is how a copy made in another
+    // application (CueMol3) arrives -- and, on macOS, how a copy made here
+    // arrives back, since the native flavors never reach the pasteboard.
+    let env = getEnvelopeFor(flavor);
+    if (!env) return null;
+    if (flavor == "application/x-cuemol2-json-paint")
+      return fromUtf8ByteStr(env.bytes);
+    return cuemol.convPolymObj( cuemol.xpc.createBAryFromStr(env.bytes) );
+  }
 
   dd("Copipe get() flavor="+flavor);
 
@@ -237,12 +426,7 @@ exports.get = function(aDataType)
   case "application/x-cuemol2-scenexml-rend":
   case "application/x-cuemol2-scenexml-obj": 
   case "application/x-cuemol2-scenexml-style": 
-  case "application/x-cuemol2-scenexml-cam": {
-    let str = data.value.QueryInterface(Ci.nsISupportsString).data;
-    data = cuemol.convPolymObj( cuemol.xpc.createBAryFromStr(str) );
-    break;
-  }    
-
+  case "application/x-cuemol2-scenexml-cam":
   case "application/x-cuemol2-scenexml-rend-array": {
     let str = data.value.QueryInterface(Ci.nsISupportsString).data;
     data = cuemol.convPolymObj( cuemol.xpc.createBAryFromStr(str) );
@@ -300,20 +484,27 @@ exports.check = function(aDataType)
     xferable.getTransferData(flavor, data, dataLen);
   }
   catch (e) {
-    // Clipboard doesn't contain data in flavor, return null.
-    dd("flavor not found: "+flavor);
-    return false;
+    // Not in this flavor -- the payload may still be there as the text
+    // envelope. The ctxmenu Paste gate goes through here, so without this
+    // fallback a pasteable payload would show a disabled menu item.
+    return checkEnvelope(flavor);
   }
 
   // There's no data available, return.
   if (data.value === null) {
-    dd("flavor not found: "+flavor);
-    return false;
+    return checkEnvelope(flavor);
   }
   
   dd("flavor found: "+flavor);
   return true;
 };
+
+/** Whether the text envelope on the clipboard matches aFlavor. */
+function checkEnvelope(aFlavor) {
+  let found = (getEnvelopeFor(aFlavor) !== null);
+  dd((found ? "envelope found: " : "flavor not found: ") + aFlavor);
+  return found;
+}
 
 exports.__defineGetter__("currentFlavors", function() {
   // Loop over kAllowableFlavors, calling hasDataMatchingFlavors for each.


### PR DESCRIPTION
PR 2 of 2, following #505. This is what opens macOS interop between CueMol2 and CueMol3.

## Why the CueMol2 side has to change at all

On macOS the custom flavors this module publishes **never reach NSPasteboard**. Gecko's `PasteboardDictFromTransferable` (`uxp_gui/platform/widget/cocoa/nsClipboard.mm:636`) writes only text / RTF / HTML / images / files / `x-moz-custom-clipdata` and drops the rest — *"If it wasn't a type that we recognize as exportable we don't put it on the system clipboard"*. `HasDataMatchingFlavors` and `GetNativeClipboardData` likewise answer from the in-process `mTransferable` cache. `uxp_diff.patch` does not touch `widget/`, so this is stock UXP.

So CueMol2's scene and paint copy/paste has always been running purely inside its own process on macOS. Nothing outside can see a copy made here — and since Gecko cannot *read* an arbitrary custom type either, text is the only channel available in both directions.

## What changes

`set()` adds a `text/unicode` mirror to the **same transferable** as the native flavor. Gecko publishes every flavor of one transferable at once, so Windows and Linux keep exporting the native format exactly as before and macOS gains the only representation that actually leaves the process.

The mirror is the three-line envelope #505 defined:

```
CueMolClipboard/1
{"kind":"renderer","form":"single"}
<base64 of the raw payload bytes>
```

Base64 because an object payload is not well-formed XML — `LDOM2Stream` appends an end-of-XML sentinel plus compressed data chunks after the document, and that has to survive as bytes. Everything after line 2 is read with whitespace stripped, so a body wrapped or CRLF-normalised on its way through the clipboard still decodes.

`get()` falls back to the envelope when the native flavor is absent. **`check()` needed the same fallback** — the context-menu gates go through it (`workspace_panel_ctxtmenu.js` `clipboard.check("qscrend")` etc.), so without it a perfectly pasteable payload would sit on the clipboard behind a disabled menu item. Parsing is total and quiet: ordinary copied text reaches it on every Paste check.

One asymmetry worth naming: the scenexml payload goes in as `convBAryToStr` returns it — one char per XML byte, since XPConnect does not transcode `T_CSTRING` — while the paint JSON is real text and is widened to UTF-8 first. That way the base64 is byte-defined for both, and matches what CueMol3 writes.

The `qscrend` / `qscrendary` distinction is preserved through `form`, so `onPasteRend`'s existing "try single, then array" fallback keeps working: an array payload fails the single check and succeeds on the second.

## Test plan

No automated tests — this module is UXP chrome JS with no harness in the repo. Verified so far:

- Syntax checked (`node --check`, with the file's pre-existing `for each` desugared).
- The wire format is pinned from the other side by a golden test in #505, written so that both apps emit byte-identical text for a given payload.
- Line endings kept CRLF, matching the file.

**Needs a real run before merge**: build CueMol2 (JS only, so packaging rather than a platform rebuild), then for renderer / rendGroup / object / camera / style / paint check CueMol2 → CueMol3 and CueMol3 → CueMol2, plus that CueMol2 → CueMol2 still works unchanged on all three platforms. On Windows and Linux the native flavor still wins, so the envelope path is exercised mainly on macOS.

Depends on #505 for the CueMol3 half. The version bump for both rides in #505 (2.3.9.497 — the revision moved because of this PR).