### PR TITLE
fix(mdtools): unwrap GRO residue numbers past the %5d rollover

### DIFF
--- a/src/modules/mdtools/GROFileReader.cpp
+++ b/src/modules/mdtools/GROFileReader.cpp
@@ -37,6 +37,12 @@ constexpr int GRO_DEFAULT_POS_WIDTH = 8;
 // Minimum length for a valid atom line: prefix + 3 standard position fields
 constexpr int GRO_MIN_ATOM_LINE_LEN = GRO_PREFIX_LEN + 3 * GRO_DEFAULT_POS_WIDTH;
 
+// The residue number is written as %5d, so it wraps around at 100000.
+constexpr int GRO_RESID_MODULO = 100000;
+
+// Upper bound on the per-file skipped-atom warnings written to the log.
+constexpr int GRO_MAX_WARN = 10;
+
 LString stripLineEnd(const LString &line)
 {
   return line.trim("\r\n");
@@ -46,7 +52,8 @@ LString stripLineEnd(const LString &line)
 
 GROFileReader::GROFileReader()
     : m_lineno(0), m_nDeclAtoms(0), m_nReadAtoms(0),
-      m_nPosWidth(GRO_DEFAULT_POS_WIDTH), m_curChain("A")
+      m_nPosWidth(GRO_DEFAULT_POS_WIDTH), m_curChain("A"), m_nResidOffset(0),
+      m_nPrevResid(0), m_bHasPrevResid(false), m_nSkipAtoms(0)
 {
 }
 
@@ -132,6 +139,10 @@ bool GROFileReader::read(qlib::InStream &ins)
   m_nPosWidth = GRO_DEFAULT_POS_WIDTH;
   m_title = LString();
   m_curChain = LString("A");
+  m_nResidOffset = 0;
+  m_nPrevResid = 0;
+  m_bHasPrevResid = false;
+  m_nSkipAtoms = 0;
 
   try {
     qlib::LineStream lin(ins);
@@ -159,6 +170,12 @@ bool GROFileReader::read(qlib::InStream &ins)
   }
 
   LOG_DPRINTLN("GROFileReader> read %d atoms", m_nReadAtoms);
+  if (m_nSkipAtoms > 0) {
+    LOG_DPRINTLN("GROFileReader> Warning: %d atom(s) skipped (duplicated in the "
+                 "same residue); the atom count no longer matches the file, so "
+                 "trajectory (xtc/trr/dcd) attachment will fail",
+                 m_nSkipAtoms);
+  }
 
   m_pMol = MolCoordPtr();
   return true;
@@ -191,7 +208,11 @@ bool GROFileReader::readFrame(qlib::LineStream &lin)
     return false;
   }
 
-  // Atom lines.
+  // Atom lines. The residue unwrapping state is per frame.
+  m_nResidOffset = 0;
+  m_nPrevResid = 0;
+  m_bHasPrevResid = false;
+
   for (int i = 0; i < m_nDeclAtoms; ++i) {
     if (!lin.ready()) {
       MB_THROW(GROFileFormatException,
@@ -204,8 +225,7 @@ bool GROFileReader::readFrame(qlib::LineStream &lin)
     if (i == 0) {
       determineFieldLayout(line);
     }
-    parseAtomLine(line);
-    ++m_nReadAtoms;
+    if (parseAtomLine(line)) ++m_nReadAtoms;
   }
 
   // Box vector line.
@@ -271,7 +291,7 @@ void GROFileReader::determineFieldLayout(const LString &line)
   m_nPosWidth = W;
 }
 
-void GROFileReader::parseAtomLine(const LString &line)
+bool GROFileReader::parseAtomLine(const LString &line)
 {
   const int len = static_cast<int>(line.length());
   const int required = GRO_PREFIX_LEN + 3 * m_nPosWidth;
@@ -280,7 +300,7 @@ void GROFileReader::parseAtomLine(const LString &line)
              LString::format("Atom line too short at line %d (length=%d, "
                              "expected>=%d): '%s'",
                              m_lineno, len, required, line.c_str()));
-    return;
+    return false;
   }
 
   // Fixed prefix: resid(0..5), resname(5..10), aname(10..15), atomid(15..20).
