### PR TITLE
feat(qsys): escalate the content-sniff byte budget instead of a flat cap

### DIFF
--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -17,8 +17,10 @@ architecture, it belongs here.
   `getScrClassObj` contract, and what external script bridges (UXP
   XPCOM, tritium N-API) must do to wrap native objects.
 - [Object Reader Content Sniff](objreader-content-sniff.md) -- the
-  tri-state `canHandleContent` contract, the byte-cap mechanism, and
-  the text / binary implementation patterns shared by every reader.
+  tri-state `canHandleContent` contract, the escalating byte-budget
+  mechanism (64 KiB, x8 for readers the budget cut off, up to a
+  ceiling), and the text / binary implementation patterns shared by
+  every reader.
 - [GTAO Screen-Space AO](gtao-screen-space-ao.md) (日本語) -- リアルタイム
   GTAO のパイプライン、projection 由来の view-space 復元と GL 座標系、MRT
   geometry 法線、Apple Metal-GL の MRT/ブレンドのハマりどころ、tritium

--- a/docs/architecture/objreader-content-sniff.md
+++ b/docs/architecture/objreader-content-sniff.md
@@ -2,8 +2,9 @@
 
 How CueMol picks an `ObjReader` when a file's extension is ambiguous
 or absent. Each reader opts into a tri-state inspection of the file's
-leading bytes; this document defines the contract, the byte-cap
-mechanism, and the implementation patterns shared by every reader.
+leading bytes; this document defines the contract, the escalating
+byte-budget mechanism, and the implementation patterns shared by every
+reader.
 
 ## Why content sniff exists
 
@@ -34,21 +35,33 @@ virtual int canHandleContent(qlib::InStream &ins) const {
 }
 ```
 
-Two rules every implementation must follow:
+Three rules every implementation must follow:
 
 1. **Read what you need, no more.** Read just enough to fingerprint
    the format -- a magic byte sequence, a header line, or a keyword
    scan until verdict.
-2. **Be cap-agnostic.** Callers may wrap `ins` in a
-   `LimitedInStream` that returns EOF once a byte budget is exhausted.
-   If you cannot decide within the cap, return `CONTENT_UNKNOWN`.
-   Never assume a specific window size; never pre-buffer arbitrary
-   amounts.
+2. **Be cap-agnostic.** Callers wrap `ins` in a `LimitedInStream`
+   that returns EOF once a byte budget is exhausted. If you cannot
+   decide within the budget, return `CONTENT_UNKNOWN`; the harness
+   will call you again with a larger budget when the budget (not the
+   file) is what stopped you. Never assume a specific window size;
+   never pre-buffer arbitrary amounts.
+3. **NO is final, so it must be prefix-monotone.** The harness never
+   retries a reader that said `CONTENT_NO`. A `LimitedInStream` is a
+   true prefix of the stream, and a `LineStream` over it is a true
+   prefix except for its *last line*, which may be cut short. A test
+   that succeeds on a prefix (`startsWith`, a fixed offset, a byte
+   that is actually present) also succeeds on the complete input, so
+   deciding YES / NO on it is safe. A test that *fails* on a cut line
+   (`equals`, line length, numeric parse, "the next line is missing")
+   is a false negative under truncation: fall through to
+   `CONTENT_UNKNOWN`, never `CONTENT_NO`.
 
 Returning `CONTENT_NO` is reserved for readers that **positively
-identify a competing format** (e.g. CCP4 sees XPLOR text and says
-NO). Binary input on a text reader, or any "not mine" feeling, is
-`CONTENT_UNKNOWN`, not `CONTENT_NO`. See the decision table below.
+identify a competing format** (e.g. `MmcifMapReader` sees
+`_atom_site.` and says NO). Binary input on a text reader, a malformed
+line, or any "not mine" feeling, is `CONTENT_UNKNOWN`, not
+`CONTENT_NO`. See the decision table below.
 
 ## Sniff entry points
 
@@ -59,36 +72,86 @@ Two callers drive sniff from C++ today:
 | `StreamManager::searchReaderByContent`  | `src/qsys/StreamManager.cpp`                  |
 | `LoadObjectCommand` (content-first)     | `src/qsys/command/LoadObjectCommand.cpp`      |
 
-Internal pipeline (see `sniffWithChain` in `StreamManager.cpp`):
+Internal pipeline (see `sniffWithChain` and `searchByContentImpl` in
+`StreamManager.cpp`):
 
 ```
-caller (path, maxBytes)
-  -> FileInStream
-  -> (Gzip / Xz decompressor, if compression magic detected)
-  -> LimitedInStream(stream, maxBytes)        // only if maxBytes > 0
-  -> reader.canHandleContent(stream)
+caller (path, maxBytes = ceiling)
+  budget = SNIFF_INITIAL_BYTES (64 KiB)
+  loop:
+    for each candidate still pending:
+      -> FileInStream
+      -> (Gzip / Xz decompressor, if compression magic detected)
+      -> LimitedInStream(stream, budget)
+      -> reader.canHandleContent(stream)
+      YES                          -> done (first-only) / collect (multi)
+      UNKNOWN && lim.isLimitHit()  -> keep pending
+      NO / UNKNOWN at EOF / early UNKNOWN / exception -> final
+    stop when nothing is pending or budget >= ceiling
+    budget *= SNIFF_GROWTH_FACTOR (8), clamped to the ceiling
 ```
 
-`sniffWithChain` opens a fresh stream per candidate reader because
-`canHandleContent` does not rewind. The OS page cache makes repeated
-reads cheap.
+`sniffWithChain` opens a fresh stream per candidate reader and per
+round because `canHandleContent` does not rewind (the decompressors
+are not seekable). The OS page cache makes repeated reads cheap, and
+only readers that were actually cut off pay for another round.
 
-## The byte cap
+## The byte budget
 
 `LimitedInStream` (`src/qlib/LimitedInStream.hpp`) caps reads to N
-bytes total and returns EOF on overage. There are two policy layers:
+bytes total, returns EOF on overage, and records whether the budget
+was the limiting factor: `isLimitHit()` is true when the budget ran
+out or a read / skip request had to be refused or shortened, and
+false when the reader stopped on its own (source EOF, early verdict)
+with budget to spare. The harness uses `verdict == UNKNOWN &&
+isLimitHit()` as the "retry with more" signal.
 
-| Layer                                       | Default          | Set in                                                              |
-|---------------------------------------------|------------------|---------------------------------------------------------------------|
-| `LoadObjectCommand.max_sniff_bytes` (qif)   | `0` (unbounded)  | `src/qsys/command/LoadObjectCommand.qif`                            |
-| Tritium service-side override               | `65536` (64 KB)  | `tritium/react-gui/src/renderer/worker/shared/sniffConfig.ts`       |
+The budget escalates instead of being a flat cap
+(`StreamManager::SNIFF_INITIAL_BYTES` / `SNIFF_GROWTH_FACTOR`):
 
-Raw C++ callers and UXP scripted paths see the unbounded default so
-existing flows are unaffected. Tritium services pass
-`DEFAULT_SNIFF_CAP` explicitly when calling `searchReaderByContent`
-and when populating `LoadObjectCommand.max_sniff_bytes`, so a
-pathological 1 GB file opened via tritium sees at most 64 KB scanned
-per reader.
+- Round 1 gives every candidate 64 KiB. Readers that decide in a few
+  bytes (magic numbers) or one `LineStream` block (2 KB) read only
+  that much -- the budget is an upper bound, not a pre-read.
+- A candidate whose `UNKNOWN` was caused by the budget is retried
+  with 8x more: 64 KiB, 512 KiB, 4 MiB, 32 MiB, ... Everything else
+  is final after its first call.
+- `maxBytes` is the **ceiling** of that growth; the last round is
+  clamped to it. `0` means no ceiling: grow until every pending reader
+  reaches EOF or a verdict. A ceiling below 64 KiB is a single round
+  at the ceiling.
+- Cost: each round re-opens the file, so the bytes read for one reader
+  sum to at most 8/7 of the deciding round's budget (plus the
+  ceiling-clamped final round). With the tritium ceiling that is
+  64K + 512K + 4M + 16M, about 1.3 x 16 MiB, and only for a reader
+  that never decides.
+- First-only search is round-major: a reader that says YES in round 1
+  wins even if a reader earlier in ABI-name order is still pending.
+  ABI order is not a priority, and two readers claiming the same file
+  is a reader-side conflict, so this is acceptable.
+- A file exactly as long as a budget, or a decisive UNKNOWN within
+  2 KB of the budget (LineStream's read-ahead block), costs one extra
+  harmless round.
+
+`LineStream::readLine` scans only the bytes appended by each block
+when looking for the delimiter, so a delimiter-free run (a minified
+JSON or base64 blob dropped on a text reader) is linear in its length.
+Raising the ceiling relies on this: a 16 MiB single line would
+otherwise rescan its buffer 8000 times.
+
+Policy layers:
+
+| Layer                                       | Default            | Set in                                                              |
+|---------------------------------------------|--------------------|---------------------------------------------------------------------|
+| `LoadObjectCommand.max_sniff_bytes` (qif)   | `0` (no ceiling)   | `src/qsys/command/LoadObjectCommand.qif`                            |
+| Tritium `pickReaderName` ceiling            | `16 MiB`           | `tritium/react-gui/src/renderer/worker/shared/sniffConfig.ts`       |
+
+Raw C++ callers and UXP scripted paths see the no-ceiling default so
+existing flows are unaffected. Tritium never uses that mode:
+`pickReaderName` passes `DEFAULT_SNIFF_CAP` to `searchReaderByContent`
+and maps an explicit `0` to the same default (it resolves the reader
+itself and does not go through `LoadObjectCommand`), so a pathological
+1 GB file opened via tritium costs at most ~20 MiB of reads per
+undecidable reader.
 
 ## Implementation patterns
 
@@ -107,12 +170,18 @@ int FooReader::canHandleContent(qlib::InStream &ins) const
 }
 ```
 
-`LineStream::ready()` returns false at EOF, which includes the cap
+`LineStream::ready()` returns false at EOF, which includes the budget
 firing on `LimitedInStream`. No per-reader peek size; the marker can
 land arbitrarily deep within the prefix. `XplorMapReader` is the
 extreme case in the current codebase -- the `ZYX` axis marker is
 preceded by up to ~5 KB of `REMARKS` lines in real CNS maps; the
 LineStream loop walks past them without any tuning.
+
+Note the `CONTENT_NO` line above is only correct because `startsWith`
+is prefix-monotone (rule 3). A whole-line `equals()` for YES is a
+(small) false-positive risk on a cut line -- `MOL2MolReader` and
+`PLYFileReader` carry this today -- and an `equals()` / length /
+numeric check must never produce NO.
 
 ### Binary readers: minimum-byte direct read
 
@@ -156,18 +225,30 @@ implements this pattern.
 
 ## Decision table: NO vs UNKNOWN
 
-A reader inspecting content is in one of three states:
+Reader layer -- a reader inspecting content is in one of three states:
 
-| Situation                                                            | Verdict           |
-|----------------------------------------------------------------------|-------------------|
-| Positive marker for this format                                      | `CONTENT_YES`     |
-| Positive marker for a *different* format                             | `CONTENT_NO`      |
-| Nothing matched, including EOF, cap-hit, or binary input on a text reader | `CONTENT_UNKNOWN` |
+| Situation                                                                    | Verdict           |
+|------------------------------------------------------------------------------|-------------------|
+| Positive marker for this format                                              | `CONTENT_YES`     |
+| Positive marker for a *different* format (prefix-monotone test)              | `CONTENT_NO`      |
+| Nothing matched: EOF, budget hit, malformed / cut line, binary on text reader | `CONTENT_UNKNOWN` |
+
+Harness layer -- what `searchByContentImpl` does with the verdict:
+
+| Verdict                                   | `LimitedInStream::isLimitHit()` | Action                          |
+|-------------------------------------------|---------------------------------|---------------------------------|
+| `CONTENT_YES`                             | any                             | hit (final)                     |
+| `CONTENT_NO`                              | any                             | final, not retried              |
+| `CONTENT_UNKNOWN`                         | true (budget ended the scan)    | retry with 8x budget, up to the ceiling |
+| `CONTENT_UNKNOWN`                         | false (EOF or early stop)       | final, not retried              |
+| exception / open failure                  | --                              | final `UNKNOWN`                 |
 
 The historical pitfall is using `CONTENT_NO` too eagerly -- e.g.
-declaring NO on any binary input from a text reader. That makes
-readers fight each other on unusual inputs. The rule: NO is for
-**positive identification of a different format**, never as "not mine".
+declaring NO on any binary input from a text reader, or NO because
+the third line was too short (which a budget can cause). That makes
+readers fight each other on unusual inputs and hides files from the
+retry. The rule: NO is for **positive identification of a different
+format** by a prefix-monotone test, never as "not mine".
 
 ## Adding sniff to a new reader
 
@@ -182,11 +263,14 @@ readers fight each other on unusual inputs. The rule: NO is for
    at minimum:
    - YES on a real exemplar payload.
    - UNKNOWN on a random / empty / very-short payload.
