### PR TITLE
fix(tritium): AO half-res presets, slider numerics, calmer busy cursor, paste in dialogs

### DIFF
--- a/tritium/react-gui/src/main/menuBlock.ts
+++ b/tritium/react-gui/src/main/menuBlock.ts
@@ -3,9 +3,18 @@
  * @description Modal-aware application-menu accelerator block machinery.
  *
  * When a Blueprint Dialog (or message box) is open in the renderer, or when
- * a native OS dialog is being shown from main, all application-menu items are
+ * a native OS dialog is being shown from main, application-menu items are
  * temporarily disabled so accelerators like Cmd+Q stop firing -- matching
  * UXP's XUL `openDialog(..., 'modal')` behaviour.
+ *
+ * The text-edit items are the one exception (`TEXT_EDIT_MENU_IDS`). They are
+ * declared as custom `ipcChannel` items rather than Electron roles (see
+ * `shared/menuTemplate.ts`), and on macOS the application menu owns the
+ * Cmd+X/C/V/A/Z key equivalents outright -- Chromium does not paste into a
+ * renderer input by itself. Disabling them therefore left every dialog's text
+ * field unable to cut, copy, paste, select-all or undo. They stay enabled
+ * through a block; the renderer keeps them confined to the focused field for
+ * the duration (see `contexts/ModalOpenCounterContext.tsx`).
  *
  * Multiple block sources are reference-counted via `blockReasons`. The
  * snapshot captures each item's `enabled` value at the moment we enter the
@@ -22,6 +31,19 @@
 
 import { Menu } from 'electron'
 import type { MenuItem } from 'electron'
+
+/**
+ * Menu item ids spared by a block, so text editing keeps working inside a
+ * modal dialog. Keep in sync with the ids in `shared/menuTemplate.ts`.
+ */
+export const TEXT_EDIT_MENU_IDS: ReadonlySet<string> = new Set([
+  'cut',
+  'copy',
+  'paste',
+  'select-all',
+  'undo',
+  'redo',
+])
 
 /** Distinct block sources, each ref-counted independently. */
 export type MenuBlockReason = 'blueprint' | 'native'
@@ -76,7 +98,11 @@ function totalBlockCount(): number {
   return total
 }
 
