### PR TITLE
fix(surface): follow the MeshMS facade header rename

### DIFF
--- a/docs/architecture/meshms-ses-backend.md
+++ b/docs/architecture/meshms-ses-backend.md
@@ -32,7 +32,7 @@ oneTBB は既にバンドルに含まれる。
 - oneTBB は単一実体: `MeshMSConfig.cmake` の `find_dependency(TBB)` が、
   libcuemol2 configure に渡る同じ `-DTBB_DIR` (deplibs の static oneTBB) で
   解決される。別の TBB を持ち込まないこと。
-- 消費側が include するのは `<meshms/capi.hpp>` のみ (C++17-clean facade。
+- 消費側が include するのは `<meshms/meshms.hpp>` のみ (C++17-clean facade。
   MeshMS 本体は C++20 ビルドだが `cxx_std_20` は PRIVATE)。
 - `ENABLE_MESHMS=ON` はキャッシュ変数: ON/OFF 切替は `task rebuild_libcuemol2`
   (再 configure) が必要。default OFF なのは umbreon と同じ理由 —

--- a/src/cmake/meshms.cmake
+++ b/src/cmake/meshms.cmake
@@ -10,7 +10,7 @@
 # libcuemol2 (and umbreon/Embree) uses, keeping exactly one oneTBB runtime in
 # the process.
 #
-# The consumer includes only <meshms/capi.hpp>, a C++17-clean facade; MeshMS
+# The consumer includes only <meshms/meshms.hpp>, a C++17-clean facade; MeshMS
 # itself is compiled as C++20 but does not force that onto its consumers.
 
 find_package(MeshMS CONFIG REQUIRED)

--- a/src/modules/surface/MolSurfBuilder.cpp
+++ b/src/modules/surface/MolSurfBuilder.cpp
@@ -29,7 +29,7 @@
 #include <array>
 #include <cmath>
 #include <stdexcept>
-#include <meshms/capi.hpp>
+#include <meshms/meshms.hpp>
 #endif
 
 #include "MolSurfObj.hpp"


### PR DESCRIPTION
## Why

CI builds MeshMS from `MESHMS_GIT_REF=main`, and CueMol/MeshMS#11 (merged 2026-08-25) renamed the public facade header `include/meshms/capi.hpp` -> `include/meshms/meshms.hpp`. Every `develop` build since then fails on all four platforms:

```
src/modules/surface/MolSurfBuilder.cpp:32:10: fatal error: meshms/capi.hpp: No such file or directory
```

(Seen on #510, but it is not that PR's doing -- `develop` itself is red against current MeshMS main.)

## What changed

Only the include line and the two places that document it:

- `src/modules/surface/MolSurfBuilder.cpp` -- `#include <meshms/meshms.hpp>`
- `src/cmake/meshms.cmake`, `docs/architecture/meshms-ses-backend.md` -- the header name in the prose

The namespace and every symbol this module uses (`meshms::RSCache`, `MeshResult`, `compute_rs_from_array`, `build_mesh_from_cache`, `remove_flaps`) are unchanged by the rename, so no call site moves.

## Verification

Local MeshMS updated to main (67656e6), `task install_meshms` + `task build_libcuemol2` clean, `task run_gtest` all green.