-   - UNKNOWN when wrapped in a `LimitedInStream` whose cap fires
-     before the marker (for text readers where the marker can be
-     pushed deep).
+   - UNKNOWN (not NO) when wrapped in a `LimitedInStream` whose
+     budget fires before the marker, and `isLimitHit()` true on the
+     wrapper (for text readers where the marker can be pushed deep;
+     see `test_xplormap_sniff.cpp` / `test_gro_sniff.cpp`).
    - NO when fed payloads of an unambiguously competing format
-     (only if the reader returns NO in any branch).
+     (only if the reader returns NO in any branch). Check that every
+     NO branch is a prefix-monotone test (rule 3); a cut last line
+     must yield UNKNOWN.
 5. Register the test in `src/tests/CMakeLists.txt` (follow existing
    `test_*_sniff.cpp` entries).
 6. Rebuild and run `task run_gtest`.
@@ -205,9 +289,12 @@ sniff chain, so no `canHandleContent` is added.
 ## Related files
 
 - `src/qsys/ObjReader.hpp` -- contract definition
-- `src/qsys/StreamManager.cpp` -- `sniffWithChain`, `searchByContentImpl`
+- `src/qsys/StreamManager.cpp` -- `sniffWithChain`, `searchByContentImpl` (escalation loop)
 - `src/qsys/command/LoadObjectCommand.cpp` -- content-first dispatch
-- `src/qlib/LimitedInStream.hpp` -- byte-cap stream adaptor
-- `src/qlib/LineStream.hpp` -- line-oriented adaptor for text readers
-- `tritium/react-gui/src/renderer/worker/shared/sniffConfig.ts` -- tritium cap
-- `src/tests/modules/importers/test_*_sniff.cpp` -- examples
+- `src/qlib/LimitedInStream.hpp` -- byte-budget stream adaptor with `isLimitHit()`
+- `src/qlib/LineStream.hpp` / `.cpp` -- line-oriented adaptor for text readers (linear delimiter scan)
+- `tritium/react-gui/src/renderer/worker/shared/sniffConfig.ts` -- tritium ceiling
+- `tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts` -- tritium call site
+- `src/tests/qsys/test_stream_manager_sniff_escalation.cpp` -- escalation loop pinned with scripted fake readers
+- `src/tests/qlib/test_limited_in_stream.cpp`, `test_line_stream.cpp` -- stream adaptors
+- `src/tests/modules/importers/test_*_sniff.cpp` -- per-reader examples

--- a/src/modules/mdtools/GROFileReader.cpp
+++ b/src/modules/mdtools/GROFileReader.cpp
@@ -80,6 +80,12 @@ qsys::ObjectPtr GROFileReader::createDefaultObj() const
 /// Content sniff: line 2 must be a non-negative integer (declared atom
 /// count) and line 3 must look like a GROMOS87 fixed-column atom line
 /// (>= 44 chars with three parseable doubles at columns 20/28/36).
+///
+/// Every fall-through is CONTENT_UNKNOWN, never CONTENT_NO: the caller
+/// may hand us a byte-capped stream whose last line is cut short, and
+/// a length / numeric-parse / missing-line failure on a truncated line
+/// says nothing about the format. NO is reserved for positively
+/// recognising a competing format, which this sniffer never does.
 int GROFileReader::canHandleContent(qlib::InStream &ins) const
 {
   qlib::LineStream lin(ins);
@@ -92,8 +98,8 @@ int GROFileReader::canHandleContent(qlib::InStream &ins) const
   if (!lin.ready()) return CONTENT_UNKNOWN;
   LString count_line = stripLineEnd(lin.readLine()).trim();
   int natoms = -1;
-  if (!count_line.toInt(&natoms)) return CONTENT_NO;
-  if (natoms < 0) return CONTENT_NO;
+  if (!count_line.toInt(&natoms)) return CONTENT_UNKNOWN;
+  if (natoms < 0) return CONTENT_UNKNOWN;
 
   // An empty .gro (natoms == 0) is theoretically valid but
   // indistinguishable from arbitrary text, so report UNKNOWN.
@@ -101,15 +107,15 @@ int GROFileReader::canHandleContent(qlib::InStream &ins) const
 
   // Line 3: first atom line. Require the standard fixed layout to be
   // recognizable -- length must accommodate the 3 position fields.
-  if (!lin.ready()) return CONTENT_NO;
+  if (!lin.ready()) return CONTENT_UNKNOWN;
   LString atom_line = stripLineEnd(lin.readLine());
   if (static_cast<int>(atom_line.length()) < GRO_MIN_ATOM_LINE_LEN)
-    return CONTENT_NO;
+    return CONTENT_UNKNOWN;
 
   double xyz;
-  if (!atom_line.substr(20, 8).trim().toDouble(&xyz)) return CONTENT_NO;
-  if (!atom_line.substr(28, 8).trim().toDouble(&xyz)) return CONTENT_NO;
-  if (!atom_line.substr(36, 8).trim().toDouble(&xyz)) return CONTENT_NO;
+  if (!atom_line.substr(20, 8).trim().toDouble(&xyz)) return CONTENT_UNKNOWN;
+  if (!atom_line.substr(28, 8).trim().toDouble(&xyz)) return CONTENT_UNKNOWN;
+  if (!atom_line.substr(36, 8).trim().toDouble(&xyz)) return CONTENT_UNKNOWN;
 
   return CONTENT_YES;
 }

--- a/src/qlib/LString.hpp
+++ b/src/qlib/LString.hpp
@@ -200,6 +200,13 @@ public:
         return m_data.find_first_of(s.m_data);
     }
 
+    /// Same as indexOneOf(s) but starts the search at `from`, so a
+    /// caller that appends to a buffer can scan only the new bytes.
+    int indexOneOf(const LString &s, size_type from) const
+    {
+        return m_data.find_first_of(s.m_data, from);
+    }
+
     int indexOf(const LString &str) const
     {
         return m_data.find(str.m_data);

--- a/src/qlib/LimitedInStream.hpp
+++ b/src/qlib/LimitedInStream.hpp
@@ -5,6 +5,12 @@
 // even if the underlying source still has data. Used by content-sniff
 // paths to bound how much of a file each reader sees.
 //
+// Besides capping, the filter records whether the cap was actually
+// reached (isLimitHit) so that a caller can tell "the reader stopped
+// because we cut it off" apart from "the reader stopped because the
+// source ran dry". Content sniffing uses this to retry a reader with a
+// larger budget only when the budget was the limiting factor.
+//
 
 #ifndef QLIB_LIMITED_IN_STREAM_HPP_
 #define QLIB_LIMITED_IN_STREAM_HPP_
@@ -19,15 +25,28 @@ namespace detail {
 class QLIB_API LimitedInFilterImpl : public InFilterImpl
 {
 private:
+    qint64 m_limit;
     qint64 m_remaining;
+    qint64 m_consumed;
+
+    /// Set when a read/skip request was refused or shortened because
+    /// of the budget. Never set by a short read from the source.
+    bool m_bClamped;
 
 public:
     typedef InFilterImpl super_t;
 
-    LimitedInFilterImpl() : super_t(), m_remaining(0) {}
+    LimitedInFilterImpl()
+        : super_t(), m_limit(0), m_remaining(0), m_consumed(0), m_bClamped(false)
+    {
+    }
 
     LimitedInFilterImpl(const impl_type &in, qint64 maxBytes)
-        : super_t(in), m_remaining(maxBytes < 0 ? 0 : maxBytes)
+        : super_t(in),
+          m_limit(maxBytes < 0 ? 0 : maxBytes),
+          m_remaining(maxBytes < 0 ? 0 : maxBytes),
+          m_consumed(0),
+          m_bClamped(false)
     {
     }
 
@@ -39,34 +58,66 @@ public:
 
     int read() override
     {
-        if (m_remaining <= 0) return -1;
+        if (m_remaining <= 0) {
+            m_bClamped = true;
+            return -1;
+        }
         int c = getImpl()->read();
         if (c < 0) return -1;
         --m_remaining;
+        ++m_consumed;
         return c;
     }
 
     int read(char *buf, int off, int len) override
     {
-        if (m_remaining <= 0) return -1;
+        if (m_remaining <= 0) {
+            m_bClamped = true;
+            return -1;
+        }
         int reqLen = len;
-        if (static_cast<qint64>(reqLen) > m_remaining)
+        if (static_cast<qint64>(reqLen) > m_remaining) {
             reqLen = static_cast<int>(m_remaining);
+            m_bClamped = true;
+        }
         int n = getImpl()->read(buf, off, reqLen);
-        if (n > 0) m_remaining -= n;
+        if (n > 0) {
+            m_remaining -= n;
+            m_consumed += n;
+        }
         return n;
     }
 
     int skip(int n) override
     {
-        if (m_remaining <= 0) return 0;
+        if (m_remaining <= 0) {
+            m_bClamped = true;
+            return 0;
+        }
         int reqN = n;
-        if (static_cast<qint64>(reqN) > m_remaining)
+        if (static_cast<qint64>(reqN) > m_remaining) {
             reqN = static_cast<int>(m_remaining);
+            m_bClamped = true;
+        }
         int skipped = getImpl()->skip(reqN);
-        if (skipped > 0) m_remaining -= skipped;
+        if (skipped > 0) {
+            m_remaining -= skipped;
+            m_consumed += skipped;
+        }
         return skipped;
     }
+
+    /// Byte budget given at construction.
+    qint64 limit() const { return m_limit; }
+
+    /// Bytes delivered (or skipped) so far.
+    qint64 consumed() const { return m_consumed; }
+
+    /// True when the budget limited what the consumer could read: it
+    /// is exhausted, or a request had to be refused / shortened. A
+    /// consumer that stopped before touching the budget (source EOF,
+    /// early verdict) leaves this false.
+    bool isLimitHit() const { return m_remaining <= 0 || m_bClamped; }
 };
 
 }  // namespace detail
@@ -83,6 +134,10 @@ public:
     }
 
     InStream::impl_type getImpl() const override { return m_pimpl; }
+
+    qint64 limit() const { return m_pimpl->limit(); }
+    qint64 consumed() const { return m_pimpl->consumed(); }
+    bool isLimitHit() const { return m_pimpl->isLimitHit(); }
 };
 
 }  // namespace qlib

--- a/src/qlib/LineStream.cpp
+++ b/src/qlib/LineStream.cpp
@@ -52,10 +52,13 @@ void LineInImpl::readLine(LString &r)
       //MB_THROW(IOException, "cannot read from stream");
     }
     sbuf[res] = '\0';
-    //printf("read %d:%s", res, sbuf);
+    // Only the bytes just appended can contain a new delimiter; the
+    // prefix was already scanned. Searching from the old length keeps
+    // a long delimiter-free run linear instead of quadratic.
+    const LString::size_type prevLen = m_buf.length();
     m_buf.append(sbuf);
 
-    int pos = m_buf.indexOneOf(m_delim);
+    int pos = m_buf.indexOneOf(m_delim, prevLen);
     if (pos>=0) {
       r.append(m_buf.substr(0, pos+1));
       // save remains

--- a/src/qsys/ObjReader.hpp
+++ b/src/qsys/ObjReader.hpp
@@ -69,10 +69,12 @@ namespace qsys {
     //////////////////////////////////////////////
     // Content sniffing (tri-state)
     //
-    // See docs/architecture/objreader-content-sniff.md for the cap
-    // contract (callers may wrap `ins` in a LimitedInStream), the
-    // NO-vs-UNKNOWN policy, and the LineStream / minimum-byte
-    // implementation patterns shared by every reader.
+    // See docs/architecture/objreader-content-sniff.md for the budget
+    // contract (callers wrap `ins` in a LimitedInStream and retry an
+    // UNKNOWN that the budget cut off with a larger one), the
+    // NO-vs-UNKNOWN policy (NO is final, so it must hold on a cut last
+    // line), and the LineStream / minimum-byte implementation patterns
+    // shared by every reader.
 
     /// Tri-state verdict returned from canHandleContent().
     /// YES: this reader recognizes the content as its own format.

--- a/src/qsys/StreamManager.cpp
+++ b/src/qsys/StreamManager.cpp
@@ -17,6 +17,9 @@
 #include <qlib/LVarArray.hpp>
 #include <qlib/LimitedInStream.hpp>
 
+#include <limits>
+#include <memory>
+
 #ifdef HAVE_LZMA_H
 #include <qlib/XzStream.hpp>
 #endif
@@ -129,10 +132,11 @@ void StreamManager::regIOHImpl(const LString &abiname)
   }
 }
 
-bool StreamManager::unregistReader(const LString &abiname, bool bWriter /*= false*/)
+bool StreamManager::unregistReader(const LString &abiname, bool /*bWriter = false*/)
 {
-  // TO DO: implementation
-  return false;
+  // Readers and writers share one table keyed by ABI name, so the
+  // category flag does not change the lookup.
+  return m_rdrinfotab.remove(abiname);
 }
 
 bool StreamManager::isReaderRegistered(const LString &abiname)