@@ -294,14 +314,37 @@ void GROFileReader::parseAtomLine(const LString &line)
     MB_THROW(GROFileFormatException,
              LString::format("Invalid residue number at line %d: '%s'",
                              m_lineno, resid_str.c_str()));
-    return;
+    return false;
   }
+
+  // The %5d residue field wraps around at 100000, so a decreasing residue
+  // number means the numbering restarted. Add a 100000 offset to keep the
+  // residue index unique and monotonic: for a genuine wraparound this
+  // restores the sequential numbering GROMACS intended, and for any other
+  // restart the original number is still recoverable as (index % 100000).
+  if (m_bHasPrevResid && resid < m_nPrevResid) {
+    m_nResidOffset += GRO_RESID_MODULO;
+    if (m_nPrevResid == GRO_RESID_MODULO - 1 && resid == 0) {
+      LOG_DPRINTLN("GROFileReader> residue number wraparound at line %d; "
+                   "renumbering the following residues from %d",
+                   m_lineno, m_nResidOffset);
+    }
+    else {
+      LOG_DPRINTLN("GROFileReader> Warning: residue number decreased at line "
+                   "%d (%d -> %d); renumbering the following residues with a "
+                   "%d offset",
+                   m_lineno, m_nPrevResid, resid, m_nResidOffset);
+    }
+  }
+  m_nPrevResid = resid;
+  m_bHasPrevResid = true;
+  const int ext_resid = resid + m_nResidOffset;
 
   if (resname.isEmpty()) resname = "UNK";
   if (aname.isEmpty()) {
     MB_THROW(GROFileFormatException,
              LString::format("Missing atom name at line %d", m_lineno));
-    return;
+    return false;
   }
 
   // Positions (nm in source, converted to Angstrom).
@@ -310,17 +353,17 @@ void GROFileReader::parseAtomLine(const LString &line)
   if (!line.substr(GRO_PREFIX_LEN + 0 * W, W).trim().toDouble(&x)) {
     MB_THROW(GROFileFormatException,
              LString::format("Invalid X coordinate at line %d", m_lineno));
-    return;
+    return false;
   }
   if (!line.substr(GRO_PREFIX_LEN + 1 * W, W).trim().toDouble(&y)) {
     MB_THROW(GROFileFormatException,
              LString::format("Invalid Y coordinate at line %d", m_lineno));
-    return;
+    return false;
   }
   if (!line.substr(GRO_PREFIX_LEN + 2 * W, W).trim().toDouble(&z)) {
     MB_THROW(GROFileFormatException,
              LString::format("Invalid Z coordinate at line %d", m_lineno));
-    return;
+    return false;
   }
   // Velocities (columns 20+3W .. 20+6W) are intentionally skipped:
   // MolAtom does not carry a velocity slot and the visualization use
@@ -333,17 +376,24 @@ void GROFileReader::parseAtomLine(const LString &line)
   pAtom->setName(aname);
   pAtom->setElement(guessElement(aname));
   pAtom->setChainName(m_curChain);
-  pAtom->setResIndex(ResidIndex(resid));
+  pAtom->setResIndex(ResidIndex(ext_resid));
   pAtom->setResName(resname);
   pAtom->setPos(pos);
 
   int aid = m_pMol->appendAtom(pAtom);
   if (aid < 0) {
-    MB_THROW(GROFileFormatException,
-             LString::format("Failed to append atom at line %d: %s/%d/%s",
-                             m_lineno, m_curChain.c_str(), resid, aname.c_str()));
-    return;
+    // Duplicated atom (same chain/residue/name): skip it and keep reading,
+    // so that a partially malformed file still loads.
+    ++m_nSkipAtoms;
+    if (m_nSkipAtoms <= GRO_MAX_WARN) {
+      LOG_DPRINTLN("GROFileReader> Warning: skipped duplicated atom at line "
+                   "%d: %s/%d/%s",
+                   m_lineno, m_curChain.c_str(), ext_resid, aname.c_str());
+    }
+    return false;
   }
