### PR TITLE
feat(render): NPR hatch layer editor and shading controls

### DIFF
--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -48,6 +48,11 @@ architecture, it belongs here.
   blendpng の `solvebeta` + 逐次 lerp との対応、POV-Ray で再現しない理由
   (`blendTab` の alpha 量子化と `>= 0.95` 不透明扱い)、半透明 group どうしが
   重なる場合に残るオーバーシュートの限界。
+- [umbreon (NPR) hatch layer editor と shading knob](umbreon-hatch-layer-editor.md) (日本語) --
+  Rendering window の NPR backend で hatch style をテンプレートとして C++ から読み込み、layer
+  構成 (太さ・密度・randomness) と shading (Strength / Curve) を編集してレンダーする設計。
+  Rendering window は worker を持たないため main 経由の 3 チャンネルリレー、dirty のときだけ
+  spec テキストを snapshot に載せる判断、form-kit による UI 構成、契約行一覧、制約と今後。
 - [umbreon の Electron メモリ制約と process 分離設計](umbreon-process-isolation.md)
   (日本語) -- tritium で umbreon GI(OIDN) が大解像度で crash する既知問題の根本原因
   (Chromium PartitionAlloc の OOM crash, OS 制限ではない)、検討した各対策と却下理由、

--- a/docs/architecture/umbreon-hatch-layer-editor.md
+++ b/docs/architecture/umbreon-hatch-layer-editor.md
@@ -1,0 +1,88 @@
+# umbreon (NPR) hatch layer editor と shading knob
+
+tritium の Rendering window (Umbreon (NPR) backend) で、hatch style をテンプレートとして
+読み込み、layer 構成 (本数・角度・pitch・太さ/径・randomness) と shading (tone → インク量) を
+編集してレンダーする仕組みの設計記録。UXP に無かった新規機能 (migration ではない)。
+
+umbreon 側の変更 (dotScale / 確率的 Stipple / 被覆→半径テーブル / auto fade /
+`ToneRecipe::strength, curve` / spec テキスト API) は
+`~/proj64/umbreon/docs/plans/npr-hatch-mark-geometry.md` を参照。
+
+## 背景
+
+- GUI の `Mark width` が網点系 style で効かなかった (umbreon の `widthPx` は Line 専用で、
+  Dot の半径は pitch と tone だけから決まっていた)。
+- stipple は中間調で薄すぎ、screentone の反転域は被覆が 50% で平坦になる、richardson 以外の
+  style は平坦な既定 tone recipe のまま、と「default が薄い / 調整できない」要因が重なっていた。
+- ユーザー要件: マーク形状は tone から独立させ、被覆による暗さは照光の明るさに連続に相関させ、
+  richardson 相当を layer の編集で自作できるようにする。
+
+## 決定事項
+
+| 項目 | 決定 |
+|---|---|
+| Style = テンプレート | Render タブの Style を選ぶと C++ (`UmbreonSceneExporter.getHatchStyleSpec`) が解決した look/preset を spec テキストで受け取り、parse して編集状態にする。Style を切り替えると編集は確認なしで破棄 (window-local・非永続、"Edited" バッジで補う) |
+| 置き場所 | Render settings pane の **"Detail" タブ** (Image / Render と並ぶ第 3 タブ、umbreon_npr のときだけ出る。Render タブの Hatching グループが既に hatching の preset 設定なので "Hatching" とは呼ばない)。Render タブの Hatching グループには preset 系 (Style / Coloring / Mark density / Mark width / 色 / 輪郭) だけを残す |
+| 効かない設定 | layer 種別で無意味なフィールドは**非表示** (kinds フィルタ: Line の width / stroke 系、Dot の dotscale / shape、Stipple では subdiv / invert 無し)。他の値で無効になるものは **disabled** (`layerFieldEnabled` / `toneFieldEnabled` / `inkFieldEnabled`: 例 slen=0 で stroke gap/taper、rim=0 で rimpow/rimbias、hl>=1 で hlsoft、AO off で contact/shape AO、base が paper で albedoquant、円ドットの dotangle、乱数なしの seed)。spacing×ss が最小 pitch 2 px を下回る layer には「clamped (raise Supersampling)」のヒント |
+| dirty-or-nothing | snapshot には編集内容が template と異なるときだけ `hatch: { layersSpec, toneSpec }` (文字列 2 本) を載せる。未編集なら C++ の従来経路と bit 同一 |
+| 適用順 (C++) | `applyHatchStyle(style)` → `hatchLayersSpec` (layer 全置換) → `hatchToneSpec` (tone/ink キー上書き) → strength/curve 乗算 → density / width (Line=widthPx, Dot・Stipple=dotScale) → Coloring / 色の明示指定 (spec より優先) |
+| Mark density / Mark width | Render タブのままマスター乗数として残す (全 layer に一律、可逆)。Hatching タブは基準値を編集し、乗数が 1 でないときは注記と各 layer の spacing / width / dot scale の**実効値**を表示する。layer 値へ焼き込まない (往復の丸め誤差で Edited 扱いになるのを避ける) |
+| Shading の一次コントロール | `Strength` (被覆ゲイン) と `Curve` (中間調の寄せ方) の 2 knob のみ常時表示。他の tone recipe と ink 系は Advanced に折りたたみ |
+| 太らせすぎの黒潰れ | 許容 (レンジは tone 精度で縛らない: width / dotscale 0.1-8) |
+| spec の型 | `data/hatchSpec.ts` のフィールドテーブル 1 枚で parse / format / 既定値 / UI レンジを駆動。レコードのフィールド名 = spec キー。未知キーは `extra` で温存 |
+
+## データフロー
+
+```
+Render window (renderer)                      main                      Main window (renderer)        worker (C++)
+useHatchTemplate --RENDER_HATCH_STYLE_GET--> renderWindowIpc --REQUEST(push)--> useRenderWindowBridge --invokeService--> hatchStyleSpec.service
+   <-- HatchStyleSpecReply <-- (reqId) <-------- REPLY(invoke) <----------------------------------- getHatchStyleSpec(name)
+parseHatchSpec -> useRenderSettings.applyHatchTemplate (stale style は無視)
+編集 -> getSnapshot().hatch -> RENDER_WINDOW_COMMAND -> UmbreonBackend.makeExporter -> exporter.hatchLayersSpec / hatchToneSpec
+```
+
+Rendering window は別 BrowserWindow で worker を持たないため、`RENDER_VIEW_CAMERA_*` と同型の
+相関 ID ラウンドトリップを 1 組追加した (timeout は `{ ok: false, error: "timeout" }`)。
+
+## 契約行
+
+| マップ | 行 |
+|---|---|
+| `worker/shared/WorkerCalls.ts` `ServiceMap` | `getHatchStyleSpec: { args: GetHatchStyleSpecArgs; result: GetHatchStyleSpecResult }` |
+| `shared/ipcChannels.ts` | `RENDER_HATCH_STYLE_GET` (invoke) / `RENDER_HATCH_STYLE_REQUEST` (push) / `RENDER_HATCH_STYLE_REPLY` (invoke) |
+| `shared/ipcContract.ts` | `InvokeChannels` に GET / REPLY、`PushChannels` に REQUEST |
+| `shared/ipcTypes.ts` | `HatchStyleSpecReply`、`RenderSettingsSnapshotWire.hatch?` |
+| `data/renderResult.ts` | `RenderSettingsSnapshot.hatch?: RenderHatchSnapshot` |
+| `.qif` (`UmbreonSceneExporter`) | `hatchLayersSpec` / `hatchToneSpec` / `hatchToneStrength` / `hatchToneCurve` / `getHatchStyleSpec(name)` |
+
+## UI 構成 (form-kit のみ、consumer でサイズ指定しない)
+
+```
+RenderSettingsPane: [Image] [Render] [Detail]   (Detail は hatch prop があるときだけ)
+└ Detail タブ = HatchLookEditor    .hatch-look
+   ├ caption "Style template: <name>" / status caption (loading / error)
+   ├ ButtonRow: FormButton "Reset to style" (dirty のときだけ有効) + "Edited"
+   ├ HatchLayersSection = FieldSection "Layers" (titleActions: +Line / +Dot)
+   │   └ HatchLayerRow x N (React.memo, key = layer.id)
+   │       ├ .h3-list-row ヘッダ (Layer n -- kind, duplicate, trash)
+   │       ├ Field "Kind" > SelectField (line / dot / stipple)
+   │       ├ SliderField: angle / spacing / width | dot scale / tone high / tone low / fade / opacity / ink darkness
+   │       └ AccordionSection "Randomness / Advanced": jitter / wobble / ... / shape / aspect / invert (kind でフィルタ)
+   └ HatchShadingSection = FieldSection "Shading"
+       ├ SliderField Strength / Curve
+       └ AccordionSection "Advanced": ambient / wrap / rim ... / ink shade / min contrast / tone fog / fill posterize
+```
+
+`hooks/useRenderSettings.ts` が `HatchEditState { style, template, spec }` と操作
+(`applyHatchTemplate` / `updateHatchLayer` / `addHatchLayer` / `removeHatchLayer` /
+`duplicateHatchLayer` / `updateHatchTone` / `updateHatchInk` / `resetHatchToTemplate`) を持ち、
+`hooks/useHatchTemplate.ts` が非同期のテンプレート取得を担う (`useRenderSettings` は同期 API のみ)。
+
+## 制約と今後
+
+- 編集値は Rendering window 内の状態で非永続。名前付き custom style として保存・一覧に並べる
+  機能は後続タスク (spec がテキストなのでそのまま保存できる)。
+- layer の並べ替え (drag) は未実装 (duplicate + remove で代替)。
+- Style 変更時の確認ダイアログを足す場合は `RenderWindowApp` 側で `onChange` を包み
+  `settings.hatchDirty` を見るだけで済む (hook API は不変)。
+- preset ごとの tone recipe 既定値は umbreon 側 `hatchPresetTone` で目視調整中。

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -425,6 +425,19 @@ LString UmbreonDisplayContext::drainLog()
 #endif
 }
 
+LString UmbreonDisplayContext::hatchStyleSpec(const LString &style)
+{
+#ifdef HAVE_UMBREON
+  umbreon::HatchOptions opt;
+  if (!umbreon::applyHatchStyle(opt, style.c_str()))
+    return LString();
+  return LString(umbreon::hatchStyleToSpec(opt).c_str());
+#else
+  (void)style;
+  return LString();
+#endif
+}
+
 UmbreonDisplayContext::~UmbreonDisplayContext()
 {
 }
@@ -950,24 +963,51 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     // richardson, so a typo degrades to a valid drawing instead of the
     // built-in defaults silently changing the look.
     const std::string style = prm.hatchStyle.c_str();