@@ -342,59 +346,88 @@ HeadEncoding detectEncoding(const LString &path)
   return ENC_RAW;
 }
 
-// Run `rdr.canHandleContent` against a freshly opened stream for `path`.
-// The file is wrapped with a Gzip/Xz decompressor when `enc` says so,
-// and again with a LimitedInStream when `maxBytes` is positive. Each
-// candidate gets its own stream chain (per-candidate re-open / re-decode)
-// because canHandleContent is non-rewinding -- the OS page cache covers
-// the cost of repeated file reads, and readers typically break out of
-// their scan within a few KB.
-int sniffWithChain(qsys::ObjReader &rdr, const LString &path,
-                   HeadEncoding enc, qlib::quint64 maxBytes)
+// Outcome of one canHandleContent call under a byte budget.
+struct SniffResult
 {
+  int verdict;
+  /// verdict == UNKNOWN and the budget (not the source) ended the scan:
+  /// the reader might still decide if given more bytes.
+  bool truncated;
+  qlib::quint64 consumed;
+};
+
+// Run `rdr.canHandleContent` against a freshly opened stream for `path`
+// with a byte budget of `maxBytes` (> 0). The file is wrapped with a
+// Gzip/Xz decompressor when `enc` says so, then with a LimitedInStream.
+// Each call gets its own stream chain (per-candidate, per-round re-open
+// / re-decode) because canHandleContent is non-rewinding -- the OS page
+// cache covers the cost of repeated file reads, and readers typically
+// break out of their scan within a few KB.
+SniffResult sniffWithChain(qsys::ObjReader &rdr, const LString &path,
+                           HeadEncoding enc, qlib::quint64 maxBytes)
+{
+  SniffResult res{qsys::ObjReader::CONTENT_UNKNOWN, false, 0};
+
   qlib::FileInStream fis;
   try {
     fis.open(path);
   }
   catch (...) {
-    return qsys::ObjReader::CONTENT_UNKNOWN;
+    return res;
   }
 
-  // Inner helper: apply the optional byte cap and call canHandleContent.
-  auto withCap = [&](qlib::InStream &stream) -> int {
-    if (maxBytes > 0) {
-      qlib::LimitedInStream lim(stream, static_cast<qlib::qint64>(maxBytes));
-      return rdr.canHandleContent(lim);
-    }
-    return rdr.canHandleContent(stream);
+  // Inner helper: apply the byte cap and call canHandleContent. The
+  // LimitedInStream must outlive the call so its accounting can be
+  // read back.
+  auto withCap = [&](qlib::InStream &stream) {
+    qlib::LimitedInStream lim(stream, static_cast<qlib::qint64>(maxBytes));
+    res.verdict = rdr.canHandleContent(lim);
+    res.consumed = static_cast<qlib::quint64>(lim.consumed());
+    res.truncated =
+        (res.verdict == qsys::ObjReader::CONTENT_UNKNOWN) && lim.isLimitHit();
   };
-
-  int verdict = qsys::ObjReader::CONTENT_UNKNOWN;
 
   try {
     if (enc == ENC_GZIP) {
       qlib::GzipInStream gzin(fis);
-      verdict = withCap(gzin);
+      withCap(gzin);
       try { gzin.close(); } catch (...) {}
     }
 #ifdef HAVE_LZMA_H
     else if (enc == ENC_XZ) {
       qlib::XzInStream xzin(fis);
-      verdict = withCap(xzin);
+      withCap(xzin);
       try { xzin.close(); } catch (...) {}
     }
 #endif
     else {
-      verdict = withCap(fis);
+      withCap(fis);
     }
   }
   catch (...) {
     // Corrupt input, mid-decompression error, reader exception, etc.
-    verdict = qsys::ObjReader::CONTENT_UNKNOWN;
+    // Final: a retry with a bigger budget would just throw again.
+    res = SniffResult{qsys::ObjReader::CONTENT_UNKNOWN, false, 0};
   }
 
   try { fis.close(); } catch (...) {}
-  return verdict;
+  return res;
+}
+
+// Budget for the round after one that used `cap`: grow by the factor,
+// never past `ceiling` (0 = no ceiling) nor past what LimitedInStream
+// can represent. Returns `cap` itself when no growth is possible.
+qlib::quint64 nextSniffCap(qlib::quint64 cap, qlib::quint64 ceiling)
+{
+  const qlib::quint64 kRepresentable =
+      static_cast<qlib::quint64>(std::numeric_limits<qlib::qint64>::max());
+  qlib::quint64 next;
+  if (cap > kRepresentable / qsys::StreamManager::SNIFF_GROWTH_FACTOR)
+    next = kRepresentable;
+  else
+    next = cap * qsys::StreamManager::SNIFF_GROWTH_FACTOR;
+  if (ceiling > 0 && next > ceiling) next = ceiling;
+  return next;
 }
 
 }  // namespace
@@ -453,20 +486,66 @@ LString StreamManager::searchByContentImpl(const LString &path,
   // Probe magic bytes once -- candidates share the encoding decision.
   HeadEncoding enc = supportCompression ? detectEncoding(path) : ENC_RAW;
 
-  qlib::LStringList hits;
+  // Escalation loop. Every candidate starts with SNIFF_INITIAL_BYTES.
+  // A candidate whose UNKNOWN was caused by the budget running out
+  // (truncated) is kept pending and asked again with a budget grown by
+  // SNIFF_GROWTH_FACTOR; everything else (YES, NO, UNKNOWN at true
+  // EOF, decisive early UNKNOWN, exception) is final after one call.
+  // `maxBytes` is the ceiling of that growth (0 = no ceiling: grow
+  // until every pending reader reaches EOF or a verdict).
+  struct Candidate
+  {
+    const ReaderInfo *pInfo;
+    std::unique_ptr<ObjReader> pRdr;
+    bool pending;
+    bool yes;
+  };
+  std::vector<Candidate> cands;
+  cands.reserve(candidates.size());
   for (const ReaderInfo *pInfo : candidates) {
     qlib::LClass *pCls = pInfo->pClass;
     MB_ASSERT(pCls != NULL);
     ObjReader *pRdr = dynamic_cast<ObjReader *>(pCls->createObj());
     if (pRdr == NULL) continue;
+    cands.push_back(Candidate{pInfo, std::unique_ptr<ObjReader>(pRdr), true, false});
+  }
 
-    int verdict = sniffWithChain(*pRdr, path, enc, maxBytes);
-    delete pRdr;
+  const qlib::quint64 ceiling = maxBytes;
+  qlib::quint64 cap = SNIFF_INITIAL_BYTES;
+  if (ceiling > 0 && ceiling < cap) cap = ceiling;
 
-    if (verdict == ObjReader::CONTENT_YES) {
-      if (bFirstOnly) return pInfo->nickname;
-      hits.push_back(pInfo->nickname);
+  for (int round = 1;; ++round) {
+    int nPending = 0;
+    for (Candidate &c : cands) {
+      if (!c.pending) continue;
+      SniffResult r = sniffWithChain(*c.pRdr, path, enc, cap);
+      if (r.verdict == ObjReader::CONTENT_YES) {
+        c.pending = false;
+        c.yes = true;
+        if (bFirstOnly) return c.pInfo->nickname;
+      }
+      else if (r.truncated) {
+        ++nPending;
+      }
+      else {
+        c.pending = false;
+      }
     }
+    if (nPending == 0) break;
+    if (ceiling > 0 && cap >= ceiling) break;
+    const qlib::quint64 next = nextSniffCap(cap, ceiling);
+    if (next <= cap) break;
+    MB_DPRINTLN("StreamManager> sniff round %d: %d reader(s) truncated at %llu bytes, retrying with %llu",
+                round, nPending, static_cast<unsigned long long>(cap),
+                static_cast<unsigned long long>(next));
+    cap = next;
+  }
+
+  // Multi-match: report YES readers in candidate (ABI name) order,
+  // independent of the round in which each one decided.
+  qlib::LStringList hits;
+  for (const Candidate &c : cands) {
+    if (c.yes) hits.push_back(c.pInfo->nickname);
   }
 
   if (hits.empty()) return LString();

--- a/src/qsys/StreamManager.hpp
+++ b/src/qsys/StreamManager.hpp
@@ -119,6 +119,16 @@ public:
     /// Returns comma separated list of compatible ObjWriter names for the object
     LString findCompatibleWriterNamesForObj(qlib::uid_t objid);
 
+    /// Content-sniff byte budget policy. Round 1 hands every candidate
+    /// reader a LimitedInStream of SNIFF_INITIAL_BYTES. A reader that
+    /// answers CONTENT_UNKNOWN because that budget ran out (and not
+    /// because the file ended) is asked again with the budget multiplied
+    /// by SNIFF_GROWTH_FACTOR, and so on up to the caller's ceiling.
+    /// Readers that decide (YES / NO), reach true EOF, stop early with
+    /// budget to spare, or throw are final after their first call.
+    static constexpr qlib::quint64 SNIFF_INITIAL_BYTES = 64 * 1024;
+    static constexpr qlib::quint64 SNIFF_GROWTH_FACTOR = 8;
+
     /// Sniff the file at `path` and return every registered reader whose
     /// canHandleContent() returns CONTENT_YES, joined with ',' (in
     /// m_rdrinfotab iteration order, which is sorted by ABI name).
@@ -133,11 +143,15 @@ public:
     /// canHandleContent(). When false, paths ending in .gz / .xz short-
     /// circuit to an empty result.
     ///
-    /// `maxBytes` caps how many bytes each candidate's
-    /// canHandleContent() is allowed to consume. The default value
-    /// (0) means unlimited -- each reader reads until it returns a
-    /// verdict or hits EOF. Pass a positive value to bound pathological
-    /// scans against huge inputs.
+    /// `maxBytes` is the ceiling of the escalating byte budget described
+    /// at SNIFF_INITIAL_BYTES: no candidate is ever handed more than
+    /// `maxBytes` bytes in one call. 0 (the default) means no ceiling --
+    /// a reader that keeps getting cut off is retried until it reaches
+    /// EOF or returns a verdict. A ceiling below SNIFF_INITIAL_BYTES
+    /// yields a single round at the ceiling. Because every round re-opens
+    /// the file, the bytes read for one reader sum to at most about 8/7
+    /// of the deciding round's budget (plus the ceiling-clamped final
+    /// round, if any).
     ///
     /// Reader nicknames are alphanumeric, so no escaping is needed.
     LString searchReadersByContent(const LString &path,
@@ -146,8 +160,10 @@ public:
                                    bool supportCompression = false,
                                    qlib::quint64 maxBytes = 0) const;
 
-    /// Same as searchReadersByContent() but returns only the first YES
-    /// match (or empty string when none matches).
+    /// Same as searchReadersByContent() but returns at the first YES
+    /// (or empty string when none matches). The search is round-major:
+    /// a reader that says YES in an early round wins even if a reader
+    /// earlier in ABI order is still pending with a larger budget.
     LString searchReaderByContent(const LString &path,
                                   const LString &nicknames_csv,
                                   int nCatID,
@@ -160,10 +176,10 @@ private:
     /// Register an object reader/writer by C++-ABI name (implementation)
     void regIOHImpl(const LString &abiname);
 
-    /// Shared core of searchReader{,s}ByContent. When `bFirstOnly` is
-    /// true, returns at the first YES verdict without querying further
-    /// readers; otherwise collects every YES match and joins them with
-    /// ','.
+    /// Shared core of searchReader{,s}ByContent: runs the escalating
+    /// budget loop over the candidate set. When `bFirstOnly` is true,
+    /// returns at the first YES verdict; otherwise collects every YES
+    /// match (candidate order) and joins them with ','.
     LString searchByContentImpl(const LString &path,
                                 const LString &nicknames_csv,
                                 int nCatID,

--- a/src/qsys/StreamManager.qif
+++ b/src/qsys/StreamManager.qif
@@ -32,9 +32,10 @@ runtime_class StreamManager
   // canHandleContent() returns YES. `nicknames` is a comma-separated
   // filter list (empty string = every registered reader of `category`).
   // When `supportCompression` is true, gzip / xz magic bytes are
-  // detected and the head is decompressed transparently. `maxBytes`
-  // caps how many bytes each reader sees during sniff; 0 = unbounded
-  // (default streaming scan to EOF or until a verdict). Returns ""
+  // detected and the head is decompressed transparently. Each reader
+  // first sees 64 KiB; a reader cut off by that budget while still
+  // undecided is retried with 8x the budget, up to the `maxBytes`
+  // ceiling (0 = no ceiling: retry until EOF or a verdict). Returns ""
   // when no reader matches.
   string searchReaderByContent(string path, string nicknames, integer category, boolean supportCompression, integer maxBytes);
 

--- a/src/qsys/command/LoadObjectCommand.hpp
+++ b/src/qsys/command/LoadObjectCommand.hpp
@@ -47,10 +47,10 @@ public:
     /// disambiguates among just those candidates, with a final
     /// alphabetic-first fallback when sniffing yields nothing.
     ///
-    /// `maxSniffBytes` caps how many bytes each reader's
-    /// canHandleContent() sees during disambiguation. 0 (the default)
-    /// means unbounded -- the streaming sniff reads each candidate's
-    /// stream until it returns a verdict or hits EOF.
+    /// `maxSniffBytes` is the ceiling of the escalating sniff budget
+    /// (see StreamManager::SNIFF_INITIAL_BYTES): each reader first sees
+    /// 64 KiB and is retried with 8x more only while the budget, not
+    /// the file, cut it off. 0 (the default) means no ceiling.
     LString guessFileFormat(int nCatID, bool bContentFirst = false,
                             qlib::quint64 maxSniffBytes = 0) const;
 
@@ -88,11 +88,12 @@ public:
     /// multiple readers share that extension.
     bool m_bContentFirst = false;
 
-    /// Maximum bytes each reader's canHandleContent() is allowed to
-    /// consume during sniff. 0 = unbounded (default), positive value
-    /// = byte cap exposed to StreamManager's searchReader{,s}ByContent.
-    /// Scripts override this when they want to bound sniffing against
-    /// pathological / very large inputs.
+    /// Ceiling of the escalating sniff budget forwarded to
+    /// StreamManager's searchReader{,s}ByContent as `maxBytes`. 0 = no
+    /// ceiling (default); a positive value bounds how many bytes any
+    /// single canHandleContent() call may consume. Scripts override
+    /// this when they want to bound sniffing against pathological /
+    /// very large inputs.
     qlib::quint64 m_nMaxSniffBytes = 0;
 
     //////////

--- a/src/qsys/command/LoadObjectCommand.qif
+++ b/src/qsys/command/LoadObjectCommand.qif
@@ -43,11 +43,12 @@ runtime_class LoadObjectCommand extends Command
     property boolean content_first => m_bContentFirst;
     default content_first = false;
 
-    /// Caps how many bytes the canHandleContent() of each reader is allowed
-    /// to consume during sniff. 0 (default) means unbounded -- the
-    /// streaming sniffer reads each candidate stream until it returns
-    /// a verdict or hits EOF. Set a positive value to bound sniffing
-    /// against pathological / very large inputs.
+    /// Ceiling of the escalating sniff byte budget: each reader first
+    /// sees 64 KiB and is retried with 8x more only while that budget
+    /// (not the file) cut it off. 0 (default) means no ceiling -- retry
+    /// until EOF or a verdict. Set a positive value to bound how many
+    /// bytes any single sniff call may consume on pathological / very
+    /// large inputs.
     property integer max_sniff_bytes => m_nMaxSniffBytes;
     default max_sniff_bytes = 0;
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(test_qlib
   qlib/test_eventmanager.cpp
   qlib/test_lprocmgr.cpp
   qlib/test_limited_in_stream.cpp
+  qlib/test_line_stream.cpp
   qlib/test_parallel.cpp
   qlib/test_chunked_array3d.cpp
   qlib/test_seekable_stream.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ add_executable(test_qsys
   qsys/test_scene.cpp
   qsys/test_streammanager.cpp
   qsys/test_stream_manager_search.cpp
+  qsys/test_stream_manager_sniff_escalation.cpp
   qsys/test_objreader.cpp
   qsys/test_objwriter.cpp
   qsys/test_sceneexporter.cpp

--- a/src/tests/modules/importers/test_gro_sniff.cpp
+++ b/src/tests/modules/importers/test_gro_sniff.cpp
@@ -2,11 +2,13 @@
 #include <common.h>
 #include "mdtools/GROFileReader.hpp"
 #include "qsys/ObjReader.hpp"
+#include <qlib/LimitedInStream.hpp>
 #include <qlib/StringStream.hpp>
 #include <string>
 
 using mdtools::GROFileReader;
 using qsys::ObjReader;
+using qlib::LimitedInStream;
 using qlib::StrInStream;
 
 namespace {
@@ -40,15 +42,17 @@ TEST(GROFileReaderSniffTest, EmptyReturnsUnknown)
     EXPECT_EQ(sniff(reader, std::string()), ObjReader::CONTENT_UNKNOWN);
 }
 
-TEST(GROFileReaderSniffTest, MissingAtomLineReturnsNo)
+TEST(GROFileReaderSniffTest, MissingAtomLineReturnsUnknown)
 {
-    // Title and count present, but no atom line.
+    // Title and count present, but no atom line. Not NO: a byte cap
+    // could have cut the stream here, so the verdict must stay
+    // retryable.
     const std::string text = "title\n    3\n";
     GROFileReader reader;
-    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_NO);
+    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_UNKNOWN);
 }
 
-TEST(GROFileReaderSniffTest, NonIntegerCountReturnsNo)
+TEST(GROFileReaderSniffTest, NonIntegerCountReturnsUnknown)
 {
     // Line 2 must be parseable as an integer.
     const std::string text =
@@ -56,7 +60,7 @@ TEST(GROFileReaderSniffTest, NonIntegerCountReturnsNo)
         "not_a_number\n"
         "    1SOL     OW    1   1.000   2.000   3.000\n";
     GROFileReader reader;
-    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_NO);
+    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_UNKNOWN);
 }
 
 TEST(GROFileReaderSniffTest, ZeroAtomsReturnsUnknown)
@@ -67,7 +71,7 @@ TEST(GROFileReaderSniffTest, ZeroAtomsReturnsUnknown)
     EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_UNKNOWN);
 }
 