+
+  return true;
 }
 
 void GROFileReader::parseBoxLine(const LString &line)

--- a/src/modules/mdtools/GROFileReader.hpp
+++ b/src/modules/mdtools/GROFileReader.hpp
@@ -52,6 +52,19 @@ namespace mdtools {
     /// chain name assigned to all atoms (.gro has no chain concept)
     LString m_curChain;
 
+    /// offset added to the raw residue number to undo the %5d wraparound
+    /// (always a multiple of the 100000 field modulus)
+    int m_nResidOffset;
+
+    /// raw (as written in the file) residue number of the previous atom line
+    int m_nPrevResid;
+
+    /// false until the first atom line of the current frame has been parsed
+    bool m_bHasPrevResid;
+
+    /// number of atoms dropped because appendAtom() failed
+    int m_nSkipAtoms;
+
     //////////////////////////////////////////////
   public:
 
@@ -93,7 +106,8 @@ namespace mdtools {
     void determineFieldLayout(const LString &line);
 
     /// Parse one atom line and append a MolAtom to m_pMol.
-    void parseAtomLine(const LString &line);
+    /// Returns false if the atom was skipped (appendAtom() failed).
+    bool parseAtomLine(const LString &line);
 
     /// Parse the box vector line and attach CrystalInfo to m_pMol.
     void parseBoxLine(const LString &line);

--- a/src/tests/modules/importers/test_grofilereader.cpp
+++ b/src/tests/modules/importers/test_grofilereader.cpp
@@ -118,6 +118,28 @@ const char *const kElementVariety =
     "    1RES    1HD    5   0.500   0.000   0.000\n"
     "   1.00000   1.00000   1.00000\n";
 
+// Residue number wraparound: the %5d field rolls 99999 over to 0, so the
+// water numbered 1 after the roll would otherwise collide with the protein
+// residue 1 (both would be A/1, and both carry an atom named "O").
+const char *const kResidWraparound =
+    "wraparound\n"
+    "    5\n"
+    "    1MET      N    1   0.100   0.000   0.000\n"
+    "    1MET      O    2   0.200   0.000   0.000\n"
+    "99999WAT      O    3   0.300   0.000   0.000\n"
+    "    0WAT      O    4   0.400   0.000   0.000\n"
+    "    1WAT      O    5   0.500   0.000   0.000\n"
+    "   1.00000   1.00000   1.00000\n";
+
+// Same atom name twice in one residue: an unfixable duplicate.
+const char *const kDuplicatedAtom =
+    "duplicated\n"
+    "    3\n"
+    "    1SOL     OW    1   0.100   0.000   0.000\n"
+    "    1SOL     OW    2   0.200   0.000   0.000\n"
+    "    1SOL    HW1    3   0.300   0.000   0.000\n"
+    "   1.00000   1.00000   1.00000\n";
+
 }  // namespace
 
 // ---- nm -> Angstrom conversion (the most important correctness pin) ----
@@ -281,6 +303,49 @@ TEST(GROFileReaderTest, NonNumericAtomCountThrows)
     GROFileReader reader;
     StrInStream ins(kBadCountLine, static_cast<int>(std::string(kBadCountLine).size()));
     EXPECT_THROW(reader.load(ins), GROFileFormatException);
+}
+
+// ---- Residue number wraparound (%5d overflow at 100000) ----
+
+TEST(GROFileReaderTest, ResidWraparoundKeepsResiduesSeparate)
+{
+    GROFileReader reader;
+    MolCoordPtr pMol = loadGRO(reader, kResidWraparound);
+    ASSERT_FALSE(pMol.isnull());
+    // No atom is lost to a residue-index collision.
+    ASSERT_EQ(pMol->getAtomSize(), 5);
+
+    // The protein residue keeps its original number.
+    MolAtomPtr pMetO = pMol->getAtom(LString("A"), molstr::ResidIndex(1),
+                                     LString("O"));
+    ASSERT_FALSE(pMetO.isnull());
+    EXPECT_EQ(pMetO->getResName(), LString("MET"));
+
+    // Residues after the wraparound are renumbered 100000, 100001, ...
+    EXPECT_FALSE(pMol->getResidue(LString("A"),
+                                  molstr::ResidIndex(99999)).isnull());
+    MolAtomPtr pWat0 = pMol->getAtom(LString("A"), molstr::ResidIndex(100000),
+                                     LString("O"));
+    ASSERT_FALSE(pWat0.isnull());
+    EXPECT_EQ(pWat0->getResName(), LString("WAT"));
+
+    MolAtomPtr pWat1 = pMol->getAtom(LString("A"), molstr::ResidIndex(100001),
+                                     LString("O"));
+    ASSERT_FALSE(pWat1.isnull());
+    EXPECT_EQ(pWat1->getResName(), LString("WAT"));
+}
+
+// ---- Unfixable duplicate: skipped, not fatal ----
+
+TEST(GROFileReaderTest, DuplicatedAtomIsSkippedNotFatal)
+{
+    GROFileReader reader;
+    MolCoordPtr pMol = loadGRO(reader, kDuplicatedAtom);
+    ASSERT_FALSE(pMol.isnull());
+    // The second OW is dropped; the remaining atoms are still read.
+    EXPECT_EQ(pMol->getAtomSize(), 2);
+    EXPECT_FALSE(pMol->getAtom(LString("A"), molstr::ResidIndex(1),
+                               LString("HW1")).isnull());
 }
 
 // ---- Element guessing from atom name ----