-/** Disable every menu item, snapshotting their current `enabled` values. */
+/**
+ * Disable every menu item except the text-edit ones, snapshotting the
+ * disabled items' current `enabled` values. Spared items are left untouched
+ * (and out of the snapshot), so a later `updateMenuState()` still owns them.
+ */
 export function applyBlock(): void {
   const menu = Menu.getApplicationMenu()
   if (!menu) return
@@ -84,6 +110,7 @@ export function applyBlock(): void {
   const snap = new Map<MenuItem, boolean>()
   walkMenuItems(menu, (item) => {
     if (item.type === 'separator') return
+    if (item.id && TEXT_EDIT_MENU_IDS.has(item.id)) return
     snap.set(item, item.enabled)
     item.enabled = false
   })

--- a/tritium/react-gui/src/renderer/__test__/dsurfaceRendererSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dsurfaceRendererSection.test.tsx
@@ -9,8 +9,8 @@
  *   - the registry resolves `type_name === "dsurface"` to two default-expanded
  *     sections (Surface / Atom radii);
  *   - each row renders only when its property exists;
- *   - "Detail" uses the plain inline stepper NumericField (no slider, no drag
- *     arrows) and commits a single-step integer `onSet`;
+ *   - "Detail" is a SliderField row (slider + number box, no drag arrows) and
+ *     commits a single-step integer `onSet`;
  *   - a drag-numeric row (Line/Point size) commits a plain single step (no
  *     realtime opts);
  *   - the "Line/Point size" row is disabled while draw mode is "fill";
@@ -161,7 +161,7 @@ describe('DSurfaceMainSection', () => {
     unmount()
   })
 
-  it('renders Detail as a stepper NumericField (no slider, no drag arrows)', () => {
+  it('renders Detail as a slider field (sweepable density, no drag arrows)', () => {
     const { container, unmount } = mountTree(
       <DSurfaceMainSection
         entries={mainEntries()}
@@ -172,13 +172,14 @@ describe('DSurfaceMainSection', () => {
       />,
     )
     const detail = rowByLabel(container, 'Detail')!
-    expect(detail.querySelector('.h3-form-numeric-row')).not.toBeNull()
-    expect(detail.querySelector('.h3-form-slider')).toBeNull()
+    expect(detail.querySelector('.h3-form-sliderfield-row')).not.toBeNull()
+    expect(detail.querySelector('.h3-form-sliderfield-slider')).not.toBeNull()
+    expect(detail.querySelector('.h3-form-sliderfield-number')).not.toBeNull()
     expect(dragArrow(detail)).toBeNull()
     unmount()
   })
 
-  it('commits Detail as a single-step integer on Enter', () => {
+  it('commits a typed Detail as a single-step integer on blur', () => {
     const onSet = vi.fn()
     const { container, unmount } = mountTree(
       <DSurfaceMainSection
@@ -189,11 +190,13 @@ describe('DSurfaceMainSection', () => {
         nodeId={2}
       />,
     )
-    const input = rowByLabel(container, 'Detail')!.querySelector('input') as HTMLInputElement
+    const input = rowByLabel(container, 'Detail')!.querySelector(
+      '.h3-form-sliderfield-number',
+    ) as HTMLInputElement
     act(() => typeInto(input, '8'))
-    act(() =>
-      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })),
-    )
+    // SliderField holds the keystrokes locally and commits on blur (Enter
+    // blurs the input), so focusout is the commit edge.
+    act(() => input.dispatchEvent(new FocusEvent('focusout', { bubbles: true })))
     expect(onSet).toHaveBeenCalledWith('detail', 'integer', 8)
     unmount()
   })

--- a/tritium/react-gui/src/renderer/__test__/editClipboard.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/editClipboard.test.ts
@@ -10,7 +10,9 @@
  *     (the menu takes DOM focus, which is why the "last scope" memory
  *     exists at all);
  *   - undo/redo report back whether they were handled, so the caller knows
- *     when to fall through to the scene-level undo.
+ *     when to fall through to the scene-level undo;
+ *   - while a modal dialog is open the keystroke stays in the dialog: it
+ *     never reaches a panel behind it, and Cmd+Z never rewinds the scene.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { IPC } from '../../shared/ipcChannels'
@@ -21,6 +23,7 @@ import {
   installClipboardScopeTracking,
   isEditableFocused,
   registerClipboardScope,
+  setClipboardModalOpen,
 } from '../utils/editClipboard'
 import { setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
 
@@ -207,5 +210,44 @@ describe('dispatchEditUndoRedo', () => {
     expect(dispatchEditUndoRedo('undo')).toBe(false)
     expect(dispatchEditUndoRedo('redo')).toBe(false)
     expect(nativeCalls()).toEqual([])
+  })
+})
+
+// A modal owns the keystroke. Without this the "last scope" memory (which
+// survives a menu click by design) would let Cmd+V inside a dialog paste into
+// the panel the user was in before opening it.
+describe('editClipboard -- while a modal dialog is open', () => {
+  it('routes clipboard actions to the native edit, not the last scope', () => {
+    const scope = makeScope()
+    _resetClipboardScopesForTest()
+    registerClipboardScope('scene-tree', scope)
+    pointerDown(mountScope('scene-tree'))
+    setClipboardModalOpen(true)
+
+    dispatchEditClipboard('paste')
+
+    expect(scope.paste).not.toHaveBeenCalled()
+    expect(api.invoke).toHaveBeenCalledWith(IPC.TEXT_CTX_ACTION, 'paste')
+  })
+
+  it('reports undo/redo as handled so the scene undo never runs', () => {
+    setClipboardModalOpen(true)
+    // No text field focused: outside a modal this would fall through (false).
+    expect(dispatchEditUndoRedo('undo')).toBe(true)
+    expect(api.invoke).toHaveBeenCalledWith(IPC.TEXT_CTX_ACTION, 'undo')
+  })
+
+  it('restores normal panel routing once the modal closes', () => {
+    const scope = makeScope()
+    _resetClipboardScopesForTest()
+    registerClipboardScope('scene-tree', scope)
+    pointerDown(mountScope('scene-tree'))
+
+    setClipboardModalOpen(true)
+    setClipboardModalOpen(false)
+    dispatchEditClipboard('paste')
+
+    expect(scope.paste).toHaveBeenCalledTimes(1)
+    expect(dispatchEditUndoRedo('undo')).toBe(false)
   })
 })

--- a/tritium/react-gui/src/renderer/__test__/menuBlock.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/menuBlock.test.ts
@@ -133,7 +133,9 @@ function installEnabledMenu(): FakeMenu {
     Object.assign(new FakeMenuItem('view-perspective'), { enabled: true }),
     Object.assign(new FakeMenuItem('view-orthographic'), { enabled: true }),
     new FakeMenuItem('sep', 'separator'),
+    // Text-edit items: spared by a block so dialogs can still edit text.
     Object.assign(new FakeMenuItem('undo'), { enabled: true }),
+    Object.assign(new FakeMenuItem('paste'), { enabled: true }),
   ])
   setApplicationMenu(menu as unknown as never)
   return menu
@@ -157,7 +159,6 @@ describe('menu block machinery (main side)', () => {
     // 0 -> 1: disable all and snapshot
     setMenuBlocked('blueprint', true)
     expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
-    expect(menu.getMenuItemById('undo')!.enabled).toBe(false)
 
     // 1 -> 2: same reason again; still blocked, idempotent on the items
     setMenuBlocked('blueprint', true)
@@ -166,12 +167,24 @@ describe('menu block machinery (main side)', () => {
     // 2 -> 1: still blocked; items NOT yet restored
     setMenuBlocked('blueprint', false)
     expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
-    expect(menu.getMenuItemById('undo')!.enabled).toBe(false)
 
     // 1 -> 0: last decrement restores the snapshotted enabled values
     setMenuBlocked('blueprint', false)
     expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(true)
     expect(menu.getMenuItemById('view-orthographic')!.enabled).toBe(true)
+  })
+
+  // On macOS the application menu owns Cmd+X/C/V/A/Z, so blocking these would
+  // leave a modal dialog's text fields unable to paste at all.
+  it('(a) text-edit items stay enabled through a block', () => {
+    const menu = installEnabledMenu()
+
+    setMenuBlocked('blueprint', true)
+    expect(menu.getMenuItemById('paste')!.enabled).toBe(true)
+    expect(menu.getMenuItemById('undo')!.enabled).toBe(true)
+    // ... and are not touched on the way out either.
+    setMenuBlocked('blueprint', false)
+    expect(menu.getMenuItemById('paste')!.enabled).toBe(true)
     expect(menu.getMenuItemById('undo')!.enabled).toBe(true)
   })
 
@@ -218,13 +231,13 @@ describe('menu block machinery (main side)', () => {
 
     setMenuBlocked('blueprint', true)
     // While blocked, updateMenuState must not mutate the live menu.
-    updateMenuState({ undo: { enabled: true }, redo: { enabled: true } })
-    // (undo item was disabled by the block; the guard prevents re-enabling)
-    expect(menu.getMenuItemById('undo')!.enabled).toBe(false)
+    updateMenuState({ viewProjection: { enabled: true, perspective: true } })
+    // (the item was disabled by the block; the guard prevents re-enabling)
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
 
     setMenuBlocked('blueprint', false)
     // After unblock the renderer re-emits; updateMenuState now applies.
-    updateMenuState({ undo: { enabled: true } })
-    expect(menu.getMenuItemById('undo')!.enabled).toBe(true)
+    updateMenuState({ viewProjection: { enabled: true, perspective: true } })
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(true)
   })
 })

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderingSection.test.tsx
@@ -54,6 +54,7 @@ import {
   SCENE_AA_QUALITY_AXIS,
   sceneStepOf,
 } from '../data/sceneQualityPresets'
+import { RENDER_QUALITY_CUSTOM } from '../data/renderSettings'
 import { getRendererPropSections } from '../components/inspector/rendererPropSections'
 import { PropertiesTab } from '../components/inspector/PropertiesTab'
 
@@ -204,6 +205,30 @@ describe('Scene quality presets', () => {
     expect(sceneStepOf(SCENE_AO_PRESET_AXIS, read(entries))).toBe('low')
   })
 
+  // The costlier AO rungs take the adaptive half-resolution path so tumbling
+  // stays responsive; Low stays full-res (and must, to match the C++ default).
+  it('AO presets drive aoHalfRes: off on Low, on from Medium up', () => {
+    const halfResOf = (id: string) =>
+      SCENE_AO_PRESET_AXIS.steps.find((s) => s.id === id)?.patch.aoHalfRes
+    expect(halfResOf('low')).toBe(false)
+    expect(halfResOf('medium')).toBe(true)
+    expect(halfResOf('high')).toBe(true)
+  })
+
+  it('a scene with Medium values but half-res off reads Custom', () => {
+    const entries = fullEntries().map((e) => {
+      if (e.key === 'aoRadius') return entry({ key: 'aoRadius', type: 'real', value: 8 })
+      if (e.key === 'aoSteps') return entry({ key: 'aoSteps', type: 'integer', value: 4 })
+      if (e.key === 'aoIntensity') return entry({ key: 'aoIntensity', type: 'real', value: 1.9 })
+      return e
+    })
+    expect(sceneStepOf(SCENE_AO_PRESET_AXIS, read(entries))).toBe(RENDER_QUALITY_CUSTOM)
+    const withHalfRes = entries.map((e) =>
+      e.key === 'aoHalfRes' ? entry({ key: 'aoHalfRes', type: 'boolean', value: true }) : e,
+    )
+    expect(sceneStepOf(SCENE_AO_PRESET_AXIS, read(withHalfRes))).toBe('medium')
+  })
+
   it('editing a prop outside the patch (aoSlices) keeps the AO preset step', () => {
     const entries = fullEntries().map((e) =>
       e.key === 'aoSlices' ? entry({ key: 'aoSlices', type: 'integer', value: 12 }) : e,
@@ -236,6 +261,7 @@ describe('Scene quality presets', () => {
       { key: 'aoRadius', valueType: 'real', value: 8 },
       { key: 'aoSteps', valueType: 'integer', value: 4 },
       { key: 'aoIntensity', valueType: 'real', value: 1.9 },
+      { key: 'aoHalfRes', valueType: 'boolean', value: true },
     ])
     expect(onSet).not.toHaveBeenCalled()
     unmount()

--- a/tritium/react-gui/src/renderer/__test__/useBusyCursor.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/useBusyCursor.test.tsx
@@ -3,14 +3,21 @@
  * document root as `data-busy="true"`, which is what the global wait-cursor
  * rule in styles/_base.css keys off. The attribute name and value are the wire
  * format between the hook and the stylesheet, so they are what is asserted.
+ *
+ * The rising edge is delayed (the pointer is the most intrusive busy signal,
+ * so a short operation must not flip it) while the falling edge is immediate;
+ * both edges are pinned here with fake timers.
  */
 
 import React from 'react'
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { act } from 'react'
 import { mountTree } from './helpers/testHarness'
 import { useBusyCursor } from '../hooks/useBusyCursor'
 void React
+
+/** Longer than the hook's rising-edge delay, so the cursor has settled. */
+const AFTER_DELAY_MS = 1000
 
 const Probe: React.FC<{ busy: boolean }> = ({ busy }) => {
     useBusyCursor(busy)
@@ -22,7 +29,12 @@ function busyAttr(): string | null {
 }
 
 describe('useBusyCursor', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
     afterEach(() => {
+        vi.useRealTimers()
         document.documentElement.removeAttribute('data-busy')
     })
 
@@ -31,9 +43,27 @@ describe('useBusyCursor', () => {
         expect(busyAttr()).toBeNull()
 
         act(() => root.render(<Probe busy={true} />))
+        act(() => void vi.advanceTimersByTime(AFTER_DELAY_MS))
         expect(busyAttr()).toBe('true')
 
+        // Falling edge is immediate -- no timer to advance.
         act(() => root.render(<Probe busy={false} />))
+        expect(busyAttr()).toBeNull()
+
+        unmount()
+    })
+
+    // A burst of short worker calls must not flicker the pointer: the busy
+    // flag has to stay up past the delay before the cursor changes at all.
+    it('does not set data-busy for a wait shorter than the rising-edge delay', () => {
+        const { root, unmount } = mountTree(<Probe busy={false} />)
+
+        act(() => root.render(<Probe busy={true} />))
+        act(() => void vi.advanceTimersByTime(100))
+        expect(busyAttr()).toBeNull()
+
+        act(() => root.render(<Probe busy={false} />))
+        act(() => void vi.advanceTimersByTime(AFTER_DELAY_MS))
         expect(busyAttr()).toBeNull()
 
         unmount()
@@ -41,6 +71,7 @@ describe('useBusyCursor', () => {
 
     it('clears data-busy when unmounted while still busy', () => {
         const { unmount } = mountTree(<Probe busy={true} />)
+        act(() => void vi.advanceTimersByTime(AFTER_DELAY_MS))
         expect(busyAttr()).toBe('true')
 
         unmount()

--- a/tritium/react-gui/src/renderer/components/dialogs/MakeMolSurfDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/MakeMolSurfDialog.tsx
@@ -22,7 +22,7 @@
 import React, { useEffect, useState } from 'react'
 import { useCueMol } from '../../hooks/useCueMol'
 import { useMolEditCommit } from '../../hooks/useMolEditCommit'
-import { CheckboxField, Field, FieldSection, NumericField, SelectField, SliderField, TextField } from '../../h3-kit/form'
+import { CheckboxField, Field, FieldSection, SelectField, SliderField, TextField } from '../../h3-kit/form'
 import { DialogShell } from './DialogShell'
 import { MolPicker } from './MolPicker'
 import { MolSelList } from '../../h3-kit/MolSelList/MolSelList'
@@ -173,17 +173,15 @@ export function MakeMolSurfDialog({
                             onCommit={setDensity}
                             disabled={submitting}
                         />
-                        <Field label="Probe radius (A)">
-                            <NumericField
-                                value={probeRadius}
-                                onChange={setProbeRadius}
-                                min={0.1}
-                                max={10}
-                                step={0.1}
-                                slider={false}
-                                disabled={submitting}
-                            />
-                        </Field>
+                        <SliderField
+                            label="Probe radius (A)"
+                            value={probeRadius}
+                            min={0.1}
+                            max={10}
+                            step={0.1}
+                            onCommit={setProbeRadius}
+                            disabled={submitting}
+                        />
                         <Field label="Algorithm">
                             <SelectField
                                 value={backend}

--- a/tritium/react-gui/src/renderer/components/inspector/DSurfaceRendererSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/DSurfaceRendererSection.tsx
@@ -22,13 +22,14 @@
  * property is absent (mirroring the UXP `findPropData` null checks).
  *
  * Per request: drag-numeric rows commit on drag end / Enter (no realtime
- * preview), and "Detail" uses the plain inline stepper, not a slider.
+ * preview), and "Detail" -- the surface tessellation density, the knob users
+ * sweep to trade smoothness against build time -- is a slider.
  */
 
 import React from "react";
 import {
   NumRow,
-  NumInputRow,
+  SliderRow,
   MappedEnumRow,
 } from "./RendererCommonSection";
 import type { GenericPropEntry } from "../../worker/server/services/genericProps.service";
@@ -51,7 +52,7 @@ const SURFTYPE_LABELS: Record<string, string> = {
  * "Surface" section: the UXP MolSurf "Draw" groupbox. Drawing mode, line / point
  * size, surface type and tessellation detail, in the UXP row order. The size row
  * is disabled while the draw mode is "fill" (a filled mesh has no line / point
- * width); "Detail" uses the plain inline stepper.
+ * width); "Detail" is a slider so the density range can be swept.
  */
 export const DSurfaceMainSection: React.FC<RendererPropSectionProps> = ({
   entries,
@@ -102,8 +103,7 @@ export const DSurfaceMainSection: React.FC<RendererPropSectionProps> = ({
         />
       )}
       {detail && (
-        <NumInputRow
-          key={`detail:${detail.value}`}
+        <SliderRow
           entry={detail}
           label="Detail"
           onSet={onSet}

--- a/tritium/react-gui/src/renderer/components/inspector/RendererCommonSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/RendererCommonSection.tsx
@@ -25,6 +25,7 @@ import {
   SelectField,
   DragNumericField,
   NumericField,
+  SliderField,
   SwitchField,
   ColorField,
 } from "../../h3-kit/form";
@@ -268,6 +269,57 @@ export const NumInputRow: React.FC<NumInputRowProps> = ({
         step={step}
         unit={unit}
         disabled={disabled || entry.readonly}
+      />
+    </PropertyField>
+  );
+};
+
+interface SliderRowProps extends RowProps {
+  min: number;
+  max: number;
+  step?: number;
+  unit?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Numeric row backed by `SliderField`: label + slider + number box + stepper.
+ * Use it for a bounded property whose whole range is meaningful to sweep (a
+ * tessellation density, an intensity), where dragging the track is the fastest
+ * way to find a value; use `NumInputRow` when only the stepper makes sense.
+ *
+ * `SliderField` owns the commit timing (slider release / blur / Enter /
+ * stepper click) and resyncs its draft from `value`, so no value-keyed remount
+ * is needed here. The visible label and the reset affordance come from
+ * `PropertyField`, so the field's own label is hidden and serves only as the
+ * accessible name.
+ */
+export const SliderRow: React.FC<SliderRowProps> = ({
+  entry,
+  label,
+  onSet,
+  onReset,
+  min,
+  max,
+  step,
+  unit,
+  disabled,
+}) => {
+  const committed = Number(entry.value);
+  return (
+    <PropertyField label={label} {...resetProps(entry, onReset)}>
+      <SliderField
+        label={label}
+        hideLabel
+        value={committed}
+        min={min}
+        max={max}
+        step={step}
+        unit={unit}
+        disabled={disabled || entry.readonly}
+        onCommit={(v) => {
+          if (v !== committed) onSet(entry.key, entry.type, v);
+        }}
       />
     </PropertyField>
   );

--- a/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/SceneRenderingSection.tsx
@@ -92,11 +92,11 @@ const QualityRow: React.FC<{
 
 /**
  * Ambient occlusion (GTAO): enable toggle, a look-preset dropdown (radius /
- * steps / intensity as one tuned set, see `SCENE_AO_PRESET_AXIS`). The
- * individual tuning knobs (aoRadius / aoIntensity / aoSlices / aoSteps /
- * aoHalfRes) are deliberately NOT surfaced here -- they remain editable in
- * the generic property tree, where edits reflect back into this dropdown as
- * "Custom". The preset is disabled while AO is off.
+ * steps / intensity / half-res as one tuned set, see `SCENE_AO_PRESET_AXIS`).
+ * The individual tuning knobs (aoRadius / aoIntensity / aoSlices / aoSteps /
+ * aoHalfRes) are deliberately NOT surfaced as their own rows here -- they
+ * remain editable in the generic property tree, where edits reflect back into
+ * this dropdown as "Custom". The preset is disabled while AO is off.
  */
 export const SceneAmbientOcclusionSection: React.FC<RendererPropSectionProps> = ({
   entries,

--- a/tritium/react-gui/src/renderer/contexts/ModalOpenCounterContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/ModalOpenCounterContext.tsx
@@ -6,10 +6,18 @@
  * while a modal is up); the 1 -> 0 transition re-enables it. Mirrors the UXP
  * behaviour where XUL modal dialogs implicitly suppress parent-window menu
  * accelerators.
+ *
+ * The block deliberately spares the text-edit items (see `TEXT_EDIT_MENU_IDS`
+ * in `main/menuBlock.ts`): on macOS the menu owns the Cmd+X/C/V/A/Z key
+ * equivalents, so disabling them would leave a dialog's text fields with no
+ * way to paste at all. The same edges therefore also tell the renderer-side
+ * clipboard router that a modal is up, so those keystrokes stay confined to
+ * the focused field instead of reaching a panel behind the dialog.
  */
 
 import React, { createContext, useCallback, useContext, useRef } from 'react'
 import { IPC } from '../../shared/ipcChannels'
+import { setClipboardModalOpen } from '../utils/editClipboard'
 
 interface ModalOpenCounter {
   inc: () => void
@@ -25,6 +33,7 @@ export const ModalOpenCounterProvider: React.FC<{ children: React.ReactNode }> =
   const countRef = useRef(0)
 
   const notify = useCallback((blocked: boolean) => {
+    setClipboardModalOpen(blocked)
     const api = window.electronAPI
     if (!api) return
     api.invoke(IPC.MENU_SET_MODAL_BLOCKED, blocked).catch((err: unknown) => {

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -74,17 +74,17 @@ const UMBREON_PROPS: PropDef[] = [
   // --- Ambient Occlusion (off by default via the aoEnabled switch, like
   //     Shadows/GI; the backend maps aoEnabled=false to aoSamples 0) ---
   { key: "aoEnabled",     label: "Enable AO",          type: "boolean", value: false, group: "Ambient Occlusion" },
-  { key: "aoSamples",     label: "AO samples",         type: "integer", value: 64,   group: "Ambient Occlusion", min: 1, max: 256, step: 8 },
+  { key: "aoSamples",     label: "AO samples",         type: "integer", value: 64,   group: "Ambient Occlusion", min: 1, max: 256, step: 8, slider: true },
   // 0 = auto: libcuemol2 derives the radius from the scene bounding box, so AO
   // strength does not depend on how large the molecule is. A positive value
   // overrides it with a fixed world radius.
-  { key: "aoDistance",    label: "AO distance (0 = auto)", type: "real", value: 0,   group: "Ambient Occlusion", min: 0, max: 1000, step: 10 },
-  { key: "aoIntensity",   label: "AO intensity",       type: "real",    value: 1.0,  group: "Ambient Occlusion", min: 0, max: 1,    step: 0.1 },
+  { key: "aoDistance",    label: "AO distance (0 = auto)", type: "real", value: 0,   group: "Ambient Occlusion", min: 0, max: 1000, step: 10, slider: true },
+  { key: "aoIntensity",   label: "AO intensity",       type: "real",    value: 1.0,  group: "Ambient Occlusion", min: 0, max: 1,    step: 0.1, slider: true },
   // AO quality recipe (umbreon quality_presets.md section 2a). aoDiffuseFactor
   // defaults to the recipe value 1.0, NOT umbreon's 0.0: with CueMol's default
   // lighting most energy is direct, and AO at 0 darkens only the ambient term,
   // so it would be all but invisible.
-  { key: "aoDiffuseFactor", label: "AO on direct light", type: "real",  value: 1.0,  group: "Ambient Occlusion", min: 0, max: 1, step: 0.1 },
+  { key: "aoDiffuseFactor", label: "AO on direct light", type: "real",  value: 1.0,  group: "Ambient Occlusion", min: 0, max: 1, step: 0.1, slider: true },
   { key: "aoMultiScale",  label: "Multi-scale AO",     type: "boolean", value: true, group: "Ambient Occlusion" },
   { key: "aoBentNormal",  label: "Bent normal",        type: "boolean", value: true, group: "Ambient Occlusion" },
   { key: "aoLowDiscrepancy", label: "Low-discrepancy sampling", type: "boolean", value: true, group: "Ambient Occlusion" },

--- a/tritium/react-gui/src/renderer/data/sceneQualityPresets.ts
+++ b/tritium/react-gui/src/renderer/data/sceneQualityPresets.ts
@@ -16,6 +16,12 @@
  *   aoIntensity falls to keep large radii from crushing the image to black.
  *   aoSlices is deliberately absent: it barely changes the denoised image
  *   (and gtao_frag.glsl clamps it to 16).
+ * - aoHalfRes rides along with that cost: Medium and High raise the per-pixel
+ *   AO work, so they take the adaptive half-resolution path (half-res only
+ *   while the camera moves, full res once it settles, always full res for
+ *   off-screen export) to keep tumbling responsive. Low is cheap enough to
+ *   stay full resolution, which is also the C++ default the default step must
+ *   match.
  */
 import { RENDER_QUALITY_CUSTOM } from "./renderSettings";
 import type { RenderQualityAxis } from "./renderSettings";
@@ -27,9 +33,9 @@ export const SCENE_AO_PRESET_AXIS: RenderQualityAxis = {
   defaultStep: "low",
   steps: [
     // = C++ defaults (Scene.qif)
-    { id: "low", label: "Low", patch: { aoRadius: 4, aoSteps: 3, aoIntensity: 2.2 } },
-    { id: "medium", label: "Medium", patch: { aoRadius: 8, aoSteps: 4, aoIntensity: 1.9 } },
-    { id: "high", label: "High", patch: { aoRadius: 12, aoSteps: 5, aoIntensity: 1.7 } },
+    { id: "low", label: "Low", patch: { aoRadius: 4, aoSteps: 3, aoIntensity: 2.2, aoHalfRes: false } },
+    { id: "medium", label: "Medium", patch: { aoRadius: 8, aoSteps: 4, aoIntensity: 1.9, aoHalfRes: true } },
+    { id: "high", label: "High", patch: { aoRadius: 12, aoSteps: 5, aoIntensity: 1.7, aoHalfRes: true } },
   ],
 };
 

--- a/tritium/react-gui/src/renderer/hooks/useBusyCursor.ts
+++ b/tritium/react-gui/src/renderer/hooks/useBusyCursor.ts
@@ -12,12 +12,28 @@
  * The hook takes `busy` as a parameter instead of calling `useCueMolBusy()`
  * itself: every `useCueMolBusy()` call opens its own worker subscription and
  * its own debounce timer, so App passes down the single value it already has.
+ *
+ * On top of that shared debounce the cursor waits again (see
+ * `CURSOR_RISING_EDGE_DELAY_MS`). The pointer sits under the user's hand and
+ * swapping it mid-interaction is the most intrusive busy signal we have, so it
+ * should appear only for waits long enough to be worth interrupting for --
+ * a higher bar than the status-bar pill, which is passive and can flip sooner.
  */
 
 import { useEffect } from 'react';
 
 /** Attribute set on `<html>` while the worker is busy. */
 const BUSY_ATTR = 'data-busy';
+
+/**
+ * Extra rising-edge delay before the wait cursor appears, on top of the
+ * debounce already applied by `useCueMolBusy`. Sized so that operations that
+ * finish in roughly half a second never flip the pointer: those read as
+ * instantaneous, and a cursor that blinks to "wait" and straight back is more
+ * distracting than no feedback at all. The falling edge stays immediate --
+ * the cursor is restored the moment the work ends.
+ */
+const CURSOR_RISING_EDGE_DELAY_MS = 400;
 
 /**
  * Apply/remove the global busy cursor.
@@ -28,10 +44,13 @@ export function useBusyCursor(busy: boolean): void {
     useEffect(() => {
         if (!busy) return;
         const root = document.documentElement;
-        root.setAttribute(BUSY_ATTR, 'true');
-        // Runs both when busy falls back to false and on unmount, so the
-        // attribute can never be left stuck on.
+        const timer = setTimeout(() => {
+            root.setAttribute(BUSY_ATTR, 'true');
+        }, CURSOR_RISING_EDGE_DELAY_MS);
+        // Runs both when busy falls back to false and on unmount, so a pending
+        // timer never fires late and the attribute can never be left stuck on.
         return () => {
+            clearTimeout(timer);
             root.removeAttribute(BUSY_ATTR);
         };
     }, [busy]);

--- a/tritium/react-gui/src/renderer/utils/editClipboard.ts
+++ b/tritium/react-gui/src/renderer/utils/editClipboard.ts
@@ -25,6 +25,14 @@
  *
  * Register a panel with `useClipboardScope` and tag its container with the
  * matching `data-clipboard-scope` attribute.
+ *
+ * While a modal dialog is open the routing collapses to step 1: a modal owns
+ * the keystroke, so Cmd+X/C/V must edit the text field the user is in and
+ * must never reach a panel behind the dialog (the last-scope memory of step 3
+ * would otherwise let a stray Cmd+V paste into the scene tree). Undo / Redo
+ * collapse the same way -- inside a modal they are the field's undo, never
+ * the scene's. `ModalOpenCounterProvider` drives this via
+ * `setClipboardModalOpen`.
  */
 
 import { IPC } from '../../shared/ipcChannels'
@@ -44,6 +52,19 @@ const scopes = new Map<string, ClipboardScopeHandlers>()
 /** Id of the scope the user last interacted with; see the file header. */
 let lastScopeId: string | null = null
 
+/** Whether a modal dialog is open; see the file header. */
+let modalOpen = false
+
+/**
+ * Tell the router whether a modal dialog is up. Called from
+ * `ModalOpenCounterProvider` on the 0 <-> 1 edges.
+ *
+ * @param open - true while at least one modal is open.
+ */
+export function setClipboardModalOpen(open: boolean): void {
+  modalOpen = open
+}
+
 /**
  * Register a panel's clipboard handlers under `id`.
  * @returns an unregister function.
@@ -59,10 +80,11 @@ export function registerClipboardScope(
   }
 }
 
-/** Test seam: forget every registration and the last-scope memory. */
+/** Test seam: forget every registration, the last-scope memory and the modal flag. */
 export function _resetClipboardScopesForTest(): void {
   scopes.clear()
   lastScopeId = null
+  modalOpen = false
 }
 
 /** Test seam: the handlers registered under `id`, if any. */
@@ -155,6 +177,11 @@ export function dispatchEditClipboard(action: ClipboardAction): void {
     runNativeEdit(action)
     return
   }
+  // A modal owns the keystroke: never let a panel behind the dialog answer.
+  if (modalOpen) {
+    runNativeEdit(action)
+    return
+  }
   const scope = resolveScope()
   const handler = scope?.[action]
   if (handler) {
@@ -170,10 +197,13 @@ export function dispatchEditClipboard(action: ClipboardAction): void {
  * Route Undo / Redo.
  *
  * @returns true when the action was handled natively (focus is in a text
- *   field), false when the caller should run the scene-level undo instead.
+ *   field, or a modal is open), false when the caller should run the
+ *   scene-level undo instead.
  */
 export function dispatchEditUndoRedo(action: 'undo' | 'redo'): boolean {
-  if (!isEditableFocused()) return false
+  // Inside a modal, Cmd+Z is the field's undo -- rewinding the scene behind a
+  // dialog the user is still filling in would be a surprise they cannot see.
+  if (!isEditableFocused() && !modalOpen) return false
   runNativeEdit(action)
   return true
 }


### PR DESCRIPTION
Four independent GUI fixes, one commit each.

## AO presets take the half-res path from Medium up

The AO look ladder raises `aoRadius` and `aoSteps` together, so Medium and High cost noticeably more per pixel than Low while the camera moves. `aoHalfRes` now rides along with that cost: Medium and High compute the AO term at half resolution during a tumble and re-render at full resolution once the view settles (off-screen export is always full res).

The axis contracts fix the shape of the patch — every step writes the same keys, and the default step must equal the C++ defaults or a fresh scene reads as `Custom` — so Low carries `aoHalfRes: false` explicitly, matching `Scene.qif`.

## Slider numerics

Bounded values whose whole range is worth sweeping:

| Where | Setting | Was |
|---|---|---|
| Render settings → Ambient Occlusion | `aoSamples`, `aoDistance`, `aoIntensity`, `aoDiffuseFactor` | `DragNumericField` |
| Inspector → dsurface / dsurf2 → Surface | "Detail" (tessellation density) | stepper `NumericField` |
| Make MolSurf dialog | Probe radius | stepper `NumericField` |

The AO rows are a data-only change (`slider: true` on the `PropDef`) — `NumericEditor` already renders a `SliderField` when a PropDef asks for one, and the Antialiasing group's `supersample` was already a slider. "Detail" needed a new `SliderRow` helper next to `NumInputRow` rather than a change to it, because six other sections share that helper. Point density in the surface dialogs was already a slider (#f69a7118); the probe radius joins it so the dialog no longer mixes both styles.

## Calmer busy cursor

The wait cursor fired on the shared 150 ms debounce, so calls that finish in a blink flipped the pointer and flipped it back — a flicker rather than feedback. The cursor now has its own 400 ms rising-edge delay on top of that debounce (≈550 ms total). The status-bar pill is passive and keeps the shorter delay; the falling edge stays immediate.

## Cut / copy / paste inside modal dialogs (macOS)

**The bug as reported:** Cmd-V does nothing in the Get PDB dialog's PDB ID box.

**Root cause, and it is not that dialog.** Opening any `createDialogHook` dialog disables *every* application-menu item so stray accelerators (Cmd+Q) cannot fire. But the clipboard items are custom `ipcChannel` entries rather than Electron roles, and on macOS the application menu owns the Cmd+X/C/V/A/Z key equivalents outright — Chromium does not paste into a renderer input by itself. With the items disabled there is no fallback at all, so this was broken in the text fields of **all ~30 dialogs**, not just Get PDB. Only the right-click menu worked, because that one uses a real `role: 'paste'`.

The fix spares the text-edit ids from the block, and confines those keystrokes to the focused field while a modal is up. That second half matters: the last-scope memory deliberately survives a menu click, so without the guard a Cmd+V inside a dialog could paste into the scene tree behind it. Undo/redo are pinned to the field's own undo the same way, so Cmd+Z cannot rewind a scene the user cannot see.

## Verification

- `task build_tritium` OK; `task run_tritium` reaches `launch worker OK` → `INITIALIZED` → `bindCanvas` → `shader program created OK`.
- Vitest 3054/3054 pass (322 files). `tsc -p tsconfig.web.json` matches the `develop` baseline exactly; `tsconfig.node.json` is clean.
- `lint:style` / `lint:comments` fail identically before and after this branch (14 style, 2 comment glyphs) — no new violations.
- Manually confirmed in the app.

Test follow-ups: `menuBlock`'s fixture used `undo` as its "gets disabled" example and needed a non-spared item; the dsurf Detail commit test moved from Enter to the SliderField blur edge. New pins cover the per-rung `aoHalfRes` values, modal-scoped clipboard routing, and the cursor's rising-edge delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqVcMVzrg6zat5L4thEbXG