-TEST(GROFileReaderSniffTest, ShortAtomLineReturnsNo)
+TEST(GROFileReaderSniffTest, ShortAtomLineReturnsUnknown)
 {
     // Atom line shorter than 44 characters fails the fixed-column check.
     const std::string text =
@@ -75,10 +79,10 @@ TEST(GROFileReaderSniffTest, ShortAtomLineReturnsNo)
         "    1\n"
         "    1SOL     OW    1 1.0 2.0 3.0\n";
     GROFileReader reader;
-    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_NO);
+    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_UNKNOWN);
 }
 
-TEST(GROFileReaderSniffTest, NonNumericCoordsReturnsNo)
+TEST(GROFileReaderSniffTest, NonNumericCoordsReturnsUnknown)
 {
     // Position columns must parse as doubles.
     const std::string text =
@@ -86,7 +90,21 @@ TEST(GROFileReaderSniffTest, NonNumericCoordsReturnsNo)
         "    1\n"
         "    1SOL     OW    1     bad      x      yz\n";
     GROFileReader reader;
-    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_NO);
+    EXPECT_EQ(sniff(reader, text), ObjReader::CONTENT_UNKNOWN);
+}
+
+// A byte cap that lands inside the first atom line must not turn into
+// NO (which the sniff harness treats as final). The reader reports
+// UNKNOWN and the LimitedInStream records that the cap was the limiting
+// factor, so the harness can retry with a larger budget.
+TEST(GROFileReaderSniffTest, TruncatedAtomLineReturnsUnknownNotNo)
+{
+    GROFileReader reader;
+    StrInStream raw(kWaterGRO.data(), static_cast<int>(kWaterGRO.size()));
+    // "water\n" (6) + "    3\n" (6) = 12; cap 30 ends mid atom line 1.
+    LimitedInStream capped(raw, 30);
+    EXPECT_EQ(reader.canHandleContent(capped), ObjReader::CONTENT_UNKNOWN);
+    EXPECT_TRUE(capped.isLimitHit());
 }
 
 TEST(GROFileReaderSniffTest, GetNameReturnsGro)

--- a/src/tests/modules/importers/test_load_object_command_guess.cpp
+++ b/src/tests/modules/importers/test_load_object_command_guess.cpp
@@ -184,29 +184,43 @@ TEST(LoadObjectCommandMaxSniffBytesDefault, IsZeroByDefault)
 
 namespace {
 
-// CIF whose `_atom_site.` token sits past ~8 KB of padding lines. With
-// a small maxBytes cap the sniffer never reaches the hit and the
-// ambiguous-extension fallback kicks in.
-std::string makeBigHeaderCoordCif()
+// CIF whose `_atom_site.` token sits past `padBytes` of padding lines.
+// With a maxBytes ceiling below that offset the sniffer never reaches
+// the hit and the ambiguous-extension fallback kicks in.
+std::string makePaddedCoordCif(size_t padBytes)
 {
     std::string out;
-    out.reserve(16 * 1024);
+    out.reserve(padBytes + 1024);
     out.append("data_test\n");
     const std::string line = std::string("# padding line - ignored by the "
                                          "sniffer (kept long enough to "
                                          "force atom_site past any small "
                                          "maxBytes cap with few lines)\n");
-    while (out.size() < 8 * 1024) out += line;
+    while (out.size() < padBytes) out += line;
     out += "loop_\n_atom_site.group_PDB\nATOM 1 N\n";
     return out;
 }
 
+// ~8 KB of padding: past a 1 KiB ceiling, inside the 64 KiB first round.
+std::string makeBigHeaderCoordCif()
+{
+    return makePaddedCoordCif(8 * 1024);
+}
+
+// ~300 KB of padding: past the 64 KiB first round, so only the
+// escalating budget (second round, 512 KiB) reaches the marker.
+std::string makeVeryBigHeaderCoordCif()
+{
+    return makePaddedCoordCif(300 * 1024);
+}
+
 }  // namespace
 
-// With m_nMaxSniffBytes > 0 in ext-first mode, the sniffer only sees
-// the capped head. For an ambiguous .cif where the verdict lies past
-// the cap, sniff disambiguation fails and guessFileFormat falls back
-// to the first ext-matched candidate. The candidate list is collected
+// With m_nMaxSniffBytes > 0 in ext-first mode, the sniffer never sees
+// past that ceiling (a ceiling below the 64 KiB initial budget is a
+// single round). For an ambiguous .cif where the verdict lies past
+// the ceiling, sniff disambiguation fails and guessFileFormat falls
+// back to the first ext-matched candidate. The candidate list is collected
 // in m_rdrinfotab iteration order (sorted by ABI name), which for the
 // CIF pair starts with mmcifmap (xtal namespace) before mmcif
 // (importers namespace). The exact identity matters less than that the
@@ -225,8 +239,8 @@ TEST(LoadObjectCommandMaxSniffBytesExtFirst, CapLimitsSniffDisambiguation)
         << "', expected one of the registered CIF readers";
 }
 
-// Same setup but in content-first mode: cap applies, no reader claims
-// the head, result is empty.
+// Same setup but in content-first mode: ceiling applies, no reader
+// claims the head, result is empty.
 TEST(LoadObjectCommandMaxSniffBytesContentFirst, CapForcesEmpty)
 {
     LoadObjectCommand cmd;
@@ -238,9 +252,9 @@ TEST(LoadObjectCommandMaxSniffBytesContentFirst, CapForcesEmpty)
     EXPECT_TRUE(fmt.isEmpty());
 }
 
-// With m_nMaxSniffBytes = 0 (unbounded, the default), the same payload
-// resolves to the right reader because the streaming scan reaches the
-// `_atom_site.` token.
+// With m_nMaxSniffBytes = 0 (no ceiling, the default), the same payload
+// resolves to the right reader because the first 64 KiB round already
+// reaches the `_atom_site.` token.
 TEST(LoadObjectCommandMaxSniffBytesContentFirst, ZeroCapIsUnbounded)
 {
     LoadObjectCommand cmd;
@@ -250,4 +264,45 @@ TEST(LoadObjectCommandMaxSniffBytesContentFirst, ZeroCapIsUnbounded)
                                       /*bContentFirst=*/true,
                                       cmd.m_nMaxSniffBytes);
     EXPECT_EQ(std::string(fmt.c_str()), std::string("mmcif"));
+}
+
+// -----------------------------------------------------------------------
+// Escalating budget: a marker past the 64 KiB first round is reached in
+// a later round unless the ceiling stops the growth first.
+// -----------------------------------------------------------------------
+
+TEST(LoadObjectCommandMaxSniffBytesContentFirst, MarkerAt300KbResolvesWithNoCeiling)
+{
+    LoadObjectCommand cmd;
+    cmd.m_filePath = writeTempCif(".cif", makeVeryBigHeaderCoordCif().c_str());
+    cmd.m_nMaxSniffBytes = 0;
+    LString fmt = cmd.guessFileFormat(InOutHandler::IOH_CAT_OBJREADER,
+                                      /*bContentFirst=*/true,
+                                      cmd.m_nMaxSniffBytes);
+    EXPECT_EQ(std::string(fmt.c_str()), std::string("mmcif"));
+}
+
+TEST(LoadObjectCommandMaxSniffBytesContentFirst, CeilingBelowMarkerYieldsEmpty)
+{
+    LoadObjectCommand cmd;
+    cmd.m_filePath = writeTempCif(".cif", makeVeryBigHeaderCoordCif().c_str());
+    cmd.m_nMaxSniffBytes = 128 * 1024;  // 64 KiB round, then clamped 128 KiB round
+    LString fmt = cmd.guessFileFormat(InOutHandler::IOH_CAT_OBJREADER,
+                                      /*bContentFirst=*/true,
+                                      cmd.m_nMaxSniffBytes);
+    EXPECT_TRUE(fmt.isEmpty());
+}
+
+TEST(LoadObjectCommandMaxSniffBytesExtFirst, CeilingBelowMarkerFallsBackToFirstCandidate)
+{
+    LoadObjectCommand cmd;
+    cmd.m_filePath = writeTempCif(".cif", makeVeryBigHeaderCoordCif().c_str());
+    cmd.m_nMaxSniffBytes = 128 * 1024;
+    LString fmt = cmd.guessFileFormat(InOutHandler::IOH_CAT_OBJREADER,
+                                      /*bContentFirst=*/false,
+                                      cmd.m_nMaxSniffBytes);
+    const std::string got(fmt.c_str());
+    EXPECT_TRUE(got == "mmcif" || got == "mmcifmap")
+        << "Fallback returned '" << got
+        << "', expected one of the registered CIF readers";
 }