-    if (!umbreon::applyHatchLook(opt.hatch, style) &&
-        !umbreon::applyHatchPreset(opt.hatch, style)) {
+    if (!umbreon::applyHatchStyle(opt.hatch, style)) {
       umbreon::logMessage(umbreon::LogLevel::Warning,
                           "unknown hatch style '%s'; using richardson",
                           style.c_str());
-      umbreon::applyHatchLook(opt.hatch, "richardson");
+      umbreon::applyHatchStyle(opt.hatch, "richardson");
     }
-    // Density / width are MULTIPLIERS over the style's per-layer values
-    // (density divides every lattice pitch: 2 = twice as many lines/dots).
+    // Hand-edited layers / tone (the GUI's layer editor sends the style it
+    // loaded through hatchStyleSpec() back, edited). Layers replace the
+    // style's, tone / ink keys override; a malformed text is reported and
+    // ignored so the render still runs with the style itself.
+    if (!prm.hatchLayersSpec.isEmpty()) {
+      std::string err;
+      if (!umbreon::applyHatchSpec(opt.hatch, prm.hatchLayersSpec.c_str(),
+                                   umbreon::kHatchSpecLayers, &err))
+        umbreon::logMessage(umbreon::LogLevel::Warning,
+                            "hatch layers spec ignored: %s", err.c_str());
+    }
+    if (!prm.hatchToneSpec.isEmpty()) {
+      std::string err;
+      if (!umbreon::applyHatchSpec(
+              opt.hatch, prm.hatchToneSpec.c_str(),
+              umbreon::kHatchSpecTone | umbreon::kHatchSpecInk, &err))
+        umbreon::logMessage(umbreon::LogLevel::Warning,
+                            "hatch tone spec ignored: %s", err.c_str());
+    }
+    // Ink amount: multipliers over the resolved recipe.
+    if (prm.hatchToneStrength > 0.0)
+      opt.hatch.tone.strength *= float(prm.hatchToneStrength);
+    if (prm.hatchToneCurve > 0.0)
+      opt.hatch.tone.curve *= float(prm.hatchToneCurve);
+    // Density / size are MULTIPLIERS over the per-layer values (density
+    // divides every lattice pitch: 2 = twice as many lines/dots; the size
+    // scales a Line layer's width and a Dot / Stipple layer's dot scale).
     // Scaling instead of overwriting preserves the relative pitches of a
     // multi-layer look, which one absolute pitch would collapse.
     const float density =
         (prm.hatchDensity > 0.0) ? float(prm.hatchDensity) : 1.0f;
-    const float widthScale =
+    const float sizeScale =
         (prm.hatchWidthScale > 0.0) ? float(prm.hatchWidthScale) : 1.0f;
     for (umbreon::HatchLayer &l : opt.hatch.layers) {
       l.spacingPx /= density;
-      l.widthPx *= widthScale;
+      if (l.kind == umbreon::LayerKind::Line)
+        l.widthPx *= sizeScale;
+      else
+        l.dotScale *= sizeScale;
     }
     // Base / ink model overrides (the manual's four coloring patterns).
     // Applied after the style so a coloring pick works on top of ANY style:

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -100,8 +100,22 @@ namespace render {
     /// (not an absolute pitch) so the relative pitches of a multi-layer look
     /// are preserved.
     double hatchDensity = 1.0;
-    /// Mark width multiplier over the style's per-layer widths.
+    /// Mark size multiplier over the style's per-layer sizes: the line width
+    /// of Line layers, the dot scale of Dot / Stipple layers.
     double hatchWidthScale = 1.0;
+    /// Hand-edited mark layers as umbreon spec text ("layer:" lines; see
+    /// umbreon applyHatchSpec). Applied after the style, so a non-empty text
+    /// REPLACES the style's layers; empty keeps them. A malformed text warns
+    /// into the render log and is ignored.
+    qlib::LString hatchLayersSpec;
+    /// Hand-edited tone recipe / ink model as spec text ("tone:" / "ink:"
+    /// lines), overriding the keys it names; empty keeps the style's own.
+    qlib::LString hatchToneSpec;
+    /// Ink-amount multipliers over the resolved tone recipe (umbreon
+    /// ToneRecipe::strength / curve): strength scales the coverage a display
+    /// tone asks for, curve bends the response (> 1 = lighter mid tones).
+    double hatchToneStrength = 1.0;
+    double hatchToneCurve = 1.0;
     /// Base / ink model overrides (umbreon --hatch-base / --hatch-ink). The
     /// four combinations are the manual's coloring patterns: paper+fixed =
     /// pen figure, paper+albedo = colored pencil (richardson), albedo+fixed =
@@ -195,6 +209,13 @@ namespace render {
     /// it over as newline-separated text for the host's render log. Empty when
     /// nothing was reported. Safe to call from any thread.
     static LString drainLog();
+
+    /// Resolve a hatch style name (look or mark preset, as hatchStyle takes
+    /// it) on fresh options and return it as umbreon spec text: the
+    /// "layer:" / "tone:" / "ink:" lines a host loads as an editable
+    /// template and sends back through hatchLayersSpec / hatchToneSpec.
+    /// Empty for an unknown name, or when built without umbreon.
+    static LString hatchStyleSpec(const LString &style);
 
     void finishAsyncRender(int &outWidth, int &outHeight, int &outNcomp,
                            std::vector<unsigned char> &outRGBA,

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -147,6 +147,8 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_dGiEnvIntensity(1.0), m_bGiDenoise(true), m_nDenoiser(0),
        m_bHatchEnable(false), m_sHatchStyle("richardson"),
        m_dHatchDensity(1.0), m_dHatchWidthScale(1.0),
+       m_sHatchLayersSpec(""), m_sHatchToneSpec(""),
+       m_dHatchToneStrength(1.0), m_dHatchToneCurve(1.0),
        m_sHatchBase(""), m_sHatchInk(""),
        m_sHatchInkColor(""), m_sHatchPaperColor(""),
        m_bHatchDefaultEdges(true),
@@ -242,12 +244,21 @@ void UmbreonSceneExporter::setupContext(UmbreonDisplayContext &ctx,
   prm.hatchStyle = m_sHatchStyle;
   prm.hatchDensity = m_dHatchDensity;
   prm.hatchWidthScale = m_dHatchWidthScale;
+  prm.hatchLayersSpec = m_sHatchLayersSpec;
+  prm.hatchToneSpec = m_sHatchToneSpec;
+  prm.hatchToneStrength = m_dHatchToneStrength;
+  prm.hatchToneCurve = m_dHatchToneCurve;
   prm.hatchBase = m_sHatchBase;
   prm.hatchInk = m_sHatchInk;
   prm.hatchInkColorSet = parseHexColor(m_sHatchInkColor, prm.hatchInkColor);
   prm.hatchPaperColorSet =
       parseHexColor(m_sHatchPaperColor, prm.hatchPaperColor);
   prm.hatchDefaultEdges = m_bHatchDefaultEdges;
+}
+
+LString UmbreonSceneExporter::getHatchStyleSpec(const LString &name) const
+{
+  return UmbreonDisplayContext::hatchStyleSpec(name);
 }
 
 void UmbreonSceneExporter::write()

--- a/src/modules/rendering/UmbreonSceneExporter.hpp
+++ b/src/modules/rendering/UmbreonSceneExporter.hpp
@@ -132,8 +132,17 @@ namespace render {
     /// mark density multiplier (2 = twice as many lines / dots)
     double m_dHatchDensity;
 
-    /// mark width multiplier over the style's per-layer widths
+    /// mark size multiplier over the style's per-layer sizes (line width /
+    /// dot scale)
     double m_dHatchWidthScale;
+
+    /// hand-edited layers / tone as umbreon spec text; empty = the style's
+    LString m_sHatchLayersSpec;
+    LString m_sHatchToneSpec;
+
+    /// ink-amount multipliers over the resolved tone recipe
+    double m_dHatchToneStrength;
+    double m_dHatchToneCurve;
 
     /// base / ink model overrides ("paper"/"albedo", "fixed"/"albedo");
     /// empty = keep the hatch style's own model
@@ -169,6 +178,10 @@ namespace render {
 
     /// render the scene and write the image (synchronous; blocks until done)
     void write() override;
+
+    /// Resolve a hatch style name and return it as umbreon spec text (the
+    /// layer editor's template); "" for an unknown name or without umbreon.
+    LString getHatchStyleSpec(const LString &name) const;
 
     /////////////////////////////////
     // Asynchronous render: drive with beginRender() -> poll -> endRender().

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -143,8 +143,27 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   /// so 2 doubles the number of hatch lines / halftone dots
   property real hatchDensity => m_dHatchDensity;
 
-  /// mark width multiplier over the style's per-layer stroke widths
+  /// mark size multiplier over the style's per-layer sizes: the line width
+  /// of Line layers, the dot scale of Dot / Stipple layers
   property real hatchWidthScale => m_dHatchWidthScale;
+
+  /// hand-edited mark layers as umbreon spec text ("layer:" lines, one per
+  /// layer; the text getHatchStyleSpec returns, edited). A non-empty text
+  /// replaces the style's layers; empty (the default) keeps them
+  property string hatchLayersSpec => m_sHatchLayersSpec;
+
+  /// hand-edited tone recipe / ink model as spec text ("tone:" / "ink:"
+  /// lines) overriding the keys it names; empty (the default) keeps the
+  /// style's own
+  property string hatchToneSpec => m_sHatchToneSpec;
+
+  /// ink-amount multiplier (umbreon ToneRecipe::strength): scales the
+  /// coverage a display tone asks for; 1 = the style's own
+  property real hatchToneStrength => m_dHatchToneStrength;
+
+  /// ink-amount curve multiplier (umbreon ToneRecipe::curve): > 1 keeps the
+  /// mid tones lighter, < 1 fills them in; 1 = the style's own
+  property real hatchToneCurve => m_dHatchToneCurve;
 
   /// base (fill) model override: "paper" (bare paper between the marks) or
   /// "albedo" (flat unshaded fill of each section's own color); empty (the
@@ -169,6 +188,12 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   /// contour in the ink color; sections with renderer-side edge settings keep
   /// their own style
   property boolean hatchDefaultEdges => m_bHatchDefaultEdges;
+
+  /// resolve a hatch style name (as hatchStyle takes it) and return it as
+  /// umbreon spec text ("layer:" / "tone:" / "ink:" lines), the editable
+  /// template behind hatchLayersSpec / hatchToneSpec; "" for an unknown
+  /// name or without umbreon
+  string getHatchStyleSpec(string name);
 
   ////////////////////
   // Asynchronous render (non-blocking, with progress + cancel).

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -7,6 +7,7 @@
 #include <gfx/SolidColor.hpp>
 #include <qlib/Vector4D.hpp>
 
+#include <functional>
 #include <vector>
 
 using qlib::Vector4D;
@@ -1603,10 +1604,12 @@ const int kHatchDim = 64;
 /// Render one sphere with the NPR tone-hatching pass. `edgeLines` gives the
 /// section renderer-side edge lines (red, so its ink is distinguishable from
 /// the black default contour); `paperHex` empty keeps the style's own paper.
-void renderHatchedSphere(bool edgeLines, bool defaultEdges,
-                         const char *style, float paperR, float paperG,
-                         float paperB, bool paperSet,
-                         std::vector<unsigned char> &outPix)
+/// `tweak` may adjust the render params before the render (hatch overrides).
+void renderHatchedSphere(
+    bool edgeLines, bool defaultEdges, const char *style, float paperR,
+    float paperG, float paperB, bool paperSet,
+    std::vector<unsigned char> &outPix,
+    const std::function<void(UmbreonRenderParams &)> &tweak = {})
 {
     const double kViewH = 6.0;
 
@@ -1646,6 +1649,7 @@ void renderHatchedSphere(bool edgeLines, bool defaultEdges,
     prm.hatchPaperColor[0] = paperR;
     prm.hatchPaperColor[1] = paperG;
     prm.hatchPaperColor[2] = paperB;
+    if (tweak) tweak(prm);
 
     int ow = 0, oh = 0, ncomp = 0;
     ctx.render(prm, ow, oh, ncomp, outPix);
@@ -1658,6 +1662,16 @@ void pixelAt(const std::vector<unsigned char> &pix, int x, int y, int rgb[3])
 {
     const std::size_t i = (static_cast<std::size_t>(y) * kHatchDim + x) * 3;
     for (int k = 0; k < 3; ++k) rgb[k] = pix[i + k];
+}
+
+/// Near-black pixels (ink marks and contour) of an RGB frame.
+std::size_t countInk(const std::vector<unsigned char> &pix)
+{
+    std::size_t n = 0;
+    for (std::size_t i = 0; i + 2 < pix.size(); i += 3) {
+        if (pix[i] < 60 && pix[i + 1] < 60 && pix[i + 2] < 60) ++n;
+    }
+    return n;
 }
 
 }  // namespace
@@ -1746,4 +1760,94 @@ TEST(UmbreonExport, UnknownHatchStyleFallsBackToRichardson)
     renderHatchedSphere(false, true, "richardson", 0.0f, 0.0f, 0.0f, false,
                         pixRichardson);
     EXPECT_EQ(pixBogus, pixRichardson);
+}
+
+// Mark width reaches the dot screens too: umbreon scales a Dot layer's
+// dotScale (a dot gain) where it scales a Line layer's width, so the halftone
+// styles no longer ignore the slider.
+TEST(UmbreonExport, HatchWidthScaleChangesDotScreens)
+{
+    for (const char *style : {"screentone-60", "manga"}) {
+        std::vector<unsigned char> pixOne, pixTwo;
+        renderHatchedSphere(false, false, style, 1.0f, 1.0f, 1.0f, true, pixOne,
+                            [](UmbreonRenderParams &p) { p.hatchWidthScale = 1.0; });
+        renderHatchedSphere(false, false, style, 1.0f, 1.0f, 1.0f, true, pixTwo,
+                            [](UmbreonRenderParams &p) { p.hatchWidthScale = 2.0; });
+        EXPECT_NE(pixOne, pixTwo) << style;
+        EXPECT_GT(countInk(pixTwo), countInk(pixOne)) << style;
+    }
+}
+
+// A hand-edited layer spec replaces the style's layers; a malformed one is
+// reported into the render log and ignored, so the render still runs with
+// the style itself.
+TEST(UmbreonExport, HatchLayersSpecOverridesTheStyleLayers)
+{
+    std::vector<unsigned char> pixPlain, pixSpec, pixBad;
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true,
+                        pixPlain);
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true,
+                        pixSpec, [](UmbreonRenderParams &p) {
+                            p.hatchLayersSpec =
+                                "layer: kind=line,angle=0,spacing=8,subdiv=0,"
+                                "width=3,tonehi=1,tonelo=0.9,fade=0";
+                        });
+    EXPECT_NE(pixPlain, pixSpec);
+
+    UmbreonDisplayContext::drainLog();
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true,
+                        pixBad, [](UmbreonRenderParams &p) {
+                            p.hatchLayersSpec = "layer: bogus=1";
+                        });
+    EXPECT_EQ(pixPlain, pixBad);
+    const LString log = UmbreonDisplayContext::drainLog();
+    EXPECT_NE(log.indexOf("hatch layers spec ignored"), -1) << log.c_str();
+}
+
+// The style template a host loads (hatchStyleSpec) sent back unedited
+// reproduces the style's own picture, for the layers and for the tone / ink
+// model alike.
+TEST(UmbreonExport, HatchStyleSpecRoundTripsToTheSamePixels)
+{
+    const LString spec = UmbreonDisplayContext::hatchStyleSpec("richardson");
+    ASSERT_FALSE(spec.isEmpty());
+    int nLayers = 0;
+    const std::string text = spec.c_str();
+    for (std::size_t pos = text.find("layer:"); pos != std::string::npos;
+         pos = text.find("layer:", pos + 1))
+        ++nLayers;
+    EXPECT_EQ(nLayers, 3);
+    EXPECT_NE(spec.indexOf("tone:"), -1);
+    EXPECT_NE(spec.indexOf("ink:"), -1);
+    EXPECT_TRUE(UmbreonDisplayContext::hatchStyleSpec("no-such-style").isEmpty());
+
+    // The paper is pinned explicitly on both sides: the spec carries colors
+    // as #rrggbb, and richardson's warm paper is not exactly representable.
+    std::vector<unsigned char> pixPlain, pixLayers, pixTone;
+    renderHatchedSphere(false, true, "richardson", 0.94f, 0.92f, 0.86f, true,
+                        pixPlain);
+    renderHatchedSphere(false, true, "richardson", 0.94f, 0.92f, 0.86f, true,
+                        pixLayers, [&](UmbreonRenderParams &p) {
+                            p.hatchLayersSpec = spec;
+                        });
+    EXPECT_EQ(pixPlain, pixLayers);
+    renderHatchedSphere(false, true, "richardson", 0.94f, 0.92f, 0.86f, true,
+                        pixTone, [&](UmbreonRenderParams &p) {
+                            p.hatchToneSpec = spec;
+                        });
+    EXPECT_EQ(pixPlain, pixTone);
+}
+
+// Ink amount: the strength multiplier darkens the drawing monotonically.
+TEST(UmbreonExport, HatchToneStrengthScalesTheInk)
+{
+    std::vector<unsigned char> pixHalf, pixOne, pixTwo;
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true, pixHalf,
+                        [](UmbreonRenderParams &p) { p.hatchToneStrength = 0.5; });
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true, pixOne,
+                        [](UmbreonRenderParams &p) { p.hatchToneStrength = 1.0; });
+    renderHatchedSphere(false, false, "ink-cross", 1.0f, 1.0f, 1.0f, true, pixTwo,
+                        [](UmbreonRenderParams &p) { p.hatchToneStrength = 2.0; });
+    EXPECT_GT(meanLevel(pixHalf), meanLevel(pixOne));
+    EXPECT_GT(meanLevel(pixOne), meanLevel(pixTwo));
 }

--- a/tritium/react-gui/src/main/renderWindowIpc.ts
+++ b/tritium/react-gui/src/main/renderWindowIpc.ts
@@ -22,6 +22,7 @@ import { IPC } from '../shared/ipcChannels'
 import type {
   RenderImageRef,
   RenderViewCamera,
+  HatchStyleSpecReply,
   RenderWindowMode,
   ViewSizePx,
 } from '../shared/ipcTypes'
@@ -175,6 +176,37 @@ export function registerRenderWindowIpc(deps: RenderWindowIpcDeps): void {
 
   handleInvoke(IPC.RENDER_VIEW_CAMERA_REPLY, (_event, { reqId, camera }) => {
     pendingCam.get(reqId)?.(camera)
+  })
+
+  // --- Hatch style template round trip ---
+  //
+  // Same shape again: the NPR layer editor loads the selected hatch style as
+  // spec text, which only the main window's worker (the C++ side) can
+  // resolve. A timeout reads as a failed load, not as an empty style.
+
+  let nextHatchReqId = 1
+  const pendingHatch = new Map<number, (result: HatchStyleSpecReply) => void>()
+
+  handleInvoke(IPC.RENDER_HATCH_STYLE_GET, (_event, { style }) => {
+    const unavailable: HatchStyleSpecReply = { ok: false, error: 'main window unavailable' }
+    if (mainWindow.isDestroyed()) return Promise.resolve(unavailable)
+    const reqId = nextHatchReqId++
+    return new Promise<HatchStyleSpecReply>((resolve) => {
+      const timer = setTimeout(() => {
+        pendingHatch.delete(reqId)
+        resolve({ ok: false, error: 'timeout' })
+      }, VIEW_SIZE_TIMEOUT_MS)
+      pendingHatch.set(reqId, (result) => {
+        clearTimeout(timer)
+        pendingHatch.delete(reqId)
+        resolve(result)
+      })
+      mainWindow.webContents.send(IPC.RENDER_HATCH_STYLE_REQUEST, { reqId, style })
+    })
+  })
+
+  handleInvoke(IPC.RENDER_HATCH_STYLE_REPLY, (_event, { reqId, result }) => {
+    pendingHatch.get(reqId)?.(result)
   })
 
   // --- Render history ---

--- a/tritium/react-gui/src/renderer/__test__/hatchSpec.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/hatchSpec.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @file __test__/hatchSpec.test.ts
+ * @description Pins the umbreon hatch spec text <-> typed record contract:
+ * key typing and defaults, boolean spellings, unknown keys surviving a round
+ * trip, float-noise-free output, kind-filtered layer keys, and the identity
+ * the dirty check relies on (formatting is a pure function of the values).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+    parseHatchSpec,
+    formatHatchSpec,
+    formatHatchLayersSpec,
+    newHatchLayer,
+    cloneHatchSpec,
+    isSameHatchSpec,
+    layerFieldEnabled,
+    toneFieldEnabled,
+    inkFieldEnabled,
+    DEFAULT_HATCH_TONE,
+    DEFAULT_HATCH_INK,
+} from '../data/hatchSpec';
+
+const RICHARDSON =
+    'layer: kind=line,angle=55,spacing=0.5,subdiv=2,width=0.45,tonehi=0.92,tonelo=0.55,fade=0,opacity=1,inkscale=1,soft=0.55,seed=0,jitter=0.22,wobble=1.2,wobwave=60,wjitter=0.45,slen=50,sgap=5,taper=0.35,anglejitter=5,lenjitter=0.5,tooth=0.15,toothscale=3\n' +
+    'layer: kind=dot,angle=45,spacing=5,subdiv=0,dotscale=1,tonehi=1,tonelo=1,fade=32,opacity=1,inkscale=1,soft=0.5,seed=0,jitter=0,shape=2,aspect=1,dotangle=0,invert=on,tooth=0,toothscale=3\n' +
+    'tone: diffuse=0.85,ambient=0.05,wrap=0.5,rim=1,rimpow=3.5,rimbias=0.35,contact=1,shape=0.6,black=0,white=1.2,hl=0.86,hlsoft=0.05,gamma=2.4,speccut=0,strength=1,curve=1,levels=0\n' +
+    'ink: mode=ink,base=paper,ink=albedo,inkcolor=#000000,papercolor=#f0ecdd,mincontrast=0.15,inkshade=0.4,tonefog=on,albedoquant=0\n';
+
+describe('parseHatchSpec', () => {
+    it('types every section of a style text', () => {
+        const spec = parseHatchSpec(RICHARDSON);
+        expect(spec.layers).toHaveLength(2);
+        const [line, dot] = spec.layers;
+        expect(line.kind).toBe('line');
+        expect(line.width).toBe(0.45);
+        expect(line.wjitter).toBe(0.45);
+        expect(line.fade).toBe(0);
+        expect(dot.kind).toBe('dot');
+        expect(dot.dotscale).toBe(1);
+        expect(dot.invert).toBe(true);
+        expect(spec.tone.wrap).toBe(0.5);
+        expect(spec.tone.strength).toBe(1);
+        expect(spec.tone.levels).toBe(0);
+        expect(spec.ink.papercolor).toBe('#f0ecdd');
+        expect(spec.ink.ink).toBe('albedo');
+        expect(spec.ink.inkshade).toBe(0.4);
+        expect(spec.ink.tonefog).toBe(true);
+    });
+
+    it('fills missing keys with the defaults and keeps unknown keys in extra', () => {
+        const spec = parseHatchSpec('layer: kind=dot,newkey=7\ntone: strength=2,future=x');
+        expect(spec.layers[0].dotscale).toBe(1);
+        expect(spec.layers[0].angle).toBe(45);
+        expect(spec.layers[0].invert).toBe(true);
+        expect(spec.layers[0].extra).toEqual({ newkey: '7' });
+        expect(spec.tone.strength).toBe(2);
+        expect(spec.tone.curve).toBe(DEFAULT_HATCH_TONE.curve);
+        expect(spec.tone.extra).toEqual({ future: 'x' });
+        // ... and re-emits them on the way out.
+        const text = formatHatchSpec(spec);
+        expect(text).toContain('newkey=7');
+        expect(text).toContain('future=x');
+    });
+
+    it('accepts every boolean spelling', () => {
+        expect(parseHatchSpec('layer: kind=dot,invert=1').layers[0].invert).toBe(true);
+        expect(parseHatchSpec('layer: kind=dot,invert=false').layers[0].invert).toBe(false);
+        expect(parseHatchSpec('ink: tonefog=off').ink.tonefog).toBe(false);
+    });
+
+    it('skips blank lines, comments and unknown sections; ";" separates too', () => {
+        const spec = parseHatchSpec('# a comment\n\nbogus: x=1\nlayer: kind=line; tone: strength=2');
+        expect(spec.layers).toHaveLength(1);
+        expect(spec.tone.strength).toBe(2);
+    });
+
+    it('an empty text is no layers and the default tone', () => {
+        const spec = parseHatchSpec('');
+        expect(spec.layers).toEqual([]);
+        expect(spec.tone.strength).toBe(1);
+    });
+});
+
+describe('formatHatchSpec', () => {
+    it('round-trips a style text (format(parse(x)) is a fixed point)', () => {
+        const once = formatHatchSpec(parseHatchSpec(RICHARDSON));
+        const twice = formatHatchSpec(parseHatchSpec(once));
+        expect(twice).toBe(once);
+        expect(once.split('\n').filter((l) => l.startsWith('layer:'))).toHaveLength(2);
+        expect(once).toContain('tone: ');
+        expect(once).toContain('ink: ');
+    });
+
+    it('writes numbers without float noise', () => {
+        const layer = newHatchLayer('line', 'a');
+        layer.width = 0.1 + 0.2;
+        expect(formatHatchLayersSpec([layer])).toContain('width=0.3,');
+    });
+
+    it('filters the layer keys by kind', () => {
+        const line = formatHatchLayersSpec([newHatchLayer('line', 'a')]);
+        expect(line).toContain('width=');
+        expect(line).toContain('wobble=');
+        expect(line).not.toContain('dotscale=');
+        expect(line).not.toContain('shape=');
+        const dot = formatHatchLayersSpec([newHatchLayer('dot', 'b')]);
+        expect(dot).toContain('dotscale=');
+        expect(dot).toContain('invert=on');
+        expect(dot).not.toContain('width=');
+        expect(dot).not.toContain('wobble=');
+        const stipple = formatHatchLayersSpec([newHatchLayer('stipple', 'c')]);
+        expect(stipple).toContain('dotscale=');
+        expect(stipple).not.toContain('invert=');
+    });
+
+    it('isSameHatchSpec ignores layer ids; cloneHatchSpec renews them', () => {
+        const spec = parseHatchSpec(RICHARDSON);
+        const copy = cloneHatchSpec(spec);
+        expect(copy.layers[0].id).not.toBe(spec.layers[0].id);
+        expect(isSameHatchSpec(spec, copy)).toBe(true);
+        copy.layers[0].width = 2;
+        expect(isSameHatchSpec(spec, copy)).toBe(false);
+    });
+});
+
+// Fields another value switches off are reported disabled (umbreon's
+// hatch_ink.hpp is the reference for each rule).
+describe('field enabling', () => {
+    it('layer fields', () => {
+        const line = newHatchLayer('line', 'a');
+        // Continuous line, no wobble, no tooth, no jitter: nothing to seed.
+        expect(layerFieldEnabled('seed', line)).toBe(false);
+        expect(layerFieldEnabled('sgap', line)).toBe(false);
+        expect(layerFieldEnabled('wobwave', line)).toBe(false);
+        expect(layerFieldEnabled('toothscale', line)).toBe(false);
+        line.slen = 40;
+        expect(layerFieldEnabled('sgap', line)).toBe(true);
+        expect(layerFieldEnabled('seed', line)).toBe(true);
+        line.wjitter = 0.3;
+        expect(layerFieldEnabled('wobwave', line)).toBe(true);
+        // No nesting and a fixed fade: toneLo never gates a mark.
+        line.subdiv = 0;
+        line.fade = 16;
+        expect(layerFieldEnabled('tonelo', line)).toBe(false);
+        line.fade = 0;
+        expect(layerFieldEnabled('tonelo', line)).toBe(true);
+        const dot = newHatchLayer('dot', 'b');
+        expect(layerFieldEnabled('dotangle', dot)).toBe(false);
+        dot.shape = 16;
+        expect(layerFieldEnabled('dotangle', dot)).toBe(true);
+        const stipple = newHatchLayer('stipple', 'c');
+        expect(layerFieldEnabled('seed', stipple)).toBe(true);
+        expect(layerFieldEnabled('tonelo', stipple)).toBe(true);
+    });
+
+    it('tone and ink fields', () => {
+        const env = { aoEnabled: false, baseIsAlbedo: false };
+        const tone = { ...DEFAULT_HATCH_TONE };
+        expect(toneFieldEnabled('hlsoft', tone, env)).toBe(false);
+        expect(toneFieldEnabled('rimpow', tone, env)).toBe(false);
+        expect(toneFieldEnabled('contact', tone, env)).toBe(false);
+        expect(toneFieldEnabled('strength', tone, env)).toBe(true);
+        tone.hl = 0.86;
+        tone.rim = 1;
+        expect(toneFieldEnabled('hlsoft', tone, env)).toBe(true);
+        expect(toneFieldEnabled('rimbias', tone, env)).toBe(true);
+        expect(toneFieldEnabled('shape', tone, { ...env, aoEnabled: true })).toBe(true);
+        expect(inkFieldEnabled('albedoquant', DEFAULT_HATCH_INK, env)).toBe(false);
+        expect(inkFieldEnabled('albedoquant', DEFAULT_HATCH_INK, { ...env, baseIsAlbedo: true })).toBe(true);
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/hatchStyleSpecService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/hatchStyleSpecService.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @file __test__/hatchStyleSpecService.test.ts
+ * @description Pins the worker service behind the hatch layer editor's
+ * template: it resolves a style through the umbreon exporter's
+ * getHatchStyleSpec, and degrades to `ok: false` (never a throw) when the
+ * build has no umbreon, the addon predates the API, or the name is unknown.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { services } from '../worker/server/services/hatchStyleSpec.service';
+import type { WorkerContext } from '../worker/server/types/WorkerContext';
+
+const ctxWith = (createHandler: (...args: unknown[]) => unknown) =>
+    ({ strMgr: { createHandler } } as unknown as WorkerContext);
+
+describe('getHatchStyleSpec service', () => {
+    it('resolves a style through the umbreon exporter', () => {
+        const getHatchStyleSpec = vi.fn(() => 'layer: kind=line\n');
+        const createHandler = vi.fn(() => ({ getHatchStyleSpec }));
+        const res = services.getHatchStyleSpec(ctxWith(createHandler), { style: 'ink-cross' });
+        expect(createHandler).toHaveBeenCalledWith('umbreon', 2);
+        expect(getHatchStyleSpec).toHaveBeenCalledWith('ink-cross');
+        expect(res).toEqual({ ok: true, spec: 'layer: kind=line\n' });
+    });
+
+    it('reports a build without umbreon instead of throwing', () => {
+        const res = services.getHatchStyleSpec(
+            ctxWith(() => { throw new Error('no handler'); }),
+            { style: 'manga' },
+        );
+        expect(res.ok).toBe(false);
+    });
+
+    it('reports an addon without the API, and an unknown style', () => {
+        const noApi = services.getHatchStyleSpec(ctxWith(() => ({})), { style: 'manga' });
+        expect(noApi.ok).toBe(false);
+        const unknown = services.getHatchStyleSpec(
+            ctxWith(() => ({ getHatchStyleSpec: () => '' })),
+            { style: 'no-such' },
+        );
+        expect(unknown).toEqual({ ok: false, error: 'unknown hatch style: no-such' });
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/renderSettingsPane.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/renderSettingsPane.test.tsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { act } from 'react';
-import { mountTree } from './helpers/testHarness';
+import { mountTree, openAccordion } from './helpers/testHarness';
 
 void React;
 
@@ -33,6 +33,8 @@ import {
   type RenderMode,
 } from '../data/renderSettings';
 import { RENDER_BACKENDS } from '../data/renderBackends';
+import { parseHatchSpec } from '../data/hatchSpec';
+import type { HatchLookEditorProps } from '../components/inspector/HatchLookEditor';
 
 function mountPane(
   opts: {
@@ -41,6 +43,7 @@ function mountPane(
     movie?: Partial<typeof DEFAULT_MOVIE_SETTINGS>;
     onUseTempDir?: () => void;
     onUseCustomDir?: () => void;
+    hatch?: HatchLookEditorProps;
   } = {},
 ): ReturnType<typeof mountTree> {
   const backend = opts.backend ?? 'povray';
@@ -64,8 +67,32 @@ function mountPane(
       onUseTempDir={opts.onUseTempDir ?? vi.fn()}
       onUseCustomDir={opts.onUseCustomDir ?? vi.fn()}
       onPickFolder={vi.fn()}
+      hatch={opts.hatch}
     />,
   );
+}
+
+/** Props of the NPR hatch layer editor with a three-layer template. */
+function hatchProps(over: Partial<HatchLookEditorProps> = {}): HatchLookEditorProps {
+  return {
+    styleName: 'richardson',
+    density: 1,
+    widthScale: 1,
+    supersample: 3,
+    env: { aoEnabled: false, baseIsAlbedo: false },
+    spec: parseHatchSpec('layer: kind=line\nlayer: kind=dot\nlayer: kind=stipple\ntone: strength=1'),
+    dirty: false,
+    status: 'ready',
+    error: null,
+    onLayerChange: vi.fn(),
+    onLayerAdd: vi.fn(),
+    onLayerRemove: vi.fn(),
+    onLayerDuplicate: vi.fn(),
+    onToneChange: vi.fn(),
+    onInkChange: vi.fn(),
+    onReset: vi.fn(),
+    ...over,
+  };
 }
 
 /** Click the tab button carrying the given label. */
@@ -275,6 +302,120 @@ describe('RenderSettingsPane Image tab backend filtering', () => {
     const text = container.textContent ?? '';
     expect(text).toContain('Post-render alpha blending');
     expect(text).toContain('Pixel labels');
+    unmount();
+  });
+});
+
+// The NPR hatch layer editor is its own "Detail" tab: the Render tab keeps
+// the style pick and its multipliers, the tab holds the loaded style's layers
+// (as rows), Strength / Curve as the only always-visible shading controls,
+// and the template actions. The tab exists only with the editor props (NPR).
+describe('RenderSettingsPane Detail tab', () => {
+  const tabLabels = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('.mode-bar button')).map((b) => (b.textContent ?? '').trim());
+
+  it('offers the tab only with the editor props', () => {
+    const plain = mountPane({ backend: 'umbreon_npr' });
+    expect(tabLabels(plain.container)).not.toContain('Detail');
+    plain.unmount();
+    const withEditor = mountPane({ backend: 'umbreon_npr', hatch: hatchProps() });
+    expect(tabLabels(withEditor.container)).toContain('Detail');
+    withEditor.unmount();
+  });
+
+  it('shows the layers and the shading section on the tab, not on the Render tab', () => {
+    const { container, unmount } = mountPane({ backend: 'umbreon_npr', hatch: hatchProps() });
+    selectTab(container, 'Render');
+    expect(container.querySelectorAll('.hatch-layer').length).toBe(0);
+    expect(container.textContent ?? '').toContain('Style');
+    selectTab(container, 'Detail');
+    const text = container.textContent ?? '';
+    expect(text).toContain('Style template: richardson');
+    expect(text).toContain('Layers');
+    expect(text).toContain('Shading');
+    expect(container.querySelectorAll('.hatch-layer').length).toBe(3);
+    // Strength / Curve stay visible; the rest waits under Advanced.
+    expect(text).toContain('Strength');
+    expect(text).toContain('Curve');
+    expect(text).not.toContain('Contour darkening');
+    // Line rows show the width, dot rows the dot scale.
+    expect(text).toContain('Width');
+    expect(text).toContain('Dot scale');
+    unmount();
+  });
+
+  it('wires the add button and gates Reset on an edited look', () => {
+    const props = hatchProps();
+    const { container, unmount } = mountPane({ backend: 'umbreon_npr', hatch: props });
+    selectTab(container, 'Detail');
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const addLine = buttons.find((b) => (b.textContent ?? '').trim() === 'Line');
+    expect(addLine).toBeDefined();
+    act(() => { addLine!.click(); });
+    expect(props.onLayerAdd).toHaveBeenCalledWith('line');
+    const reset = buttons.find((b) => (b.textContent ?? '').includes('Reset to style')) as HTMLButtonElement;
+    expect(reset.disabled).toBe(true);
+    unmount();
+    const edited = mountPane({ backend: 'umbreon_npr', hatch: hatchProps({ dirty: true }) });
+    selectTab(edited.container, 'Detail');
+    const reset2 = Array.from(edited.container.querySelectorAll('button'))
+      .find((b) => (b.textContent ?? '').includes('Reset to style')) as HTMLButtonElement;
+    expect(reset2.disabled).toBe(false);
+    expect(edited.container.textContent ?? '').toContain('Edited');
+    edited.unmount();
+  });
+
+  it('shows the Render tab multipliers as effective values, only when they are not 1', () => {
+    const neutral = mountPane({ backend: 'umbreon_npr', hatch: hatchProps() });
+    selectTab(neutral.container, 'Detail');
+    expect(neutral.container.textContent ?? '').not.toContain('Render tab multipliers');
+    expect(neutral.container.querySelectorAll('.hatch-effective').length).toBe(0);
+    neutral.unmount();
+    const scaled = mountPane({
+      backend: 'umbreon_npr',
+      hatch: hatchProps({
+        density: 2,
+        widthScale: 1.5,
+        spec: parseHatchSpec('layer: kind=line,spacing=10,width=1\nlayer: kind=dot,spacing=5,dotscale=2'),
+      }),
+    });
+    selectTab(scaled.container, 'Detail');
+    const text = scaled.container.textContent ?? '';
+    expect(text).toContain('Mark density x2, Mark width x1.5');
+    // Pitch / density, line width and dot scale * width scale.
+    expect(text).toContain('effective 5 px at Mark density x2');
+    expect(text).toContain('effective 1.5 px at Mark width x1.5');
+    expect(text).toContain('effective 3 at Mark width x1.5');
+    scaled.unmount();
+  });
+
+  it('hides fields a layer kind ignores and flags a pitch pinned at the minimum', () => {
+    const { container, unmount } = mountPane({
+      backend: 'umbreon_npr',
+      hatch: hatchProps({
+        supersample: 3,
+        spec: parseHatchSpec('layer: kind=stipple,spacing=0.5'),
+      }),
+    });
+    selectTab(container, 'Detail');
+    openAccordion(container, 'Randomness / Advanced');
+    const text = container.textContent ?? '';
+    expect(text).toContain('Shape exponent');
+    expect(text).not.toContain('Nesting levels');
+    expect(text).not.toContain('Merge to solid');
+    // 0.5 px * ss 3 = 1.5 px on the ink grid: below the 2 px minimum.
+    expect(text).toContain('minimum pitch');
+    unmount();
+  });
+
+  it('shows the load status while the template is missing', () => {
+    const { container, unmount } = mountPane({
+      backend: 'umbreon_npr',
+      hatch: hatchProps({ spec: null, status: 'error', error: 'unknown hatch style: x' }),
+    });
+    selectTab(container, 'Detail');
+    expect(container.textContent ?? '').toContain('unknown hatch style: x');
+    expect(container.querySelectorAll('.hatch-layer').length).toBe(0);
     unmount();
   });
 });

--- a/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
@@ -517,3 +517,40 @@ describe('umbreonNprBackend.beginInProcess', () => {
         expect(exporter.useGI).toBe(true)
     })
 })
+
+// The edited hatch look (layer editor) rides the snapshot as spec text and is
+// forwarded verbatim; without it the exporter keeps the style's own layers.
+describe('umbreonNprBackend hatch spec forwarding', () => {
+    const base = (): RenderSettingsSnapshot => ({
+        mode: 'still',
+        backend: 'umbreon_npr',
+        commonProps: [p('width', 64), p('height', 64), p('unit', 'px'), p('dpi', 600)],
+        backendProps: [p('hatchStyle', 'richardson')],
+    })
+    const begin = (backend: typeof umbreonBackend, snapshot: RenderSettingsSnapshot) => {
+        const exporter = makeExporter()
+        const ctx = { strMgr: { createHandler: vi.fn(() => exporter) } } as unknown as WorkerContext
+        backend.beginInProcess!(ctx, {} as never, snapshot, '/o.png')
+        return exporter
+    }
+
+    it('forwards the layers and tone spec text verbatim', () => {
+        const exporter = begin(umbreonNprBackend, {
+            ...base(),
+            hatch: { layersSpec: 'layer: kind=line,width=2\n', toneSpec: 'tone: strength=2\nink: tonefog=off\n' },
+        })
+        expect(exporter.hatchLayersSpec).toBe('layer: kind=line,width=2\n')
+        expect(exporter.hatchToneSpec).toBe('tone: strength=2\nink: tonefog=off\n')
+    })
+
+    it('sends nothing for an unedited look, and never on the plain umbreon backend', () => {
+        expect(begin(umbreonNprBackend, base()).hatchLayersSpec).toBeUndefined()
+        const plain = begin(umbreonBackend, {
+            ...base(),
+            backend: 'umbreon',
+            hatch: { layersSpec: 'layer: kind=line\n', toneSpec: '' },
+        })
+        expect(plain.hatchLayersSpec).toBeUndefined()
+        expect(plain.hatchEnable).toBeUndefined()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/useHatchTemplate.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useHatchTemplate.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @file __test__/useHatchTemplate.test.ts
+ * @description Contract tests for the hatch style template loader: it fetches
+ * the selected style while it is not loaded, hands the parsed template over,
+ * drops a reply that arrives after the style moved on, and only reports a
+ * failed load (the render then uses the style's own configuration).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { act, useState } from 'react';
+import { makeRenderHook, flushPromises } from './helpers/testHarness';
+import { useHatchTemplate } from '../hooks/useHatchTemplate';
+import type { HatchStyleSpecReply } from '../../shared/ipcTypes';
+
+const okReply = (spec: string): HatchStyleSpecReply => ({ ok: true, spec });
+
+describe('useHatchTemplate', () => {
+    it('fetches an unloaded style and hands the parsed template over', async () => {
+        const fetchSpec = vi.fn(() => Promise.resolve(okReply('layer: kind=dot\ntone: strength=2')));
+        const onLoaded = vi.fn();
+        const h = makeRenderHook(() =>
+            useHatchTemplate({ enabled: true, style: 'manga', loaded: false, fetchSpec, onLoaded }),
+        );
+        expect(h.result.status).toBe('loading');
+        await act(async () => { await flushPromises(); });
+        expect(fetchSpec).toHaveBeenCalledWith('manga');
+        expect(onLoaded).toHaveBeenCalledTimes(1);
+        const [style, spec] = onLoaded.mock.calls[0];
+        expect(style).toBe('manga');
+        expect(spec.layers[0].kind).toBe('dot');
+        expect(spec.tone.strength).toBe(2);
+        expect(h.result.status).toBe('ready');
+        h.unmount();
+    });
+
+    it('does not fetch a loaded style, nor anything when disabled', () => {
+        const fetchSpec = vi.fn(() => Promise.resolve(okReply('')));
+        const loaded = makeRenderHook(() =>
+            useHatchTemplate({ enabled: true, style: 'manga', loaded: true, fetchSpec, onLoaded: vi.fn() }),
+        );
+        expect(loaded.result.status).toBe('ready');
+        const off = makeRenderHook(() =>
+            useHatchTemplate({ enabled: false, style: 'manga', loaded: false, fetchSpec, onLoaded: vi.fn() }),
+        );
+        expect(off.result.status).toBe('idle');
+        expect(fetchSpec).not.toHaveBeenCalled();
+        loaded.unmount();
+        off.unmount();
+    });
+
+    it('reports a failed load without touching the settings', async () => {
+        const fetchSpec = vi.fn(() => Promise.resolve({ ok: false, error: 'unknown hatch style: x' } as HatchStyleSpecReply));
+        const onLoaded = vi.fn();
+        const h = makeRenderHook(() =>
+            useHatchTemplate({ enabled: true, style: 'x', loaded: false, fetchSpec, onLoaded }),
+        );
+        await act(async () => { await flushPromises(); });
+        expect(h.result.status).toBe('error');
+        expect(h.result.error).toBe('unknown hatch style: x');
+        expect(onLoaded).not.toHaveBeenCalled();
+        h.unmount();
+    });
+
+    it('drops a reply that arrives after the style changed', async () => {
+        let resolveA: ((r: HatchStyleSpecReply) => void) | null = null;
+        const fetchSpec = vi.fn((style: string) =>
+            style === 'a'
+                ? new Promise<HatchStyleSpecReply>((res) => { resolveA = res; })
+                : Promise.resolve(okReply('layer: kind=line')),
+        );
+        const onLoaded = vi.fn();
+        // The style lives in state so switching it re-renders the hook (a bare
+        // rerender of the same element bails out).
+        const h = makeRenderHook(() => {
+            const [style, setStyle] = useState('a');
+            const r = useHatchTemplate({ enabled: true, style, loaded: false, fetchSpec, onLoaded });
+            return { ...r, setStyle };
+        });
+        act(() => { h.result.setStyle('b'); });
+        await act(async () => { await flushPromises(); });
+        act(() => { resolveA!(okReply('layer: kind=dot')); });
+        await act(async () => { await flushPromises(); });
+        // Only the current style's template reached the settings.
+        expect(onLoaded.mock.calls.map((c) => c[0])).toEqual(['b']);
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 import { act } from 'react';
 import { makeRenderHook } from './helpers/testHarness';
 import { useRenderSettings } from '../hooks/useRenderSettings';
+import { parseHatchSpec } from '../data/hatchSpec';
 
 const valueOf = (props: { key: string; value: unknown }[], key: string) =>
     props.find((p) => p.key === key)?.value;
@@ -414,6 +415,107 @@ describe('useRenderSettings NPR backend', () => {
         expect(valueOf(h.result.backendProps, 'aoEnabled')).toBe(true);
         act(() => h.result.setLighting('none'));
         expect(h.result.lighting).toBe('none');
+        h.unmount();
+    });
+});
+
+// The NPR hatch look: the selected style is a template loaded from C++, the
+// edited copy travels with the render only while it differs from it.
+describe('useRenderSettings hatch look', () => {
+    const TEMPLATE = 'layer: kind=line,width=1\nlayer: kind=dot\ntone: strength=1\nink: base=paper\n';
+    const template = () => parseHatchSpec(TEMPLATE);
+
+    const mountNpr = () => {
+        const h = makeRenderHook(() => useRenderSettings({ umbreonAvailable: true }));
+        act(() => h.result.setBackend('umbreon_npr'));
+        return h;
+    };
+
+    it('starts without a look and loads the selected style as template', () => {
+        const h = mountNpr();
+        expect(h.result.hatchStyle).toBe('richardson');
+        expect(h.result.hatch.spec).toBeNull();
+        expect(h.result.hatchLoaded).toBe(false);
+        act(() => h.result.applyHatchTemplate('richardson', template()));
+        expect(h.result.hatchLoaded).toBe(true);
+        expect(h.result.hatchDirty).toBe(false);
+        expect(h.result.hatch.spec?.layers).toHaveLength(2);
+        // The editable copy is not the template object.
+        expect(h.result.hatch.spec).not.toBe(h.result.hatch.template);
+        h.unmount();
+    });
+
+    it('ignores a template for a style that is no longer selected', () => {
+        const h = mountNpr();
+        act(() => h.result.applyHatchTemplate('manga', template()));
+        expect(h.result.hatch.spec).toBeNull();
+        h.unmount();
+    });
+
+    it('edits mark the look dirty and travel in the snapshot; reset clears them', () => {
+        const h = mountNpr();
+        act(() => h.result.applyHatchTemplate('richardson', template()));
+        expect(h.result.getSnapshot().hatch).toBeUndefined();
+        const [first, second] = h.result.hatch.spec!.layers;
+        act(() => h.result.updateHatchLayer(first.id, { width: 2 }));
+        expect(h.result.hatchDirty).toBe(true);
+        // Untouched layers keep their identity (memoised rows).
+        expect(h.result.hatch.spec!.layers[1]).toBe(second);
+        act(() => h.result.updateHatchTone({ strength: 2 }));
+        const snap = h.result.getSnapshot();
+        expect(snap.hatch?.layersSpec).toContain('width=2');
+        expect(snap.hatch?.toneSpec).toContain('strength=2');
+        act(() => h.result.resetHatchToTemplate());
+        expect(h.result.hatchDirty).toBe(false);
+        expect(h.result.getSnapshot().hatch).toBeUndefined();
+        h.unmount();
+    });
+
+    it('adds, duplicates and removes layers', () => {
+        const h = mountNpr();
+        act(() => h.result.applyHatchTemplate('richardson', template()));
+        act(() => h.result.addHatchLayer('stipple'));
+        expect(h.result.hatch.spec!.layers.map((l) => l.kind)).toEqual(['line', 'dot', 'stipple']);
+        const first = h.result.hatch.spec!.layers[0];
+        act(() => h.result.duplicateHatchLayer(first.id));
+        const layers = h.result.hatch.spec!.layers;
+        expect(layers).toHaveLength(4);
+        expect(layers[1].kind).toBe('line');
+        expect(layers[1].id).not.toBe(first.id);
+        act(() => h.result.removeHatchLayer(layers[1].id));
+        expect(h.result.hatch.spec!.layers).toHaveLength(3);
+        h.unmount();
+    });
+
+    it('a new style or backend drops the look', () => {
+        const h = mountNpr();
+        act(() => h.result.applyHatchTemplate('richardson', template()));
+        act(() => h.result.handleChange('hatchStyle', 'manga'));
+        expect(h.result.hatchStyle).toBe('manga');
+        expect(h.result.hatch.spec).toBeNull();
+        expect(h.result.hatchLoaded).toBe(false);
+        act(() => h.result.applyHatchTemplate('manga', template()));
+        act(() => h.result.setBackend('umbreon'));
+        expect(h.result.hatch.spec).toBeNull();
+        h.unmount();
+    });
+
+    it('restores an edited look from a snapshot and keeps it when the template arrives', () => {
+        const h = mountNpr();
+        act(() => h.result.applyHatchTemplate('richardson', template()));
+        act(() => h.result.updateHatchTone({ strength: 3 }));
+        const snap = h.result.getSnapshot();
+        act(() => h.result.handleChange('hatchStyle', 'manga'));
+        act(() => h.result.restore(snap));
+        expect(h.result.hatchStyle).toBe('richardson');
+        expect(h.result.hatchLoaded).toBe(false);
+        expect(h.result.hatch.spec?.tone.strength).toBe(3);
+        act(() => h.result.applyHatchTemplate('richardson', template()));
+        expect(h.result.hatch.spec?.tone.strength).toBe(3);
+        expect(h.result.hatchDirty).toBe(true);
+        // A snapshot without a look restores none.
+        act(() => h.result.restore({ ...snap, hatch: undefined }));
+        expect(h.result.hatch.spec).toBeNull();
         h.unmount();
     });
 });

--- a/tritium/react-gui/src/renderer/__test__/useRenderWindowBridge.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderWindowBridge.test.ts
@@ -78,6 +78,8 @@ function setupApi() {
         exec: (cmd: unknown) => pushCbs.get(IPC.RENDER_WINDOW_EXEC)?.(cmd),
         requestViewSize: (reqId: number) =>
             pushCbs.get(IPC.RENDER_VIEW_SIZE_REQUEST)?.({ reqId }),
+        requestHatchStyle: (reqId: number, style: string) =>
+            pushCbs.get(IPC.RENDER_HATCH_STYLE_REQUEST)?.({ reqId, style }),
         stateUpdates: () =>
             (api.invoke as ReturnType<typeof vi.fn>).mock.calls
                 .filter((c) => c[0] === IPC.RENDER_WINDOW_STATE)
@@ -299,5 +301,42 @@ describe('useRenderWindowBridge', () => {
         });
         h.unmount();
         document.body.removeChild(canvas);
+    });
+});
+
+// Hatch style template round trip: the render window's layer editor asks for
+// a style, the main window resolves it through the worker and replies.
+describe('useRenderWindowBridge hatch style template', () => {
+    const cmWith = (result: unknown) => ({
+        subscribeRenderProgress: vi.fn(() => () => {}),
+        invokeService: vi.fn((name: string) =>
+            name === 'getHatchStyleSpec' ? Promise.resolve(result) : Promise.resolve({ ok: true }),
+        ),
+    });
+
+    it('resolves the style through the worker and replies with the spec', async () => {
+        const { api, requestHatchStyle } = setupApi();
+        const cm = cmWith({ ok: true, spec: 'layer: kind=line\n' });
+        const h = mountBridge(cm);
+        act(() => { requestHatchStyle(5, 'ink-cross'); });
+        await flushPromises();
+        expect(cm.invokeService).toHaveBeenCalledWith('getHatchStyleSpec', { style: 'ink-cross' });
+        expect(api.invoke).toHaveBeenCalledWith(IPC.RENDER_HATCH_STYLE_REPLY, {
+            reqId: 5,
+            result: { ok: true, spec: 'layer: kind=line\n' },
+        });
+        h.unmount();
+    });
+
+    it('replies ok: false without a worker', async () => {
+        const { api, requestHatchStyle } = setupApi();
+        const h = mountBridge(null);
+        act(() => { requestHatchStyle(6, 'manga'); });
+        await flushPromises();
+        const reply = (api.invoke as ReturnType<typeof vi.fn>).mock.calls
+            .find((c) => c[0] === IPC.RENDER_HATCH_STYLE_REPLY)?.[1] as { reqId: number; result: { ok: boolean } };
+        expect(reply.reqId).toBe(6);
+        expect(reply.result.ok).toBe(false);
+        h.unmount();
     });
 });

--- a/tritium/react-gui/src/renderer/__test__/useRenderWindowClient.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderWindowClient.test.ts
@@ -367,3 +367,41 @@ describe('useRenderWindowClient render history', () => {
         h.unmount();
     });
 });
+
+// The render window asks main for a hatch style's spec text; a failed invoke
+// is folded into the reply shape (the editor shows it, nothing throws).
+describe('useRenderWindowClient.getHatchStyleSpec', () => {
+    afterEach(() => teardownElectronAPI());
+
+    const mountWithInvoke = (invoke: (channel: string, payload?: unknown) => Promise<unknown>) => {
+        const api = setupElectronAPI({
+            onPush: vi.fn(() => () => {}),
+            invoke: vi.fn(invoke),
+        });
+        const h = makeRenderHook(() => useRenderWindowClient());
+        return { api, h };
+    };
+
+    it('invokes RENDER_HATCH_STYLE_GET with the style and returns the reply', async () => {
+        const { api, h } = mountWithInvoke((channel) =>
+            channel === IPC.RENDER_HATCH_STYLE_GET
+                ? Promise.resolve({ ok: true, spec: 'layer: kind=dot\n' })
+                : Promise.resolve(undefined),
+        );
+        const reply = await h.result.getHatchStyleSpec('manga');
+        expect(api.invoke).toHaveBeenCalledWith(IPC.RENDER_HATCH_STYLE_GET, { style: 'manga' });
+        expect(reply).toEqual({ ok: true, spec: 'layer: kind=dot\n' });
+        h.unmount();
+    });
+
+    it('turns a rejected invoke into ok: false', async () => {
+        const { h } = mountWithInvoke((channel) =>
+            channel === IPC.RENDER_HATCH_STYLE_GET
+                ? Promise.reject(new Error('relay down'))
+                : Promise.resolve(undefined),
+        );
+        const reply = await h.result.getHatchStyleSpec('manga');
+        expect(reply).toEqual({ ok: false, error: 'relay down' });
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/components/inspector/HatchLayerRow.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/HatchLayerRow.tsx
@@ -1,0 +1,171 @@
+/**
+ * @file components/inspector/HatchLayerRow.tsx
+ * @description One mark layer of the NPR hatch layer editor: a header row
+ * (name, duplicate, remove), the kind selector, the primary numeric fields
+ * and a collapsed "Randomness / Advanced" area with the rest. Which fields
+ * show follows the layer kind (line width vs. dot scale, stroke perturbations
+ * vs. dot shape) through the field table in data/hatchSpec.ts.
+ */
+
+import React, { useCallback } from "react";
+
+import { AccordionSection } from "./AccordionSection";
+import { AppIcon } from "../AppIcon";
+import { Field, FormButton, SelectField, SliderField, SwitchField } from "../../h3-kit/form";
+import {
+  LAYER_FIELDS,
+  fieldAppliesTo,
+  layerFieldEnabled,
+  type HatchFieldDef,
+  type HatchLayer,
+  type HatchLayerKind,
+} from "../../data/hatchSpec";
+
+export interface HatchLayerRowProps {
+  /** 0-based position in the layer list (shown 1-based). */
+  index: number;
+  layer: HatchLayer;
+  /**
+   * Render tab multipliers: pitch / density and width (or dot scale) *
+   * widthScale are what actually render, shown as a hint under the field
+   * whenever a multiplier is not 1.
+   */
+  density: number;
+  widthScale: number;
+  /** Render supersampling: the ink grid the 2 px minimum pitch applies on. */
+  supersample: number;
+  onChange: (id: string, patch: Partial<HatchLayer>) => void;
+  onRemove: (id: string) => void;
+  onDuplicate: (id: string) => void;
+}
+
+/** umbreon's minimum lattice pitch on the ink grid (hatch_ink.hpp). */
+const MIN_PITCH_PX = 2;
+
+const KIND_LABEL: Record<HatchLayerKind, string> = {
+  line: "Line",
+  dot: "Dot screen",
+  stipple: "Stipple",
+};
+
+/** Fields the editor may show for a layer: those of its kind, by place. */
+const fieldsFor = (kind: HatchLayerKind, place: HatchFieldDef["place"]): HatchFieldDef[] =>
+  LAYER_FIELDS.filter((f) => f.place === place && fieldAppliesTo(f, kind));
+
+/** Effective-value text without float noise. */
+const fmtEff = (v: number): string => String(Number(v.toFixed(3)));
+
+const HatchLayerRowImpl: React.FC<HatchLayerRowProps> = ({
+  index,
+  layer,
+  density,
+  widthScale,
+  supersample,
+  onChange,
+  onRemove,
+  onDuplicate,
+}) => {
+  const patch = useCallback(
+    (p: Partial<HatchLayer>) => onChange(layer.id, p),
+    [onChange, layer.id],
+  );
+
+  /** The Render tab multiplier hint for a size field, or null. */
+  const effectiveHint = (f: HatchFieldDef, value: number): React.ReactNode => {
+    let text: string | null = null;
+    if (f.key === "spacing") {
+      const eff = value / density;
+      const parts: string[] = [];
+      if (density !== 1) parts.push(`effective ${fmtEff(eff)} px at Mark density x${fmtEff(density)}`);
+      // The ink is laid on the supersampled grid, where the pitch cannot go
+      // below 2 px: a finer pitch (or a higher density) changes nothing.
+      if (eff * Math.max(1, supersample) < MIN_PITCH_PX) {
+        parts.push(
+          `below the ${MIN_PITCH_PX} px minimum pitch on the supersample grid: clamped (raise Supersampling)`,
+        );
+      }
+      text = parts.length ? parts.join("; ") : null;
+    } else if ((f.key === "width" || f.key === "dotscale") && widthScale !== 1) {
+      const unit = f.key === "width" ? " px" : "";
+      text = `effective ${fmtEff(value * widthScale)}${unit} at Mark width x${fmtEff(widthScale)}`;
+    }
+    return text ? (
+      <span key={`${f.key}-eff`} className="type-caption hatch-effective">
+        {text}
+      </span>
+    ) : null;
+  };
+
+  const renderField = (f: HatchFieldDef) => {
+    const value = (layer as unknown as Record<string, unknown>)[f.key];
+    const enabled = layerFieldEnabled(f.key, layer);
+    if (f.type === "bool") {
+      return (
+        <Field key={f.key} label={f.label} inline>
+          <SwitchField
+            checked={Boolean(value)}
+            disabled={!enabled}
+            onChange={(v) => patch({ [f.key]: v })}
+          />
+        </Field>
+      );
+    }
+    return (
+      <React.Fragment key={f.key}>
+        <SliderField
+          label={f.label}
+          value={Number(value)}
+          min={f.min ?? 0}
+          max={f.max ?? 1}
+          step={f.step}
+          unit={f.unit}
+          slider={f.type !== "int"}
+          disabled={!enabled}
+          onCommit={(v) => patch({ [f.key]: v })}
+        />
+        {effectiveHint(f, Number(value))}
+      </React.Fragment>
+    );
+  };
+
+  return (
+    <div className="hatch-layer">
+      <div className="h3-list-row hatch-layer-head">
+        <span className="type-row">
+          Layer {index + 1} -- {KIND_LABEL[layer.kind]}
+        </span>
+        <FormButton
+          minimal
+          icon={<AppIcon name="ui.duplicate" aria-hidden />}
+          aria-label="Duplicate layer"
+          title="Duplicate layer"
+          onClick={() => onDuplicate(layer.id)}
+        />
+        <FormButton
+          minimal
+          icon={<AppIcon name="ui.trash" aria-hidden />}
+          aria-label="Remove layer"
+          title="Remove layer"
+          onClick={() => onRemove(layer.id)}
+        />
+      </div>
+      <Field label="Kind" inline>
+        <SelectField
+          value={layer.kind}
+          onChange={(v) => patch({ kind: v as HatchLayerKind })}
+          aria-label="Layer kind"
+        >
+          <option value="line">Line</option>
+          <option value="dot">Dot screen</option>
+          <option value="stipple">Stipple</option>
+        </SelectField>
+      </Field>
+      {fieldsFor(layer.kind, "primary").map(renderField)}
+      <AccordionSection title="Randomness / Advanced">
+        {fieldsFor(layer.kind, "advanced").map(renderField)}
+      </AccordionSection>
+    </div>
+  );
+};
+
+export const HatchLayerRow = React.memo(HatchLayerRowImpl);

--- a/tritium/react-gui/src/renderer/components/inspector/HatchLayersSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/HatchLayersSection.tsx
@@ -1,0 +1,75 @@
+/**
+ * @file components/inspector/HatchLayersSection.tsx
+ * @description The "Layers" section of the NPR hatch layer editor: the mark
+ * layers of the selected style, each editable, with add buttons in the
+ * section title.
+ */
+
+import React from "react";
+
+import { HatchLayerRow } from "./HatchLayerRow";
+import { AppIcon } from "../AppIcon";
+import { FieldSection, FormButton } from "../../h3-kit/form";
+import type { HatchLayer, HatchLayerKind } from "../../data/hatchSpec";
+
+export interface HatchLayersSectionProps {
+  layers: HatchLayer[];
+  /** Render tab multipliers, for the effective-value hints. */
+  density: number;
+  widthScale: number;
+  supersample: number;
+  onLayerChange: (id: string, patch: Partial<HatchLayer>) => void;
+  onLayerAdd: (kind: HatchLayerKind) => void;
+  onLayerRemove: (id: string) => void;
+  onLayerDuplicate: (id: string) => void;
+}
+
+export const HatchLayersSection: React.FC<HatchLayersSectionProps> = ({
+  layers,
+  density,
+  widthScale,
+  supersample,
+  onLayerChange,
+  onLayerAdd,
+  onLayerRemove,
+  onLayerDuplicate,
+}) => (
+  <FieldSection
+    title="Layers"
+    titleActions={
+      <>
+        <FormButton
+          minimal
+          icon={<AppIcon name="ui.add" aria-hidden />}
+          text="Line"
+          title="Add a line layer"
+          onClick={() => onLayerAdd("line")}
+        />
+        <FormButton
+          minimal
+          icon={<AppIcon name="ui.add" aria-hidden />}
+          text="Dot"
+          title="Add a dot layer"
+          onClick={() => onLayerAdd("dot")}
+        />
+      </>
+    }
+  >
+    {layers.map((layer, i) => (
+      <HatchLayerRow
+        key={layer.id}
+        index={i}
+        layer={layer}
+        density={density}
+        widthScale={widthScale}
+        supersample={supersample}
+        onChange={onLayerChange}
+        onRemove={onLayerRemove}
+        onDuplicate={onLayerDuplicate}
+      />
+    ))}
+    {layers.length === 0 && (
+      <span className="type-caption hatch-look-status">No layers: add one above.</span>
+    )}
+  </FieldSection>
+);

--- a/tritium/react-gui/src/renderer/components/inspector/HatchLookEditor.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/HatchLookEditor.tsx
@@ -1,0 +1,125 @@
+/**
+ * @file components/inspector/HatchLookEditor.tsx
+ * @description The NPR hatch layer editor: the Rendering window's "Hatching"
+ * settings tab. The style picked in the Render tab is a TEMPLATE: its layers
+ * and shading are loaded from the C++ side and edited here; an edited look is
+ * sent with the render as spec text, and "Reset to style" reloads the
+ * template. Template loading itself lives in hooks/useHatchTemplate.ts.
+ */
+
+import React from "react";
+
+import { HatchLayersSection } from "./HatchLayersSection";
+import { HatchShadingSection } from "./HatchShadingSection";
+import { AppIcon } from "../AppIcon";
+import { ButtonRow, FormButton } from "../../h3-kit/form";
+import type {
+  HatchFieldEnv,
+  HatchInk,
+  HatchLayer,
+  HatchLayerKind,
+  HatchSpec,
+  HatchTone,
+} from "../../data/hatchSpec";
+import type { HatchTemplateStatus } from "../../hooks/useHatchTemplate";
+
+/** Multiplier text without float noise. */
+const fmtMul = (v: number): string => String(Number(v.toFixed(3)));
+
+export interface HatchLookEditorProps {
+  /** The style whose template is being edited (the Render tab's pick). */
+  styleName: string;
+  /**
+   * The Render tab's Mark density / Mark width. They multiply every layer at
+   * render time (pitch / density, width or dot scale * widthScale) and are
+   * shown here as the effective values, never folded into the layer values.
+   */
+  density: number;
+  widthScale: number;
+  /** Render supersampling (the ink grid's minimum-pitch hint). */
+  supersample: number;
+  /** Other render settings that switch tone / ink fields off. */
+  env: HatchFieldEnv;
+  /** The editable look; null until the style's template arrives. */
+  spec: HatchSpec | null;
+  /** True once the look differs from the style's template. */
+  dirty: boolean;
+  status: HatchTemplateStatus;
+  error: string | null;
+  onLayerChange: (id: string, patch: Partial<HatchLayer>) => void;
+  onLayerAdd: (kind: HatchLayerKind) => void;
+  onLayerRemove: (id: string) => void;
+  onLayerDuplicate: (id: string) => void;
+  onToneChange: (patch: Partial<HatchTone>) => void;
+  onInkChange: (patch: Partial<HatchInk>) => void;
+  onReset: () => void;
+}
+
+export const HatchLookEditor: React.FC<HatchLookEditorProps> = ({
+  styleName,
+  density,
+  widthScale,
+  supersample,
+  env,
+  spec,
+  dirty,
+  status,
+  error,
+  onLayerChange,
+  onLayerAdd,
+  onLayerRemove,
+  onLayerDuplicate,
+  onToneChange,
+  onInkChange,
+  onReset,
+}) => (
+  <div className="hatch-look">
+    <span className="type-caption hatch-look-status">
+      Style template: {styleName || "(none)"}
+    </span>
+    {(density !== 1 || widthScale !== 1) && (
+      <span className="type-caption hatch-look-status">
+        Render tab multipliers: Mark density x{fmtMul(density)}, Mark width x{fmtMul(widthScale)}
+        {" "}(applied on top of the values below)
+      </span>
+    )}
+    {status === "loading" && (
+      <span className="type-caption hatch-look-status">Loading the style template...</span>
+    )}
+    {status === "error" && (
+      <span className="type-caption hatch-look-status is-error">
+        {error ?? "The style template could not be loaded."}
+      </span>
+    )}
+    {spec && (
+      <>
+        <ButtonRow className="hatch-look-actions">
+          <FormButton
+            icon={<AppIcon name="ui.resetDefaults" aria-hidden />}
+            text="Reset to style"
+            disabled={!dirty}
+            onClick={onReset}
+          />
+          {dirty && <span className="type-caption hatch-look-edited">Edited</span>}
+        </ButtonRow>
+        <HatchLayersSection
+          layers={spec.layers}
+          density={density}
+          widthScale={widthScale}
+          supersample={supersample}
+          onLayerChange={onLayerChange}
+          onLayerAdd={onLayerAdd}
+          onLayerRemove={onLayerRemove}
+          onLayerDuplicate={onLayerDuplicate}
+        />
+        <HatchShadingSection
+          tone={spec.tone}
+          ink={spec.ink}
+          env={env}
+          onToneChange={onToneChange}
+          onInkChange={onInkChange}
+        />
+      </>
+    )}
+  </div>
+);

--- a/tritium/react-gui/src/renderer/components/inspector/HatchShadingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/HatchShadingSection.tsx
@@ -1,0 +1,93 @@
+/**
+ * @file components/inspector/HatchShadingSection.tsx
+ * @description The "Shading" section of the NPR hatch layer editor: how the
+ * lighting tone becomes an ink amount. Strength and Curve stay visible (the
+ * two knobs that matter day to day); the rest of the tone recipe and the
+ * ink-model extras sit under a collapsed Advanced area.
+ */
+
+import React from "react";
+
+import { AccordionSection } from "./AccordionSection";
+import { Field, FieldSection, SliderField, SwitchField } from "../../h3-kit/form";
+import {
+  INK_FIELDS,
+  TONE_FIELDS,
+  inkFieldEnabled,
+  toneFieldEnabled,
+  type HatchFieldDef,
+  type HatchFieldEnv,
+  type HatchInk,
+  type HatchTone,
+} from "../../data/hatchSpec";
+
+export interface HatchShadingSectionProps {
+  tone: HatchTone;
+  ink: HatchInk;
+  /** What the other render settings make ineffective (shown disabled). */
+  env: HatchFieldEnv;
+  onToneChange: (patch: Partial<HatchTone>) => void;
+  onInkChange: (patch: Partial<HatchInk>) => void;
+}
+
+const renderField = (
+  f: HatchFieldDef,
+  value: unknown,
+  enabled: boolean,
+  commit: (patch: Record<string, unknown>) => void,
+): React.ReactNode => {
+  if (f.type === "str") return null;
+  if (f.type === "bool") {
+    return (
+      <Field key={f.key} label={f.label} inline>
+        <SwitchField
+          checked={Boolean(value)}
+          disabled={!enabled}
+          onChange={(v) => commit({ [f.key]: v })}
+        />
+      </Field>
+    );
+  }
+  return (
+    <SliderField
+      key={f.key}
+      label={f.label}
+      value={Number(value)}
+      min={f.min ?? 0}
+      max={f.max ?? 1}
+      step={f.step}
+      unit={f.unit}
+      slider={f.type !== "int"}
+      disabled={!enabled}
+      onCommit={(v) => commit({ [f.key]: v })}
+    />
+  );
+};
+
+export const HatchShadingSection: React.FC<HatchShadingSectionProps> = ({
+  tone,
+  ink,
+  env,
+  onToneChange,
+  onInkChange,
+}) => {
+  const toneRec = tone as unknown as Record<string, unknown>;
+  const inkRec = ink as unknown as Record<string, unknown>;
+  const commitTone = (p: Record<string, unknown>) => onToneChange(p as Partial<HatchTone>);
+  const commitInk = (p: Record<string, unknown>) => onInkChange(p as Partial<HatchInk>);
+  return (
+    <FieldSection title="Shading">
+      {TONE_FIELDS.filter((f) => f.place === "primary").map((f) =>
+        renderField(f, toneRec[f.key], toneFieldEnabled(f.key, tone, env), commitTone),
+      )}
+      <AccordionSection title="Advanced">
+        {TONE_FIELDS.filter((f) => f.place === "advanced").map((f) =>
+          renderField(f, toneRec[f.key], toneFieldEnabled(f.key, tone, env), commitTone),
+        )}
+        {INK_FIELDS.map((f) =>
+          renderField(f, inkRec[f.key], inkFieldEnabled(f.key, ink, env), commitInk),
+        )}
+      </AccordionSection>
+    </FieldSection>
+  );
+};

--- a/tritium/react-gui/src/renderer/components/inspector/PropEditors.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/PropEditors.tsx
@@ -19,6 +19,7 @@ import {
   ComboBoxField,
   SwitchField,
   ColorField,
+  SliderField,
 } from "../../h3-kit/form";
 
 // ------------------------------------------------------------
@@ -66,11 +67,27 @@ interface NumericEditorProps {
  * When `prop.inline` is set the field renders as a compact plain number box
  * (no drag) with the label beside it on a single row -- used by the
  * render-settings width / height fields, where a drag control and a two-row
- * layout are both unwanted.
+ * layout are both unwanted. When `prop.slider` is set it renders the
+ * slider + number + stepper row instead (settings adjusted by feel within a
+ * known range, e.g. the NPR hatch multipliers).
  */
 export const NumericEditor: React.FC<NumericEditorProps> = ({ prop, onChange }) => {
   const step = prop.step ?? (prop.type === "integer" ? 1 : 0.01);
   const decimals = prop.decimals ?? (prop.type === "integer" ? 0 : undefined);
+  if (prop.slider) {
+    // SliderField carries its own label; no Field wrapper (double label).
+    return (
+      <SliderField
+        label={prop.label}
+        value={Number(prop.value)}
+        min={prop.min ?? 0}
+        max={prop.max ?? 100}
+        step={step}
+        unit={prop.unit}
+        onCommit={(v) => onChange(prop.key, v)}
+      />
+    );
+  }
   if (prop.inline) {
     return (
       <Field label={prop.label} inline>

--- a/tritium/react-gui/src/renderer/components/renderwindow/RenderSettingsPane.tsx
+++ b/tritium/react-gui/src/renderer/components/renderwindow/RenderSettingsPane.tsx
@@ -1,13 +1,15 @@
 /**
  * @file components/renderwindow/RenderSettingsPane.tsx
  * @description Right pane of the Rendering window: the render settings, split
- * into two tabs behind one header.
+ * into tabs behind one header.
  *
  * "Image" holds everything describing the produced file (size, output toggles,
  * and the movie output settings in movie mode) and opens first, since size is
  * what a render is set up around; "Render" holds the backend-driven groups
  * (Camera / Quality / Edges / the backend's own). The split keeps a single
- * scrolling column short enough to scan in a narrow pane.
+ * scrolling column short enough to scan in a narrow pane. The Umbreon (NPR)
+ * backend adds a "Detail" tab with the hatch layer editor (the Render tab's
+ * Hatching group keeps the style pick and its simple multipliers).
  *
  * The header and the tab strip are the shared .panel-header / .mode-bar roles
  * the main window's Inspector uses, so the two panes are titled and switched
@@ -21,6 +23,7 @@ import React, { useState } from "react";
 import { SegmentField } from "../../h3-kit/form";
 import { AppIcon } from "../AppIcon";
 import { RenderSettingsEditor } from "../inspector/RenderSettingsEditor";
+import { HatchLookEditor, type HatchLookEditorProps } from "../inspector/HatchLookEditor";
 import { RenderImageTab } from "./RenderImageTab";
 import { RENDER_BACKENDS } from "../../data/renderBackends";
 import type { PropDef } from "../../data/rendererProperties";
@@ -34,7 +37,7 @@ import type {
 } from "../../data/renderSettings";
 
 /** Which settings tab is visible. */
-type RenderSettingsTab = "render" | "image";
+type RenderSettingsTab = "render" | "image" | "hatch";
 
 interface RenderSettingsPaneProps {
   /** Currently selected backend (drives the Render tab's groups). */
@@ -73,6 +76,8 @@ interface RenderSettingsPaneProps {
   onPickFolder?: () => void;
   /** Disable the movie controls (a render is in flight). */
   movieDisabled?: boolean;
+  /** NPR hatch layer editor: adds the "Detail" tab (umbreon_npr only). */
+  hatch?: HatchLookEditorProps;
 }
 
 export const RenderSettingsPane: React.FC<RenderSettingsPaneProps> = ({
@@ -94,8 +99,12 @@ export const RenderSettingsPane: React.FC<RenderSettingsPaneProps> = ({
   onUseCustomDir,
   onPickFolder,
   movieDisabled = false,
+  hatch,
 }) => {
   const [tab, setTab] = useState<RenderSettingsTab>("image");
+  // The Detail tab exists only while the NPR backend is active; leaving the
+  // backend while on it falls back to the Render tab.
+  const activeTab: RenderSettingsTab = tab === "hatch" && !hatch ? "render" : tab;
 
   return (
     <div className="render-window-settings">
@@ -106,17 +115,22 @@ export const RenderSettingsPane: React.FC<RenderSettingsPaneProps> = ({
 
       <div className="render-window-settings-tabbar mode-bar">
         <SegmentField<RenderSettingsTab>
-          value={tab}
+          value={activeTab}
           onValueChange={setTab}
           options={[
             { label: "Image", value: "image" },
             { label: "Render", value: "render" },
+            ...(hatch ? [{ label: "Detail", value: "hatch" as const }] : []),
           ]}
         />
       </div>
 
       <div className="render-window-settings-body">
-        {tab === "render" ? (
+        {activeTab === "hatch" && hatch ? (
+          <div className="insp-properties-tab">
+            <HatchLookEditor {...hatch} />
+          </div>
+        ) : activeTab === "render" ? (
           <RenderSettingsEditor
             backend={backend}
             commonProps={commonProps}

--- a/tritium/react-gui/src/renderer/components/renderwindow/RenderWindowApp.tsx
+++ b/tritium/react-gui/src/renderer/components/renderwindow/RenderWindowApp.tsx
@@ -27,6 +27,8 @@ import { RenderImageViewer } from "../panes/RenderImageViewer";
 import { RenderPanel } from "../panels/RenderPanel";
 import { RenderSettingsPane } from "./RenderSettingsPane";
 import { useRenderSettings } from "../../hooks/useRenderSettings";
+import { useHatchTemplate } from "../../hooks/useHatchTemplate";
+import type { HatchLookEditorProps } from "../inspector/HatchLookEditor";
 import { useMovieOutputPrefs } from "../../hooks/useMovieOutputPrefs";
 import { isRenderJobActive } from "../../hooks/useRenderJob";
 import { useRenderWindowClient } from "../../hooks/useRenderWindowClient";
@@ -40,6 +42,46 @@ export const RenderWindowApp: React.FC = () => {
   // the main window); otherwise fall back to the static default (POV-Ray).
   const umbreonAvailable = client.state.umbreonAvailable;
   const settings = useRenderSettings({ umbreonAvailable });
+  // NPR hatch layer editor: the selected style is loaded from the C++ side as
+  // an editable template (through the main window's worker).
+  const isNpr = settings.backend === "umbreon_npr";
+  const hatchTemplate = useHatchTemplate({
+    enabled: isNpr,
+    style: settings.hatchStyle,
+    loaded: settings.hatchLoaded,
+    fetchSpec: client.getHatchStyleSpec,
+    onLoaded: settings.applyHatchTemplate,
+  });
+  const numSetting = (key: string, def: number): number => {
+    const v = Number(settings.backendProps.find((p) => p.key === key)?.value);
+    return Number.isFinite(v) ? v : def;
+  };
+  // The fill under the marks: the Coloring pick, or the style's own base.
+  const coloring = String(settings.backendProps.find((p) => p.key === "hatchColoring")?.value ?? "");
+  const baseIsAlbedo =
+    coloring === "Style default"
+      ? settings.hatch.spec?.ink.base === "albedo"
+      : coloring.includes("color fill");
+  const hatchEditor: HatchLookEditorProps | undefined = isNpr
+    ? {
+        styleName: settings.hatchStyle,
+        density: numSetting("hatchDensity", 1),
+        widthScale: numSetting("hatchWidthScale", 1),
+        supersample: numSetting("supersample", 3),
+        env: { aoEnabled: settings.lighting === "ao", baseIsAlbedo },
+        spec: settings.hatch.spec,
+        dirty: settings.hatchDirty,
+        status: hatchTemplate.status,
+        error: hatchTemplate.error,
+        onLayerChange: settings.updateHatchLayer,
+        onLayerAdd: settings.addHatchLayer,
+        onLayerRemove: settings.removeHatchLayer,
+        onLayerDuplicate: settings.duplicateHatchLayer,
+        onToneChange: settings.updateHatchTone,
+        onInkChange: settings.updateHatchInk,
+        onReset: settings.resetHatchToTemplate,
+      }
+    : undefined;
   // Default the movie output to the app-managed folder and remember the
   // settings across window closes (see hooks/useMovieOutputPrefs.ts).
   const movieOutput = useMovieOutputPrefs(settings.movie, settings.updateMovie);
@@ -307,6 +349,7 @@ export const RenderWindowApp: React.FC = () => {
             onUseCustomDir={movieOutput.selectCustomDir}
             onPickFolder={handlePickFolder}
             movieDisabled={jobActive}
+            hatch={hatchEditor}
           />
         </Allotment.Pane>
       </Allotment>

--- a/tritium/react-gui/src/renderer/data/hatchSpec.ts
+++ b/tritium/react-gui/src/renderer/data/hatchSpec.ts
@@ -1,0 +1,435 @@
+/**
+ * @file data/hatchSpec.ts
+ * @description The umbreon hatch spec text (`layer:` / `tone:` / `ink:`
+ * lines) as typed records, with the parse / format pair the layer editor and
+ * the NPR render backend share. Pure module: no React, no IPC.
+ *
+ * The grammar is umbreon's (npr/hatch_shade.hpp, applyHatchSpec): one
+ * `layer:` line per mark layer, a `tone:` line for the tone recipe and an
+ * `ink:` line for the paper / ink model, each a comma-separated list of
+ * `key=value` entries. Numbers use the C locale, booleans are on/off, colors
+ * #rrggbb. Record fields are named after the spec keys, and one field table
+ * per section drives parsing, formatting, defaults and the editor's ranges,
+ * so a key added on the C++ side is one table row here. Unknown keys survive
+ * a round trip through `extra`.
+ */
+
+// --- Types ---
+
+export type HatchLayerKind = "line" | "dot" | "stipple";
+
+/** One mark layer (a "pencil" of the drawing). */
+export interface HatchLayer {
+  /** Stable UI key; never written to the spec text. */
+  id: string;
+  kind: HatchLayerKind;
+  angle: number;
+  spacing: number;
+  subdiv: number;
+  /** Line layers: full line width (output px). */
+  width: number;
+  /** Dot / Stipple layers: relative dot radius (1 = area-exact). */
+  dotscale: number;
+  tonehi: number;
+  tonelo: number;
+  /** Grow-in speed below the appearance threshold; 0 = auto (continuous). */
+  fade: number;
+  opacity: number;
+  inkscale: number;
+  soft: number;
+  seed: number;
+  jitter: number;
+  wobble: number;
+  wobwave: number;
+  wjitter: number;
+  slen: number;
+  sgap: number;
+  taper: number;
+  anglejitter: number;
+  lenjitter: number;
+  tooth: number;
+  toothscale: number;
+  shape: number;
+  aspect: number;
+  dotangle: number;
+  invert: boolean;
+  /** Keys this module does not know, kept verbatim for the round trip. */
+  extra: Record<string, string>;
+}
+
+/** The tone recipe: how the shading tone becomes an ink amount. */
+export interface HatchTone {
+  /** Ink gain in coverage space (1 = the style's own). Primary control. */
+  strength: number;
+  /** Coverage exponent: > 1 lighter mid tones, < 1 heavier. Primary control. */
+  curve: number;
+  diffuse: number;
+  ambient: number;
+  wrap: number;
+  rim: number;
+  rimpow: number;
+  rimbias: number;
+  contact: number;
+  shape: number;
+  black: number;
+  white: number;
+  hl: number;
+  hlsoft: number;
+  gamma: number;
+  speccut: number;
+  levels: number;
+  extra: Record<string, string>;
+}
+
+/** The paper / ink model. The base / ink / color keys are kept as text: the
+ * Coloring dropdown and the custom colors own them in the GUI. */
+export interface HatchInk {
+  mode: string;
+  base: string;
+  ink: string;
+  inkcolor: string;
+  papercolor: string;
+  mincontrast: number;
+  inkshade: number;
+  tonefog: boolean;
+  albedoquant: number;
+  extra: Record<string, string>;
+}
+
+export interface HatchSpec {
+  layers: HatchLayer[];
+  tone: HatchTone;
+  ink: HatchInk;
+}
+
+// --- Field tables ---
+
+/** Where the editor shows a field. */
+export type HatchFieldPlace = "primary" | "advanced";
+
+export interface HatchFieldDef {
+  /** Spec key == record field name. */
+  key: string;
+  type: "num" | "int" | "bool" | "str";
+  def: number | boolean | string;
+  label: string;
+  place: HatchFieldPlace;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  /** Layer fields only: the kinds the field applies to (absent = all). */
+  kinds?: HatchLayerKind[];
+}
+
+const LINE: HatchLayerKind[] = ["line"];
+const DOTS: HatchLayerKind[] = ["dot", "stipple"];
+const DOT: HatchLayerKind[] = ["dot"];
+/** Kinds with nesting levels (a Stipple layer is one flat lattice). */
+const LATTICE: HatchLayerKind[] = ["line", "dot"];
+
+/** Mark-layer fields, in the order the spec text lists them. */
+export const LAYER_FIELDS: readonly HatchFieldDef[] = [
+  { key: "angle", type: "num", def: 45, label: "Angle", place: "primary", min: -180, max: 180, step: 1, unit: "deg" },
+  { key: "spacing", type: "num", def: 10, label: "Spacing", place: "primary", min: 0.25, max: 64, step: 0.25, unit: "px" },
+  { key: "subdiv", type: "int", def: 2, label: "Nesting levels", place: "advanced", min: 0, max: 5, step: 1, kinds: LATTICE },
+  { key: "width", type: "num", def: 1.1, label: "Width", place: "primary", min: 0.1, max: 8, step: 0.05, unit: "px", kinds: LINE },
+  { key: "dotscale", type: "num", def: 1, label: "Dot scale", place: "primary", min: 0.1, max: 8, step: 0.05, kinds: DOTS },
+  { key: "tonehi", type: "num", def: 0.95, label: "Tone high", place: "primary", min: 0, max: 1, step: 0.01 },
+  { key: "tonelo", type: "num", def: 0.55, label: "Tone low", place: "primary", min: 0, max: 1, step: 0.01 },
+  { key: "fade", type: "num", def: 16, label: "Fade (0 = auto)", place: "primary", min: 0, max: 64, step: 1 },
+  { key: "opacity", type: "num", def: 1, label: "Opacity", place: "primary", min: 0, max: 1, step: 0.05 },
+  { key: "inkscale", type: "num", def: 1, label: "Ink darkness", place: "primary", min: 0, max: 1, step: 0.02 },
+  { key: "soft", type: "num", def: 0.5, label: "Edge softness", place: "advanced", min: 0.5, max: 2, step: 0.05, unit: "px" },
+  { key: "seed", type: "int", def: 0, label: "Seed", place: "advanced", min: 0, max: 9999, step: 1 },
+  { key: "jitter", type: "num", def: 0, label: "Position jitter", place: "advanced", min: 0, max: 0.5, step: 0.01 },
+  { key: "wobble", type: "num", def: 0, label: "Wobble", place: "advanced", min: 0, max: 8, step: 0.1, unit: "px", kinds: LINE },
+  { key: "wobwave", type: "num", def: 40, label: "Wobble wavelength", place: "advanced", min: 2, max: 200, step: 1, unit: "px", kinds: LINE },
+  { key: "wjitter", type: "num", def: 0, label: "Width jitter", place: "advanced", min: 0, max: 1, step: 0.05, kinds: LINE },
+  { key: "slen", type: "num", def: 0, label: "Stroke length", place: "advanced", min: 0, max: 200, step: 1, unit: "px", kinds: LINE },
+  { key: "sgap", type: "num", def: 0, label: "Stroke gap", place: "advanced", min: 0, max: 50, step: 0.5, unit: "px", kinds: LINE },
+  { key: "taper", type: "num", def: 0.3, label: "Stroke taper", place: "advanced", min: 0, max: 0.9, step: 0.05, kinds: LINE },
+  { key: "anglejitter", type: "num", def: 0, label: "Angle jitter", place: "advanced", min: 0, max: 15, step: 0.5, unit: "deg", kinds: LINE },
+  { key: "lenjitter", type: "num", def: 0, label: "Length jitter", place: "advanced", min: 0, max: 0.9, step: 0.05, kinds: LINE },
+  { key: "shape", type: "num", def: 2, label: "Shape exponent", place: "advanced", min: 1, max: 16, step: 0.5, kinds: DOTS },
+  { key: "aspect", type: "num", def: 1, label: "Aspect", place: "advanced", min: 0.5, max: 2, step: 0.05, kinds: DOTS },
+  { key: "dotangle", type: "num", def: 0, label: "Dot angle", place: "advanced", min: -90, max: 90, step: 1, unit: "deg", kinds: DOTS },
+  { key: "invert", type: "bool", def: true, label: "Merge to solid", place: "advanced", kinds: DOT },
+  { key: "tooth", type: "num", def: 0, label: "Paper tooth", place: "advanced", min: 0, max: 1, step: 0.05 },
+  { key: "toothscale", type: "num", def: 3, label: "Tooth scale", place: "advanced", min: 0.5, max: 20, step: 0.5, unit: "px" },
+];
+
+/** Tone-recipe fields; strength / curve first (the primary controls). */
+export const TONE_FIELDS: readonly HatchFieldDef[] = [
+  { key: "strength", type: "num", def: 1, label: "Strength", place: "primary", min: 0.25, max: 3, step: 0.05 },
+  { key: "curve", type: "num", def: 1, label: "Curve", place: "primary", min: 0.5, max: 2, step: 0.05 },
+  { key: "diffuse", type: "num", def: 1, label: "Diffuse weight", place: "advanced", min: 0, max: 2, step: 0.05 },
+  { key: "ambient", type: "num", def: 0.12, label: "Ambient", place: "advanced", min: 0, max: 0.5, step: 0.01 },
+  { key: "wrap", type: "num", def: 0, label: "Wrap", place: "advanced", min: 0, max: 1, step: 0.05 },
+  { key: "rim", type: "num", def: 0, label: "Contour darkening", place: "advanced", min: 0, max: 1, step: 0.05 },
+  { key: "rimpow", type: "num", def: 1, label: "Contour power", place: "advanced", min: 0.5, max: 8, step: 0.1 },
+  { key: "rimbias", type: "num", def: 0.6, label: "Contour light bias", place: "advanced", min: 0, max: 1, step: 0.05 },
+  { key: "contact", type: "num", def: 1, label: "Contact AO", place: "advanced", min: 0, max: 2, step: 0.05 },
+  { key: "shape", type: "num", def: 0.6, label: "Shape AO", place: "advanced", min: 0, max: 2, step: 0.05 },
+  { key: "black", type: "num", def: 0, label: "Black point", place: "advanced", min: 0, max: 0.5, step: 0.01 },
+  { key: "white", type: "num", def: 1, label: "White point", place: "advanced", min: 0.5, max: 2, step: 0.01 },
+  { key: "hl", type: "num", def: 1, label: "Highlight knee", place: "advanced", min: 0.5, max: 1, step: 0.01 },
+  { key: "hlsoft", type: "num", def: 0.06, label: "Highlight softness", place: "advanced", min: 0, max: 0.3, step: 0.01 },
+  { key: "gamma", type: "num", def: 1, label: "Gamma", place: "advanced", min: 0.2, max: 4, step: 0.05 },
+  { key: "speccut", type: "num", def: 0, label: "Specular cut", place: "advanced", min: 0, max: 2, step: 0.05 },
+  { key: "levels", type: "int", def: 0, label: "Tone levels", place: "advanced", min: 0, max: 16, step: 1 },
+];
+
+/** Paper / ink model fields. */
+export const INK_FIELDS: readonly HatchFieldDef[] = [
+  { key: "mode", type: "str", def: "ink", label: "Mode", place: "advanced" },
+  { key: "base", type: "str", def: "paper", label: "Base", place: "advanced" },
+  { key: "ink", type: "str", def: "fixed", label: "Ink", place: "advanced" },
+  { key: "inkcolor", type: "str", def: "#000000", label: "Ink color", place: "advanced" },
+  { key: "papercolor", type: "str", def: "#ffffff", label: "Paper color", place: "advanced" },
+  { key: "mincontrast", type: "num", def: 0.25, label: "Min contrast", place: "advanced", min: 0, max: 1, step: 0.05 },
+  { key: "inkshade", type: "num", def: 1, label: "Ink shade", place: "advanced", min: 0, max: 1, step: 0.05 },
+  { key: "tonefog", type: "bool", def: true, label: "Tone fog", place: "advanced" },
+  { key: "albedoquant", type: "int", def: 0, label: "Fill posterize", place: "advanced", min: 0, max: 16, step: 1 },
+];
+
+/** Whether a layer field applies to a layer kind. */
+export const fieldAppliesTo = (f: HatchFieldDef, kind: HatchLayerKind): boolean =>
+  !f.kinds || f.kinds.includes(kind);
+
+// --- Fields with no effect under the current values (shown disabled) ---
+
+/**
+ * Whether a layer field currently has any effect on the picture, given the
+ * layer's other values (umbreon npr/hatch_ink.hpp): a field that another
+ * value switches off is shown disabled rather than silently ignored.
+ */
+export function layerFieldEnabled(key: string, l: HatchLayer): boolean {
+  const line = l.kind === "line";
+  switch (key) {
+    // No nesting and a fixed fade: only toneHi gates the marks.
+    case "tonelo":
+      return l.kind === "stipple" || l.subdiv > 0 || l.fade <= 0;
+    // The wavelength drives the wobble and the width modulation noise.
+    case "wobwave":
+      return l.wobble > 0 || l.wjitter > 0;
+    // Stroke-only parameters (a continuous line has no strokes).
+    case "sgap":
+    case "taper":
+    case "anglejitter":
+    case "lenjitter":
+      return l.slen > 0;
+    case "toothscale":
+      return l.tooth > 0;
+    // A circle does not rotate.
+    case "dotangle":
+      return !(l.aspect === 1 && l.shape === 2);
+    // The seed feeds the hashes: nothing to seed without any randomness
+    // (a Stipple layer always hashes its thresholds).
+    case "seed":
+      return (
+        l.kind === "stipple" ||
+        l.jitter > 0 ||
+        l.tooth > 0 ||
+        (line && (l.wobble > 0 || l.wjitter > 0 || l.slen > 0))
+      );
+    default:
+      return true;
+  }
+}
+
+/** Render-settings context the tone / ink fields depend on. */
+export interface HatchFieldEnv {
+  /** Ambient occlusion is on (the AO exponents shape the tone only then). */
+  aoEnabled: boolean;
+  /** The fill under the marks is the object color (albedo), not paper. */
+  baseIsAlbedo: boolean;
+}
+
+/** Whether a tone-recipe field currently has any effect. */
+export function toneFieldEnabled(key: string, t: HatchTone, env: HatchFieldEnv): boolean {
+  switch (key) {
+    case "hlsoft":
+      return t.hl < 1;
+    case "rimpow":
+    case "rimbias":
+      return t.rim > 0;
+    case "contact":
+    case "shape":
+      return env.aoEnabled;
+    default:
+      return true;
+  }
+}
+
+/** Whether an ink-model field currently has any effect. */
+export function inkFieldEnabled(key: string, _ink: HatchInk, env: HatchFieldEnv): boolean {
+  switch (key) {
+    case "albedoquant":
+      return env.baseIsAlbedo;
+    default:
+      return true;
+  }
+}
+
+// --- Defaults / construction ---
+
+let idSeq = 0;
+/** A fresh UI id for a layer. */
+export const nextHatchLayerId = (): string => `hl${++idSeq}`;
+
+const defaultsOf = (fields: readonly HatchFieldDef[]): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const f of fields) out[f.key] = f.def;
+  return out;
+};
+
+export const DEFAULT_HATCH_TONE: HatchTone = {
+  ...(defaultsOf(TONE_FIELDS) as unknown as Omit<HatchTone, "extra">),
+  extra: {},
+};
+
+export const DEFAULT_HATCH_INK: HatchInk = {
+  ...(defaultsOf(INK_FIELDS) as unknown as Omit<HatchInk, "extra">),
+  extra: {},
+};
+
+/** A new layer of `kind` with umbreon's field defaults. */
+export const newHatchLayer = (kind: HatchLayerKind, id: string = nextHatchLayerId()): HatchLayer => ({
+  ...(defaultsOf(LAYER_FIELDS) as unknown as Omit<HatchLayer, "id" | "kind" | "extra">),
+  id,
+  kind,
+  extra: {},
+});
+
+/** Deep copy with fresh layer ids (a template becoming the editable copy). */
+export const cloneHatchSpec = (spec: HatchSpec): HatchSpec => ({
+  layers: spec.layers.map((l) => ({ ...l, id: nextHatchLayerId(), extra: { ...l.extra } })),
+  tone: { ...spec.tone, extra: { ...spec.tone.extra } },
+  ink: { ...spec.ink, extra: { ...spec.ink.extra } },
+});
+
+// --- Parse ---
+
+const parseBool = (v: string): boolean | undefined => {
+  const t = v.trim().toLowerCase();
+  if (t === "on" || t === "1" || t === "true") return true;
+  if (t === "off" || t === "0" || t === "false") return false;
+  return undefined;
+};
+
+/** Apply `key=value` entries onto a record by its field table. */
+const applyEntries = (
+  target: Record<string, unknown>,
+  fields: readonly HatchFieldDef[],
+  entries: string,
+): void => {
+  const extra = target.extra as Record<string, string>;
+  for (const raw of entries.split(",")) {
+    const entry = raw.trim();
+    if (!entry) continue;
+    const eq = entry.indexOf("=");
+    if (eq < 0) continue;
+    const key = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1).trim();
+    if (key === "kind") {
+      if (value === "line" || value === "dot" || value === "stipple") target.kind = value;
+      continue;
+    }
+    const f = fields.find((d) => d.key === key);
+    if (!f) {
+      extra[key] = value;
+      continue;
+    }
+    if (f.type === "bool") {
+      const b = parseBool(value);
+      if (b !== undefined) target[key] = b;
+    } else if (f.type === "str") {
+      target[key] = value;
+    } else {
+      const n = Number(value);
+      if (Number.isFinite(n)) target[key] = f.type === "int" ? Math.trunc(n) : n;
+    }
+  }
+};
+
+/**
+ * Parse a spec text. Missing keys take the defaults, unknown keys land in
+ * `extra`, blank lines / `#` comments / unknown sections are skipped, and no
+ * value is clamped (the text is the C++ side's truth).
+ */
+export function parseHatchSpec(text: string): HatchSpec {
+  const spec: HatchSpec = {
+    layers: [],
+    tone: { ...DEFAULT_HATCH_TONE, extra: {} },
+    ink: { ...DEFAULT_HATCH_INK, extra: {} },
+  };
+  for (const rawLine of text.split(/\r?\n|;/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const section = line.slice(0, colon).trim();
+    const entries = line.slice(colon + 1);
+    if (section === "layer") {
+      const layer = newHatchLayer("line");
+      applyEntries(layer as unknown as Record<string, unknown>, LAYER_FIELDS, entries);
+      spec.layers.push(layer);
+    } else if (section === "tone") {
+      applyEntries(spec.tone as unknown as Record<string, unknown>, TONE_FIELDS, entries);
+    } else if (section === "ink") {
+      applyEntries(spec.ink as unknown as Record<string, unknown>, INK_FIELDS, entries);
+    }
+  }
+  return spec;
+}
+
+// --- Format ---
+
+/** Number text without float noise (0.1 + 0.2 -> "0.3"). */
+const fmtNum = (v: number): string => String(Number(v.toFixed(4)));
+
+const formatEntries = (
+  source: Record<string, unknown>,
+  fields: readonly HatchFieldDef[],
+  keep: (f: HatchFieldDef) => boolean,
+): string => {
+  const parts: string[] = [];
+  for (const f of fields) {
+    if (!keep(f)) continue;
+    const v = source[f.key];
+    if (f.type === "bool") parts.push(`${f.key}=${v ? "on" : "off"}`);
+    else if (f.type === "str") parts.push(`${f.key}=${String(v)}`);
+    else parts.push(`${f.key}=${fmtNum(Number(v))}`);
+  }
+  const extra = (source.extra ?? {}) as Record<string, string>;
+  for (const key of Object.keys(extra)) parts.push(`${key}=${extra[key]}`);
+  return parts.join(",");
+};
+
+/** The `layer:` lines (one per layer, keys filtered by the layer's kind). */
+export function formatHatchLayersSpec(layers: HatchLayer[]): string {
+  return layers
+    .map((l) => {
+      const body = formatEntries(l as unknown as Record<string, unknown>, LAYER_FIELDS, (f) =>
+        fieldAppliesTo(f, l.kind),
+      );
+      return `layer: kind=${l.kind}${body ? "," + body : ""}\n`;
+    })
+    .join("");
+}
+
+/** The `tone:` and `ink:` lines. */
+export function formatHatchToneSpec(tone: HatchTone, ink: HatchInk): string {
+  const t = formatEntries(tone as unknown as Record<string, unknown>, TONE_FIELDS, () => true);
+  const i = formatEntries(ink as unknown as Record<string, unknown>, INK_FIELDS, () => true);
+  return `tone: ${t}\nink: ${i}\n`;
+}
+
+/** The whole text (layers, then tone and ink). */
+export const formatHatchSpec = (spec: HatchSpec): string =>
+  formatHatchLayersSpec(spec.layers) + formatHatchToneSpec(spec.tone, spec.ink);
+
+/** Same configuration (layer ids ignored). */
+export const isSameHatchSpec = (a: HatchSpec, b: HatchSpec): boolean =>
+  formatHatchSpec(a) === formatHatchSpec(b);

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -70,7 +70,7 @@ const UMBREON_PROPS: PropDef[] = [
   // 3 = the "aa" axis' default step, which every fresh backend selection
   // applies anyway; declared to match so the three places that state a
   // supersampling default (here, the axis, UmbreonBackend's fallback) agree.
-  { key: "supersample",   label: "Supersampling",      type: "integer", value: 3,    group: "Antialiasing", min: 1, max: 8,    step: 1 },
+  { key: "supersample",   label: "Supersampling",      type: "integer", value: 3,    group: "Antialiasing", min: 1, max: 8,    step: 1, slider: true },
   // --- Ambient Occlusion (off by default via the aoEnabled switch, like
   //     Shadows/GI; the backend maps aoEnabled=false to aoSamples 0) ---
   { key: "aoEnabled",     label: "Enable AO",          type: "boolean", value: false, group: "Ambient Occlusion" },
@@ -264,8 +264,8 @@ const UMBREON_NPR_PROPS: PropDef[] = [
   // Multipliers over the style's own layer values, so the relative pitches
   // of a multi-layer look survive: density divides every lattice pitch
   // (2 = twice as many lines / halftone dots), width scales the marks.
-  { key: "hatchDensity",    label: "Mark density", type: "real", value: 1.0, group: "Hatching", min: 0.25, max: 4, step: 0.05 },
-  { key: "hatchWidthScale", label: "Mark width",   type: "real", value: 1.0, group: "Hatching", min: 0.25, max: 4, step: 0.05 },
+  { key: "hatchDensity",    label: "Mark density", type: "real", value: 1.0, group: "Hatching", min: 0.25, max: 4, step: 0.05, slider: true },
+  { key: "hatchWidthScale", label: "Mark width",   type: "real", value: 1.0, group: "Hatching", min: 0.25, max: 4, step: 0.05, slider: true },
   // Ink/paper overrides are gated by the Custom switches: the styles carry
   // their own colors (richardson's warm paper, its per-section ink), which
   // an always-on black/white default would silently destroy. The backend

--- a/tritium/react-gui/src/renderer/data/renderResult.ts
+++ b/tritium/react-gui/src/renderer/data/renderResult.ts
@@ -19,6 +19,18 @@ export interface RenderSource {
   viewId?: number;
 }
 
+/**
+ * A hand-edited NPR hatch look, as the umbreon spec text the exporter takes.
+ * Present only while the look differs from its style's template; absent, the
+ * style renders with its own layers and tone (the default C++ path).
+ */
+export interface RenderHatchSnapshot {
+  /** `layer:` lines (replace the style's layers). */
+  layersSpec: string;
+  /** `tone:` / `ink:` lines (override the style's tone recipe / ink model). */
+  toneSpec: string;
+}
+
 /** Frozen copy of the render settings used for a result. */
 export interface RenderSettingsSnapshot {
   /** Whether this render produces one image or the animation's frames. */
@@ -28,6 +40,8 @@ export interface RenderSettingsSnapshot {
   backendProps: PropDef[];
   /** Movie settings; only present when mode is "movie". */
   movie?: MovieSettings;
+  /** Edited hatch look (umbreon_npr only, and only while edited). */
+  hatch?: RenderHatchSnapshot;
 }
 
 /**

--- a/tritium/react-gui/src/renderer/data/rendererProperties.ts
+++ b/tritium/react-gui/src/renderer/data/rendererProperties.ts
@@ -51,4 +51,10 @@ export interface PropDef {
    * used by the render-settings width/height fields.
    */
   inline?: boolean;
+  /**
+   * Numeric props only: render the slider + number box + stepper row
+   * (`SliderField`) instead of the drag field. For settings adjusted by feel
+   * within a known range (the NPR hatch multipliers).
+   */
+  slider?: boolean;
 }

--- a/tritium/react-gui/src/renderer/hooks/useHatchTemplate.ts
+++ b/tritium/react-gui/src/renderer/hooks/useHatchTemplate.ts
@@ -1,0 +1,86 @@
+/**
+ * @file hooks/useHatchTemplate.ts
+ * @description Loads the NPR hatch style selected in the render settings as
+ * an editable template: whenever the style changes (and its template is not
+ * loaded yet), the resolved style is fetched from the C++ side as spec text,
+ * parsed, and handed to the settings state. Kept outside useRenderSettings
+ * so that hook stays synchronous and IPC-free.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { parseHatchSpec, type HatchSpec } from "../data/hatchSpec";
+import type { HatchStyleSpecReply } from "../../shared/ipcTypes";
+
+export type HatchTemplateStatus = "idle" | "loading" | "ready" | "error";
+
+export interface UseHatchTemplateArgs {
+  /** Only the NPR backend has a hatch style to load. */
+  enabled: boolean;
+  /** The selected style name (renderBackends "hatchStyle"). */
+  style: string;
+  /** True once the settings hold this style's template. */
+  loaded: boolean;
+  /** Resolve a style name to its spec text (the render window's relay). */
+  fetchSpec: (style: string) => Promise<HatchStyleSpecReply>;
+  /** Receives the parsed template; ignored by the settings when stale. */
+  onLoaded: (style: string, spec: HatchSpec) => void;
+}
+
+/**
+ * Fetch the template of `style` while it is not loaded. A fetch that
+ * resolves after the style moved on is dropped; a failed fetch only reports
+ * its status (the render then uses the style's own configuration).
+ */
+export function useHatchTemplate({
+  enabled,
+  style,
+  loaded,
+  fetchSpec,
+  onLoaded,
+}: UseHatchTemplateArgs): { status: HatchTemplateStatus; error: string | null } {
+  const [status, setStatus] = useState<HatchTemplateStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  // Read through refs so a re-created callback does not refetch.
+  const fetchRef = useRef(fetchSpec);
+  fetchRef.current = fetchSpec;
+  const loadedRef = useRef(onLoaded);
+  loadedRef.current = onLoaded;
+
+  useEffect(() => {
+    if (!enabled || !style) {
+      setStatus("idle");
+      setError(null);
+      return;
+    }
+    if (loaded) {
+      setStatus("ready");
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setStatus("loading");
+    setError(null);
+    fetchRef
+      .current(style)
+      .then((reply) => {
+        if (cancelled) return;
+        if (reply.ok) {
+          loadedRef.current(style, parseHatchSpec(reply.spec));
+          setStatus("ready");
+        } else {
+          setStatus("error");
+          setError(reply.error);
+        }
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setStatus("error");
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, style, loaded]);
+
+  return { status, error };
+}

--- a/tritium/react-gui/src/renderer/hooks/useRenderSettings.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderSettings.ts
@@ -42,6 +42,35 @@ import {
 } from "../data/renderSettings";
 import { RENDER_BACKENDS, DEFAULT_RENDER_BACKEND } from "../data/renderBackends";
 import type { RenderSettingsSnapshot } from "../data/renderResult";
+import {
+  cloneHatchSpec,
+  formatHatchLayersSpec,
+  formatHatchToneSpec,
+  isSameHatchSpec,
+  newHatchLayer,
+  nextHatchLayerId,
+  parseHatchSpec,
+  type HatchInk,
+  type HatchLayer,
+  type HatchLayerKind,
+  type HatchSpec,
+  type HatchTone,
+} from "../data/hatchSpec";
+
+/**
+ * The NPR hatch look being edited. The selected style (backend prop
+ * "hatchStyle") is a template: `template` is what the C++ side resolved it
+ * to, `spec` the editable copy. Both are null until the template arrives (or
+ * while the backend is not umbreon_npr).
+ */
+export interface HatchEditState {
+  /** Style name the template / spec belong to ("" = none loaded). */
+  style: string;
+  template: HatchSpec | null;
+  spec: HatchSpec | null;
+}
+
+const INITIAL_HATCH: HatchEditState = { style: "", template: null, spec: null };
 
 /** Deep-copy a PropDef list so edits never mutate the shared defaults. */
 const cloneProps = (props: PropDef[]): PropDef[] => props.map((p) => ({ ...p }));
@@ -141,6 +170,7 @@ export function useRenderSettings(
   const [movie, setMovie] = useState<MovieSettings>(DEFAULT_MOVIE_SETTINGS);
   // Once the user (or a restore) picks a backend, stop auto-defaulting to umbreon.
   const userPickedRef = useRef(false);
+  const [hatch, setHatch] = useState<HatchEditState>(INITIAL_HATCH);
 
   /** Switch the active backend, keeping common settings, resetting backend ones. */
   const applyBackend = useCallback((id: RenderBackendId) => {
@@ -148,6 +178,7 @@ export function useRenderSettings(
     // Start the new backend on its default method + default step of every
     // axis, so the quality dropdowns and the prop values agree from the start.
     setBackendProps(cloneProps(backendPropsWithDefaults(id)));
+    setHatch(INITIAL_HATCH);
   }, []);
 
   /** User-initiated backend switch (sticks against the umbreon auto-default). */
@@ -240,6 +271,12 @@ export function useRenderSettings(
       if (key === "width" || key === "height") {
         setPreset(DEFAULT_RENDER_PRESET);
       }
+      // A new hatch style is a new template: drop the edited look and let the
+      // template hook fetch the style (no confirmation -- the state is
+      // window-local, and the "Edited" badge tells the user it will go).
+      if (key === "hatchStyle") {
+        setHatch(INITIAL_HATCH);
+      }
       // An edit needs no bookkeeping: each axis' dropdown reads back from the
       // values, so it drops to Custom -- or lands on another step -- by itself.
     },
@@ -306,6 +343,92 @@ export function useRenderSettings(
     }
   }, [applyPresetSize]);
 
+  // --- NPR hatch look (layer editor) ---
+
+  /** The selected hatch style (umbreon_npr backend prop). */
+  const hatchStyle = String(readVal(backendProps, "hatchStyle") ?? "");
+  /** True once the template of the selected style is held. */
+  const hatchLoaded = hatch.template !== null && hatch.style === hatchStyle;
+  /** True while the edited look differs from the style's template. */
+  const hatchDirty =
+    hatch.spec !== null &&
+    hatch.template !== null &&
+    !isSameHatchSpec(hatch.spec, hatch.template);
+
+  /**
+   * Take the template the C++ side resolved `style` to. A reply for a style
+   * that is no longer selected is dropped; a look restored from a snapshot is
+   * kept and only the template is filled in behind it.
+   */
+  const applyHatchTemplate = useCallback(
+    (style: string, spec: HatchSpec) => {
+      if (style !== hatchStyle) return;
+      setHatch((prev) => ({
+        style,
+        template: spec,
+        spec: prev.spec ?? cloneHatchSpec(spec),
+      }));
+    },
+    [hatchStyle],
+  );
+
+  const updateHatchSpec = useCallback((fn: (spec: HatchSpec) => HatchSpec) => {
+    setHatch((prev) => (prev.spec ? { ...prev, spec: fn(prev.spec) } : prev));
+  }, []);
+
+  /** Patch one layer; the other layers keep their identity (memoised rows). */
+  const updateHatchLayer = useCallback(
+    (id: string, patch: Partial<HatchLayer>) =>
+      updateHatchSpec((spec) => ({
+        ...spec,
+        layers: spec.layers.map((l) => (l.id === id ? { ...l, ...patch } : l)),
+      })),
+    [updateHatchSpec],
+  );
+
+  const addHatchLayer = useCallback(
+    (kind: HatchLayerKind) =>
+      updateHatchSpec((spec) => ({ ...spec, layers: [...spec.layers, newHatchLayer(kind)] })),
+    [updateHatchSpec],
+  );
+
+  const removeHatchLayer = useCallback(
+    (id: string) =>
+      updateHatchSpec((spec) => ({ ...spec, layers: spec.layers.filter((l) => l.id !== id) })),
+    [updateHatchSpec],
+  );
+
+  /** Insert a copy right after the layer. */
+  const duplicateHatchLayer = useCallback(
+    (id: string) =>
+      updateHatchSpec((spec) => {
+        const i = spec.layers.findIndex((l) => l.id === id);
+        if (i < 0) return spec;
+        const copy: HatchLayer = { ...spec.layers[i], id: nextHatchLayerId(), extra: { ...spec.layers[i].extra } };
+        const layers = [...spec.layers];
+        layers.splice(i + 1, 0, copy);
+        return { ...spec, layers };
+      }),
+    [updateHatchSpec],
+  );
+
+  const updateHatchTone = useCallback(
+    (patch: Partial<HatchTone>) =>
+      updateHatchSpec((spec) => ({ ...spec, tone: { ...spec.tone, ...patch } })),
+    [updateHatchSpec],
+  );
+
+  const updateHatchInk = useCallback(
+    (patch: Partial<HatchInk>) =>
+      updateHatchSpec((spec) => ({ ...spec, ink: { ...spec.ink, ...patch } })),
+    [updateHatchSpec],
+  );
+
+  /** Back to the style's own look. */
+  const resetHatchToTemplate = useCallback(() => {
+    setHatch((prev) => (prev.template ? { ...prev, spec: cloneHatchSpec(prev.template) } : prev));
+  }, []);
+
   /** Frozen copy of the current settings, used for a render result. */
   const getSnapshot = useCallback(
     (): RenderSettingsSnapshot => ({
@@ -314,8 +437,18 @@ export function useRenderSettings(
       commonProps: cloneProps(commonProps),
       backendProps: cloneProps(backendProps),
       ...(mode === "movie" ? { movie: { ...movie } } : {}),
+      // The edited look travels only while it differs from the template, so
+      // an untouched style renders through the C++ side's own configuration.
+      ...(backend === "umbreon_npr" && hatchDirty && hatch.spec
+        ? {
+            hatch: {
+              layersSpec: formatHatchLayersSpec(hatch.spec.layers),
+              toneSpec: formatHatchToneSpec(hatch.spec.tone, hatch.spec.ink),
+            },
+          }
+        : {}),
     }),
-    [mode, backend, commonProps, backendProps, movie],
+    [mode, backend, commonProps, backendProps, movie, hatch.spec, hatchDirty],
   );
 
   /** Load settings from a snapshot (used by "Re-render"). */
@@ -331,6 +464,17 @@ export function useRenderSettings(
     // Restored sizes are explicit, so no size preset is active. The quality
     // dropdowns need no reset: they read the restored values back.
     setPreset(DEFAULT_RENDER_PRESET);
+    // An edited look comes back as the spec; its template is fetched again
+    // (applyHatchTemplate keeps the spec and only fills the template in).
+    setHatch(
+      snapshot.hatch
+        ? {
+            style: String(readVal(snapshot.backendProps, "hatchStyle") ?? ""),
+            template: null,
+            spec: parseHatchSpec(snapshot.hatch.layersSpec + "\n" + snapshot.hatch.toneSpec),
+          }
+        : INITIAL_HATCH,
+    );
   }, []);
 
   /**
@@ -374,5 +518,17 @@ export function useRenderSettings(
     applyViewCamera,
     getSnapshot,
     restore,
+    hatch,
+    hatchStyle,
+    hatchLoaded,
+    hatchDirty,
+    applyHatchTemplate,
+    updateHatchLayer,
+    addHatchLayer,
+    removeHatchLayer,
+    duplicateHatchLayer,
+    updateHatchTone,
+    updateHatchInk,
+    resetHatchToTemplate,
   } as const;
 }

--- a/tritium/react-gui/src/renderer/hooks/useRenderWindowBridge.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderWindowBridge.ts
@@ -25,6 +25,7 @@ import type {
   RenderJobWire,
   RenderTargetViewWire,
   RenderViewCamera,
+  HatchStyleSpecReply,
   RenderWindowCommand,
   RenderWindowStateUpdate,
   ViewSizePx,
@@ -247,10 +248,26 @@ export function useRenderWindowBridge(args: UseRenderWindowBridgeArgs): void {
         )
         .catch(() => reply(null));
     });
+    // Hatch style template for the render window's NPR layer editor: resolve
+    // the style name through the worker (the C++ umbreon exporter).
+    const offHatch = api.onPush(IPC.RENDER_HATCH_STYLE_REQUEST, ({ reqId, style }) => {
+      const reply = (result: HatchStyleSpecReply) =>
+        api.invoke(IPC.RENDER_HATCH_STYLE_REPLY, { reqId, result }).catch(() => {});
+      if (!cm) {
+        reply({ ok: false, error: "no worker" });
+        return;
+      }
+      cm.invokeService("getHatchStyleSpec", { style })
+        .then((res) => reply(res ?? { ok: false, error: "no reply" }))
+        .catch((e: unknown) =>
+          reply({ ok: false, error: e instanceof Error ? e.message : String(e) }),
+        );
+    });
     return () => {
       offExec();
       offSize();
       offCamera();
+      offHatch();
     };
   }, [execCommand, cm]);
 }

--- a/tritium/react-gui/src/renderer/hooks/useRenderWindowClient.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderWindowClient.ts
@@ -28,6 +28,7 @@ import type {
   RenderWindowModeRequest,
   RenderWindowStateUpdate,
   RenderViewCamera,
+  HatchStyleSpecReply,
   ViewSizePx,
 } from "../../shared/ipcTypes";
 import type { RenderJob } from "./useRenderJob";
@@ -102,6 +103,8 @@ export function useRenderWindowClient(): {
   getViewSize: () => Promise<ViewSizePx | null>;
   /** The target view's camera settings, used to default the Camera group. */
   getViewCamera: (viewId: number) => Promise<RenderViewCamera | null>;
+  /** A hatch style resolved to its spec text (the NPR layer editor's template). */
+  getHatchStyleSpec: (style: string) => Promise<HatchStyleSpecReply>;
   /** The result currently on screen (a history entry), or null. */
   shownResult: RenderResult | null;
   /**
@@ -330,6 +333,19 @@ export function useRenderWindowClient(): {
     [],
   );
 
+  const getHatchStyleSpec = useCallback(
+    async (style: string): Promise<HatchStyleSpecReply> => {
+      const api = window.electronAPI;
+      if (!api) return { ok: false, error: "no electron api" };
+      try {
+        return await api.invoke(IPC.RENDER_HATCH_STYLE_GET, { style });
+      } catch (e: unknown) {
+        return { ok: false, error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+    [],
+  );
+
   const getViewSize = useCallback(async (): Promise<ViewSizePx | null> => {
     const api = window.electronAPI;
     if (!api) return null;
@@ -354,6 +370,7 @@ export function useRenderWindowClient(): {
     showSource,
     getViewSize,
     getViewCamera,
+    getHatchStyleSpec,
     shownResult,
     shownImage,
     goBack,

--- a/tritium/react-gui/src/renderer/styles/_inspector-panel.css
+++ b/tritium/react-gui/src/renderer/styles/_inspector-panel.css
@@ -419,3 +419,50 @@
 .atomintr-stipple-caption {
   color: var(--text-secondary);
 }
+
+/* ═══════════════════════════════════════════════════════════
+   NPR hatch layer editor (render settings > Hatching)
+   ═══════════════════════════════════════════════════════════ */
+
+.hatch-look {
+  display: flex;
+  flex-direction: column;
+  gap: var(--form-section-gap);
+}
+
+.hatch-look-actions {
+  align-items: center;
+}
+
+.hatch-layer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--form-row-gap);
+}
+
+.hatch-layer-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.hatch-layer-head .type-row {
+  flex: 1;
+  min-width: 0;
+}
+
+.hatch-look-status {
+  color: var(--text-muted);
+}
+
+.hatch-look-status.is-error {
+  color: var(--accent-red);
+}
+
+.hatch-look-edited {
+  color: var(--text-muted);
+}
+
+.hatch-effective {
+  color: var(--text-muted);
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/hatchStyleSpec.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/hatchStyleSpec.service.ts
@@ -1,0 +1,36 @@
+// Runs in Web Worker thread. Wrappers are sync (no await on C++ wrappers).
+//
+// Resolve an NPR hatch style name to umbreon's spec text (the layer editor's
+// template) through the umbreon exporter's getHatchStyleSpec.
+import type { WorkerContext } from '../types/WorkerContext';
+
+export interface GetHatchStyleSpecArgs {
+    style: string;
+}
+
+export type GetHatchStyleSpecResult =
+    | { ok: true; spec: string }
+    | { ok: false; error: string };
+
+function getHatchStyleSpec(ctx: WorkerContext, args: GetHatchStyleSpecArgs): GetHatchStyleSpecResult {
+    // Same handler the render backends create; a build without umbreon has none.
+    let exporter: Record<string, unknown> | null = null;
+    try {
+        exporter = ctx.strMgr.createHandler('umbreon', 2) as unknown as Record<string, unknown>;
+    } catch {
+        exporter = null;
+    }
+    if (!exporter) return { ok: false, error: 'umbreon is not available in this build' };
+    // Probe the method: an addon built against an older libcuemol2 lacks it.
+    const fn = exporter.getHatchStyleSpec;
+    if (typeof fn !== 'function') {
+        return { ok: false, error: 'this build has no hatch style spec API' };
+    }
+    const spec = String((fn as (name: string) => string).call(exporter, args.style) ?? '');
+    if (!spec) return { ok: false, error: `unknown hatch style: ${args.style}` };
+    return { ok: true, spec };
+}
+
+export const services = {
+    getHatchStyleSpec,
+};

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/UmbreonBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/UmbreonBackend.ts
@@ -166,6 +166,13 @@ function makeExporter(
       ? strVal(ub, "hatchPaperColor", "#ffffff")
       : "";
     exporter.hatchDefaultEdges = boolVal(ub, "hatchDefaultEdges", true);
+    // A hand-edited look (the layer editor). The snapshot carries it only
+    // while the look differs from the style's template, so an untouched style
+    // renders through the C++ side's own layers and tone, byte-identically.
+    if (snapshot.hatch) {
+      exporter.hatchLayersSpec = snapshot.hatch.layersSpec;
+      exporter.hatchToneSpec = snapshot.hatch.toneSpec;
+    }
   } else {
     // Diffuse global illumination (pt1 path-traced integrator).
     exporter.useGI = boolVal(ub, "useGI", false);

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -28,6 +28,7 @@ import type {
 } from './renderTypes'
 
 import type { AppInfoResult } from '../server/services/appInfo.service'
+import type { GetHatchStyleSpecArgs, GetHatchStyleSpecResult } from '../server/services/hatchStyleSpec.service'
 import type { DrainLogMessagesResult } from '../server/services/drainLogMessages.service'
 import type { AnimListTimelineArgs, AnimGetMgrStateArgs, AnimPlayArgs, AnimPauseArgs, AnimStopArgs, AnimGoTimeArgs, AnimSetLoopArgs, AnimSetStartCamArgs, AnimTransportResult, AnimSetElementTimeArgs, AnimAddElementArgs, AnimRemoveElementArgs, AnimMoveElementArgs, AnimEditResult, AnimAddResult } from '../server/services/animation.service'
 import type { GetAnimElementDetailArgs, GetAnimElementDetailResult, SetAnimElementPropArgs, SetAnimElementPropResult, GetAnimTargetOptionsArgs, GetAnimTargetOptionsResult, GetAnimElementGenericPropsArgs, SetAnimElementGenericPropArgs, ResetAnimElementGenericPropsArgs, AnimGenericPropsResult } from '../server/services/animDetail.service'
@@ -675,6 +676,7 @@ export interface ServiceMap {
   saveCameraToCurrentSrc:     { args: SaveCameraToCurrentSrcArgs;      result: SaveCameraToCurrentSrcResult }
   reloadCameraFromSrc:        { args: ReloadCameraFromSrcArgs;         result: ReloadCameraFromSrcResult }
   getViewProjection:          { args: ViewProjectionArgs;              result: ViewProjectionResult }
+  getHatchStyleSpec:          { args: GetHatchStyleSpecArgs;           result: GetHatchStyleSpecResult }
   setViewProjection:          { args: ViewProjectionArgs;              result: ViewProjectionResult }
   getViewCenterMark:          { args: ViewCenterMarkArgs;              result: ViewCenterMarkResult }
   setViewCenterMark:          { args: ViewCenterMarkArgs;              result: ViewCenterMarkResult }

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -142,6 +142,9 @@ export const IPC = {
   RENDER_VIEW_CAMERA_GET:     'render-window:view-camera-get',     // invoke: render window -> main
   RENDER_VIEW_CAMERA_REQUEST: 'render-window:view-camera-request', // push:   main -> main window
   RENDER_VIEW_CAMERA_REPLY:   'render-window:view-camera-reply',   // invoke: main window -> main
+  RENDER_HATCH_STYLE_GET:     'render-window:hatch-style-get',     // invoke: render window -> main
+  RENDER_HATCH_STYLE_REQUEST: 'render-window:hatch-style-request', // push:   main -> main window
+  RENDER_HATCH_STYLE_REPLY:   'render-window:hatch-style-reply',   // invoke: main window -> main
   RENDER_HISTORY_STORE:     'render-window:history-store',     // invoke: main window -> main
   RENDER_HISTORY_READ:      'render-window:history-read',      // invoke: render window -> main
   RENDER_IMAGE_SAVE:        'render-window:image-save',        // invoke: render window -> main

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -37,6 +37,7 @@ import type {
   ViewSizePx,
   RenderImageRef,
   RenderViewCamera,
+  HatchStyleSpecReply,
   CuemolClipWriteReq,
   CuemolClipReadRes,
   CuemolClipPeekRes,
@@ -110,6 +111,11 @@ export interface InvokeChannels {
   [IPC.RENDER_VIEW_CAMERA_GET]: { req: { viewId: number }; res: RenderViewCamera | null }
   [IPC.RENDER_VIEW_CAMERA_REPLY]: {
     req: { reqId: number; camera: RenderViewCamera | null }
+    res: void
+  }
+  [IPC.RENDER_HATCH_STYLE_GET]: { req: { style: string }; res: HatchStyleSpecReply }
+  [IPC.RENDER_HATCH_STYLE_REPLY]: {
+    req: { reqId: number; result: HatchStyleSpecReply }
     res: void
   }
   /**
@@ -203,6 +209,7 @@ export interface PushChannels {
   [IPC.RENDER_WINDOW_MODE_PUSH]:  RenderWindowModeRequest
   [IPC.RENDER_VIEW_SIZE_REQUEST]: { reqId: number }
   [IPC.RENDER_VIEW_CAMERA_REQUEST]: { reqId: number; viewId: number }
+  [IPC.RENDER_HATCH_STYLE_REQUEST]: { reqId: number; style: string }
 }
 
 export type InvokeChannel = keyof InvokeChannels

--- a/tritium/react-gui/src/shared/ipcTypes.ts
+++ b/tritium/react-gui/src/shared/ipcTypes.ts
@@ -659,6 +659,8 @@ export interface RenderSettingsSnapshotWire {
   backend: string
   commonProps: RenderPropDefWire[]
   backendProps: RenderPropDefWire[]
+  /** Edited NPR hatch look as spec text (mirrors RenderHatchSnapshot). */
+  hatch?: { layersSpec: string; toneSpec: string }
   /** Movie settings (mirrors MovieSettings); absent for a still render. */
   movie?: {
     outputDir: string
@@ -758,6 +760,16 @@ export interface RenderViewCamera {
   /** True = perspective projection, false = orthographic. */
   perspective: boolean
 }
+
+/**
+ * Reply of the hatch-style template round trip: a style name resolved to
+ * umbreon's spec text by the main window's worker (the render window has no
+ * worker of its own). `ok: false` carries the reason (unknown style, a build
+ * without umbreon, a timeout).
+ */
+export type HatchStyleSpecReply =
+  | { ok: true; spec: string }
+  | { ok: false; error: string }
 
 /** Output mode of the Rendering window (mirrors renderer-side RenderMode). */
 export type RenderWindowMode = 'still' | 'movie'


### PR DESCRIPTION
Depends on **CueMol/umbreon#79** (umbreon 0.2.0). CI builds umbreon from `UMBREON_GIT_REF=main`, so that PR has to land first.

## Why

The Umbreon (NPR) backend offered a style name plus two multipliers, and the multipliers did not reach the halftone styles at all: umbreon's mark width was a Line-layer parameter, while a Dot layer's radius came from the lattice pitch and the tone alone. The shading tone itself was not exposed, so a flash-lit CueMol scene -- which sits near tone 1 almost everywhere -- could only be hatched as sparsely as the style's own recipe decided. Reported as "Mark width does nothing on manga / screentone / stipple", "stipple is far too light in the mid tones", and "richardson-like looks cannot be customised".

## What changed

**libcuemol2 (`src/modules/rendering/`)**

- The style name resolves through umbreon's `applyHatchStyle` (a look, or a mark preset **with its tone recipe**).
- Mark width scales a Line layer's `widthPx` and a Dot / Stipple layer's `dotScale`, so it works for every style.
- New exporter properties: `hatchLayersSpec` / `hatchToneSpec` (umbreon spec text applied after the style -- layers replaced, tone / ink keys overridden; a malformed text warns into the render log and is ignored), `hatchToneStrength` / `hatchToneCurve`, and `getHatchStyleSpec(name)`, which resolves a style to the spec text a host loads as an editable template.

**tritium (`react-gui`)**

- A **"Detail" tab** (umbreon_npr only) next to Image / Render: the style picked in the Render tab is a **template**, and its layers (kind, angle, spacing, width / dot scale, tone range, fade, opacity, ink darkness, plus the perturbations under *Randomness / Advanced*) and its shading (**Strength** and **Curve** always visible, the rest of the tone recipe and the ink model under *Advanced*) are editable. "Reset to style" reloads the template; an "Edited" badge marks a changed look.
- The edited look travels with the render as spec text **only while it differs from the template**, so an untouched style renders through the C++ side's own configuration, byte-identically.
- Fields that cannot affect the picture are **hidden** (fields another mark kind owns) or **disabled** (stroke gap without a stroke length, contour power / bias without contour darkening, highlight softness without the knee, the AO exponents without AO, fill posterize on a paper base, the seed with no randomness, ...). A layer whose pitch is pinned at umbreon's 2 px minimum on the supersample grid says so.
- The Render tab's Mark density / Mark width stay **master multipliers**; the Detail tab shows the resulting **effective values** instead of folding them into the layer values (so the edit stays reversible).
- Numeric settings adjusted by feel within a known range (Supersampling, Mark density, Mark width) render as slider rows (`PropDef.slider`).

The Rendering window has no worker of its own, so the template request takes the same main-window relay the target-view camera uses (`RENDER_HATCH_STYLE_GET` / `_REQUEST` / `_REPLY` + the `getHatchStyleSpec` worker service).

Design record: `docs/architecture/umbreon-hatch-layer-editor.md`.

## Tests

- gtest `test_umbreon_export.cpp` +4: Mark width now changes a `screentone-60` / `manga` render; a layers spec overrides the style and a malformed one is ignored with a log warning; `getHatchStyleSpec("richardson")` sent back unedited reproduces the same pixels; the strength multiplier darkens monotonically. (`task run_gtest FILTER=Umbreon`: 32/32.)
- Vitest +3 files (`hatchSpec`, `useHatchTemplate`, `hatchStyleSpecService`) and additions to `useRenderSettings` / `umbreonBackend` / `renderSettingsPane` / `useRenderWindowBridge` / `useRenderWindowClient`: spec round-trip and field-enabling rules, template loading with stale-reply and failure handling, dirty-only snapshot forwarding, the tab's rendering and actions, and both legs of the relay. (319 files, all passing.)
- `tsc` clean on the touched files; `lint:style` unchanged from its baseline.