### PR DESCRIPTION
## Problem

Loading a large GROMACS `.gro` system failed with:

```
Failed to append atom at line 451083: A/1/O
```

The residue number in a `.gro` file is written as `%5d`, so it rolls over from
`99999` to `0`. `GROFileReader` put every atom in chain `"A"` with the raw
number, so the first solvent residue after the rollover (`1WAT`) merged into the
protein's residue 1 (`1MET`). Both carry an atom named `O`, so
`MolCoord::appendAtom()` returned -1 and the reader threw
`GROFileFormatException`, aborting the whole read. In the reported file
(665322 atoms, ~166k residues) the rollover is at line 451080 and the load
stopped three lines later.

## Fix

- **Unwrap the residue number.** Track the previous raw residue number and add a
  100000 offset whenever it decreases. For a genuine rollover this restores the
  sequential numbering GROMACS intended (100000, 100001, ...). For any other
  restart (a hand-made multi-molecule file) the index is still unique and
  monotonic, and the number as written stays recoverable as `index % 100000`.
  A log line records the rollover; a non-rollover decrease is logged as a
  warning. Chain assignment is unchanged (all atoms remain in chain `"A"`).
- **A failed `appendAtom()` is no longer fatal.** A duplicated atom is skipped
  with a warning (capped at 10 per file) and reading continues; `read()` then
  logs a summary noting that the atom count no longer matches the file, so
  xtc/trr/dcd attachment will not line up. Structural errors (short line,
  unparseable coordinate) still throw as before.

## Tests

Two cases added to `test_grofilereader.cpp`:

- `ResidWraparoundKeepsResiduesSeparate` — minimal reproduction of the bug
  (`1MET` with `N`/`O`, then `99999WAT` -> `0WAT` -> `1WAT`): no exception, all
  atoms read, `A/1` (MET) and `A/100001` (WAT) are distinct residues.
- `DuplicatedAtomIsSkippedNotFatal` — pins the new non-fatal contract.

## Verification

- `task build_libcuemol2` — OK
- `ctest` — 1401/1401 pass
- The reported 665322-atom file, checked with a throwaway local test:

```
GROFileReader> residue number wraparound at line 451080; renumbering the following residues from 100000
GROFileReader> read 665322 atoms
```

  0 atoms skipped; `A/1` (MET `O`) and `A/100001` (WAT `O`) both present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxnKFU6a2wMK4i5iberU52