--- a/src/tests/modules/importers/test_mmcif_sniff.cpp
+++ b/src/tests/modules/importers/test_mmcif_sniff.cpp
@@ -20,7 +20,8 @@ using qlib::StrInStream;
 
 // -----------------------------------------------------------------------
 // Minimal synthesised CIF fragments. These are *headers only*, sized to
-// fit comfortably inside the 8 KB sniff buffer used by StreamManager.
+// fit comfortably inside the 64 KiB first-round budget of StreamManager's
+// content sniff.
 // They're not valid enough to read() into a MolCoord / DensityMap (that
 // is the read-path's job), but they are valid enough for the sniffer's
 // line-prefix scan.
@@ -335,8 +336,9 @@ TEST(MmcifSniffIntegration, LongHeaderSfCifIsFoundBeyondLegacyPeekCap)
     EXPECT_EQ(std::string(hit.c_str()), std::string("mmcifmap"));
 }
 
-// maxBytes=0 (the default) means unbounded -- equivalent to omitting
-// the parameter. Long-header CIF still hits.
+// maxBytes=0 (the default) means no ceiling on the escalating budget --
+// equivalent to omitting the parameter. The marker sits past the 64 KiB
+// first round, so the second round (512 KiB) finds it.
 TEST(MmcifSniffIntegration, MaxBytesZeroIsUnbounded)
 {
     const std::string content = makeLongHeaderCif(
@@ -349,10 +351,10 @@ TEST(MmcifSniffIntegration, MaxBytesZeroIsUnbounded)
     EXPECT_EQ(std::string(hit.c_str()), std::string("mmcif"));
 }
 
-// maxBytes set to a small cap prevents readers from seeing the hit
-// even when content sits later in the file. Result: no YES verdict,
-// empty string returned. Acts as the safety knob script callers can
-// use against pathological / very large inputs.
+// A maxBytes ceiling below the 64 KiB initial budget means a single
+// round at that ceiling: readers never see a hit that sits past it.
+// Result: no YES verdict, empty string returned. Acts as the safety
+// knob script callers can use against pathological / very large inputs.
 TEST(MmcifSniffIntegration, MaxBytesCapPreventsLateHitDiscovery)
 {
     const std::string content = makeLongHeaderCif(
@@ -365,8 +367,8 @@ TEST(MmcifSniffIntegration, MaxBytesCapPreventsLateHitDiscovery)
     EXPECT_TRUE(hit.isEmpty());
 }
 
-// Same maxBytes cap, but with the hit positioned within the cap range:
-// the verdict comes back normally.
+// Same maxBytes ceiling, but with the hit positioned within it: the
+// verdict comes back normally.
 TEST(MmcifSniffIntegration, MaxBytesAllowsHitInsideCap)
 {
     // No padding: `_atom_site.` is near the top of the file, well
@@ -448,5 +450,53 @@ TEST(MmcifSniffIntegration, NonCifGarbageReturnsEmpty)
     LString path = writeTempCif(".dat", content.c_str());
     LString hit = StreamManager::getInstance()->searchReaderByContent(
         path, LString(), InOutHandler::IOH_CAT_OBJREADER);
+    EXPECT_TRUE(hit.isEmpty());
+}
+
+// -----------------------------------------------------------------------
+// Byte-budget escalation: `maxBytes` is the ceiling of a growing budget
+// (64 KiB first, then x8 for a reader that was cut off while still
+// undecided), not a flat cap. See test_stream_manager_sniff_escalation
+// for the loop itself; these pin the real mmCIF readers under it.
+// -----------------------------------------------------------------------
+
+// The marker sits at ~300 KB: past the 64 KiB first round, inside the
+// 512 KiB second round, under a 1 MiB ceiling. Both the coordinate and
+// the structure-factor marker resolve.
+TEST(MmcifSniffIntegration, MarkerAt300KbResolvesViaEscalationUnderMibCeiling)
+{
+    const qlib::quint64 ceiling = 1 << 20;
+
+    const std::string coord = makeLongHeaderCif(
+        /*padBytes=*/300 * 1024,
+        std::string("loop_\n_atom_site.group_PDB\nATOM 1 N N\n"));
+    LString path = writeTempCif(".cif", coord.c_str());
+    LString hit = StreamManager::getInstance()->searchReaderByContent(
+        path, LString(), InOutHandler::IOH_CAT_OBJREADER,
+        /*supportCompression=*/false, ceiling);
+    EXPECT_EQ(std::string(hit.c_str()), std::string("mmcif"));
+
+    const std::string sf = makeLongHeaderCif(
+        /*padBytes=*/300 * 1024,
+        std::string("loop_\n_refln.index_h\n0 0 0 1.0\n"));
+    path = writeTempCif(".cif", sf.c_str());
+    hit = StreamManager::getInstance()->searchReaderByContent(
+        path, LString(), InOutHandler::IOH_CAT_OBJREADER,
+        /*supportCompression=*/false, ceiling);
+    EXPECT_EQ(std::string(hit.c_str()), std::string("mmcifmap"));
+}
+
+// A ceiling under the marker (128 KiB < 300 KB) stops the escalation
+// short: the 64 KiB round is cut off, the clamped 128 KiB round is cut
+// off too, and the search gives up with no verdict.
+TEST(MmcifSniffIntegration, MarkerBeyondCeilingReturnsEmpty)
+{
+    const std::string coord = makeLongHeaderCif(
+        /*padBytes=*/300 * 1024,
+        std::string("loop_\n_atom_site.group_PDB\nATOM 1 N N\n"));
+    LString path = writeTempCif(".cif", coord.c_str());
+    LString hit = StreamManager::getInstance()->searchReaderByContent(
+        path, LString(), InOutHandler::IOH_CAT_OBJREADER,
+        /*supportCompression=*/false, /*maxBytes=*/128 * 1024);
     EXPECT_TRUE(hit.isEmpty());
 }

--- a/src/tests/modules/importers/test_xplormap_sniff.cpp
+++ b/src/tests/modules/importers/test_xplormap_sniff.cpp
@@ -15,7 +15,7 @@ namespace {
 
 // Build a minimal CCP4 binary header buffer: 216 bytes of zero with
 // "MAP " at offset 208. Used as the negative-case payload for Xplor's
-// sniffer (binary input -> CONTENT_NO via NUL-byte rejection).
+// sniffer (binary input never carries the ZYX line -> CONTENT_UNKNOWN).
 std::string makeMinimalCcp4Header()
 {
     std::string buf(216, '\0');
@@ -143,4 +143,7 @@ TEST(XplorMapReaderSniffTest, CapShorterThanZyxReturnsUnknown)
     StrInStream raw(payload.data(), static_cast<int>(payload.size()));
     LimitedInStream capped(raw, 1024);
     EXPECT_EQ(reader.canHandleContent(capped), ObjReader::CONTENT_UNKNOWN);
+    // The cap, not the payload, ended the scan: the sniff harness uses
+    // this flag to retry the reader with a larger budget.
+    EXPECT_TRUE(capped.isLimitHit());
 }

--- a/src/tests/qlib/test_limited_in_stream.cpp
+++ b/src/tests/qlib/test_limited_in_stream.cpp
@@ -2,6 +2,7 @@
 #include <common.h>
 
 #include <qlib/LimitedInStream.hpp>
+#include <qlib/LineStream.hpp>
 #include <qlib/StringStream.hpp>
 
 #include <string>
@@ -87,4 +88,143 @@ TEST(LimitedInStream, CapZero)
     LimitedInStream lim(src, 0);
     EXPECT_FALSE(lim.ready());
     EXPECT_EQ(lim.read(), -1);
+}
+
+// -----------------------------------------------------------------------
+// Budget accounting: limit() / consumed() / isLimitHit(). Content sniff
+// relies on isLimitHit() to tell "reader stopped because the cap cut it
+// off" apart from "reader stopped because the source ended".
+// -----------------------------------------------------------------------
+
+TEST(LimitedInStream, NotHitBeforeAnyRead)
+{
+    StrInStream src("abcdef");
+    LimitedInStream lim(src, 4);
+    EXPECT_EQ(lim.limit(), 4);
+    EXPECT_EQ(lim.consumed(), 0);
+    EXPECT_FALSE(lim.isLimitHit());
+}
+
+TEST(LimitedInStream, ConsumedTracksBytesAndStaysUnhitInsideBudget)
+{
+    StrInStream src("abcdef");
+    LimitedInStream lim(src, 10);
+    EXPECT_EQ(lim.read(), 'a');
+    EXPECT_EQ(lim.read(), 'b');
+    EXPECT_EQ(lim.read(), 'c');
+    EXPECT_EQ(lim.consumed(), 3);
+    EXPECT_FALSE(lim.isLimitHit());
+}
+
+// Draining exactly the budget counts as a hit even though the source
+// ended at the same byte: the limiter cannot know whether more data
+// would have followed, so callers see one (harmless) extra retry.
+TEST(LimitedInStream, CapEqualsSourceCountsAsHit)
+{
+    StrInStream src("abcdef");
+    LimitedInStream lim(src, 6);
+    EXPECT_EQ(drainByByte(lim), "abcdef");
+    EXPECT_EQ(lim.consumed(), 6);
+    EXPECT_TRUE(lim.isLimitHit());
+}
+
+// A block read whose request exceeds the remaining budget is shortened;
+// that shortening is what marks the limit as hit.
+TEST(LimitedInStream, BlockReadClampedSetsHit)
+{
+    StrInStream src("0123456789ABCDEF");
+    LimitedInStream lim(src, 5);
+    char buf[16] = {0};
+    EXPECT_FALSE(lim.isLimitHit());
+    EXPECT_EQ(lim.read(buf, 0, 16), 5);
+    EXPECT_TRUE(lim.isLimitHit());
+    EXPECT_EQ(lim.consumed(), 5);
+}
+
+// The source running dry inside the budget is not a limit hit: the
+// request was passed through unshortened and the source returned less.
+TEST(LimitedInStream, ShortSourceReadDoesNotSetHit)
+{
+    StrInStream src("abcdef");
+    LimitedInStream lim(src, 100);
+    char buf[16] = {0};
+    EXPECT_EQ(lim.read(buf, 0, 16), 6);
+    EXPECT_LE(lim.read(buf, 0, 16), 0);  // source EOF
+    EXPECT_FALSE(lim.ready());
+    EXPECT_FALSE(lim.isLimitHit());
+    EXPECT_EQ(lim.consumed(), 6);
+}
+
+// Byte-wise reads: the budget running out (not the source) is a hit,
+// and a further read after exhaustion keeps it a hit.
+TEST(LimitedInStream, ByteReadPastBudgetIsHit)
+{
+    StrInStream src("abcdefghij");
+    LimitedInStream lim(src, 4);
+    EXPECT_EQ(drainByByte(lim), "abcd");
+    EXPECT_TRUE(lim.isLimitHit());
+    EXPECT_EQ(lim.read(), -1);
+    EXPECT_TRUE(lim.isLimitHit());
+    EXPECT_EQ(lim.consumed(), 4);
+}
+
+TEST(LimitedInStream, CapZeroIsHitImmediately)
+{
+    StrInStream src("hello");
+    LimitedInStream lim(src, 0);
+    EXPECT_TRUE(lim.isLimitHit());
+    EXPECT_EQ(lim.consumed(), 0);
+}
+
+TEST(LimitedInStream, SkipCountsTowardBudget)
+{
+    StrInStream src("0123456789ABCDEF");
+    LimitedInStream lim(src, 5);
+    EXPECT_EQ(lim.skip(3), 3);
+    EXPECT_EQ(lim.consumed(), 3);
+    EXPECT_FALSE(lim.isLimitHit());
+    // Request beyond the remaining budget is shortened to 2 -> hit.
+    EXPECT_EQ(lim.skip(10), 2);
+    EXPECT_EQ(lim.consumed(), 5);
+    EXPECT_TRUE(lim.isLimitHit());
+}
+
+// The pattern every text sniffer uses: LineStream over the capped
+// stream, `while (lin.ready()) lin.readLine();`. When the loop exits
+// because the cap ran out, isLimitHit() is true ...
+TEST(LimitedInStream, LineStreamLoopOverCapReportsHit)
+{
+    std::string text;
+    for (int i = 0; i < 200; ++i) text += "line padding padding padding padding padding padding padding\n";
+    ASSERT_GT(text.size(), 3000u);
+    StrInStream src(text.data(), static_cast<int>(text.size()));
+    LimitedInStream lim(src, 3000);
+    qlib::LineStream lin(lim);
+    int nlines = 0;
+    while (lin.ready()) {
+        lin.readLine();
+        ++nlines;
+    }
+    EXPECT_GT(nlines, 0);
+    EXPECT_TRUE(lim.isLimitHit());
+    EXPECT_EQ(lim.consumed(), 3000);
+}
+
+// ... and when it exits because the source reached EOF with budget to
+// spare, isLimitHit() is false.
+TEST(LimitedInStream, LineStreamLoopOverEofDoesNotReportHit)
+{
+    std::string text;
+    for (int i = 0; i < 10; ++i) text += "short line\n";
+    StrInStream src(text.data(), static_cast<int>(text.size()));
+    LimitedInStream lim(src, 3000);
+    qlib::LineStream lin(lim);
+    int nlines = 0;
+    while (lin.ready()) {
+        lin.readLine();
+        ++nlines;
+    }
+    EXPECT_EQ(nlines, 10);
+    EXPECT_FALSE(lim.isLimitHit());
+    EXPECT_EQ(lim.consumed(), static_cast<qlib::qint64>(text.size()));
 }

--- a/src/tests/qlib/test_line_stream.cpp
+++ b/src/tests/qlib/test_line_stream.cpp
@@ -1,0 +1,103 @@
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include <qlib/LineStream.hpp>
+#include <qlib/StringStream.hpp>
+
+#include <chrono>
+#include <string>
+
+using qlib::LString;
+using qlib::LineStream;
+using qlib::StrInStream;
+
+namespace {
+
+std::string toStd(const LString &s)
+{
+    return std::string(s.c_str(), s.length());
+}
+
+}  // namespace
+
+// A line longer than the internal 2 KB read block (and much longer than
+// that) comes back whole, and the following line is intact. Together
+// with the timing guard below this pins that readLine() scans only the
+// newly appended bytes per block instead of rescanning the buffer.
+TEST(LineStream, LongLineWithoutDelimiterIsReturnedWhole)
+{
+    const std::string longLine(1024 * 1024, 'a');
+    const std::string payload = longLine + "\nb\n";
+    StrInStream src(payload.data(), static_cast<int>(payload.size()));
+    LineStream lin(src);
+
+    ASSERT_TRUE(lin.ready());
+    EXPECT_EQ(toStd(lin.readLine()), longLine + "\n");
+    EXPECT_EQ(lin.getLineNo(), 1);
+    ASSERT_TRUE(lin.ready());
+    EXPECT_EQ(toStd(lin.readLine()), "b\n");
+    EXPECT_EQ(lin.getLineNo(), 2);
+    EXPECT_FALSE(lin.ready());
+}
+
+// Delimiters sitting exactly on the internal block boundary (the block
+// is 2047 bytes) are still found, including an empty line that starts
+// the next block.
+TEST(LineStream, DelimiterAtBlockBoundary)
+{
+    const std::string payload = std::string(2046, 'x') + "\n" + "\n" + "y\n";
+    StrInStream src(payload.data(), static_cast<int>(payload.size()));
+    LineStream lin(src);
+
+    EXPECT_EQ(toStd(lin.readLine()), std::string(2046, 'x') + "\n");
+    EXPECT_EQ(toStd(lin.readLine()), "\n");
+    EXPECT_EQ(toStd(lin.readLine()), "y\n");
+    EXPECT_FALSE(lin.ready());
+    EXPECT_EQ(lin.getLineNo(), 3);
+}
+
+// The trailing fragment without a delimiter is returned as the last
+// line at EOF.
+TEST(LineStream, TrailingFragmentWithoutDelimiterIsLastLine)
+{
+    const std::string payload = "first\nsecond";
+    StrInStream src(payload.data(), static_cast<int>(payload.size()));
+    LineStream lin(src);
+
+    EXPECT_EQ(toStd(lin.readLine()), "first\n");
+    EXPECT_EQ(toStd(lin.readLine()), "second");
+    EXPECT_FALSE(lin.ready());
+}
+
+TEST(LineStream, CustomDelimiterStillHonoured)
+{
+    const std::string payload = "a;b;c";
+    StrInStream src(payload.data(), static_cast<int>(payload.size()));
+    LineStream lin(src);
+    lin.setDelim(";");
+
+    EXPECT_EQ(toStd(lin.readLine()), "a;");
+    EXPECT_EQ(toStd(lin.readLine()), "b;");
+    EXPECT_EQ(toStd(lin.readLine()), "c");
+    EXPECT_FALSE(lin.ready());
+}
+
+// Coarse regression guard for the scan cost: an 8 MiB single line is a
+// few milliseconds when readLine() is linear in the line length, and
+// tens of seconds when every 2 KB block rescans the whole buffer. The
+// bound is deliberately loose (10x+ margin) so it cannot flake on a
+// slow CI box.
+TEST(LineStream, EightMiBSingleLineReadsInBoundedTime)
+{
+    const std::string payload(8 * 1024 * 1024, 'a');
+    StrInStream src(payload.data(), static_cast<int>(payload.size()));
+    LineStream lin(src);
+
+    const auto t0 = std::chrono::steady_clock::now();
+    const LString line = lin.readLine();
+    const auto elapsed = std::chrono::steady_clock::now() - t0;
+
+    EXPECT_EQ(line.length(), payload.size());
+    EXPECT_FALSE(lin.ready());
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 3000);
+}

--- a/src/tests/qsys/test_stream_manager_search.cpp
+++ b/src/tests/qsys/test_stream_manager_search.cpp
@@ -14,10 +14,11 @@ using qsys::InOutHandler;
 
 // -----------------------------------------------------------------------
 // Test fixtures: write temp files and probe the search API.
-// We can't register a mock ObjReader (would require a full wrap.cpp /
-// LClass registration), so these tests pin the *API contract*: empty
-// candidate set returns empty, .gz paths short-circuit the peek, etc.
-// Full sniff-scenario coverage lives in Phase 2 alongside Mmcif*Reader.
+// These tests pin the *API contract* with the real (empty) reader set:
+// empty candidate set returns empty, .gz paths short-circuit the peek,
+// etc. The byte-budget escalation loop is exercised with scripted fake
+// readers in test_stream_manager_sniff_escalation.cpp, and real-format
+// scenarios live in src/tests/modules/importers/test_*_sniff.cpp.
 // -----------------------------------------------------------------------
 
 namespace {

--- a/src/tests/qsys/test_stream_manager_sniff_escalation.cpp
+++ b/src/tests/qsys/test_stream_manager_sniff_escalation.cpp
@@ -1,0 +1,425 @@
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "qsys/InOutHandler.hpp"
+#include "qsys/ObjReader.hpp"
+#include "qsys/StreamManager.hpp"
+
+#include <qlib/ClassRegistry.hpp>
+#include <qlib/FileStream.hpp>
+#include <qlib/GzipStream.hpp>
+#include <qlib/LClassUtils.hpp>
+#include <qlib/LString.hpp>
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using qlib::LString;
+using qsys::ObjReader;
+using qsys::StreamManager;
+
+// -----------------------------------------------------------------------
+// Byte-budget escalation of searchReader{,s}ByContent, pinned with two
+// scripted fake readers registered under a private category. Each fake
+// reads its stream in 4 KiB blocks and records, per canHandleContent
+// call, how many bytes it consumed before the stream ended or its
+// script fired. The tests assert the sequence of budgets the harness
+// hands out (SNIFF_INITIAL_BYTES, x SNIFF_GROWTH_FACTOR, ceiling clamp)
+// and which verdicts are final versus retried.
+// -----------------------------------------------------------------------
+
+namespace sniff_escalation {
+
+// Behaviour script, in bytes consumed from the stream.
+struct Script
+{
+    long long yesAt = -1;   // return YES once this many bytes were read
+    long long noAt = -1;    // return NO once this many bytes were read
+    long long stopAt = -1;  // return UNKNOWN (decisive) once this many bytes were read
+    bool throwOnCall = false;
+};
+
+struct Call
+{
+    long long bytesRead;
+    bool sawEof;  // the stream returned <= 0 (source EOF or budget cap)
+};
+
+struct Recorder
+{
+    Script script;
+    std::vector<Call> calls;
+    void reset()
+    {
+        script = Script();
+        calls.clear();
+    }
+};
+
+int runScript(Recorder &rec, qlib::InStream &ins)
+{
+    if (rec.script.throwOnCall) {
+        rec.calls.push_back(Call{0, false});
+        throw std::runtime_error("scripted sniff failure");
+    }
+    char buf[4096];
+    long long total = 0;
+    for (;;) {
+        if (rec.script.yesAt >= 0 && total >= rec.script.yesAt) {
+            rec.calls.push_back(Call{total, false});
+            return ObjReader::CONTENT_YES;
+        }
+        if (rec.script.noAt >= 0 && total >= rec.script.noAt) {
+            rec.calls.push_back(Call{total, false});
+            return ObjReader::CONTENT_NO;
+        }
+        if (rec.script.stopAt >= 0 && total >= rec.script.stopAt) {
+            rec.calls.push_back(Call{total, false});
+            return ObjReader::CONTENT_UNKNOWN;
+        }
+        int n = ins.read(buf, 0, static_cast<int>(sizeof(buf)));
+        if (n <= 0) break;
+        total += n;
+    }
+    rec.calls.push_back(Call{total, true});
+    return ObjReader::CONTENT_UNKNOWN;
+}
+
+// Private category: the fakes never appear in other tests' searches.
+constexpr int kFakeCategory = 1000;
+
+class RecReaderA : public ObjReader
+{
+public:
+    static Recorder &recorder()
+    {
+        static Recorder r;
+        return r;
+    }
+    bool read(qlib::InStream &) override { return true; }
+    qsys::ObjectPtr createDefaultObj() const override { return qsys::ObjectPtr(); }
+    const char *getName() const override { return "esc_a"; }
+    const char *getTypeDescr() const override { return "Escalation fake A"; }
+    const char *getFileExt() const override { return "*.esca"; }
+    int getCatID() const override { return kFakeCategory; }
+    int canHandleContent(qlib::InStream &ins) const override
+    {
+        return runScript(recorder(), ins);
+    }
+};
+
+class RecReaderB : public ObjReader
+{
+public:
+    static Recorder &recorder()
+    {
+        static Recorder r;
+        return r;
+    }
+    bool read(qlib::InStream &) override { return true; }
+    qsys::ObjectPtr createDefaultObj() const override { return qsys::ObjectPtr(); }
+    const char *getName() const override { return "esc_b"; }
+    const char *getTypeDescr() const override { return "Escalation fake B"; }
+    const char *getFileExt() const override { return "*.escb"; }
+    int getCatID() const override { return kFakeCategory; }
+    int canHandleContent(qlib::InStream &ins) const override
+    {
+        return runScript(recorder(), ins);
+    }
+};
+
+}  // namespace sniff_escalation
+
+using sniff_escalation::RecReaderA;
+using sniff_escalation::RecReaderB;
+
+namespace {
+
+constexpr long long kInitial = static_cast<long long>(StreamManager::SNIFF_INITIAL_BYTES);
+constexpr long long kGrowth = static_cast<long long>(StreamManager::SNIFF_GROWTH_FACTOR);
+constexpr long long kKiB = 1024;
+
+std::string makeText(long long nbytes)
+{
+    std::string out;
+    out.reserve(static_cast<size_t>(nbytes) + 64);
+    const std::string line = "0123456789abcdefghijklmnopqrstuvwxyz filler line\n";
+    while (static_cast<long long>(out.size()) < nbytes) out += line;
+    out.resize(static_cast<size_t>(nbytes));
+    return out;
+}
+
+LString writeTempFile(const std::string &suffix, const std::string &content)
+{
+    static int s_counter = 0;
+    const std::string path = ::testing::TempDir() + "/sniff_esc_" +
+                             std::to_string(++s_counter) + suffix;
+    std::ofstream out(path, std::ios::binary);
+    out.write(content.data(), static_cast<std::streamsize>(content.size()));
+    out.close();
+    return LString(path.c_str());
+}
+
+LString writeTempGzip(const std::string &content)
+{
+    static int s_counter = 0;
+    const std::string path = ::testing::TempDir() + "/sniff_esc_gz_" +
+                             std::to_string(++s_counter) + ".txt.gz";
+    qlib::FileOutStream fos;
+    fos.open(LString(path.c_str()));
+    qlib::GzipOutStream gz(fos);
+    gz.write(content.data(), 0, static_cast<int>(content.size()));
+    gz.close();
+    fos.close();
+    return LString(path.c_str());
+}
+
+std::vector<long long> bytesPerCall(const sniff_escalation::Recorder &rec)
+{
+    std::vector<long long> out;
+    for (const auto &c : rec.calls) out.push_back(c.bytesRead);
+    return out;
+}
+
+class SniffEscalationTest : public ::testing::Test
+{
+protected:
+    static qlib::LClass *s_pClsA;
+    static qlib::LClass *s_pClsB;
+
+    static void SetUpTestSuite()
+    {
+        qlib::ClassRegistry *pCR = qlib::ClassRegistry::getInstance();
+        s_pClsA = MB_NEW qlib::LSpecificClass<RecReaderA>("sniff_escalation::RecReaderA");
+        s_pClsB = MB_NEW qlib::LSpecificClass<RecReaderB>("sniff_escalation::RecReaderB");
+        pCR->regClassObj(s_pClsA);
+        pCR->regClassObj(s_pClsB);
+        StreamManager *sm = StreamManager::getInstance();
+        sm->registReader<RecReaderA>();
+        sm->registReader<RecReaderB>();
+    }
+
+    static void TearDownTestSuite()
+    {
+        StreamManager *sm = StreamManager::getInstance();
+        sm->unregistReader(LString(typeid(RecReaderA).name()));
+        sm->unregistReader(LString(typeid(RecReaderB).name()));
+        qlib::ClassRegistry *pCR = qlib::ClassRegistry::getInstance();
+        pCR->unregClassObj<RecReaderA>();
+        pCR->unregClassObj<RecReaderB>();
+        delete s_pClsA;
+        delete s_pClsB;
+        s_pClsA = nullptr;
+        s_pClsB = nullptr;
+    }
+
+    void SetUp() override
+    {
+        RecReaderA::recorder().reset();
+        RecReaderB::recorder().reset();
+    }
+
+    static LString searchFirst(const LString &path, qlib::quint64 ceiling,
+                               bool supportCompression = false)
+    {
+        return StreamManager::getInstance()->searchReaderByContent(
+            path, LString(), sniff_escalation::kFakeCategory, supportCompression, ceiling);
+    }
+
+    static LString searchAll(const LString &path, qlib::quint64 ceiling)
+    {
+        return StreamManager::getInstance()->searchReadersByContent(
+            path, LString(), sniff_escalation::kFakeCategory, false, ceiling);
+    }
+};
+
+qlib::LClass *SniffEscalationTest::s_pClsA = nullptr;
+qlib::LClass *SniffEscalationTest::s_pClsB = nullptr;
+
+}  // namespace
+
+// Sanity: the private category is visible to the search and both fakes
+// are candidates (ABI-name order puts A before B).
+TEST_F(SniffEscalationTest, FakesAreRegisteredUnderPrivateCategory)
+{
+    StreamManager *sm = StreamManager::getInstance();
+    EXPECT_TRUE(sm->isReaderRegistered(LString(typeid(RecReaderA).name())));
+    EXPECT_TRUE(sm->isReaderRegistered(LString(typeid(RecReaderB).name())));
+
+    RecReaderA::recorder().script.yesAt = 0;
+    RecReaderB::recorder().script.yesAt = 0;
+    const LString path = writeTempFile(".txt", makeText(100));
+    EXPECT_EQ(searchAll(path, 0), LString("esc_a,esc_b"));
+}
+
+// A marker past the initial budget is reached in round 2: the reader
+// was cut off at exactly SNIFF_INITIAL_BYTES (truncated UNKNOWN) and
+// retried with a bigger budget.
+TEST_F(SniffEscalationTest, MarkerPastInitialCapIsFoundByEscalation)
+{
+    const long long marker = 200 * kKiB;
+    RecReaderA::recorder().script.yesAt = marker;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_EQ(searchFirst(path, 0), LString("esc_a"));
+
+    const auto &calls = RecReaderA::recorder().calls;
+    ASSERT_EQ(calls.size(), 2u);
+    EXPECT_EQ(calls[0].bytesRead, kInitial);
+    EXPECT_TRUE(calls[0].sawEof);
+    EXPECT_GE(calls[1].bytesRead, marker);
+    EXPECT_FALSE(calls[1].sawEof);
+}
+
+// UNKNOWN because the file really ended (smaller than the budget) is
+// final: no second call.
+TEST_F(SniffEscalationTest, UnknownAtTrueEofIsNotRetried)
+{
+    const long long size = 10 * kKiB;
+    const LString path = writeTempFile(".txt", makeText(size));
+
+    EXPECT_TRUE(searchFirst(path, 0).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({size}));
+    EXPECT_EQ(bytesPerCall(RecReaderB::recorder()), std::vector<long long>({size}));
+    EXPECT_TRUE(RecReaderA::recorder().calls[0].sawEof);
+}
+
+// With no ceiling the loop grows the budget by the factor and stops as
+// soon as the retried reader reaches true EOF.
+TEST_F(SniffEscalationTest, SecondRoundReachingEofStopsLoop)
+{
+    const long long size = 300 * kKiB;
+    ASSERT_LT(size, kInitial * kGrowth);
+    const LString path = writeTempFile(".txt", makeText(size));
+
+    EXPECT_TRUE(searchFirst(path, 0).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({kInitial, size}));
+    EXPECT_EQ(bytesPerCall(RecReaderB::recorder()), std::vector<long long>({kInitial, size}));
+}
+
+// The ceiling clamps the final round: 64 KiB then 128 KiB, then stop
+// even though the reader was still cut off.
+TEST_F(SniffEscalationTest, CeilingClampsFinalRound)
+{
+    const long long ceiling = 128 * kKiB;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_TRUE(searchFirst(path, static_cast<qlib::quint64>(ceiling)).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({kInitial, ceiling}));
+    EXPECT_EQ(bytesPerCall(RecReaderB::recorder()), std::vector<long long>({kInitial, ceiling}));
+}
+
+// A ceiling below the initial budget means one round at the ceiling.
+TEST_F(SniffEscalationTest, CeilingBelowInitialIsSingleRound)
+{
+    const long long ceiling = 1024;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_TRUE(searchFirst(path, static_cast<qlib::quint64>(ceiling)).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({ceiling}));
+    EXPECT_EQ(bytesPerCall(RecReaderB::recorder()), std::vector<long long>({ceiling}));
+}
+
+TEST_F(SniffEscalationTest, CeilingEqualToInitialIsSingleRound)
+{
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_TRUE(searchFirst(path, static_cast<qlib::quint64>(kInitial)).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({kInitial}));
+    EXPECT_EQ(bytesPerCall(RecReaderB::recorder()), std::vector<long long>({kInitial}));
+}
+
+// NO is final even though the reader had consumed only part of its
+// budget; the other (truncated) reader still escalates on its own.
+TEST_F(SniffEscalationTest, NoIsFinal)
+{
+    RecReaderA::recorder().script.noAt = 4096;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_TRUE(searchFirst(path, 0).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({4096}));
+    EXPECT_EQ(RecReaderB::recorder().calls.size(), 2u);
+}
+
+// A reader that stops early with budget to spare (decisive UNKNOWN,
+// e.g. "line 2 is not a number") is final: the budget was not what
+// stopped it.
+TEST_F(SniffEscalationTest, DecisiveUnknownIsFinal)
+{
+    RecReaderA::recorder().script.stopAt = 8192;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_TRUE(searchFirst(path, 0).isEmpty());
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({8192}));
+    EXPECT_EQ(RecReaderB::recorder().calls.size(), 2u);
+}
+
+// An exception inside canHandleContent is swallowed as a final UNKNOWN
+// and does not abort the search for the other readers.
+TEST_F(SniffEscalationTest, ThrowingReaderIsFinalUnknown)
+{
+    RecReaderA::recorder().script.throwOnCall = true;
+    RecReaderB::recorder().script.yesAt = 100 * kKiB;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_EQ(searchFirst(path, 0), LString("esc_b"));
+
+    EXPECT_EQ(RecReaderA::recorder().calls.size(), 1u);
+    EXPECT_EQ(RecReaderB::recorder().calls.size(), 2u);
+}
+
+// First-only search is round-major: a YES from a later candidate in
+// round 1 wins immediately, and the earlier (still pending) candidate
+// is never retried.
+TEST_F(SniffEscalationTest, FirstOnlyReturnsEarlyYesWithoutEscalatingOthers)
+{
+    RecReaderB::recorder().script.yesAt = 0;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_EQ(searchFirst(path, 0), LString("esc_b"));
+
+    EXPECT_EQ(bytesPerCall(RecReaderA::recorder()), std::vector<long long>({kInitial}));
+    EXPECT_EQ(RecReaderB::recorder().calls.size(), 1u);
+}
+
+// Multi-match keeps escalating the pending reader after another one
+// said YES, and reports hits in candidate order regardless of the
+// round in which each decided.
+TEST_F(SniffEscalationTest, AllModeKeepsEscalatingAndPreservesCandidateOrder)
+{
+    RecReaderA::recorder().script.yesAt = 200 * kKiB;
+    RecReaderB::recorder().script.yesAt = 0;
+    const LString path = writeTempFile(".txt", makeText(300 * kKiB));
+
+    EXPECT_EQ(searchAll(path, 0), LString("esc_a,esc_b"));
+
+    EXPECT_EQ(RecReaderA::recorder().calls.size(), 2u);
+    EXPECT_EQ(RecReaderA::recorder().calls[0].bytesRead, kInitial);
+    EXPECT_EQ(RecReaderB::recorder().calls.size(), 1u);
+}
+
+// The budget counts decompressed bytes: a small .gz whose payload puts
+// the marker past 64 KiB still needs (and gets) a second round.
+TEST_F(SniffEscalationTest, GzipPayloadEscalatesOnDecompressedBytes)
+{
+    const long long marker = 200 * kKiB;
+    RecReaderA::recorder().script.yesAt = marker;
+    RecReaderB::recorder().script.stopAt = 0;
+    const LString path = writeTempGzip(makeText(300 * kKiB));
+
+    EXPECT_EQ(searchFirst(path, 0, /*supportCompression=*/true), LString("esc_a"));
+
+    const auto &calls = RecReaderA::recorder().calls;
+    ASSERT_EQ(calls.size(), 2u);
+    EXPECT_EQ(calls[0].bytesRead, kInitial);
+    EXPECT_GE(calls[1].bytesRead, marker);
+}

--- a/src/tests/qsys/test_streammanager.cpp
+++ b/src/tests/qsys/test_streammanager.cpp
@@ -367,22 +367,33 @@ TEST(StreamManagerTest, GetWriterInfoJSONStructureAndSizeZero)
 }
 
 // -----------------------------------------------------------------------
-// unregistReader (always returns false — TODO stub)
+// unregistReader
 // -----------------------------------------------------------------------
 
-TEST(StreamManagerTest, UnregistReaderAlwaysReturnsFalse)
+TEST(StreamManagerTest, UnregistReaderUnknownAbiNameReturnsFalse)
 {
-    // The function body is "// TO DO: implementation" — returns false unconditionally.
-    LString abiname(typeid(qsys::SceneXMLReader).name());
-    bool result = StreamManager::getInstance()->unregistReader(abiname);
-    EXPECT_FALSE(result);
+    StreamManager *sm = StreamManager::getInstance();
+    EXPECT_FALSE(sm->unregistReader(LString("no::such::Reader")));
+    // The writer flag does not change the lookup (one table, ABI-keyed).
+    EXPECT_FALSE(sm->unregistReader(LString("no::such::Writer"), true));
 }
 
-TEST(StreamManagerTest, UnregistReaderWithWriterFlagAlwaysReturnsFalse)
+// Unregistering a registered handler removes it from the table; the
+// same ABI name can then be registered again (regIOHImpl throws on
+// duplicates, so this also proves the entry is really gone).
+TEST(StreamManagerTest, UnregistReaderRoundTrip)
 {
-    LString abiname(typeid(qsys::SceneXMLWriter).name());
-    bool result = StreamManager::getInstance()->unregistReader(abiname, true);
-    EXPECT_FALSE(result);
+    StreamManager *sm = StreamManager::getInstance();
+    LString abiname(typeid(qsys::SceneXMLReader).name());
+    ASSERT_TRUE(sm->isReaderRegistered(abiname));
+
+    EXPECT_TRUE(sm->unregistReader(abiname));
+    EXPECT_FALSE(sm->isReaderRegistered(abiname));
+    EXPECT_FALSE(sm->unregistReader(abiname));
+
+    // Restore for the rest of the suite.
+    sm->registReader<qsys::SceneXMLReader>();
+    EXPECT_TRUE(sm->isReaderRegistered(abiname));
 }
 
 // -----------------------------------------------------------------------

--- a/tritium/react-gui/src/renderer/__test__/pickReaderName.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/pickReaderName.test.ts
@@ -7,12 +7,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { WorkerContext } from '../worker/server/types/WorkerContext'
 import { pickReaderName } from '../worker/server/services/helpers/pickReaderName'
+import { DEFAULT_SNIFF_CAP } from '../worker/shared/sniffConfig'
 
 interface ReaderInfo { name: string; fext: string; category: number }
 
 function makeCtx(readers: ReaderInfo[], sniff: (csv: string) => string) {
     const searchReaderByContent = vi.fn(
-        (_path: string, csv: string) => sniff(csv),
+        (_path: string, csv: string, _category: number, _compression: boolean, _maxBytes: number) =>
+            sniff(csv),
     )
     const ctx = {
         strMgr: {
@@ -74,5 +76,40 @@ describe('pickReaderName -- qdf* exclusion', () => {
         expect(name).toBe('mmcif')
         const csv = searchReaderByContent.mock.calls[0][1] as string
         expect(csv.split(',').sort()).toEqual(['mmcif', 'mmcifmap'])
+    })
+})
+
+// The 5th argument of searchReaderByContent is the ceiling of the C++
+// escalating sniff budget (64 KiB first, x8 while cut off, up to the
+// ceiling). tritium must always pass a finite ceiling.
+describe('pickReaderName -- sniff ceiling', () => {
+    function ceilingOfFirstCall(searchReaderByContent: ReturnType<typeof vi.fn>): number {
+        return searchReaderByContent.mock.calls[0][4] as number
+    }
+
+    it('passes DEFAULT_SNIFF_CAP when maxSniffBytes is omitted', () => {
+        const { ctx, searchReaderByContent } = makeCtx(PDB_READERS, () => 'mmcif')
+        pickReaderName(ctx, '/x/foo.cif', true)
+        expect(ceilingOfFirstCall(searchReaderByContent)).toBe(DEFAULT_SNIFF_CAP)
+    })
+
+    it('maps 0 to DEFAULT_SNIFF_CAP instead of the C++ "no ceiling" mode', () => {
+        const { ctx, searchReaderByContent } = makeCtx(PDB_READERS, () => 'mmcif')
+        pickReaderName(ctx, '/x/foo.cif', true, 0)
+        expect(ceilingOfFirstCall(searchReaderByContent)).toBe(DEFAULT_SNIFF_CAP)
+    })
+
+    it('forwards an explicit positive ceiling unchanged (content-first and ext-first)', () => {
+        const a = makeCtx(PDB_READERS, () => 'mmcif')
+        pickReaderName(a.ctx, '/x/foo.cif', true, 4096)
+        expect(ceilingOfFirstCall(a.searchReaderByContent)).toBe(4096)
+
+        const b = makeCtx(PDB_READERS, () => 'mmcif')
+        pickReaderName(b.ctx, '/x/foo.cif', false, 4096)
+        expect(ceilingOfFirstCall(b.searchReaderByContent)).toBe(4096)
+    })
+
+    it('DEFAULT_SNIFF_CAP is large enough for a marker several hundred KB in', () => {
+        expect(DEFAULT_SNIFF_CAP).toBeGreaterThanOrEqual(1 << 20)
     })
 })

--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -284,6 +284,9 @@ export class AsyncCueMol {
      * ignored; when false (a specific filter was selected), the
      * extension narrows the candidate set first and sniff disambiguates
      * only when multiple readers share the extension.
+     *
+     * `maxSniffBytes` is the ceiling of the escalating sniff byte budget
+     * (0 / undefined = DEFAULT_SNIFF_CAP, see worker/shared/sniffConfig.ts).
      */
     loadObject(filePath: string, scene_id: number, options: FileOpenOptions,
                contentFirst = false, maxSniffBytes?: number, readerName?: string): Promise<boolean> {

--- a/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/fileApi.ts
@@ -161,10 +161,10 @@ export async function loadScene(
  * @param contentFirst - When true, the worker selects the reader purely
  *   from content sniffing (extension is ignored). When false (default),
  *   the extension narrows the candidate set first.
- * @param maxSniffBytes - Optional byte cap forwarded to
- *   LoadObjectCommand.max_sniff_bytes. 0 / undefined leaves the worker
- *   in unbounded mode (each reader scans its stream until it returns a
- *   verdict or hits EOF).
+ * @param maxSniffBytes - Optional ceiling of the escalating content-sniff
+ *   byte budget used by the worker's pickReaderName (see
+ *   worker/shared/sniffConfig.ts). 0 / undefined uses DEFAULT_SNIFF_CAP;
+ *   the worker never runs the C++ "no ceiling" mode.
  * @returns `true` on success.
  * @remarks Calls `loadObject` worker service.
  */

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts
@@ -22,8 +22,10 @@ export const OBJREADER_CATEGORY = 0;
  *   purely by content-sniffing every registered reader; when false, the
  *   extension narrows the candidate set first and content sniff only
  *   disambiguates when several readers share the extension.
- * @param maxSniffBytes - upper bound on bytes each reader's canHandleContent
- *   may consume during sniff. Defaults to DEFAULT_SNIFF_CAP.
+ * @param maxSniffBytes - ceiling of the escalating content-sniff byte
+ *   budget (see shared/sniffConfig.ts). Defaults to DEFAULT_SNIFF_CAP;
+ *   0 / negative map to the default as well, so tritium never runs the
+ *   C++ "no ceiling" mode.
  * @returns the resolved reader nickname, or '' when none matches.
  */
 export function pickReaderName(
@@ -32,6 +34,8 @@ export function pickReaderName(
     contentFirst: boolean,
     maxSniffBytes: number = DEFAULT_SNIFF_CAP,
 ): string {
+    // 0 would mean "no ceiling" on the C++ side; the worker always bounds
+    // the scan so a huge undecidable file cannot stall it.
     const cap = maxSniffBytes > 0 ? maxSniffBytes : DEFAULT_SNIFF_CAP;
 
     // Every user-facing obj reader (internal qdf* readers are never chosen --
@@ -47,8 +51,8 @@ export function pickReaderName(
         // Content-first: sniff every user-facing reader's canHandleContent;
         // the first YES wins. Restrict the candidate list to non-qdf readers
         // (passing a CSV instead of '' so the C++ sniff never considers qdf*).
-        // The cap bounds each candidate's stream scan so pathological inputs
-        // can't stall the sniff loop.
+        // The ceiling bounds each candidate's escalating stream scan so
+        // pathological inputs can't stall the sniff loop.
         const csv = objReaders.map((e) => e.name).join(',');
         if (!csv) return '';
         return ctx.strMgr.searchReaderByContent(filePath, csv, OBJREADER_CATEGORY, false, cap);

--- a/tritium/react-gui/src/renderer/worker/server/services/loadObject.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/loadObject.service.ts
@@ -42,7 +42,8 @@ export interface LoadObjectArgs {
      */
     contentFirst: boolean;
     /**
-     * Optional byte cap forwarded to pickReaderName's content-sniff. 0 /
+     * Optional ceiling of the escalating content-sniff byte budget
+     * forwarded to pickReaderName (see shared/sniffConfig.ts). 0 /
      * undefined falls back to DEFAULT_SNIFF_CAP. Lets scripts bound sniff
      * against pathological / very large inputs.
      */

--- a/tritium/react-gui/src/renderer/worker/shared/sniffConfig.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/sniffConfig.ts
@@ -4,17 +4,21 @@
  */
 
 /**
- * Default upper bound on bytes each reader's canHandleContent() is
- * allowed to consume from the input stream during sniff. Forwarded to
- * `LoadObjectCommand.max_sniff_bytes` and the `maxBytes` argument of
- * `StreamManager::searchReader{,s}ByContent`.
+ * Ceiling of the content-sniff byte budget that `pickReaderName` hands
+ * to `StreamManager::searchReaderByContent` (`maxBytes`).
  *
- * Set so that real-world headers resolve, while pathological /
- * mistakenly-renamed huge files cannot stall the worker scanning
- * gigabytes of garbage. A current PDB mmCIF puts its `_atom_site.` loop
- * hundreds of KB in (271 KB for 5IRE, 462 KB for 7A6A), which the old
- * 64 KB cap could not reach; the mmCIF sniffers now settle on the
- * coordinate categories in the first ~10 KB, and this cap is the
- * fallback for files whose markers sit further in.
+ * The C++ side escalates rather than reading this much up front: every
+ * reader first sees 64 KiB, and only a reader that was cut off by that
+ * budget while still undecided is retried with 8x more (512 KiB, 4 MiB,
+ * then this ceiling). Readers that decide, reach EOF, or stop early are
+ * never retried, so the ceiling is paid only by undecidable inputs
+ * (garbage dropped on a line-scanning reader): at most ~1.3 x 16 MiB
+ * read per such reader.
+ *
+ * 16 MiB comfortably covers any real header (a current PDB mmCIF puts
+ * `_atom_site.` a few hundred KB in, 271 KB for 5IRE and 462 KB for
+ * 7A6A, while the mmCIF sniffers usually settle on the coordinate
+ * categories in the first ~10 KB) and still bounds the worst case so a
+ * mistakenly-renamed huge file cannot stall the worker.
  */
-export const DEFAULT_SNIFF_CAP = 1048576;
+export const DEFAULT_SNIFF_CAP = 16 * 1024 * 1024;


### PR DESCRIPTION
## Why

`StreamManager::searchReader{,s}ByContent` wraps each reader's `canHandleContent()` in a `LimitedInStream` byte cap and treats every non-YES verdict the same. `CONTENT_UNKNOWN` therefore meant four different things at once: "the cap cut me off", "the file really ended", "the fixed-size header was short" and "this reader does not sniff". A marker that sits past the cap (`_atom_site.` at 271 KB in 5IRE, 462 KB in 7A6A) could only be rescued by raising the cap for every reader (#512 moved tritium from 64 KB to 1 MiB), which does not remove the structural problem.

## What

### Escalating budget (`src/qsys/StreamManager.*`)

- `LimitedInStream` now reports `limit()` / `consumed()` / `isLimitHit()`: true when the budget ran out or a read / skip request had to be refused or shortened, false when the reader stopped on its own (source EOF, early verdict).
- The harness runs rounds. Every candidate first sees `SNIFF_INITIAL_BYTES` (64 KiB). A reader whose UNKNOWN came with `isLimitHit()` is retried with the budget multiplied by `SNIFF_GROWTH_FACTOR` (8): 64 KiB, 512 KiB, 4 MiB, ... YES, NO, UNKNOWN at true EOF, a decisive early UNKNOWN and exceptions are final after one call, so readers that decide in a few bytes or one line are never touched again.
- `maxBytes` changes meaning from flat cap to **ceiling** of that growth (the last round is clamped to it; 0 = no ceiling). Bytes read per reader sum to at most ~8/7 of the deciding round's budget (plus the clamped final round), because every round re-opens the file (the decompressors are not seekable).
- First-only search is round-major (a YES in round 1 wins even if an earlier candidate in ABI order is still pending); multi-match keeps candidate order.
- `unregistReader` is implemented (the table is ABI-keyed) so tests can register scripted fake readers under a private category.

### Reader policy: NO is final, so it must be prefix-monotone

A `LineStream` over a capped stream is a true prefix except for its last line. Tests that succeed on a prefix (`startsWith`, fixed offsets) stay safe; tests that fail on a cut line (`equals`, length, numeric parse, missing next line) must fall through to UNKNOWN. `GROFileReader` was the only reader returning NO from such tests; it now returns UNKNOWN. The other 17 sniffers were audited and are unchanged (documented in `objreader-content-sniff.md`, including the known `equals()` YES sites in MOL2 / PLY).

### `LineStream::readLine` linear scan (`src/qlib/LineStream.cpp`)

`readLine` searched the whole buffer for the delimiter after every 2 KB block, so a delimiter-free run (minified JSON, base64 blob) was quadratic: fine at a 1 MiB cap, tens of seconds per reader at 16 MiB. It now scans only the appended bytes (`LString::indexOneOf(s, from)`), which is what makes the higher ceiling safe.

### tritium

`DEFAULT_SNIFF_CAP` becomes 16 MiB as the escalation ceiling; `pickReaderName` still maps 0 to the default so the worker never runs the no-ceiling mode. JSDoc that claimed the value was forwarded to `LoadObjectCommand.max_sniff_bytes` is corrected (`pickReaderName` calls `searchReaderByContent` directly).

### Tests

- `test_stream_manager_sniff_escalation.cpp` (new, 13 tests): scripted fake readers pin the budget sequence, the ceiling clamp, single-round conditions, final-vs-retry rules, round-major first-only, multi-match order and that gzip payloads are budgeted on decompressed bytes.
- `test_limited_in_stream.cpp` (+10), `test_line_stream.cpp` (new, 5, with a coarse timing guard for the linear scan), GRO / XPLOR / mmCIF / `LoadObjectCommand` sniff tests extended with 300 KB markers and ceilings, `pickReaderName.test.ts` pins the fifth argument.

### Docs

`docs/architecture/objreader-content-sniff.md`: contract rule 3, the round loop, budget / ceiling / cost figures, reader-layer and harness-layer decision tables, the linear-scan prerequisite; the stale 64 KB / `LoadObjectCommand` statements are fixed.

## Verification

- `task run_gtest`: 1431 / 1431 pass; `task build_tritium` OK; Vitest 3047 / 3047 pass; `tsc -p tsconfig.web.json` errors identical to `develop`.
- Manual (tritium): 5ire.cif / 7a6a.cif open by content; garbage and a delimiter-free multi-MB text file dropped on the app return "no reader" promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqVcMVzrg6zat5L4thEbXG
