### PR TITLE
fix(react-gui): 30 latent bugs found by a full-surface audit

### DIFF
--- a/tritium/react-gui/src/main/handlers/fileDialogs.ts
+++ b/tritium/react-gui/src/main/handlers/fileDialogs.ts
@@ -246,7 +246,10 @@ export async function handleObjectSaveDialog(
   // Electron does not return the chosen filter index. Best-effort recover
   // it from the file extension. Falls back to defaultFilterIndex (or 0)
   // when no match -- the worker will use that writer name.
-  const ext = (result.filePath.split('.').pop() ?? '').toLowerCase()
+  // path.extname, not split('.'): a parent directory containing a dot
+  // ("/Users/me/v1.2/output") made split() return "2/output", so no filter
+  // matched and the object was written with a writer the user did not choose.
+  const ext = path.extname(result.filePath).slice(1).toLowerCase()
   let filterIndex = payload.defaultFilterIndex ?? 0
   for (let i = 0; i < payload.filters.length; i++) {
     if (payload.filters[i].extensions.some((e) => e.toLowerCase() === ext)) {

--- a/tritium/react-gui/src/main/handlers/fileDialogs.ts
+++ b/tritium/react-gui/src/main/handlers/fileDialogs.ts
@@ -15,6 +15,7 @@ import type { BrowserWindow, FileFilter } from 'electron'
 import path from 'path'
 import { promises as fsp } from 'fs'
 import { withMenuBlocked } from '../menu'
+import { hasExt } from '@shared/fileExt'
 
 /**
  * Show a native save dialog (menu blocked while it is up) and normalize the
@@ -246,13 +247,13 @@ export async function handleObjectSaveDialog(
   // Electron does not return the chosen filter index. Best-effort recover
   // it from the file extension. Falls back to defaultFilterIndex (or 0)
   // when no match -- the worker will use that writer name.
-  // path.extname, not split('.'): a parent directory containing a dot
-  // ("/Users/me/v1.2/output") made split() return "2/output", so no filter
-  // matched and the object was written with a writer the user did not choose.
-  const ext = path.extname(result.filePath).slice(1).toLowerCase()
+  // Suffix match, not a dot-segment: a parent directory containing a dot
+  // ("/Users/me/v1.2/output") used to yield "2/output", so no filter matched
+  // and the object was written with a writer the user did not choose. See
+  // shared/fileExt.ts.
   let filterIndex = payload.defaultFilterIndex ?? 0
   for (let i = 0; i < payload.filters.length; i++) {
-    if (payload.filters[i].extensions.some((e) => e.toLowerCase() === ext)) {
+    if (payload.filters[i].extensions.some((e) => hasExt(result.filePath, e))) {
       filterIndex = i
       break
     }

--- a/tritium/react-gui/src/main/helpers/inferContentFirst.test.ts
+++ b/tritium/react-gui/src/main/helpers/inferContentFirst.test.ts
@@ -77,3 +77,34 @@ describe('inferContentFirst', () => {
         expect(inferContentFirst('/data/1UBQ.PDB', FILTERS)).toBe(false)
     })
 })
+
+/**
+ * The filter rows carry multi-dot extensions (PDB Coordinates ->
+ * *.pdb;*.ent;*.pdb.gz). Reducing the path to a single trailing segment made
+ * "1crn.pdb.gz" match no reader-specific row, so the user's explicit PDB
+ * choice was discarded and the reader re-sniffed from content.
+ */
+describe('multi-dot extensions', () => {
+    const filters = [
+        { name: 'All Supported', extensions: ['pdb', 'ent', 'pdb.gz', 'cif', 'cif.gz'] },
+        { name: 'PDB Coordinates', extensions: ['pdb', 'ent', 'pdb.gz'] },
+        { name: 'mmCIF Coordinates', extensions: ['cif', 'cif.gz'] },
+        { name: 'All Files', extensions: ['*'] },
+    ]
+
+    it('resolves a .pdb.gz to the PDB row alone', () => {
+        expect(inferContentFirst('/tmp/1crn.pdb.gz', filters)).toBe(false)
+    })
+
+    it('resolves a .cif.gz to the mmCIF row alone', () => {
+        expect(inferContentFirst('/tmp/1crn.cif.gz', filters)).toBe(false)
+    })
+
+    it('still resolves a plain .pdb', () => {
+        expect(inferContentFirst('/tmp/1crn.pdb', filters)).toBe(false)
+    })
+
+    it('falls back to sniffing for an extension no row claims', () => {
+        expect(inferContentFirst('/tmp/1crn.xyz', filters)).toBe(true)
+    })
+})

--- a/tritium/react-gui/src/main/helpers/inferContentFirst.ts
+++ b/tritium/react-gui/src/main/helpers/inferContentFirst.ts
@@ -32,12 +32,21 @@ export interface FileFilter {
  *   only catch-all matches), `false` when the extension should win.
  */
 export function inferContentFirst(filePath: string, filters: FileFilter[]): boolean {
-    const ext = (filePath.split('.').pop() ?? '').toLowerCase();
+    // Match against the tail of the path, not against a single trailing
+    // segment: the filter rows carry multi-dot extensions (*.pdb.gz, *.cif.gz),
+    // and `split('.').pop()` reduced "1crn.pdb.gz" to "gz", which matches no
+    // reader-specific row. The user's explicit PDB choice was then discarded
+    // and the reader re-sniffed from content.
+    const lower = filePath.toLowerCase();
+    const matchesExt = (e: string): boolean => {
+        const suffix = '.' + e.toLowerCase();
+        return lower.endsWith(suffix);
+    };
     let matched = 0;
     for (const f of filters) {
         if (f.extensions.includes('*')) continue;
         if (f.name === 'All Supported') continue;
-        if (f.extensions.some((e) => e.toLowerCase() === ext)) {
+        if (f.extensions.some(matchesExt)) {
             matched++;
             if (matched > 1) break;
         }

--- a/tritium/react-gui/src/main/helpers/inferContentFirst.ts
+++ b/tritium/react-gui/src/main/helpers/inferContentFirst.ts
@@ -13,6 +13,8 @@
  * sniffing (return true).
  */
 
+import { hasExt } from '@shared/fileExt';
+
 export interface FileFilter {
     name: string;
     extensions: string[];
@@ -32,21 +34,13 @@ export interface FileFilter {
  *   only catch-all matches), `false` when the extension should win.
  */
 export function inferContentFirst(filePath: string, filters: FileFilter[]): boolean {
-    // Match against the tail of the path, not against a single trailing
-    // segment: the filter rows carry multi-dot extensions (*.pdb.gz, *.cif.gz),
-    // and `split('.').pop()` reduced "1crn.pdb.gz" to "gz", which matches no
-    // reader-specific row. The user's explicit PDB choice was then discarded
-    // and the reader re-sniffed from content.
-    const lower = filePath.toLowerCase();
-    const matchesExt = (e: string): boolean => {
-        const suffix = '.' + e.toLowerCase();
-        return lower.endsWith(suffix);
-    };
+    // Suffix match, not a single trailing segment: the filter rows carry
+    // multi-dot extensions (*.pdb.gz, *.cif.gz). See shared/fileExt.ts.
     let matched = 0;
     for (const f of filters) {
         if (f.extensions.includes('*')) continue;
         if (f.name === 'All Supported') continue;
-        if (f.extensions.some(matchesExt)) {
+        if (f.extensions.some((e) => hasExt(filePath, e))) {
             matched++;
             if (matched > 1) break;
         }

--- a/tritium/react-gui/src/main/index.ts
+++ b/tritium/react-gui/src/main/index.ts
@@ -9,7 +9,7 @@ import { IPC } from '@shared/ipcChannels'
 import { applyDevDockIcon } from './helpers/appIcon'
 import { loadUi } from './stateStore'
 import { isAppQuitting, isForceQuit, setAppQuitting } from './quitState'
-import { clearRenderHistory } from './renderHistory'
+import { clearRenderHistory, sweepStaleRenderHistory } from './renderHistory'
 import { sweepMovieOutputs } from './movieOutput'
 import { APP_PRODUCT_NAME } from '@shared/appInfo'
 import { installMainCrashHandlers } from './installMainCrashHandlers'
@@ -48,9 +48,7 @@ if (!gotSingleInstanceLock) {
   // requestSingleInstanceLock() has already handed our argv and cwd to the
   // primary instance, which opens the files. Every side effect below is gated
   // on this flag rather than relying on app.quit() winning the race: quit is
-  // asynchronous, whenReady() can still resolve, and will-quit's
-  // clearRenderHistory() would wipe the RUNNING instance's history (the
-  // history directory is a fixed path under os.tmpdir()).
+  // asynchronous, so whenReady() can still resolve and run them.
   console.log('[Main] another instance owns the single-instance lock; exiting')
   app.quit()
 }
@@ -120,10 +118,10 @@ app.whenReady().then(() => {
   // Dev runs have no .app bundle to take the dock icon from (see appIcon.ts).
   applyDevDockIcon()
 
-  // Drop any render-history images a previous run left behind (its metadata
-  // died with that run, so the files are unreachable). Marked as the startup
-  // sweep so it stands down when another live instance owns the directory.
-  clearRenderHistory({ startup: true })
+  // Drop what previous runs left behind (their metadata died with them, so the
+  // images are unreachable). Only directories whose owning process is gone are
+  // touched -- another instance may be running right now.
+  sweepStaleRenderHistory()
 
   // Age out past runs' movie output. Unlike the render history this is not
   // wiped wholesale: a movie can represent hours of rendering, so only stale
@@ -151,9 +149,8 @@ app.whenReady().then(() => {
 // The render history is per-run: its images are temp files and the settings
 // that produced them are not persisted either.
 app.on('will-quit', () => {
-  // Guarded: the history directory is a fixed path under os.tmpdir(), shared by
-  // every instance. Without this, an instance that loses the single-instance
-  // lock and quits would wipe the running instance's render history.
+  // Each run owns its own directory, so this only ever removes ours. The lock
+  // check just keeps a losing instance from creating one on its way out.
   if (!gotSingleInstanceLock) return
   clearRenderHistory()
 })

--- a/tritium/react-gui/src/main/index.ts
+++ b/tritium/react-gui/src/main/index.ts
@@ -182,11 +182,16 @@ app.on('before-quit', (event) => {
   // skip the confirm funnel entirely.
   if (isForceQuit()) return
   if (isAppQuitting()) return
-  const wins = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed())
-  if (wins.length === 0) return
+  // Close the main window only. It is the one with a confirm funnel, and its
+  // 'closed' handler takes the Rendering window down with it. Closing every
+  // window here destroyed the Rendering window first -- it has no funnel -- so
+  // cancelling the main window's save prompt restored the app minus its render
+  // history view and any in-flight settings.
+  const main = getMainWindow()
+  if (!main || main.isDestroyed()) return
   setAppQuitting(true)
   event.preventDefault()
-  for (const w of wins) w.close()
+  main.close()
 })
 
 // Utility/GPU process crashes (Web Workers run inside the renderer process

--- a/tritium/react-gui/src/main/index.ts
+++ b/tritium/react-gui/src/main/index.ts
@@ -121,8 +121,9 @@ app.whenReady().then(() => {
   applyDevDockIcon()
 
   // Drop any render-history images a previous run left behind (its metadata
-  // died with that run, so the files are unreachable).
-  clearRenderHistory()
+  // died with that run, so the files are unreachable). Marked as the startup
+  // sweep so it stands down when another live instance owns the directory.
+  clearRenderHistory({ startup: true })
 
   // Age out past runs' movie output. Unlike the render history this is not
   // wiped wholesale: a movie can represent hours of rendering, so only stale

--- a/tritium/react-gui/src/main/installMainCrashHandlers.test.ts
+++ b/tritium/react-gui/src/main/installMainCrashHandlers.test.ts
@@ -1,5 +1,7 @@
 /**
- * Pins the two behaviours the main-process crash funnel exists for:
+ * @file main/installMainCrashHandlers.test.ts
+ *
+ * Pins the behaviours the main-process crash funnel exists for:
  *
  *   1. A closed stdout pipe (`npm start | head`) must be swallowed, not turned
  *      into an uncaught exception -- that is what popped the untranslatable
@@ -14,11 +16,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-// installMainCrashHandlers lives in src/main (tsconfig.node project). A
-// string-variable dynamic import keeps tsc's cross-project check (TS6307) off
-// this file while Vitest still resolves it at runtime -- same trick as
-// quitState.test.ts.
-const crashHandlersEntry = '../../main/installMainCrashHandlers'
+const crashHandlersEntry = './installMainCrashHandlers'
 
 interface CrashHandlersModule {
     installMainCrashHandlers(): void
@@ -115,5 +113,79 @@ describe('installMainCrashHandlers', () => {
         addedListener(before, UNCAUGHT)(new Error('boom'))
 
         expect(writeSpy).not.toHaveBeenCalled()
+    })
+})
+
+/**
+ * Electron's own `uncaughtException` listener (verified in the shipped
+ * Electron 42 binary) reads:
+ *
+ *   process.on("uncaughtException", function (e) {
+ *     process.listenerCount("uncaughtException") > 1 || ...showErrorBox(...)
+ *   })
+ *
+ * So registering a listener here suppresses the only user-visible sign that
+ * anything went wrong, leaving a single stderr line a GUI user never sees.
+ * (Electron does not exit either, before or after -- that is its deliberate
+ * choice for a desktop app, and this funnel does not change it.)
+ */
+describe('uncaughtException visibility', () => {
+    const added: Array<[NodeJS.EventEmitter, string, Listener]> = []
+
+    async function install(): Promise<Listener> {
+        const before = process.listeners('uncaughtException') as Listener[]
+        const mod = (await import(crashHandlersEntry)) as CrashHandlersModule
+        mod.installMainCrashHandlers()
+        const after = process.listeners('uncaughtException') as Listener[]
+        const mine = after.filter((l) => !before.includes(l))
+        for (const l of mine) added.push([process, 'uncaughtException', l])
+        return mine[0]
+    }
+
+    afterEach(() => {
+        for (const [t, e, l] of added) t.removeListener(e, l)
+        added.length = 0
+        vi.doUnmock('electron')
+        vi.resetModules()
+    })
+
+    it('shows the error box Electron would have shown', async () => {
+        const showErrorBox = vi.fn()
+        vi.resetModules()
+        vi.doMock('electron', () => ({ dialog: { showErrorBox } }))
+
+        const handler = await install()
+        const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+        handler(new Error('main blew up'))
+        writeSpy.mockRestore()
+
+        expect(showErrorBox).toHaveBeenCalledTimes(1)
+        const [title, body] = showErrorBox.mock.calls[0] as [string, string]
+        expect(title).toMatch(/JavaScript error occurred in the main process/i)
+        expect(body).toMatch(/main blew up/)
+    })
+
+    it('still writes the stderr copy alongside the dialog', async () => {
+        vi.resetModules()
+        vi.doMock('electron', () => ({ dialog: { showErrorBox: vi.fn() } }))
+
+        const handler = await install()
+        const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+        handler(new Error('main blew up'))
+        const written = writeSpy.mock.calls.map((c) => String(c[0])).join('')
+        writeSpy.mockRestore()
+
+        expect(written).toMatch(/uncaughtException/)
+        expect(written).toMatch(/main blew up/)
+    })
+
+    it('never throws when the dialog API is unavailable', async () => {
+        vi.resetModules()
+        vi.doMock('electron', () => ({ dialog: undefined }))
+
+        const handler = await install()
+        const writeSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+        expect(() => handler(new Error('boom'))).not.toThrow()
+        writeSpy.mockRestore()
     })
 })

--- a/tritium/react-gui/src/main/installMainCrashHandlers.ts
+++ b/tritium/react-gui/src/main/installMainCrashHandlers.ts
@@ -6,13 +6,27 @@
  *
  * Electron's built-in handler only pops a modal "A JavaScript error occurred
  * in the main process" dialog, whose text cannot be copied and which never
- * reaches the log a headless / piped run captures. These listeners are added
- * alongside it (Node runs every `uncaughtException` listener), so the dialog
- * still appears while the same report also lands on stderr.
+ * reaches the log a headless / piped run captures. This funnel adds the stderr
+ * copy.
+ *
+ * It has to raise the dialog itself, though. Electron's listener (verified in
+ * the shipped binary) is:
+ *
+ *   process.on('uncaughtException', function (e) {
+ *     process.listenerCount('uncaughtException') > 1 || ...showErrorBox(...)
+ *   })
+ *
+ * -- so merely registering a listener here suppresses it, and a GUI user would
+ * be left with no sign at all that anything went wrong. Neither Electron's
+ * handler nor this one exits: staying up after an uncaught exception is
+ * Electron's deliberate choice for a desktop app, and this file does not
+ * change it.
  *
  * The renderer has its own funnel in `renderer/crash/`; this covers the main
  * process only.
  */
+
+import { dialog } from 'electron';
 
 /** stdio write errors that mean "nobody is reading" rather than a real fault. */
 const PIPE_ERROR_CODES = new Set(['EPIPE', 'ERR_STREAM_DESTROYED', 'ERR_STREAM_WRITE_AFTER_END']);
@@ -38,6 +52,27 @@ function report(kind: string, err: unknown): void {
 }
 
 /**
+ * Raise the modal Electron's own handler would have shown, since registering a
+ * listener here suppressed it.
+ *
+ * @remarks Fully guarded: this runs on the crash path, where the dialog API may
+ *   be unavailable (before `ready`, in tests), and a throw here would replace
+ *   the report with a different crash.
+ */
+function showErrorDialog(err: unknown): void {
+    try {
+        const detail =
+            err instanceof Error ? (err.stack ?? `${err.name}: ${err.message}`) : String(err);
+        dialog?.showErrorBox(
+            'A JavaScript error occurred in the main process',
+            `Uncaught Exception:\n${detail}`,
+        );
+    } catch {
+        // No dialog available -- the stderr report above is the whole record.
+    }
+}
+
+/**
  * Install the main-process crash handlers. Call once, as early as possible in
  * `main/index.ts` (before any window or store access).
  */
@@ -57,6 +92,9 @@ export function installMainCrashHandlers(): void {
         });
     }
 
-    process.on('uncaughtException', (err) => report('uncaughtException', err));
+    process.on('uncaughtException', (err) => {
+        report('uncaughtException', err);
+        showErrorDialog(err);
+    });
     process.on('unhandledRejection', (reason) => report('unhandledRejection', reason));
 }

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -24,7 +24,6 @@ import { inferContentFirst } from './helpers/inferContentFirst'
 import { rebuildApplicationMenu, setMenuBlocked, updateMenuState, withMenuBlocked } from './menu'
 import { addRecent, clearRecents, getRecents } from './recentFiles'
 import { takeShellOpen } from './shellOpenQueue'
-import { armCloseWatchdog } from './windowManager'
 import {
   clearCloseWatchdog,
   setAppQuitting,
@@ -346,14 +345,6 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
       case 'redo': wc.redo(); break
       case 'selectAll': wc.selectAll(); break
     }
-  })
-
-  // "Still working on the close": the renderer is about to wait on the user
-  // (a per-tab save confirm) or on a slow save. Re-arm the watchdog so its
-  // timeout measures renderer silence rather than how long a person takes to
-  // decide -- firing mid-decision discarded the unsaved scenes.
-  handleInvoke(IPC.WINDOW_CLOSE_PROGRESS, () => {
-    armCloseWatchdog(mainWindow)
   })
 
   // Renderer reply to a WINDOW_CLOSE_REQUEST. `proceed: true` means every

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -331,8 +331,11 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
   // Edit role picked from the Windows/Linux React text context menu
   // (registerTextContextMenu pushes IPC.TEXT_CTX_SHOW; selectAll is handled
   // renderer-side and never reaches here).
-  handleInvoke(IPC.TEXT_CTX_ACTION, (_event, role) => {
-    const wc = mainWindow.webContents
+  handleInvoke(IPC.TEXT_CTX_ACTION, (event, role) => {
+    // The sender's own webContents, not mainWindow's: the Rendering window
+    // registers the same context menu, so a paste there used to land in
+    // whatever field was focused in the main window.
+    const wc = event.sender.isDestroyed() ? mainWindow.webContents : event.sender
     switch (role) {
       case 'cut': wc.cut(); break
       case 'copy': wc.copy(); break
@@ -341,6 +344,7 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
       // field: Cmd+Z there must undo the typing, not the scene.
       case 'undo': wc.undo(); break
       case 'redo': wc.redo(); break
+      case 'selectAll': wc.selectAll(); break
     }
   })
 

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -25,7 +25,6 @@ import { rebuildApplicationMenu, setMenuBlocked, updateMenuState, withMenuBlocke
 import { addRecent, clearRecents, getRecents } from './recentFiles'
 import { takeShellOpen } from './shellOpenQueue'
 import {
-  clearCloseWatchdog,
   setAppQuitting,
   setCloseConfirmed,
   setCloseInFlight,
@@ -353,7 +352,6 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
   // the in-flight flag and aborts any in-progress quit so the next Cmd+Q
   // starts a fresh confirm chain.
   handleInvoke(IPC.WINDOW_CLOSE_PROCEED, (_event, { proceed }) => {
-    clearCloseWatchdog(mainWindow)
     setCloseInFlight(mainWindow, false)
     if (proceed) {
       setCloseConfirmed(mainWindow, true)
@@ -387,7 +385,6 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
     setForceQuit(true)
     setAppQuitting(true)
     for (const w of mainWindow.isDestroyed() ? [] : [mainWindow]) {
-      clearCloseWatchdog(w)
       setCloseConfirmed(w, true)
     }
     app.exit(0)

--- a/tritium/react-gui/src/main/ipcHandlers.ts
+++ b/tritium/react-gui/src/main/ipcHandlers.ts
@@ -24,6 +24,7 @@ import { inferContentFirst } from './helpers/inferContentFirst'
 import { rebuildApplicationMenu, setMenuBlocked, updateMenuState, withMenuBlocked } from './menu'
 import { addRecent, clearRecents, getRecents } from './recentFiles'
 import { takeShellOpen } from './shellOpenQueue'
+import { armCloseWatchdog } from './windowManager'
 import {
   clearCloseWatchdog,
   setAppQuitting,
@@ -341,6 +342,14 @@ export function registerIpcHandlers(mainWindow: BrowserWindow): void {
       case 'undo': wc.undo(); break
       case 'redo': wc.redo(); break
     }
+  })
+
+  // "Still working on the close": the renderer is about to wait on the user
+  // (a per-tab save confirm) or on a slow save. Re-arm the watchdog so its
+  // timeout measures renderer silence rather than how long a person takes to
+  // decide -- firing mid-decision discarded the unsaved scenes.
+  handleInvoke(IPC.WINDOW_CLOSE_PROGRESS, () => {
+    armCloseWatchdog(mainWindow)
   })
 
   // Renderer reply to a WINDOW_CLOSE_REQUEST. `proceed: true` means every

--- a/tritium/react-gui/src/main/menu.ts
+++ b/tritium/react-gui/src/main/menu.ts
@@ -30,6 +30,7 @@ import {
 // importing the block API from `./menu` unchanged.
 export {
   setMenuBlocked,
+  resetMenuBlockReason,
   withMenuBlocked,
   walkMenuItems,
   applyBlock,
@@ -287,15 +288,24 @@ function flushPendingRebuild(): void {
   if (pendingRebuild && mainWindowRef) {
     pendingRebuild = false
     buildAndSetMenu(mainWindowRef)
+    // buildAndSetMenu already replays lastMenuState onto the new items.
+    return
   }
+  // No rebuild was pending, but state may have arrived during the block
+  // (updateMenuState merges it and skips the live write). Apply it now.
+  if (!lastMenuState) return
+  const menu = Menu.getApplicationMenu()
+  if (menu) applyMenuStateTo(menu, lastMenuState)
 }
+
+// Wire the unblock callback at module load rather than from createMenu: it also
+// replays state pushed during a block, which can happen before -- or without --
+// a menu ever being created for a window.
+setDeferredRebuild(flushPendingRebuild)
 
 /** Build and install the application menu for the given window (first run). */
 export function createMenu(mainWindow: BrowserWindow): void {
   mainWindowRef = mainWindow
-  // Wire the deferred-rebuild callback so a rebuild requested while the menu
-  // is blocked fires once on unblock (see menuBlock.applyUnblock).
-  setDeferredRebuild(flushPendingRebuild)
   buildAndSetMenu(mainWindow)
 }
 
@@ -325,6 +335,9 @@ export function _resetMenuBlockForTest(): void {
   mainWindowRef = null
   pendingRebuild = false
   lastMenuState = null
+  // The menuBlock reset drops the injected callback; restore the production
+  // wiring so a test does not silently run without the unblock hook.
+  setDeferredRebuild(flushPendingRebuild)
 }
 
 /**
@@ -333,16 +346,17 @@ export function _resetMenuBlockForTest(): void {
  * No-op while the menu is blocked.
  */
 export function updateMenuState(state: MenuState): void {
-  // While the menu is blocked, ignore renderer-side state updates. The
-  // renderer is expected to re-emit on the next active-view change after
-  // unblock; the snapshot itself preserves whatever enabled values were
-  // current at block entry, so on unblock the menu returns to its last
-  // known-good state.
-  if (isBlocked()) return
-
-  // Merge into the persistent cache so a later menu rebuild can replay
-  // the full view/scene state onto the freshly built MenuItem instances.
+  // Always merge into the persistent cache, even while blocked. The cache is
+  // what a rebuild -- and the unblock replay below -- work from, so dropping
+  // an update here loses it for good: nothing prompts the renderer to re-emit.
+  // (An edit committed from inside a dialog pushes {undo:{enabled:true}} while
+  // the dialog holds the block; Edit > Undo then stayed greyed out until the
+  // next scene event happened to fire one.)
   lastMenuState = mergeMenuState(lastMenuState, state)
+
+  // Writing to the live items while blocked would fight the block snapshot,
+  // which restores the pre-block `enabled` values on unblock. Defer instead.
+  if (isBlocked()) return
 
   const menu = Menu.getApplicationMenu()
   if (!menu) return

--- a/tritium/react-gui/src/main/menu.ts
+++ b/tritium/react-gui/src/main/menu.ts
@@ -18,7 +18,7 @@ import {
 } from '@shared/menuActionMap'
 import type { MenuState, RecentFileEntry } from '@shared/ipcTypes'
 import { applyMenuStateTo, mergeMenuState } from '@shared/menuStateApply'
-import { getExistingRecents } from './recentFiles'
+import { getExistingRecents, refreshRecentsExistence } from './recentFiles'
 import {
   isBlocked,
   setDeferredRebuild,
@@ -312,6 +312,11 @@ setDeferredRebuild(flushPendingRebuild)
 export function createMenu(mainWindow: BrowserWindow): void {
   mainWindowRef = mainWindow
   buildAndSetMenu(mainWindow)
+  // Prune MRU entries whose file is gone. Deliberately after the first build
+  // and off the menu path: this touches the filesystem, and one entry on a
+  // disconnected network mount used to block every window for the mount
+  // timeout. The menu is rebuilt only if the result actually changed.
+  void refreshRecentsExistence(() => rebuildApplicationMenu())
 }
 
 /**

--- a/tritium/react-gui/src/main/menu.ts
+++ b/tritium/react-gui/src/main/menu.ts
@@ -109,6 +109,10 @@ function buildSpecificHandlers(
     [IPC.MENU_EDIT_PASTE, 'paste'],
     [IPC.MENU_UNDO, 'undo'],
     [IPC.MENU_REDO, 'redo'],
+    // Cmd+A is focus-dependent too: with the Rendering window focused it used
+    // to run selectAllInScope() in the MAIN window instead of selecting the
+    // text in the field under the cursor.
+    [IPC.MENU_SELECT_ALL, 'selectAll'],
   ]
   for (const [ch, native] of focusRouted) {
     const toRenderer = handlers[ch] ?? (() => mainWindow.webContents.send(IPC.MENU_GENERIC, ch))
@@ -125,7 +129,7 @@ function buildSpecificHandlers(
 }
 
 /** Native edit actions a focused webContents can run against its own selection. */
-type NativeEditAction = 'cut' | 'copy' | 'paste' | 'undo' | 'redo'
+type NativeEditAction = 'cut' | 'copy' | 'paste' | 'undo' | 'redo' | 'selectAll'
 
 function runNativeEdit(wc: WebContents, action: NativeEditAction): void {
   switch (action) {
@@ -134,6 +138,7 @@ function runNativeEdit(wc: WebContents, action: NativeEditAction): void {
     case 'paste': wc.paste(); break
     case 'undo': wc.undo(); break
     case 'redo': wc.redo(); break
+    case 'selectAll': wc.selectAll(); break
   }
 }
 

--- a/tritium/react-gui/src/main/menuBlock.test.ts
+++ b/tritium/react-gui/src/main/menuBlock.test.ts
@@ -122,6 +122,7 @@ import {
   createMenu,
   rebuildApplicationMenu,
   setMenuBlocked,
+  resetMenuBlockReason,
   updateMenuState,
   _resetMenuBlockForTest,
 } from '@main/menu'
@@ -226,18 +227,65 @@ describe('menu block machinery (main side)', () => {
     expect(setApplicationMenu).toHaveBeenCalledTimes(1)
   })
 
-  it('(c) updateMenuState is a no-op while blocked, applies after unblock', () => {
+  it('(c) updateMenuState does not touch the live menu while blocked', () => {
     const menu = installEnabledMenu()
 
     setMenuBlocked('blueprint', true)
-    // While blocked, updateMenuState must not mutate the live menu.
+    // Writing here would fight the block snapshot, which restores the
+    // pre-block enabled values on unblock.
     updateMenuState({ viewProjection: { enabled: true, perspective: true } })
-    // (the item was disabled by the block; the guard prevents re-enabling)
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
+  })
+
+  /**
+   * State pushed during a block must not be dropped. Nothing prompts the
+   * renderer to re-emit: useUndoRedoState only pushes on a scene undo event or
+   * a tab switch, and useActiveViewState only on a tab switch or an explicit
+   * user action. An edit committed from inside a dialog therefore left
+   * Edit > Undo greyed out until some later scene event happened to fire one.
+   */
+  it('(c2) state pushed while blocked is applied on unblock without a re-emit', () => {
+    const menu = installEnabledMenu()
+
+    setMenuBlocked('blueprint', true)
+    updateMenuState({ viewProjection: { enabled: true, perspective: true } })
+    setMenuBlocked('blueprint', false)
+
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(true)
+    expect(menu.getMenuItemById('view-perspective')!.checked).toBe(true)
+  })
+
+  /**
+   * The 'blueprint' count is incremented and decremented from the renderer. A
+   * reload between the two destroys the component that owed the decrement, so
+   * the menu stayed disabled -- Cmd+Q included -- for the rest of the run, with
+   * no way back: a later open/close goes 1 -> 2 -> 1.
+   */
+  it('(d) resetMenuBlockReason lifts a block the renderer can no longer release', () => {
+    const menu = installEnabledMenu()
+
+    setMenuBlocked('blueprint', true)
     expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
 
+    resetMenuBlockReason('blueprint')
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(true)
+
+    // And the counter really is zero: one open/close cycle unblocks again.
+    setMenuBlocked('blueprint', true)
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
     setMenuBlocked('blueprint', false)
-    // After unblock the renderer re-emits; updateMenuState now applies.
-    updateMenuState({ viewProjection: { enabled: true, perspective: true } })
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(true)
+  })
+
+  it('(e) resetMenuBlockReason leaves an unrelated reason blocking', () => {
+    const menu = installEnabledMenu()
+
+    setMenuBlocked('blueprint', true)
+    setMenuBlocked('native', true)
+    resetMenuBlockReason('blueprint')
+    expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(false)
+
+    setMenuBlocked('native', false)
     expect(menu.getMenuItemById('view-perspective')!.enabled).toBe(true)
   })
 })

--- a/tritium/react-gui/src/main/menuBlock.test.ts
+++ b/tritium/react-gui/src/main/menuBlock.test.ts
@@ -110,6 +110,7 @@ vi.mock('electron', () => {
 
 vi.mock('@main/recentFiles', () => ({
   getExistingRecents: vi.fn(() => []),
+  refreshRecentsExistence: vi.fn(() => Promise.resolve()),
 }))
 
 import { Menu } from 'electron'

--- a/tritium/react-gui/src/main/menuBlock.ts
+++ b/tritium/react-gui/src/main/menuBlock.ts
@@ -144,6 +144,32 @@ export function setMenuBlocked(reason: MenuBlockReason, blocked: boolean): void 
   const prev = blockReasons.get(reason) ?? 0
   const next = blocked ? prev + 1 : Math.max(0, prev - 1)
   blockReasons.set(reason, next)
+  settleBlockState()
+}
+
+/**
+ * Drop every outstanding block for one reason.
+ *
+ * The 'blueprint' counter is incremented from the renderer (a Blueprint dialog
+ * mounting) and decremented from the renderer too. A reload or navigation
+ * between those two points -- devtools Cmd+R, a dev HMR full reload,
+ * webContents.reload() -- destroys the component that owed the decrement, so
+ * the count never returns to zero and every menu item except the text-edit
+ * ones stays disabled for the rest of the run, Cmd+Q included. Nothing
+ * recovers it: a later open/close goes 1 -> 2 -> 1.
+ *
+ * Main observes the reload itself, so it can clear the reason there.
+ *
+ * @param reason - the block source to clear.
+ */
+export function resetMenuBlockReason(reason: MenuBlockReason): void {
+  if ((blockReasons.get(reason) ?? 0) === 0) return
+  blockReasons.set(reason, 0)
+  settleBlockState()
+}
+
+/** Apply or lift the block to match the current total count. */
+function settleBlockState(): void {
   const total = totalBlockCount()
   if (total > 0 && !snapshot) applyBlock()
   else if (total === 0 && snapshot) applyUnblock()

--- a/tritium/react-gui/src/main/quitFunnel.test.ts
+++ b/tritium/react-gui/src/main/quitFunnel.test.ts
@@ -82,6 +82,8 @@ interface FakeWebContents {
   on: ReturnType<typeof vi.fn>
   openDevTools: ReturnType<typeof vi.fn>
   listeners: Map<string, Listener[]>
+  isDestroyed: ReturnType<typeof vi.fn>
+  isCrashed: ReturnType<typeof vi.fn>
 }
 
 interface FakeWindow {
@@ -97,6 +99,8 @@ function makeWebContents(): FakeWebContents {
   return {
     send: vi.fn(),
     openDevTools: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    isCrashed: vi.fn(() => false),
     on: vi.fn((event: string, cb: Listener) => {
       const l = listeners.get(event) ?? []
       l.push(cb)
@@ -168,12 +172,15 @@ vi.mock('@main/stateStore', () => ({
   loadWindowBounds: vi.fn(() => null),
   saveWindowBounds: vi.fn(),
 }))
+const menuBlocked = { value: false }
 vi.mock('@main/menu', () => ({
   rebuildApplicationMenu: vi.fn(),
   setMenuBlocked: vi.fn(),
+  resetMenuBlockReason: vi.fn(),
   updateMenuState: vi.fn(),
   withMenuBlocked: vi.fn((_m: unknown, fn: () => unknown) => fn()),
   createMenu: vi.fn(),
+  isBlocked: vi.fn(() => menuBlocked.value),
 }))
 vi.mock('@main/textContextMenu', () => ({ registerTextContextMenu: vi.fn() }))
 vi.mock('@main/recentFiles', () => ({
@@ -207,6 +214,8 @@ interface IpcHandlersModule {
   registerIpcHandlers(win: unknown): void
 }
 interface QuitStateModule {
+  WINDOW_CLOSE_WATCHDOG_MS: number
+  setCloseInFlight(win: object, value: boolean): void
   isAppQuitting(): boolean
   setAppQuitting(v: boolean): void
   isForceQuit(): boolean
@@ -435,5 +444,89 @@ describe('handleWindowClose funnel + render-process-gone (main/windowManager.ts)
     expect(quitState.isForceQuit()).toBe(true)
     expect(quitState.isAppQuitting()).toBe(true)
     expect(appExit).toHaveBeenCalledWith(1)
+  })
+
+  /**
+   * The watchdog is there so the user is never trapped by a renderer that
+   * cannot answer. It must never fire because the renderer is busy, or because
+   * the *user* is taking their time -- forcing the window shut then discards
+   * the very scenes the confirm chain was asking about.
+   */
+  describe('close watchdog', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      menuBlocked.value = false
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+      menuBlocked.value = false
+    })
+
+    /** Let the watchdog interval elapse `times` over. */
+    function elapse(times = 1): void {
+      for (let i = 0; i < times; i++) {
+        vi.advanceTimersByTime(quitState.WINDOW_CLOSE_WATCHDOG_MS + 1)
+      }
+    }
+
+    it('does not close while a dialog is on screen, however long the user takes', async () => {
+      const { win, fireClose } = await buildWindow()
+      fireClose(makeEvent())
+      win.close.mockClear()
+      // The renderer reported a modal through MENU_SET_MODAL_BLOCKED.
+      menuBlocked.value = true
+
+      elapse(6)
+
+      expect(win.close).not.toHaveBeenCalled()
+      expect(quitState.isCloseInFlight(win as object)).toBe(true)
+    })
+
+    it('does not close while the renderer is alive and simply slow', async () => {
+      const { win, fireClose } = await buildWindow()
+      fireClose(makeEvent())
+      win.close.mockClear()
+
+      elapse(3)
+
+      expect(win.close).not.toHaveBeenCalled()
+      expect(quitState.isCloseInFlight(win as object)).toBe(true)
+    })
+
+    it('closes once Chromium reports the renderer unresponsive', async () => {
+      const { win, fireClose } = await buildWindow()
+      fireClose(makeEvent())
+      win.close.mockClear()
+
+      const unresponsive = win.webContents.listeners.get('unresponsive') ?? []
+      unresponsive[0]?.()
+      elapse()
+
+      expect(win.close).toHaveBeenCalledTimes(1)
+      expect(quitState.isCloseConfirmed(win as object)).toBe(true)
+    })
+
+    it('closes when the renderer has crashed', async () => {
+      const { win, fireClose } = await buildWindow()
+      fireClose(makeEvent())
+      win.close.mockClear()
+      win.webContents.isCrashed.mockReturnValue(true)
+
+      elapse()
+
+      expect(win.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('stops once the renderer replies', async () => {
+      const { win, fireClose } = await buildWindow()
+      fireClose(makeEvent())
+      win.close.mockClear()
+      // WINDOW_CLOSE_PROCEED clears the in-flight flag.
+      quitState.setCloseInFlight(win as object, false)
+
+      elapse(3)
+
+      expect(win.close).not.toHaveBeenCalled()
+    })
   })
 })

--- a/tritium/react-gui/src/main/quitFunnel.test.ts
+++ b/tritium/react-gui/src/main/quitFunnel.test.ts
@@ -180,6 +180,7 @@ vi.mock('@main/recentFiles', () => ({
   addRecent: vi.fn(() => []),
   clearRecents: vi.fn(() => []),
   getRecents: vi.fn(() => []),
+  refreshRecentsExistence: vi.fn(() => Promise.resolve()),
 }))
 vi.mock('@main/naviContextMenu', () => ({ showNaviContextMenu: vi.fn() }))
 vi.mock('@main/sceneContextMenu', () => ({ showSceneContextMenu: vi.fn() }))

--- a/tritium/react-gui/src/main/quitFunnel.test.ts
+++ b/tritium/react-gui/src/main/quitFunnel.test.ts
@@ -244,19 +244,31 @@ async function importIndexAndGetBeforeQuit(): Promise<Listener> {
 }
 
 describe('before-quit guard (main/index.ts)', () => {
-  it('routes a fresh quit through every live window: preventDefault + close() each, sets appQuitting', async () => {
+  /**
+   * Only the main window is closed. It is the one with a confirm funnel, and
+   * its 'closed' handler takes the Rendering window down with it. Closing every
+   * window here destroyed the Rendering window first -- it has no funnel -- so
+   * cancelling the main window's save prompt restored the app minus its render
+   * history view and any in-flight settings.
+   */
+  it('routes a fresh quit through the main window only, and sets appQuitting', async () => {
     const beforeQuit = await importIndexAndGetBeforeQuit()
-    const winA = makeWin()
-    const winB = makeWin()
-    allWindows = [winA, winB]
+    constructedWin = null
+    const wm = (await import(windowManagerEntry)) as unknown as { createWindow(): void }
+    wm.createWindow()
+    const mainWin = getConstructedWin()
+    if (!mainWin) throw new Error('createWindow did not construct a BrowserWindow')
+
+    // A second live window (the Rendering window) must be left alone.
+    const other = makeWin()
+    allWindows = [mainWin, other]
 
     const ev = makeEvent()
     beforeQuit(ev)
 
-    // Quit is intercepted so each window runs its own confirm funnel.
     expect(ev.preventDefault).toHaveBeenCalledTimes(1)
-    expect(winA.close).toHaveBeenCalledTimes(1)
-    expect(winB.close).toHaveBeenCalledTimes(1)
+    expect(mainWin.close).toHaveBeenCalledTimes(1)
+    expect(other.close).not.toHaveBeenCalled()
     expect(quitState.isAppQuitting()).toBe(true)
   })
 

--- a/tritium/react-gui/src/main/quitFunnel.test.ts
+++ b/tritium/react-gui/src/main/quitFunnel.test.ts
@@ -214,8 +214,6 @@ interface IpcHandlersModule {
   registerIpcHandlers(win: unknown): void
 }
 interface QuitStateModule {
-  WINDOW_CLOSE_WATCHDOG_MS: number
-  setCloseInFlight(win: object, value: boolean): void
   isAppQuitting(): boolean
   setAppQuitting(v: boolean): void
   isForceQuit(): boolean
@@ -447,86 +445,35 @@ describe('handleWindowClose funnel + render-process-gone (main/windowManager.ts)
   })
 
   /**
-   * The watchdog is there so the user is never trapped by a renderer that
-   * cannot answer. It must never fire because the renderer is busy, or because
-   * the *user* is taking their time -- forcing the window shut then discards
-   * the very scenes the confirm chain was asking about.
+   * There is deliberately no close timeout. A stopwatch cannot tell "the
+   * renderer is stuck" from "the renderer is busy" or "the user is thinking",
+   * and the chain shows a "Save changes?" confirm per modified scene -- so a
+   * timeout fires on a slow decision and discards the very scenes it was
+   * asking about. The cases where the renderer genuinely cannot answer are
+   * covered elsewhere: a crash by 'render-process-gone' above, and a hung
+   * renderer by the OS's own force-quit.
    */
-  describe('close watchdog', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-      menuBlocked.value = false
-    })
-    afterEach(() => {
-      vi.useRealTimers()
-      menuBlocked.value = false
-    })
+  describe('no close timeout', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
 
-    /** Let the watchdog interval elapse `times` over. */
-    function elapse(times = 1): void {
-      for (let i = 0; i < times; i++) {
-        vi.advanceTimersByTime(quitState.WINDOW_CLOSE_WATCHDOG_MS + 1)
-      }
-    }
-
-    it('does not close while a dialog is on screen, however long the user takes', async () => {
+    it('never closes the window on its own, however long the renderer takes', async () => {
       const { win, fireClose } = await buildWindow()
       fireClose(makeEvent())
       win.close.mockClear()
-      // The renderer reported a modal through MENU_SET_MODAL_BLOCKED.
-      menuBlocked.value = true
 
-      elapse(6)
+      // Far longer than any timeout this funnel ever had.
+      vi.advanceTimersByTime(10 * 60 * 1000)
 
       expect(win.close).not.toHaveBeenCalled()
       expect(quitState.isCloseInFlight(win as object)).toBe(true)
     })
 
-    it('does not close while the renderer is alive and simply slow', async () => {
-      const { win, fireClose } = await buildWindow()
+    it('schedules no timer when the close request goes out', async () => {
+      const { fireClose } = await buildWindow()
+      const before = vi.getTimerCount()
       fireClose(makeEvent())
-      win.close.mockClear()
-
-      elapse(3)
-
-      expect(win.close).not.toHaveBeenCalled()
-      expect(quitState.isCloseInFlight(win as object)).toBe(true)
-    })
-
-    it('closes once Chromium reports the renderer unresponsive', async () => {
-      const { win, fireClose } = await buildWindow()
-      fireClose(makeEvent())
-      win.close.mockClear()
-
-      const unresponsive = win.webContents.listeners.get('unresponsive') ?? []
-      unresponsive[0]?.()
-      elapse()
-
-      expect(win.close).toHaveBeenCalledTimes(1)
-      expect(quitState.isCloseConfirmed(win as object)).toBe(true)
-    })
-
-    it('closes when the renderer has crashed', async () => {
-      const { win, fireClose } = await buildWindow()
-      fireClose(makeEvent())
-      win.close.mockClear()
-      win.webContents.isCrashed.mockReturnValue(true)
-
-      elapse()
-
-      expect(win.close).toHaveBeenCalledTimes(1)
-    })
-
-    it('stops once the renderer replies', async () => {
-      const { win, fireClose } = await buildWindow()
-      fireClose(makeEvent())
-      win.close.mockClear()
-      // WINDOW_CLOSE_PROCEED clears the in-flight flag.
-      quitState.setCloseInFlight(win as object, false)
-
-      elapse(3)
-
-      expect(win.close).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(before)
     })
   })
 })

--- a/tritium/react-gui/src/main/quitState.ts
+++ b/tritium/react-gui/src/main/quitState.ts
@@ -83,38 +83,3 @@ export function setForceQuit(value: boolean): void {
   forceQuit = value
 }
 
-// --- Close-request watchdog ---
-
-/**
- * Time the main process will wait for a WINDOW_CLOSE_PROCEED reply before
- * assuming the renderer is wedged and forcing the window closed. Tuned to
- * avoid false positives during slow confirm dialogs; shorten if hangs
- * become a routine issue.
- */
-export const WINDOW_CLOSE_WATCHDOG_MS = 10000
-
-const closeWatchdogs = new WeakMap<BrowserWindow, ReturnType<typeof setTimeout>>()
-
-export function setCloseWatchdog(
-  win: BrowserWindow,
-  timer: ReturnType<typeof setTimeout>,
-): void {
-  closeWatchdogs.set(win, timer)
-}
-
-/**
- * Cancel the WINDOW_CLOSE_REQUEST watchdog for `win`. Called when the
- * renderer replies via WINDOW_CLOSE_PROCEED so the timer does not fire
- * after a successful confirm.
- */
-export function clearCloseWatchdog(win: BrowserWindow): void {
-  const timer = closeWatchdogs.get(win)
-  if (timer !== undefined) {
-    clearTimeout(timer)
-    closeWatchdogs.delete(win)
-  }
-}
-
-export function hasCloseWatchdog(win: BrowserWindow): boolean {
-  return closeWatchdogs.has(win)
-}

--- a/tritium/react-gui/src/main/recentFiles.ts
+++ b/tritium/react-gui/src/main/recentFiles.ts
@@ -10,7 +10,7 @@
  * second window mutated the store.
  */
 
-import fs from 'fs'
+import { promises as fsp } from 'fs'
 import type { RecentFileEntry } from '@shared/ipcTypes'
 import { addToRecents, MAX_RECENTS } from '@shared/recentFilesLogic'
 import { loadRecentFiles, saveRecentFiles } from './stateStore'
@@ -45,12 +45,45 @@ export function clearRecents(): RecentFileEntry[] {
  * not pruned -- a transiently unmounted volume must not cause permanent
  * loss of history.
  */
+/**
+ * Paths last seen as missing. Everything not in here is treated as present.
+ *
+ * The menu is rebuilt on startup and on every RECENT_ADD / RECENT_CLEAR, and
+ * this used to stat each entry synchronously on the main thread. One MRU path
+ * on a disconnected SMB / NFS mount then blocked every window's IPC and input
+ * for the mount timeout -- tens of seconds. The check runs off the menu path
+ * now; the worst case is one stale entry shown until the refresh lands.
+ */
+const missingPaths = new Set<string>()
+
+/** Recent entries minus the ones the last refresh found missing. */
 export function getExistingRecents(): RecentFileEntry[] {
-  return getRecents().filter((e) => {
-    try {
-      return fs.existsSync(e.path)
-    } catch {
-      return false
-    }
-  })
+  return getRecents().filter((e) => !missingPaths.has(e.path))
+}
+
+/**
+ * Re-check which recent paths still exist, off the main thread's critical path.
+ *
+ * @param onChange - called when the missing set actually changed, so the caller
+ *   can rebuild the menu.
+ */
+export async function refreshRecentsExistence(onChange?: () => void): Promise<void> {
+  const before = new Set(missingPaths)
+  const entries = getRecents()
+  const results = await Promise.all(
+    entries.map(async (e) => {
+      try {
+        await fsp.access(e.path)
+        return [e.path, true] as const
+      } catch {
+        return [e.path, false] as const
+      }
+    }),
+  )
+  missingPaths.clear()
+  for (const [p, exists] of results) if (!exists) missingPaths.add(p)
+
+  const changed =
+    before.size !== missingPaths.size || [...missingPaths].some((p) => !before.has(p))
+  if (changed) onChange?.()
 }

--- a/tritium/react-gui/src/main/renderHistory.test.ts
+++ b/tritium/react-gui/src/main/renderHistory.test.ts
@@ -158,3 +158,70 @@ describe('main render history work directories', () => {
     expect(fs.existsSync(outside)).toBe(true);
   });
 });
+
+/**
+ * HISTORY_DIR is a fixed path under os.tmpdir() shared by every instance, and
+ * CUEMOL_FRESH_PREFS deliberately gives a second instance its own
+ * single-instance lock domain -- so it acquires the lock, reaches the startup
+ * sweep, and used to delete the running instance's history and rm -rf its live
+ * work directories. movieOutput.sweepMovieSessions already guarded this way.
+ */
+/**
+ * HISTORY_DIR is a fixed path under os.tmpdir() shared by every instance, and
+ * CUEMOL_FRESH_PREFS deliberately gives a second instance its own
+ * single-instance lock domain -- so it acquires the lock, reaches the startup
+ * sweep, and used to delete the running instance's history and rm -rf its live
+ * work directories. movieOutput.sweepMovieSessions already guarded this way.
+ */
+describe('clearRenderHistory startup sweep ownership', () => {
+  /** The shared history directory the module writes into. */
+  const historyDir = (): string => path.join(os.tmpdir(), 'cuemol-render-history');
+  const indexFile = (): string => path.join(historyDir(), 'workdirs.json');
+
+  /** Seed the on-disk index as if `pid` had written it. */
+  function writeIndex(pid: number, dirs: string[]): void {
+    fs.mkdirSync(historyDir(), { recursive: true });
+    fs.writeFileSync(indexFile(), JSON.stringify({ pid, dirs }));
+  }
+
+  it('stands down when the index names another live process', () => {
+    const dir = path.join(srcDir, 'live-workdir');
+    fs.mkdirSync(dir, { recursive: true });
+    // The parent process: alive, and not us -- exactly the shape of a second
+    // instance finding the first one's index. (Portable, unlike pid 1.)
+    writeIndex(process.ppid, [dir]);
+
+    clearRenderHistory({ startup: true });
+
+    expect(fs.existsSync(dir)).toBe(true);
+    expect(fs.existsSync(indexFile())).toBe(true);
+  });
+
+  it('sweeps when the recorded owner is gone', () => {
+    // A pid no live process can hold on any supported platform.
+    writeIndex(2147483646, []);
+
+    clearRenderHistory({ startup: true });
+
+    expect(fs.existsSync(historyDir())).toBe(false);
+  });
+
+  it('the quit sweep always runs, even for its own index', () => {
+    writeIndex(process.pid, []);
+
+    clearRenderHistory();
+
+    expect(fs.existsSync(historyDir())).toBe(false);
+  });
+
+  it('still adopts a legacy bare-array index', () => {
+    const dir = path.join(srcDir, 'legacy-workdir');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(historyDir(), { recursive: true });
+    fs.writeFileSync(indexFile(), JSON.stringify([dir]));
+
+    clearRenderHistory({ startup: true });
+
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+});

--- a/tritium/react-gui/src/main/renderHistory.test.ts
+++ b/tritium/react-gui/src/main/renderHistory.test.ts
@@ -9,12 +9,13 @@
  * order, and that a cleared store reports its images as gone.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import {
   clearRenderHistory,
+  sweepStaleRenderHistory,
   clearRenderWorkDirs,
   readRenderImage,
   registerRenderWorkDir,
@@ -133,19 +134,21 @@ describe('main render history work directories', () => {
     expect(() => clearRenderWorkDirs()).not.toThrow();
   });
 
-  it('reclaims a crashed run\'s directories on the next start', async () => {
-    // A run registers a work dir ...
+  it('records a registered directory in this run\'s index, for a later start to reclaim', () => {
+    // The in-memory list dies with a crashed run, so the index on disk is what
+    // makes its work directories identifiable afterwards. Reclaiming them is
+    // the boot sweep's job now that each run owns a directory -- a crashed run
+    // has a different pid, which is what marks it as reclaimable. The sweep
+    // itself is covered under 'per-run isolation' below.
     const dir = makeWorkDir();
     registerRenderWorkDir(dir);
 
-    // ... then dies without reaching its cleanup, losing the in-memory list.
-    // A fresh module instance is exactly that: same files, no state.
-    vi.resetModules();
-    const restarted = await import('@main/renderHistory');
-
-    // The next start clears the history, which adopts the on-disk index.
-    restarted.clearRenderHistory();
-    expect(fs.existsSync(dir)).toBe(false);
+    const index = path.join(
+      os.tmpdir(), 'cuemol-render-history', `run-${process.pid}`, 'workdirs.json',
+    );
+    const parsed = JSON.parse(fs.readFileSync(index, 'utf8')) as { pid: number; dirs: string[] };
+    expect(parsed.pid).toBe(process.pid);
+    expect(parsed.dirs).toContain(path.resolve(dir));
   });
 
   it('ignores a directory outside the temp dir', () => {
@@ -173,55 +176,77 @@ describe('main render history work directories', () => {
  * sweep, and used to delete the running instance's history and rm -rf its live
  * work directories. movieOutput.sweepMovieSessions already guarded this way.
  */
-describe('clearRenderHistory startup sweep ownership', () => {
-  /** The shared history directory the module writes into. */
-  const historyDir = (): string => path.join(os.tmpdir(), 'cuemol-render-history');
-  const indexFile = (): string => path.join(historyDir(), 'workdirs.json');
+/**
+ * Two instances really do run at once: CUEMOL_FRESH_PREFS gives the second one
+ * its own single-instance lock domain. They used to share one directory under
+ * os.tmpdir(), so the second one's boot sweep deleted the first one's archived
+ * images and rm -rf'd its live work directories.
+ *
+ * A marker file inside a shared directory cannot express ownership -- whichever
+ * instance writes last owns it, and the marker only existed once a work
+ * directory had been registered, so a run that had only archived images was
+ * unprotected. Each run now owns its own directory instead, which makes the
+ * separation structural.
+ */
+describe('per-run isolation', () => {
+  const root = (): string => path.join(os.tmpdir(), 'cuemol-render-history');
+  const runDir = (pid: number): string => path.join(root(), `run-${pid}`);
 
-  /** Seed the on-disk index as if `pid` had written it. */
-  function writeIndex(pid: number, dirs: string[]): void {
-    fs.mkdirSync(historyDir(), { recursive: true });
-    fs.writeFileSync(indexFile(), JSON.stringify({ pid, dirs }));
+  /** Plant a directory as if `pid` had written it. */
+  function plantRun(pid: number, workDirs: string[] = []): string {
+    const dir = runDir(pid);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'image.png'), 'PLANTED');
+    fs.writeFileSync(path.join(dir, 'workdirs.json'), JSON.stringify({ pid, dirs: workDirs }));
+    return dir;
   }
 
-  it('stands down when the index names another live process', () => {
-    const dir = path.join(srcDir, 'live-workdir');
-    fs.mkdirSync(dir, { recursive: true });
-    // The parent process: alive, and not us -- exactly the shape of a second
-    // instance finding the first one's index. (Portable, unlike pid 1.)
-    writeIndex(process.ppid, [dir]);
-
-    clearRenderHistory({ startup: true });
-
-    expect(fs.existsSync(dir)).toBe(true);
-    expect(fs.existsSync(indexFile())).toBe(true);
+  it('archives into this run own directory', () => {
+    expect(storeRenderImage('own-1', makeImage('own', 'X'))).toBe(true);
+    expect(fs.existsSync(runDir(process.pid))).toBe(true);
   });
 
-  it('sweeps when the recorded owner is gone', () => {
+  it('leaves a live instance directory alone', () => {
+    // The parent process: alive, and not us -- the shape of a second instance
+    // finding the first one's directory. (Portable, unlike pid 1.)
+    const live = plantRun(process.ppid);
+    const liveWork = path.join(srcDir, 'live-work');
+    fs.mkdirSync(liveWork, { recursive: true });
+    fs.writeFileSync(path.join(live, 'workdirs.json'), JSON.stringify({ pid: process.ppid, dirs: [liveWork] }));
+
+    sweepStaleRenderHistory();
+
+    expect(fs.existsSync(live)).toBe(true);
+    expect(fs.existsSync(liveWork)).toBe(true);
+    fs.rmSync(live, { recursive: true, force: true });
+  });
+
+  it('removes a dead run directory and the work dirs it registered', () => {
+    const deadWork = path.join(srcDir, 'dead-work');
+    fs.mkdirSync(deadWork, { recursive: true });
     // A pid no live process can hold on any supported platform.
-    writeIndex(2147483646, []);
+    const dead = plantRun(2147483646, [deadWork]);
 
-    clearRenderHistory({ startup: true });
+    sweepStaleRenderHistory();
 
-    expect(fs.existsSync(historyDir())).toBe(false);
+    expect(fs.existsSync(dead)).toBe(false);
+    expect(fs.existsSync(deadWork)).toBe(false);
   });
 
-  it('the quit sweep always runs, even for its own index', () => {
-    writeIndex(process.pid, []);
+  it('never removes its own directory during the boot sweep', () => {
+    storeRenderImage('own-2', makeImage('own2', 'Y'));
+    sweepStaleRenderHistory();
+    expect(readRenderImage('own-2')).not.toBeNull();
+  });
+
+  it('clearRenderHistory removes only this run', () => {
+    storeRenderImage('own-3', makeImage('own3', 'Z'));
+    const live = plantRun(process.ppid);
 
     clearRenderHistory();
 
-    expect(fs.existsSync(historyDir())).toBe(false);
-  });
-
-  it('still adopts a legacy bare-array index', () => {
-    const dir = path.join(srcDir, 'legacy-workdir');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.mkdirSync(historyDir(), { recursive: true });
-    fs.writeFileSync(indexFile(), JSON.stringify([dir]));
-
-    clearRenderHistory({ startup: true });
-
-    expect(fs.existsSync(dir)).toBe(false);
+    expect(fs.existsSync(runDir(process.pid))).toBe(false);
+    expect(fs.existsSync(live)).toBe(true);
+    fs.rmSync(live, { recursive: true, force: true });
   });
 });

--- a/tritium/react-gui/src/main/renderHistory.ts
+++ b/tritium/react-gui/src/main/renderHistory.ts
@@ -57,16 +57,52 @@ function ensureDir(): boolean {
 }
 
 /**
+ * Whether a process is still running. EPERM means it exists but belongs to
+ * another user -- alive as far as this check is concerned. Mirrors the guard
+ * movieOutput.ts uses for the same reason.
+ */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/**
  * Remove the whole store. Called at startup (clearing a crashed run's images)
  * and on quit; the history is deliberately not kept across app runs, since the
  * settings that produced each render are not either.
+ *
+ * @param opts.startup - true for the boot-time sweep. HISTORY_DIR is a fixed
+ *   path under os.tmpdir() shared by every instance, and CUEMOL_FRESH_PREFS
+ *   deliberately gives a second instance its own single-instance lock domain,
+ *   so that instance reaches this sweep while the first is still running. The
+ *   startup sweep therefore stands down when the recorded owner is another
+ *   live process -- otherwise it deleted the running instance's history and
+ *   rm -rf'd its live work directories. The quit sweep always runs: it is
+ *   clearing up after itself.
  */
-export function clearRenderHistory(): void {
+export function clearRenderHistory(opts: { startup?: boolean } = {}): void {
+  const index = readWorkDirIndex()
+  if (
+    opts.startup &&
+    index.ownerPid !== null &&
+    index.ownerPid !== process.pid &&
+    isPidAlive(index.ownerPid)
+  ) {
+    console.log(
+      `[Main] render history is owned by live pid ${index.ownerPid}; leaving it alone`,
+    )
+    return
+  }
+
   // Adopt a previous run's directories: the on-disk index outlived the
   // in-memory list when that run crashed. Done silently -- the images they
   // hold are unreachable (the history metadata died with that run), so there
   // is nothing for a user to decide.
-  for (const dir of readWorkDirIndex()) registerRenderWorkDir(dir)
+  for (const dir of index.dirs) registerRenderWorkDir(dir)
   clearRenderWorkDirs()
   archived = []
   try {
@@ -76,15 +112,25 @@ export function clearRenderHistory(): void {
   }
 }
 
-/** Work directories recorded on disk, or none when there is no usable index. */
-function readWorkDirIndex(): string[] {
+/**
+ * Work directories recorded on disk, with the pid of the run that wrote them.
+ *
+ * Accepts the legacy bare-array format as "no recorded owner", so an index
+ * written by an older build is still adopted rather than stranded.
+ */
+function readWorkDirIndex(): { ownerPid: number | null; dirs: string[] } {
+  const asDirs = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((d): d is string => typeof d === 'string') : []
   try {
     const parsed: unknown = JSON.parse(fs.readFileSync(WORKDIR_INDEX, 'utf8'))
-    return Array.isArray(parsed)
-      ? parsed.filter((d): d is string => typeof d === 'string')
-      : []
+    if (Array.isArray(parsed)) return { ownerPid: null, dirs: asDirs(parsed) }
+    const pid = (parsed as { pid?: unknown }).pid
+    return {
+      ownerPid: typeof pid === 'number' && Number.isInteger(pid) && pid > 0 ? pid : null,
+      dirs: asDirs((parsed as { dirs?: unknown }).dirs),
+    }
   } catch {
-    return []
+    return { ownerPid: null, dirs: [] }
   }
 }
 
@@ -92,7 +138,9 @@ function readWorkDirIndex(): string[] {
 function writeWorkDirIndex(): void {
   if (!ensureDir()) return
   try {
-    fs.writeFileSync(WORKDIR_INDEX, JSON.stringify(workDirs))
+    // The pid identifies the owner so another instance's startup sweep can
+    // tell "a crashed run's leftovers" from "a running instance's live data".
+    fs.writeFileSync(WORKDIR_INDEX, JSON.stringify({ pid: process.pid, dirs: workDirs }))
   } catch {
     /* losing the index only costs the next start's cleanup */
   }

--- a/tritium/react-gui/src/main/renderHistory.ts
+++ b/tritium/react-gui/src/main/renderHistory.ts
@@ -18,18 +18,37 @@ import * as os from 'os'
 import * as path from 'path'
 import { RENDER_HISTORY_LIMIT, renderHistoryFileName } from '@shared/renderHistory'
 
-/** Fixed directory name, so a crashed run's leftovers are found on restart. */
-const HISTORY_DIR = path.join(os.tmpdir(), 'cuemol-render-history')
+/** Fixed root, so a crashed run's leftovers are found on restart. */
+const HISTORY_ROOT = path.join(os.tmpdir(), 'cuemol-render-history')
+
+/** Prefix of a per-run directory under {@link HISTORY_ROOT}. */
+const RUN_PREFIX = 'run-'
 
 /**
- * Index of the work directories this run registered, kept beside the archived
- * images. The directories have random names, so a run that dies without
- * reaching its cleanup would otherwise leave them unidentifiable; the next
- * start reads this file and removes exactly those. Sweeping the temp dir by
- * name pattern instead would risk deleting a second instance's in-flight
- * directory.
+ * This run's own directory.
+ *
+ * The root is a fixed path under os.tmpdir() shared by every instance, and
+ * CUEMOL_FRESH_PREFS deliberately gives a second instance its own
+ * single-instance lock domain -- so two instances really do run at once. When
+ * they shared one directory, the second one's boot sweep deleted the first
+ * one's archived images and rm -rf'd its live work directories.
+ *
+ * Ownership cannot be expressed with a marker file inside a shared directory:
+ * whichever instance writes last owns it, and the marker only existed at all
+ * once a work directory had been registered. Giving each run its own directory
+ * makes the separation structural -- no instance can reach another's files --
+ * which is the same shape movieOutput.ts uses for movie sessions.
  */
-const WORKDIR_INDEX = path.join(HISTORY_DIR, 'workdirs.json')
+const RUN_DIR = path.join(HISTORY_ROOT, `${RUN_PREFIX}${process.pid}`)
+
+/**
+ * Index of the work directories this run registered, kept beside its archived
+ * images. The directories have random names and live elsewhere under the temp
+ * dir, so a run that dies without reaching its cleanup would otherwise leave
+ * them unidentifiable; a later start reads this file out of the dead run's
+ * directory and removes exactly those.
+ */
+const WORKDIR_INDEX = path.join(RUN_DIR, 'workdirs.json')
 
 /** Archived ids, oldest first -- the eviction order. */
 let archived: string[] = []
@@ -46,10 +65,10 @@ let archived: string[] = []
  */
 let workDirs: string[] = []
 
-/** Create the history directory, returning false when it cannot be used. */
+/** Create this run's history directory, returning false when it cannot be used. */
 function ensureDir(): boolean {
   try {
-    fs.mkdirSync(HISTORY_DIR, { recursive: true })
+    fs.mkdirSync(RUN_DIR, { recursive: true })
     return true
   } catch {
     return false
@@ -71,66 +90,85 @@ function isPidAlive(pid: number): boolean {
 }
 
 /**
- * Remove the whole store. Called at startup (clearing a crashed run's images)
- * and on quit; the history is deliberately not kept across app runs, since the
- * settings that produced each render are not either.
+ * Remove this run's own history: its archived images and the work directories
+ * it registered.
  *
- * @param opts.startup - true for the boot-time sweep. HISTORY_DIR is a fixed
- *   path under os.tmpdir() shared by every instance, and CUEMOL_FRESH_PREFS
- *   deliberately gives a second instance its own single-instance lock domain,
- *   so that instance reaches this sweep while the first is still running. The
- *   startup sweep therefore stands down when the recorded owner is another
- *   live process -- otherwise it deleted the running instance's history and
- *   rm -rf'd its live work directories. The quit sweep always runs: it is
- *   clearing up after itself.
+ * Called on quit, and when the user clears the history from the Rendering
+ * window. Only ever touches this run's directory, so a second instance running
+ * at the same time is unaffected.
  */
-export function clearRenderHistory(opts: { startup?: boolean } = {}): void {
-  const index = readWorkDirIndex()
-  if (
-    opts.startup &&
-    index.ownerPid !== null &&
-    index.ownerPid !== process.pid &&
-    isPidAlive(index.ownerPid)
-  ) {
-    console.log(
-      `[Main] render history is owned by live pid ${index.ownerPid}; leaving it alone`,
-    )
-    return
-  }
-
-  // Adopt a previous run's directories: the on-disk index outlived the
-  // in-memory list when that run crashed. Done silently -- the images they
-  // hold are unreachable (the history metadata died with that run), so there
-  // is nothing for a user to decide.
-  for (const dir of index.dirs) registerRenderWorkDir(dir)
+export function clearRenderHistory(): void {
   clearRenderWorkDirs()
   archived = []
   try {
-    fs.rmSync(HISTORY_DIR, { recursive: true, force: true })
+    fs.rmSync(RUN_DIR, { recursive: true, force: true })
   } catch {
     /* a locked or already-removed directory is not worth failing over */
   }
 }
 
 /**
- * Work directories recorded on disk, with the pid of the run that wrote them.
+ * Remove what previous runs left behind, at boot.
  *
- * Accepts the legacy bare-array format as "no recorded owner", so an index
- * written by an older build is still adopted rather than stranded.
+ * Only directories belonging to a process that is no longer running are
+ * touched: another instance may be live right now (CUEMOL_FRESH_PREFS gives it
+ * its own lock domain), and its images and in-flight work directories must
+ * survive. Each dead run's work directories are read out of its own index and
+ * removed before its directory goes -- they live elsewhere under the temp dir
+ * and would otherwise be unidentifiable.
  */
-function readWorkDirIndex(): { ownerPid: number | null; dirs: string[] } {
-  const asDirs = (v: unknown): string[] =>
-    Array.isArray(v) ? v.filter((d): d is string => typeof d === 'string') : []
+export function sweepStaleRenderHistory(): void {
+  let names: string[]
   try {
-    const parsed: unknown = JSON.parse(fs.readFileSync(WORKDIR_INDEX, 'utf8'))
-    if (Array.isArray(parsed)) return { ownerPid: null, dirs: asDirs(parsed) }
-    const pid = (parsed as { pid?: unknown }).pid
-    return {
-      ownerPid: typeof pid === 'number' && Number.isInteger(pid) && pid > 0 ? pid : null,
-      dirs: asDirs((parsed as { dirs?: unknown }).dirs),
-    }
+    names = fs.readdirSync(HISTORY_ROOT)
   } catch {
-    return { ownerPid: null, dirs: [] }
+    return // nothing has ever been written
+  }
+
+  let removed = 0
+  for (const name of names) {
+    if (!name.startsWith(RUN_PREFIX)) continue
+    const pid = Number.parseInt(name.slice(RUN_PREFIX.length), 10)
+    if (!Number.isInteger(pid) || pid <= 0) continue
+    if (pid === process.pid) continue
+    if (isPidAlive(pid)) continue
+
+    const dir = path.join(HISTORY_ROOT, name)
+    for (const workDir of readWorkDirIndex(path.join(dir, 'workdirs.json'))) {
+      try {
+        fs.rmSync(workDir, { recursive: true, force: true })
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      fs.rmSync(dir, { recursive: true, force: true })
+      removed++
+    } catch {
+      /* ignore */
+    }
+  }
+  if (removed > 0) {
+    const plural = removed === 1 ? '' : 's'
+    console.log(`[Main] render history: removed ${removed} stale run director${plural ? 'ies' : 'y'}`)
+  }
+}
+
+/**
+ * Work directories recorded in one run's index file.
+ *
+ * Ownership is the directory the file sits in, not anything inside it, so the
+ * bare-array format an older build wrote reads back unchanged.
+ *
+ * @param file - index path; a dead run's during the boot sweep, ours otherwise.
+ */
+function readWorkDirIndex(file: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf8'))
+    const list = Array.isArray(parsed) ? parsed : (parsed as { dirs?: unknown }).dirs
+    return Array.isArray(list) ? list.filter((d): d is string => typeof d === 'string') : []
+  } catch {
+    return []
   }
 }
 
@@ -138,8 +176,6 @@ function readWorkDirIndex(): { ownerPid: number | null; dirs: string[] } {
 function writeWorkDirIndex(): void {
   if (!ensureDir()) return
   try {
-    // The pid identifies the owner so another instance's startup sweep can
-    // tell "a crashed run's leftovers" from "a running instance's live data".
     fs.writeFileSync(WORKDIR_INDEX, JSON.stringify({ pid: process.pid, dirs: workDirs }))
   } catch {
     /* losing the index only costs the next start's cleanup */
@@ -194,7 +230,7 @@ export function clearRenderWorkDirs(): void {
  */
 export function storeRenderImage(resultId: string, sourcePath: string): boolean {
   if (!resultId || !sourcePath || !ensureDir()) return false
-  const dest = path.join(HISTORY_DIR, renderHistoryFileName(resultId))
+  const dest = path.join(RUN_DIR, renderHistoryFileName(resultId))
   try {
     fs.copyFileSync(sourcePath, dest)
   } catch {
@@ -207,7 +243,7 @@ export function storeRenderImage(resultId: string, sourcePath: string): boolean 
     const evicted = archived.shift()
     if (evicted === undefined) break
     try {
-      fs.rmSync(path.join(HISTORY_DIR, renderHistoryFileName(evicted)), { force: true })
+      fs.rmSync(path.join(RUN_DIR, renderHistoryFileName(evicted)), { force: true })
     } catch {
       /* ignore */
     }
@@ -217,7 +253,7 @@ export function storeRenderImage(resultId: string, sourcePath: string): boolean 
 
 /** Where an archived render lives, whether or not it is still there. */
 export function renderImagePath(resultId: string): string {
-  return path.join(HISTORY_DIR, renderHistoryFileName(resultId))
+  return path.join(RUN_DIR, renderHistoryFileName(resultId))
 }
 
 /**

--- a/tritium/react-gui/src/main/renderWindowIpc.ts
+++ b/tritium/react-gui/src/main/renderWindowIpc.ts
@@ -41,6 +41,7 @@ import {
   storeRenderImage,
 } from './renderHistory'
 import { handleInvoke } from './ipcHandlers'
+import { withMenuBlocked } from './menu'
 
 /** How long to wait for a main-window reply (view size / view camera). */
 const VIEW_SIZE_TIMEOUT_MS = 2000
@@ -251,14 +252,19 @@ export function registerRenderWindowIpc(deps: RenderWindowIpcDeps): void {
     }
     const rw = getRenderWindow()
     const parent = rw && !rw.isDestroyed() ? rw : mainWindow
-    const picked = await dialog.showSaveDialog(parent, {
-      title: 'Save Rendered Image',
-      defaultPath: defaultName,
-      filters: [
-        { name: 'PNG Image', extensions: ['png'] },
-        { name: 'All Files', extensions: ['*'] },
-      ],
-    })
+    // Blocked like every other native dialog (see handlers/fileDialogs.ts):
+    // without it the application-menu accelerators -- Cmd+Q, Cmd+W, Cmd+S --
+    // still fire while the save sheet is up.
+    const picked = await withMenuBlocked('native', () =>
+      dialog.showSaveDialog(parent, {
+        title: 'Save Rendered Image',
+        defaultPath: defaultName,
+        filters: [
+          { name: 'PNG Image', extensions: ['png'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      }),
+    )
     if (picked.canceled || !picked.filePath) return { canceled: true }
     try {
       fs.copyFileSync(source, picked.filePath)
@@ -278,14 +284,16 @@ export function registerRenderWindowIpc(deps: RenderWindowIpcDeps): void {
     const rw = getRenderWindow()
     const parent = rw && !rw.isDestroyed() ? rw : mainWindow
     const ext = path.extname(moviePath).replace(/^\./, '')
-    const picked = await dialog.showSaveDialog(parent, {
-      title: 'Save Movie',
-      defaultPath: defaultName,
-      filters: [
-        ...(ext ? [{ name: `${ext.toUpperCase()} Movie`, extensions: [ext] }] : []),
-        { name: 'All Files', extensions: ['*'] },
-      ],
-    })
+    const picked = await withMenuBlocked('native', () =>
+      dialog.showSaveDialog(parent, {
+        title: 'Save Movie',
+        defaultPath: defaultName,
+        filters: [
+          ...(ext ? [{ name: `${ext.toUpperCase()} Movie`, extensions: [ext] }] : []),
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      }),
+    )
     if (picked.canceled || !picked.filePath) return { canceled: true }
     try {
       fs.copyFileSync(moviePath, picked.filePath)

--- a/tritium/react-gui/src/main/stateStore.test.ts
+++ b/tritium/react-gui/src/main/stateStore.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @file main/stateStore.test.ts
+ * @description Pins that a damaged app-state.json cannot stop the app booting.
+ *
+ * `new Store({ name, defaults })` without a schema leaves conf's
+ * `clearInvalidConfig` at false, so unparseable JSON makes the *constructor*
+ * throw. The first store read happens inside `app.whenReady()`, which has no
+ * catch, so createWindow() never ran: no window was ever created, therefore
+ * `window-all-closed` never fired either, and the app sat there as a windowless
+ * process with one line on stderr. A truncated write (power loss, full disk) is
+ * all it takes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const storeCtor = vi.fn()
+
+vi.mock('electron-store', () => ({
+  default: class {
+    constructor(opts: unknown) { storeCtor(opts) }
+    get() { return undefined }
+    set() { /* no-op */ }
+  },
+}))
+
+const renameSync = vi.fn<(from: string, to: string) => void>()
+const existsSync = vi.fn<(p: string) => boolean>(() => true)
+vi.mock('fs', () => ({
+  default: { renameSync, existsSync },
+  renameSync,
+  existsSync,
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/userData' },
+}))
+
+async function freshStore() {
+  vi.resetModules()
+  return await import('./stateStore')
+}
+
+beforeEach(() => {
+  storeCtor.mockReset()
+  renameSync.mockReset()
+  existsSync.mockReturnValue(true)
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe('stateStore corrupt-file recovery', () => {
+  it('does not throw when the store file is unparseable', async () => {
+    let calls = 0
+    storeCtor.mockImplementation(() => {
+      calls += 1
+      if (calls === 1) throw new SyntaxError('Unexpected end of JSON input')
+    })
+    const { loadUi } = await freshStore()
+    expect(() => loadUi()).not.toThrow()
+  })
+
+  it('moves the damaged file aside and re-creates the store', async () => {
+    let calls = 0
+    storeCtor.mockImplementation(() => {
+      calls += 1
+      if (calls === 1) throw new SyntaxError('Unexpected end of JSON input')
+    })
+    const { loadUi } = await freshStore()
+    loadUi()
+    expect(renameSync).toHaveBeenCalledTimes(1)
+    const [from, to] = renameSync.mock.calls[0] as [string, string]
+    expect(String(from)).toMatch(/app-state\.json$/)
+    expect(String(to)).toMatch(/app-state\.json\.corrupt$/)
+    expect(calls).toBe(2)
+  })
+
+  it('constructs the store once on the happy path', async () => {
+    const { loadUi } = await freshStore()
+    loadUi()
+    loadUi()
+    expect(storeCtor).toHaveBeenCalledTimes(1)
+    expect(renameSync).not.toHaveBeenCalled()
+  })
+})

--- a/tritium/react-gui/src/main/stateStore.ts
+++ b/tritium/react-gui/src/main/stateStore.ts
@@ -7,6 +7,9 @@
  *   - `ui`           -- miscellaneous UI preferences
  */
 
+import fs from 'fs'
+import path from 'path'
+import { app } from 'electron'
 import Store from 'electron-store'
 import type { LayoutState, RecentFileEntry, UiState } from '@shared/ipcTypes'
 
@@ -56,11 +59,47 @@ const DEFAULTS: StoreSchema = {
 
 // --- Store instance (lazy singleton) ---
 
+const STORE_NAME = 'app-state'
+
 let _store: Store<StoreSchema> | null = null
 
+/**
+ * Move a damaged store file aside so the next construction starts clean.
+ *
+ * Renaming rather than deleting keeps the file for support: everything in it
+ * is a UI preference, so losing it costs the user their window geometry and
+ * panel layout, not data.
+ */
+function quarantineStoreFile(): void {
+  try {
+    const file = path.join(app.getPath('userData'), `${STORE_NAME}.json`)
+    if (fs.existsSync(file)) {
+      fs.renameSync(file, `${file}.corrupt`)
+      console.error(`[stateStore] unreadable ${file}; moved to ${file}.corrupt`)
+    }
+  } catch (e) {
+    console.error('[stateStore] could not quarantine the damaged store file:', e)
+  }
+}
+
+/**
+ * The electron-store singleton.
+ *
+ * conf leaves `clearInvalidConfig` false, so unparseable JSON throws out of the
+ * constructor. The first read happens inside `app.whenReady()`, which has no
+ * catch: a truncated write (power loss, full disk) meant createWindow() never
+ * ran, no window was ever created, `window-all-closed` therefore never fired,
+ * and the app sat there as a windowless process. Recover instead -- the file
+ * holds only UI preferences.
+ */
 function getStore(): Store<StoreSchema> {
-  if (!_store) {
-    _store = new Store<StoreSchema>({ name: 'app-state', defaults: DEFAULTS })
+  if (_store) return _store
+  try {
+    _store = new Store<StoreSchema>({ name: STORE_NAME, defaults: DEFAULTS })
+  } catch (e) {
+    console.error('[stateStore] failed to open the state store:', e)
+    quarantineStoreFile()
+    _store = new Store<StoreSchema>({ name: STORE_NAME, defaults: DEFAULTS })
   }
   return _store
 }

--- a/tritium/react-gui/src/main/stateStore.ts
+++ b/tritium/react-gui/src/main/stateStore.ts
@@ -106,8 +106,19 @@ function getStore(): Store<StoreSchema> {
 
 // --- Public API ---
 
-export function loadWindowBounds(): WindowBounds {
-  return getStore().get('windowBounds')
+/**
+ * Load the main-window geometry, or undefined when it has never been saved.
+ *
+ * The `{0,0}` guard is the same one loadRenderWindowBounds uses, and for the
+ * same reason: the schema default sits at 0,0, and it passes
+ * isVisibleOnAnyDisplay, so on a fresh profile the window was pinned to the
+ * top-left corner instead of getting the OS's own placement.
+ */
+export function loadWindowBounds(): WindowBounds | undefined {
+  const b = getStore().get('windowBounds')
+  if (!b) return undefined
+  if (b.x === 0 && b.y === 0) return undefined
+  return b
 }
 
 export function saveWindowBounds(bounds: WindowBounds): void {

--- a/tritium/react-gui/src/main/textContextMenu.test.ts
+++ b/tritium/react-gui/src/main/textContextMenu.test.ts
@@ -148,3 +148,30 @@ describe('buildTextCtxMenuNodes (win/linux React path)', () => {
     expect(nodes).toEqual([])
   })
 })
+
+/**
+ * The Rendering window registers the same context menu. Its Select All used to
+ * push MENU_GENERIC, which only the main window listens for, so from the
+ * Rendering window it was a silent no-op. Acting on the window's own contents
+ * works for both.
+ */
+describe('text context menu Select All (macOS native path)', () => {
+    it('selects in the window that showed the menu', async () => {
+        const { buildTextContextMenuTemplate } = await import('./textContextMenu')
+        const selectAll = vi.fn()
+        const template = buildTextContextMenuTemplate(
+            {
+                isEditable: true,
+                selectionText: '',
+                editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: true },
+            },
+            selectAll,
+        )
+        const item = template.find(
+            (t) => typeof t.label === 'string' && /select all/i.test(t.label),
+        )
+        expect(item).toBeDefined()
+        item!.click?.(undefined as never, undefined as never, undefined as never)
+        expect(selectAll).toHaveBeenCalledTimes(1)
+    })
+})

--- a/tritium/react-gui/src/main/textContextMenu.ts
+++ b/tritium/react-gui/src/main/textContextMenu.ts
@@ -111,7 +111,10 @@ export function registerTextContextMenu(mainWindow: BrowserWindow): void {
 
     const template = buildTextContextMenuTemplate(
       menuParams,
-      () => mainWindow.webContents.send(IPC.MENU_GENERIC, 'menu:select-all'),
+      // Act on this window's own contents. Routing through MENU_GENERIC only
+      // works for the main window, which is the only one with a listener --
+      // from the Rendering window it was a silent no-op.
+      () => mainWindow.webContents.selectAll(),
     )
     if (template.length === 0) return
     const menu = Menu.buildFromTemplate(template)

--- a/tritium/react-gui/src/main/windowManager.ts
+++ b/tritium/react-gui/src/main/windowManager.ts
@@ -13,22 +13,19 @@ import {
 } from './stateStore'
 import { registerIpcHandlers } from './ipcHandlers'
 import { registerRenderWindowIpc } from './renderWindowIpc'
-import { isBlocked, resetMenuBlockReason, createMenu } from './menu'
+import { resetMenuBlockReason, createMenu } from './menu'
 import { registerTextContextMenu } from './textContextMenu'
 import { registerCuemolClipboardIpc } from './cuemolClipboard'
 import { getDevIconPath } from './helpers/appIcon'
 import { APP_PRODUCT_NAME } from '@shared/appInfo'
 import { IPC } from '@shared/ipcChannels'
 import {
-  clearCloseWatchdog,
   isCloseConfirmed,
   isCloseInFlight,
   setAppQuitting,
   setCloseConfirmed,
   setCloseInFlight,
-  setCloseWatchdog,
   setForceQuit,
-  WINDOW_CLOSE_WATCHDOG_MS,
 } from './quitState'
 
 function isVisibleOnAnyDisplay(bounds: WindowBounds): boolean {
@@ -87,6 +84,16 @@ function trackWindowState(
  * IPC.WINDOW_CLOSE_PROCEED the window is marked confirmed and re-closed,
  * and this funnel lets the second 'close' through. The red-button and
  * Cmd+Q (which calls win.close() per window) both reach this funnel.
+ *
+ * There is deliberately no timeout here. A stopwatch cannot tell "the renderer
+ * is stuck" from "the renderer is busy" or "the user is thinking", and the
+ * chain shows a "Save changes?" confirm per modified scene -- so a timeout
+ * fires on a slow decision and discards the very scenes it was asking about.
+ * The two cases where the renderer genuinely cannot answer are covered
+ * elsewhere: a crash exits through 'render-process-gone' below, and a hung
+ * renderer is what the OS's own "application not responding" force-quit is
+ * for. If an in-app escape is ever wanted for the hung case, it should ask
+ * (a native message box from main) rather than close on its own.
  */
 function handleWindowClose(win: BrowserWindow, event: Electron.Event): void {
   if (isCloseConfirmed(win)) return
@@ -96,84 +103,6 @@ function handleWindowClose(win: BrowserWindow, event: Electron.Event): void {
   if (isCloseInFlight(win)) return
   setCloseInFlight(win, true)
   win.webContents.send(IPC.WINDOW_CLOSE_REQUEST)
-  armCloseWatchdog(win)
-}
-
-/** Windows whose renderer Chromium currently reports as unresponsive. */
-const unresponsiveWindows = new WeakSet<BrowserWindow>()
-
-/** Record Chromium's responsiveness verdict for `win`. */
-export function setRendererUnresponsive(win: BrowserWindow, value: boolean): void {
-  if (value) unresponsiveWindows.add(win)
-  else unresponsiveWindows.delete(win)
-}
-
-/**
- * Whether the renderer is provably not running JavaScript right now.
- *
- * This -- not a stopwatch -- is what "the renderer cannot answer" means.
- */
-function rendererCannotAnswer(win: BrowserWindow): boolean {
-  if (win.webContents.isDestroyed()) return true
-  if (win.webContents.isCrashed()) return true
-  return unresponsiveWindows.has(win)
-}
-
-/**
- * (Re-)start the WINDOW_CLOSE_REQUEST watchdog for `win`.
- *
- * The watchdog exists so the user is never trapped by a renderer that cannot
- * answer the close request. It must never fire because the renderer is *busy*
- * or because the *user* is taking their time -- forcing the window shut then
- * discards the unsaved scenes the confirm chain was asking about, which is the
- * exact opposite of what the chain is for.
- *
- * A timeout alone cannot tell those apart, so the timeout is only a polling
- * interval here. When it elapses the window is closed only if the renderer is
- * provably not running JavaScript (crashed, or reported unresponsive by
- * Chromium). Otherwise:
- *
- *   - a modal is on screen -- the chain is waiting on a person. Main already
- *     knows this: the renderer reports every dialog through
- *     IPC.MENU_SET_MODAL_BLOCKED, and native dialogs go through
- *     withMenuBlocked('native'). Wait.
- *   - no modal, renderer alive -- it is working (a large scene write can take
- *     a while). Wait.
- *
- * A renderer that is alive but whose chain has stalled on a logic bug is
- * therefore never force-closed. That is deliberate: it cannot be told apart
- * from slow work, its own re-entrancy guard means clearing the in-flight flag
- * would not let the user retry anyway, and quitting on a guess costs the user
- * their unsaved scenes. A crash still exits through 'render-process-gone'.
- */
-export function armCloseWatchdog(win: BrowserWindow): void {
-  clearCloseWatchdog(win)
-  const timer = setTimeout(() => {
-    if (win.isDestroyed()) return
-    if (!isCloseInFlight(win)) return
-
-    if (!rendererCannotAnswer(win)) {
-      // Alive. Either a dialog is up or the chain is still working; keep
-      // waiting rather than throwing away what it is trying to save.
-      if (!isBlocked()) {
-        console.warn(
-          '[Main] no WINDOW_CLOSE_PROCEED after',
-          WINDOW_CLOSE_WATCHDOG_MS,
-          'ms, but the renderer is responsive; still waiting',
-        )
-      }
-      armCloseWatchdog(win)
-      return
-    }
-
-    console.error(
-      '[Main] renderer cannot answer WINDOW_CLOSE_REQUEST (crashed or unresponsive); forcing close',
-    )
-    setCloseInFlight(win, false)
-    setCloseConfirmed(win, true)
-    win.close()
-  }, WINDOW_CLOSE_WATCHDOG_MS)
-  setCloseWatchdog(win, timer)
 }
 
 const isMac = process.platform === 'darwin'
@@ -291,7 +220,6 @@ export function createWindow(): void {
       details.reason,
       'exitCode=' + details.exitCode,
     )
-    clearCloseWatchdog(win)
     setCloseConfirmed(win, true)
     setForceQuit(true)
     setAppQuitting(true)
@@ -314,11 +242,9 @@ export function createWindow(): void {
   // work and false-positive force-quits would be worse than the symptom.
   win.webContents.on('unresponsive', () => {
     console.error('[Main] renderer unresponsive')
-    setRendererUnresponsive(win, true)
   })
   win.webContents.on('responsive', () => {
     console.log('[Main] renderer responsive again')
-    setRendererUnresponsive(win, false)
   })
 
   trackWindowState(win, loadWindowBounds, saveWindowBounds)

--- a/tritium/react-gui/src/main/windowManager.ts
+++ b/tritium/react-gui/src/main/windowManager.ts
@@ -13,7 +13,7 @@ import {
 } from './stateStore'
 import { registerIpcHandlers } from './ipcHandlers'
 import { registerRenderWindowIpc } from './renderWindowIpc'
-import { createMenu } from './menu'
+import { resetMenuBlockReason, createMenu } from './menu'
 import { registerTextContextMenu } from './textContextMenu'
 import { registerCuemolClipboardIpc } from './cuemolClipboard'
 import { getDevIconPath } from './helpers/appIcon'
@@ -223,6 +223,17 @@ export function createWindow(): void {
     setForceQuit(true)
     setAppQuitting(true)
     app.exit(1)
+  })
+
+  // A reload discards the React tree, and with it every component that owed a
+  // menu-unblock. The 'blueprint' block count is incremented when a dialog
+  // mounts and decremented when it unmounts, both from the renderer, so a
+  // reload with a dialog open left the count stuck above zero and every menu
+  // item except the text-edit ones disabled for the rest of the run -- Cmd+Q
+  // included, with no way to recover. Main sees the navigation, so it clears
+  // the reason here.
+  win.webContents.on('did-start-navigation', (_event, _url, _isInPlace, isMainFrame) => {
+    if (isMainFrame) resetMenuBlockReason('blueprint')
   })
 
   // Renderer is hung (e.g. infinite loop in JS or blocked on a sync call).

--- a/tritium/react-gui/src/main/windowManager.ts
+++ b/tritium/react-gui/src/main/windowManager.ts
@@ -50,22 +50,34 @@ function trackWindowState(
 ): void {
   let saveTimer: ReturnType<typeof setTimeout> | null = null
 
+  const writeBounds = (): void => {
+    if (win.isDestroyed()) return
+    const isMaximized = win.isMaximized()
+    const bounds = isMaximized ? (loadBounds() ?? win.getBounds()) : win.getBounds()
+    saveBounds({ ...bounds, isMaximized })
+  }
+
   const persist = (): void => {
     if (saveTimer) clearTimeout(saveTimer)
-    saveTimer = setTimeout(() => {
-      if (!win.isDestroyed()) {
-        const isMaximized = win.isMaximized()
-        const bounds = isMaximized ? (loadBounds() ?? win.getBounds()) : win.getBounds()
-        saveBounds({ ...bounds, isMaximized })
-      }
-    }, 300)
+    saveTimer = setTimeout(writeBounds, 300)
   }
 
   win.on('resize', persist)
   win.on('move', persist)
   win.on('maximize', persist)
   win.on('unmaximize', persist)
-  win.on('close', persist)
+  // Write synchronously on close. Going through `persist` cancelled whatever
+  // resize/move was still pending and re-scheduled it 300 ms past the point
+  // where `win.isDestroyed()` becomes true, so moving or resizing a window and
+  // closing it straight away lost the new geometry. For the Rendering window,
+  // which has no confirm funnel to delay its teardown, that was every close.
+  win.on('close', () => {
+    if (saveTimer) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+    writeBounds()
+  })
 }
 
 /**
@@ -84,17 +96,32 @@ function handleWindowClose(win: BrowserWindow, event: Electron.Event): void {
   if (isCloseInFlight(win)) return
   setCloseInFlight(win, true)
   win.webContents.send(IPC.WINDOW_CLOSE_REQUEST)
+  armCloseWatchdog(win)
+}
 
-  // Watchdog: if the renderer never replies (crashed or wedged), force the
-  // window closed so the user is not stuck unable to quit. Cleared on
-  // WINDOW_CLOSE_PROCEED via `clearCloseWatchdog`.
+/**
+ * (Re-)start the WINDOW_CLOSE_REQUEST watchdog for `win`.
+ *
+ * The watchdog exists for a renderer that never replies at all -- crashed, or
+ * wedged in a loop -- so the user is not left unable to quit. It must not fire
+ * while the renderer is simply *waiting on the user*: the close chain walks
+ * every tab and shows a "Save changes?" confirm for each modified scene, so a
+ * user who thinks for more than the timeout, or a save that takes longer than
+ * it, would have had the window forced shut and the unsaved scenes discarded.
+ *
+ * The renderer therefore re-arms this before each step that can block on a
+ * person (see IPC.WINDOW_CLOSE_PROGRESS), and the timeout only measures
+ * silence.
+ */
+export function armCloseWatchdog(win: BrowserWindow): void {
+  clearCloseWatchdog(win)
   const timer = setTimeout(() => {
     if (win.isDestroyed()) return
     if (!isCloseInFlight(win)) return
     console.error(
       '[Main] WINDOW_CLOSE_REQUEST watchdog fired after',
       WINDOW_CLOSE_WATCHDOG_MS,
-      'ms; forcing close',
+      'ms of silence; forcing close',
     )
     setCloseInFlight(win, false)
     setCloseConfirmed(win, true)

--- a/tritium/react-gui/src/main/windowManager.ts
+++ b/tritium/react-gui/src/main/windowManager.ts
@@ -13,7 +13,7 @@ import {
 } from './stateStore'
 import { registerIpcHandlers } from './ipcHandlers'
 import { registerRenderWindowIpc } from './renderWindowIpc'
-import { resetMenuBlockReason, createMenu } from './menu'
+import { isBlocked, resetMenuBlockReason, createMenu } from './menu'
 import { registerTextContextMenu } from './textContextMenu'
 import { registerCuemolClipboardIpc } from './cuemolClipboard'
 import { getDevIconPath } from './helpers/appIcon'
@@ -99,29 +99,75 @@ function handleWindowClose(win: BrowserWindow, event: Electron.Event): void {
   armCloseWatchdog(win)
 }
 
+/** Windows whose renderer Chromium currently reports as unresponsive. */
+const unresponsiveWindows = new WeakSet<BrowserWindow>()
+
+/** Record Chromium's responsiveness verdict for `win`. */
+export function setRendererUnresponsive(win: BrowserWindow, value: boolean): void {
+  if (value) unresponsiveWindows.add(win)
+  else unresponsiveWindows.delete(win)
+}
+
+/**
+ * Whether the renderer is provably not running JavaScript right now.
+ *
+ * This -- not a stopwatch -- is what "the renderer cannot answer" means.
+ */
+function rendererCannotAnswer(win: BrowserWindow): boolean {
+  if (win.webContents.isDestroyed()) return true
+  if (win.webContents.isCrashed()) return true
+  return unresponsiveWindows.has(win)
+}
+
 /**
  * (Re-)start the WINDOW_CLOSE_REQUEST watchdog for `win`.
  *
- * The watchdog exists for a renderer that never replies at all -- crashed, or
- * wedged in a loop -- so the user is not left unable to quit. It must not fire
- * while the renderer is simply *waiting on the user*: the close chain walks
- * every tab and shows a "Save changes?" confirm for each modified scene, so a
- * user who thinks for more than the timeout, or a save that takes longer than
- * it, would have had the window forced shut and the unsaved scenes discarded.
+ * The watchdog exists so the user is never trapped by a renderer that cannot
+ * answer the close request. It must never fire because the renderer is *busy*
+ * or because the *user* is taking their time -- forcing the window shut then
+ * discards the unsaved scenes the confirm chain was asking about, which is the
+ * exact opposite of what the chain is for.
  *
- * The renderer therefore re-arms this before each step that can block on a
- * person (see IPC.WINDOW_CLOSE_PROGRESS), and the timeout only measures
- * silence.
+ * A timeout alone cannot tell those apart, so the timeout is only a polling
+ * interval here. When it elapses the window is closed only if the renderer is
+ * provably not running JavaScript (crashed, or reported unresponsive by
+ * Chromium). Otherwise:
+ *
+ *   - a modal is on screen -- the chain is waiting on a person. Main already
+ *     knows this: the renderer reports every dialog through
+ *     IPC.MENU_SET_MODAL_BLOCKED, and native dialogs go through
+ *     withMenuBlocked('native'). Wait.
+ *   - no modal, renderer alive -- it is working (a large scene write can take
+ *     a while). Wait.
+ *
+ * A renderer that is alive but whose chain has stalled on a logic bug is
+ * therefore never force-closed. That is deliberate: it cannot be told apart
+ * from slow work, its own re-entrancy guard means clearing the in-flight flag
+ * would not let the user retry anyway, and quitting on a guess costs the user
+ * their unsaved scenes. A crash still exits through 'render-process-gone'.
  */
 export function armCloseWatchdog(win: BrowserWindow): void {
   clearCloseWatchdog(win)
   const timer = setTimeout(() => {
     if (win.isDestroyed()) return
     if (!isCloseInFlight(win)) return
+
+    if (!rendererCannotAnswer(win)) {
+      // Alive. Either a dialog is up or the chain is still working; keep
+      // waiting rather than throwing away what it is trying to save.
+      if (!isBlocked()) {
+        console.warn(
+          '[Main] no WINDOW_CLOSE_PROCEED after',
+          WINDOW_CLOSE_WATCHDOG_MS,
+          'ms, but the renderer is responsive; still waiting',
+        )
+      }
+      armCloseWatchdog(win)
+      return
+    }
+
     console.error(
-      '[Main] WINDOW_CLOSE_REQUEST watchdog fired after',
-      WINDOW_CLOSE_WATCHDOG_MS,
-      'ms of silence; forcing close',
+      '[Main] renderer cannot answer WINDOW_CLOSE_REQUEST (crashed or unresponsive); forcing close',
     )
     setCloseInFlight(win, false)
     setCloseConfirmed(win, true)
@@ -268,9 +314,11 @@ export function createWindow(): void {
   // work and false-positive force-quits would be worse than the symptom.
   win.webContents.on('unresponsive', () => {
     console.error('[Main] renderer unresponsive')
+    setRendererUnresponsive(win, true)
   })
   win.webContents.on('responsive', () => {
     console.log('[Main] renderer responsive again')
+    setRendererUnresponsive(win, false)
   })
 
   trackWindowState(win, loadWindowBounds, saveWindowBounds)

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -284,7 +284,9 @@ const App: React.FC = () => {
     if (tab?.type === 'molview' && tab.viewId !== undefined) {
       if (cm && cueMolReady) {
         setActiveViewByID(tab.viewId);
-        cm.activateView(tab.viewId);
+        cm.activateView(tab.viewId).catch((err: unknown) => {
+          console.warn('activateView failed:', err);
+        });
       }
     } else {
       clearActiveView();

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -77,6 +77,7 @@ const App: React.FC = () => {
     setInspectorOpen: persistInspectorOpen,
     setViewSizes,
     setViewCollapsed,
+    flushPendingSaves,
   } = useLayoutPersistence();
 
   // --- Activity-bar state ---
@@ -250,11 +251,15 @@ const App: React.FC = () => {
   // the user style file when the window closes -- UXP `Qm2Main.onUnLoad`
   // parity. The path is resolved by Main via APP_PATH.
   const saveUserStyleOnClose = useCallback(async (): Promise<void> => {
+    // Closing the window does not unmount the renderer, so the debounced
+    // layout / UI writes have no other chance to land: dragging a splitter and
+    // closing straight after used to lose the new layout.
+    await flushPendingSaves();
     if (!cm) return;
     const info = await window.electronAPI?.invoke(IPC.APP_PATH);
     const path = info?.userStylePath;
     if (path) await cm.saveUserStyle(path);
-  }, [cm]);
+  }, [cm, flushPendingSaves]);
 
   useWindowCloseHandler({
     tabsRef,

--- a/tritium/react-gui/src/renderer/App.tsx
+++ b/tritium/react-gui/src/renderer/App.tsx
@@ -256,6 +256,21 @@ const App: React.FC = () => {
     // closing straight after used to lose the new layout.
     await flushPendingSaves();
     if (!cm) return;
+    // Stop anything still running before the worker goes away with the window.
+    // Renders and APBS runs are external processes (posix_spawn children of
+    // this app), so they outlive it unless they are killed -- and their work
+    // directory is only registered for cleanup on completion, so it would be
+    // left behind too.
+    try {
+      const stopped = await cm.invokeService('cancelAllJobs', {});
+      if (stopped.render > 0 || stopped.apbs > 0) {
+        console.log(
+          `[close] cancelled ${stopped.render} render / ${stopped.apbs} apbs job(s)`,
+        );
+      }
+    } catch (err: unknown) {
+      console.warn('cancelling in-flight jobs failed:', err);
+    }
     const info = await window.electronAPI?.invoke(IPC.APP_PATH);
     const path = info?.userStylePath;
     if (path) await cm.saveUserStyle(path);

--- a/tritium/react-gui/src/renderer/__test__/commandRegistry.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/commandRegistry.test.tsx
@@ -69,6 +69,31 @@ describe('CommandRegistry', () => {
     h.unmount()
   })
 
+  // A handler that throws synchronously must still come back as a rejected
+  // promise. Every call site attaches `.catch(logErr(...))` to the returned
+  // promise; if dispatch throws instead, that catch is never attached and the
+  // error escapes through the IPC push callback into window.onerror.
+  it('a synchronously throwing handler rejects instead of throwing', async () => {
+    const h = makeRenderHook(() => {
+      useRegisterCommand(CmdId.SceneNew, () => {
+        throw new Error('handler blew up')
+      })
+      return useCommands()
+    }, Wrapper)
+    await flushPromises()
+
+    let threw = false
+    let promise: Promise<unknown> | undefined
+    try {
+      promise = h.result.dispatch(CmdId.SceneNew)
+    } catch {
+      threw = true
+    }
+    expect(threw).toBe(false)
+    await expect(promise).rejects.toThrow(/handler blew up/)
+    h.unmount()
+  })
+
   it('has() reflects registration state', async () => {
     const h = makeRenderHook(() => {
       useRegisterCommand(CmdId.FileSave, () => false)

--- a/tritium/react-gui/src/renderer/__test__/crashReporter.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/crashReporter.test.ts
@@ -2,11 +2,13 @@
  * @file renderer/__test__/crashReporter.test.ts
  * @description Pin the CrashReporter wire contract.
  *
- * These tests are degrade-detectors: the four crash sources (worker, react,
- * window.onerror, unhandledrejection) all go through `report()` and rely on
- * it routing the FIRST call to log + IPC + DOM + subscribers, and silently
- * dropping subsequent calls. A future refactor that re-orders these steps
- * or breaks idempotency would break crash visibility for the user.
+ * These tests are degrade-detectors for the FATAL path: a worker or React
+ * crash must route the first call to log + IPC + DOM + subscribers and drop
+ * subsequent ones. A refactor that re-orders those steps or breaks idempotency
+ * would break crash visibility for the user.
+ *
+ * Which sources are fatal (and that the others stay recoverable) is pinned
+ * separately in crashSeverity.test.ts.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -22,7 +24,7 @@ import { setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
 
 function makeReport(overrides: Partial<CrashReport> = {}): CrashReport {
   return {
-    source: 'window-error',
+    source: 'worker-global',
     message: 'boom',
     timestamp: 1234,
     ...overrides,

--- a/tritium/react-gui/src/renderer/__test__/crashSeverity.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/crashSeverity.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @file __test__/crashSeverity.test.ts
+ * @description Pins which crash sources are fatal.
+ *
+ * `report()` used to treat every source alike: the first report -- whatever it
+ * was -- mounted a full-screen overlay whose only control is Quit. Because
+ * `installGlobalCrashHandlers` funnels *every* unhandled promise rejection into
+ * it, one recoverable failure (a worker service rejecting, a `UI_SAVE` failing
+ * on a full disk) replaced the working UI with a crash screen and the only way
+ * back was to restart.
+ *
+ * A rejection is still reported -- logged and forwarded to main so it reaches
+ * stderr -- but it must not take the app down, and it must not consume the
+ * first-report slot that a genuine crash needs.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { CrashReport, CrashSource } from '@shared/ipcTypes'
+import { IPC } from '@shared/ipcChannels'
+
+const mountFallbackDom = vi.fn()
+vi.mock('../crash/mountFallbackDom', () => ({
+  mountFallbackDom: (r: CrashReport) => mountFallbackDom(r),
+}))
+
+function mkReport(source: CrashSource): CrashReport {
+  return { source, message: `boom from ${source}`, timestamp: 1 }
+}
+
+let invoke: ReturnType<typeof vi.fn>
+
+async function freshReporter() {
+  vi.resetModules()
+  return await import('../crash/CrashReporter')
+}
+
+beforeEach(() => {
+  mountFallbackDom.mockClear()
+  invoke = vi.fn(() => Promise.resolve())
+  ;(globalThis as unknown as { electronAPI: unknown }).electronAPI = { invoke }
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  delete (globalThis as unknown as { electronAPI?: unknown }).electronAPI
+  vi.restoreAllMocks()
+})
+
+const FATAL: CrashSource[] = [
+  'worker-global',
+  'worker-message',
+  'worker-render-loop',
+  'react-error-boundary',
+]
+const NON_FATAL: CrashSource[] = ['window-error', 'window-unhandledrejection']
+
+describe('crash severity', () => {
+  it.each(FATAL)('%s mounts the fallback overlay', async (source) => {
+    const { report } = await freshReporter()
+    report(mkReport(source))
+    expect(mountFallbackDom).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(NON_FATAL)('%s does not mount the fallback overlay', async (source) => {
+    const { report } = await freshReporter()
+    report(mkReport(source))
+    expect(mountFallbackDom).not.toHaveBeenCalled()
+  })
+
+  it.each(NON_FATAL)('%s is still reported to main', async (source) => {
+    const { report } = await freshReporter()
+    report(mkReport(source))
+    expect(invoke).toHaveBeenCalledWith(IPC.CRASH_REPORT, expect.objectContaining({ source }))
+  })
+
+  it('a non-fatal report does not consume the slot a real crash needs', async () => {
+    const { report, getCurrentCrash } = await freshReporter()
+    report(mkReport('window-unhandledrejection'))
+    expect(getCurrentCrash()).toBeNull()
+
+    report(mkReport('worker-global'))
+    expect(mountFallbackDom).toHaveBeenCalledTimes(1)
+    expect(getCurrentCrash()?.source).toBe("worker-global")
+  })
+
+  it('subscribers are notified for a fatal crash only', async () => {
+    const { report, subscribe } = await freshReporter()
+    const seen: CrashSource[] = []
+    subscribe((r) => { seen.push(r.source) })
+
+    report(mkReport('window-unhandledrejection'))
+    expect(seen).toEqual([])
+
+    report(mkReport('react-error-boundary'))
+    expect(seen).toEqual(['react-error-boundary'])
+  })
+
+  it('still reports only the first fatal crash', async () => {
+    const { report } = await freshReporter()
+    report(mkReport('worker-global'))
+    report(mkReport('worker-message'))
+    expect(mountFallbackDom).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/dialogFactorySupersede.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogFactorySupersede.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @file __test__/dialogFactorySupersede.test.tsx
+ * @description Pins that a second show() settles the first caller's promise.
+ *
+ * `show()` stores the resolver in a ref. A second call while one dialog is
+ * still open overwrote it, so the first caller's `await` never settled.
+ *
+ * That is not hypothetical: useShellOpenFiles awaits showErrorAlert() for
+ * missing paths *outside* the useOpenFilePaths module mutex, so two Finder
+ * "Open With" invocations in quick succession left the first drain parked on
+ * the alert forever -- and the files it was holding were never opened. The
+ * same shape hangs App.confirmCloseTab when a tab close and the window-close
+ * sweep overlap.
+ */
+
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { makeRenderHook, flushPromises } from './helpers/testHarness'
+import { createDialogHook, createConfirmCancelDialog } from '../hooks/useDialogFactory'
+
+void React
+
+describe('createDialogHook supersede semantics', () => {
+  it('settles the first promise with undefined by default', async () => {
+    const { Provider, useShow } = createDialogHook<void, string | undefined>({
+      name: 'Plain',
+      render: () => null,
+    })
+    const h = makeRenderHook(() => useShow(), ({ children }) => (
+      <Provider>{children}</Provider>
+    ))
+
+    let first: string | undefined | 'PENDING' = 'PENDING'
+    void h.result().then((r) => { first = r })
+    void h.result()
+    await flushPromises()
+
+    expect(first).toBeUndefined()
+    h.unmount()
+  })
+
+  it('settles the first promise with the configured superseded result', async () => {
+    const { Provider, useShow } = createDialogHook<void, 'yes' | 'cancel'>({
+      name: 'Explicit',
+      render: () => null,
+      supersededResult: 'cancel',
+    })
+    const h = makeRenderHook(() => useShow(), ({ children }) => (
+      <Provider>{children}</Provider>
+    ))
+
+    let first: string | 'PENDING' = 'PENDING'
+    void h.result().then((r) => { first = r })
+    void h.result()
+    await flushPromises()
+
+    expect(first).toBe('cancel')
+    h.unmount()
+  })
+
+  it('a confirm/cancel dialog supersedes as a cancel (null)', async () => {
+    const Dummy: React.FC<{ visible: boolean }> = () => null
+    const { Provider, useShow } = createConfirmCancelDialog<
+      Record<string, never>,
+      { picked: string }
+    >({ name: 'Confirmish', component: Dummy as never })
+    const h = makeRenderHook(() => useShow(), ({ children }) => (
+      <Provider>{children}</Provider>
+    ))
+
+    let first: unknown = 'PENDING'
+    void h.result({}).then((r) => { first = r })
+    void h.result({})
+    await flushPromises()
+
+    expect(first).toBeNull()
+    h.unmount()
+  })
+
+  it('the surviving dialog still resolves normally', async () => {
+    let resolveFn: ((v: string) => void) | null = null
+    const { Provider, useShow } = createDialogHook<void, string>({
+      name: 'Survivor',
+      render: ({ resolve }) => { resolveFn = resolve; return null },
+    })
+    const h = makeRenderHook(() => useShow(), ({ children }) => (
+      <Provider>{children}</Provider>
+    ))
+
+    void h.result()
+    const second = h.result()
+    await flushPromises()
+    resolveFn!('answered')
+    await expect(second).resolves.toBe('answered')
+    h.unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/pickReaderName.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/pickReaderName.test.ts
@@ -113,3 +113,50 @@ describe('pickReaderName -- sniff ceiling', () => {
         expect(DEFAULT_SNIFF_CAP).toBeGreaterThanOrEqual(1 << 20)
     })
 })
+
+/**
+ * Readers declare multi-dot extensions -- the PDB reader's fext is
+ * "*.pdb; *.ent; *.pdb.gz". Reducing the path to its last dot-segment turned
+ * "znub.pdb.gz" into "gz", which matched no reader, so the ext-first branch
+ * returned "" and the open failed with "could not determine a compatible
+ * reader". It only surfaced once inferContentFirst started routing such files
+ * here instead of to the content sniff.
+ */
+describe('pickReaderName -- multi-dot extensions', () => {
+    const GZ_READERS: ReaderInfo[] = [
+        { name: 'pdb', fext: '*.pdb;*.ent;*.pdb.gz', category: 0 },
+        { name: 'mmcif', fext: '*.cif;*.cif.gz', category: 0 },
+    ]
+
+    it('resolves a .pdb.gz to the PDB reader without sniffing', () => {
+        const { ctx, searchReaderByContent } = makeCtx(GZ_READERS, () => '')
+        expect(pickReaderName(ctx, '/x/znub.pdb.gz', false)).toBe('pdb')
+        expect(searchReaderByContent).not.toHaveBeenCalled()
+    })
+
+    it('resolves a .cif.gz to the mmCIF reader', () => {
+        const { ctx } = makeCtx(GZ_READERS, () => '')
+        expect(pickReaderName(ctx, '/x/znub.cif.gz', false)).toBe('mmcif')
+    })
+
+    it('still resolves a plain .pdb', () => {
+        const { ctx } = makeCtx(GZ_READERS, () => '')
+        expect(pickReaderName(ctx, '/x/znub.pdb', false)).toBe('pdb')
+    })
+
+    it('prefers the most specific extension when two readers overlap', () => {
+        // A generic gzip reader must not win over the one claiming pdb.gz.
+        const readers: ReaderInfo[] = [
+            ...GZ_READERS,
+            { name: 'anygz', fext: '*.gz', category: 0 },
+        ]
+        const { ctx, searchReaderByContent } = makeCtx(readers, () => '')
+        expect(pickReaderName(ctx, '/x/znub.pdb.gz', false)).toBe('pdb')
+        expect(searchReaderByContent).not.toHaveBeenCalled()
+    })
+
+    it('returns "" for an extension no reader claims', () => {
+        const { ctx } = makeCtx(GZ_READERS, () => '')
+        expect(pickReaderName(ctx, '/x/znub.xyz', false)).toBe('')
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/renderJobInProcess.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/renderJobInProcess.test.ts
@@ -202,3 +202,99 @@ describe('renderStart in-process branch', () => {
         expect(res.error).toMatch(/umbreon backend not compiled in/)
     })
 })
+
+/**
+ * Shutdown cancellation. Renders started through the ProcessManager are
+ * external processes (posix_spawn children), so they outlive the app unless
+ * they are killed -- and their work directory is only registered for cleanup
+ * once the job completes. Nothing was cancelling them when the window closed.
+ */
+describe('cancelAllRenderJobs', () => {
+    let intervalCb: (() => void) | null
+
+    beforeEach(() => {
+        intervalCb = null
+        vi.spyOn(globalThis, 'setInterval').mockImplementation(((cb: () => void) => {
+            intervalCb = cb
+            return 1 as never
+        }) as never)
+        vi.spyOn(globalThis, 'clearInterval').mockImplementation((() => {}) as never)
+    })
+    afterEach(() => vi.restoreAllMocks())
+
+    function startInProcessJob(): { jobId: string; handle: ReturnType<typeof makeInProcHandle> } {
+        const handle = makeInProcHandle()
+        hoisted.getRenderBackend.mockReturnValue({
+            id: 'umbreon',
+            exportScene: vi.fn((_c: unknown, _s: unknown, _snap: unknown, workDir: string) => ({
+                inputPath: '',
+                workDir,
+                blendTable: {},
+            })),
+            outputImagePath: () => '/tmp/never-written.png',
+            beginInProcess: vi.fn(() => handle),
+            buildTasks: vi.fn(),
+            parseProgress: () => null,
+        })
+        const ctx = { svc: { pushMessage: vi.fn(), getService: vi.fn() } } as unknown as WorkerContext
+        const res = services.renderStart(ctx, {
+            sceneId: 1,
+            viewId: 2,
+            snapshot: {
+                mode: 'still',
+                backend: 'umbreon',
+                commonProps: [
+                    { key: 'width', label: 'w', type: 'real', value: 320, group: 'g' },
+                    { key: 'height', label: 'h', type: 'real', value: 240, group: 'g' },
+                    { key: 'unit', label: 'u', type: 'string', value: 'px', group: 'g' },
+                    { key: 'dpi', label: 'd', type: 'real', value: 600, group: 'g' },
+                ] as PropDef[],
+                backendProps: [],
+            } as RenderSettingsSnapshot,
+            binaries: { povrayExe: '', povrayInc: '', blendpng: '', ffmpeg: '' },
+        })
+        if (!res.ok || !res.jobId) throw new Error('renderStart did not start a job')
+        return { jobId: res.jobId, handle }
+    }
+
+    function makeInProcHandle() {
+        return {
+            progress: vi.fn(() => 0.1),
+            phase: vi.fn(() => 'Primary'),
+            isDone: vi.fn(() => false),
+            finish: vi.fn(() => false),
+            cancel: vi.fn(),
+        }
+    }
+
+    it('cancels a running job and reports the count', async () => {
+        const { handle } = startInProcessJob()
+        expect(intervalCb).toBeTypeOf('function')
+
+        const { cancelAllRenderJobs } = await import('../worker/server/services/renderJob.service')
+        const ctx = { svc: { pushMessage: vi.fn(), getService: vi.fn() } } as unknown as WorkerContext
+
+        expect(cancelAllRenderJobs(ctx)).toBe(1)
+        // In-process renders are cancelled cooperatively (the poll loop then
+        // joins the C++ thread); external ones are killed through ProcessManager.
+        expect(handle.cancel).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps going when one job refuses to cancel', async () => {
+        const bad = startInProcessJob()
+        bad.handle.cancel.mockImplementation(() => {
+            throw new Error('cancel blew up')
+        })
+        const good = startInProcessJob()
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const { cancelAllRenderJobs } = await import('../worker/server/services/renderJob.service')
+        const ctx = { svc: { pushMessage: vi.fn(), getService: vi.fn() } } as unknown as WorkerContext
+        expect(() => cancelAllRenderJobs(ctx)).not.toThrow()
+        warn.mockRestore()
+
+        // The second job is still cancelled: one failure must not strand the
+        // rest, since each one may own an external process.
+        expect(good.handle.cancel).toHaveBeenCalled()
+    })
+})

--- a/tritium/react-gui/src/renderer/__test__/scenePaneRenameKeys.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/scenePaneRenameKeys.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @file __test__/scenePaneRenameKeys.test.tsx
+ * @description Pins that the scene tree stops acting on keystrokes while the
+ * inline rename editor is open.
+ *
+ * The tree binds Delete / Backspace (bulk delete) and F2 (begin rename) on the
+ * scrolling wrapper. The rename editor is an ordinary `<input>` rendered inside
+ * that wrapper, so every keystroke typed into it bubbles to the same handler.
+ * Before this was guarded, pressing Backspace to correct a typo in a node name
+ * called `onDeleteSelected` and removed the node from the scene -- and, because
+ * the handler also called preventDefault, the character was not even deleted.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { mountTree } from './helpers/testHarness'
+import { ScenePane } from '../components/panes/ScenePane'
+import type { SceneTreeNode } from '../worker/shared/sceneTreeTypes'
+
+void React
+
+function mkNode(
+  p: Partial<SceneTreeNode> & { id: number; type: SceneTreeNode['type'] },
+): SceneTreeNode {
+  return {
+    name: `node${p.id}`,
+    className: '',
+    visible: true,
+    locked: false,
+    uiCollapsed: false,
+    uiOrder: 0,
+    effectiveVisible: true,
+    children: [],
+    ...p,
+  }
+}
+
+const tree = (): SceneTreeNode =>
+  mkNode({
+    id: 0,
+    type: 'scene',
+    children: [
+      mkNode({ id: 1, type: 'object', className: 'PDBMol', children: [] }),
+    ],
+  })
+
+interface Mounted {
+  container: HTMLElement
+  unmount: () => void
+  onDeleteSelected: ReturnType<typeof vi.fn>
+  onBeginInlineRename: ReturnType<typeof vi.fn>
+}
+
+function mount(editingNodeId: string | null): Mounted {
+  const onDeleteSelected = vi.fn()
+  const onBeginInlineRename = vi.fn()
+  const { container, unmount } = mountTree(
+    <ScenePane
+      tree={tree()}
+      selectedId="1"
+      selectedIds={new Set(['1'])}
+      onSelect={() => {}}
+      onToggleVisibility={() => {}}
+      onMoveNode={() => {}}
+      onDeleteSelected={onDeleteSelected}
+      onBeginInlineRename={onBeginInlineRename}
+      editingNodeId={editingNodeId}
+    />,
+  )
+  return { container, unmount, onDeleteSelected, onBeginInlineRename }
+}
+
+/** Dispatch a bubbling keydown from inside the tree's scrolling wrapper. */
+function pressKey(container: HTMLElement, key: string): void {
+  const scroll = container.querySelector('.sp-pane-scroll')
+  if (!scroll) throw new Error('scene tree scroll wrapper not rendered')
+  // The rename editor lives inside the wrapper, so a key typed into it
+  // reaches the wrapper's handler exactly like this.
+  const target = (scroll.querySelector('input') ?? scroll) as HTMLElement
+  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }))
+}
+
+describe('ScenePane keyboard handling vs the inline rename editor', () => {
+  it.each(['Backspace', 'Delete'])(
+    'does not delete the node when %s is pressed while renaming',
+    (key) => {
+      const m = mount('1')
+      pressKey(m.container, key)
+      expect(m.onDeleteSelected).not.toHaveBeenCalled()
+      m.unmount()
+    },
+  )
+
+  it('does not restart the rename when F2 is pressed while renaming', () => {
+    const m = mount('1')
+    pressKey(m.container, 'F2')
+    expect(m.onBeginInlineRename).not.toHaveBeenCalled()
+    m.unmount()
+  })
+
+  it.each(['Backspace', 'Delete'])(
+    'still deletes the selection when %s is pressed and nothing is being renamed',
+    (key) => {
+      const m = mount(null)
+      pressKey(m.container, key)
+      expect(m.onDeleteSelected).toHaveBeenCalledWith('1')
+      m.unmount()
+    },
+  )
+
+  it('still begins a rename on F2 when nothing is being renamed', () => {
+    const m = mount(null)
+    pressKey(m.container, 'F2')
+    expect(m.onBeginInlineRename).toHaveBeenCalledWith('1')
+    m.unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/startupResilience.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/startupResilience.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @file __test__/startupResilience.test.tsx
+ * @description Pins that a failure on a launch path leaves the app usable.
+ *
+ * Both hooks here gate something the whole window depends on, and both awaited
+ * a promise with no rejection handling:
+ *
+ *   - useLayoutPersistence.loaded gates `{loaded && <Allotment>}` in App, i.e.
+ *     the entire main content area. If LAYOUT_LOAD or UI_LOAD rejected, the
+ *     flag stayed false and the user got a permanently blank window.
+ *   - useAppInitialization.initialSceneSettled gates the shell/command-line
+ *     file-open drain in useShellOpenFiles. If the first scene failed to
+ *     create, the gate never opened and a file passed on the command line or
+ *     via Finder was silently dropped for the rest of the session.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { makeRenderHook, flushPromises, setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
+import { IPC } from '@shared/ipcChannels'
+import { useLayoutPersistence } from '../hooks/useLayoutPersistence'
+import { useAppInitialization } from '../hooks/useAppInitialization'
+
+void React
+
+describe('useLayoutPersistence load failure', () => {
+  afterEach(() => { teardownElectronAPI(); vi.restoreAllMocks() })
+
+  it('still sets loaded when LAYOUT_LOAD rejects, so the UI renders', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setupElectronAPI({
+      invoke: vi.fn((channel: string) =>
+        channel === IPC.LAYOUT_LOAD
+          ? Promise.reject(new Error('store read failed'))
+          : Promise.resolve(undefined),
+      ),
+    })
+
+    const h = makeRenderHook(() => useLayoutPersistence())
+    await flushPromises()
+    await flushPromises()
+    expect(h.result.loaded).toBe(true)
+    h.unmount()
+  })
+
+  it('still sets loaded when UI_LOAD rejects', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setupElectronAPI({
+      invoke: vi.fn((channel: string) =>
+        channel === IPC.UI_LOAD
+          ? Promise.reject(new Error('store read failed'))
+          : Promise.resolve(undefined),
+      ),
+    })
+
+    const h = makeRenderHook(() => useLayoutPersistence())
+    await flushPromises()
+    await flushPromises()
+    expect(h.result.loaded).toBe(true)
+    h.unmount()
+  })
+})
+
+describe('useAppInitialization launch failure', () => {
+  beforeEach(() => { vi.spyOn(console, 'warn').mockImplementation(() => {}) })
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('settles the gate when the first scene rejects', async () => {
+    const newScene = vi.fn(() => Promise.reject(new Error('createNewSceneAndView failed')))
+    const h = makeRenderHook(() =>
+      useAppInitialization({ cueMolReady: true, newScene: newScene as never }),
+    )
+    await flushPromises()
+    await flushPromises()
+    expect(newScene).toHaveBeenCalledTimes(1)
+    expect(h.result.initialSceneSettled).toBe(true)
+    h.unmount()
+  })
+
+  it('settles the gate when the first scene returns falsy', async () => {
+    const newScene = vi.fn(() => Promise.resolve(undefined))
+    const h = makeRenderHook(() =>
+      useAppInitialization({ cueMolReady: true, newScene: newScene as never }),
+    )
+    await flushPromises()
+    await flushPromises()
+    expect(h.result.initialSceneSettled).toBe(true)
+    h.unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/__test__/startupResilience.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/startupResilience.test.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
 import { makeRenderHook, flushPromises, setupElectronAPI, teardownElectronAPI } from './helpers/testHarness'
 import { IPC } from '@shared/ipcChannels'
 import { useLayoutPersistence } from '../hooks/useLayoutPersistence'
@@ -85,6 +86,44 @@ describe('useAppInitialization launch failure', () => {
     await flushPromises()
     await flushPromises()
     expect(h.result.initialSceneSettled).toBe(true)
+    h.unmount()
+  })
+})
+
+/**
+ * Closing the window does not unmount the renderer -- main preventDefaults the
+ * close, asks the renderer to confirm each tab, and then destroys the window --
+ * and there is no `beforeunload` handler anywhere. The unmount cleanup that was
+ * supposed to flush the debounced writes therefore never ran, so dragging a
+ * splitter and closing straight after lost the new layout.
+ */
+describe('useLayoutPersistence flushPendingSaves', () => {
+  afterEach(() => { teardownElectronAPI(); vi.restoreAllMocks() })
+
+  it('writes the pending layout immediately instead of waiting out the debounce', async () => {
+    const api = setupElectronAPI()
+    const h = makeRenderHook(() => useLayoutPersistence())
+    await flushPromises()
+
+    act(() => { h.result.setMainSizes([100, 200]) })
+    expect((api.invoke.mock.calls as unknown[][]).filter((c) => c[0] === IPC.LAYOUT_SAVE)).toHaveLength(0)
+
+    await act(async () => { await h.result.flushPendingSaves() })
+
+    const saves = (api.invoke.mock.calls as unknown[][]).filter((c) => c[0] === IPC.LAYOUT_SAVE)
+    expect(saves).toHaveLength(1)
+    expect((saves[0][1] as { mainSizes: number[] }).mainSizes).toEqual([100, 200])
+    h.unmount()
+  })
+
+  it('is a no-op when nothing is pending', async () => {
+    const api = setupElectronAPI()
+    const h = makeRenderHook(() => useLayoutPersistence())
+    await flushPromises()
+    api.invoke.mockClear()
+
+    await act(async () => { await h.result.flushPendingSaves() })
+    expect(api.invoke).not.toHaveBeenCalled()
     h.unmount()
   })
 })

--- a/tritium/react-gui/src/renderer/__test__/useRenderWindowBridge.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderWindowBridge.test.ts
@@ -72,6 +72,12 @@ function setupApi() {
             pushCbs.set(channel, cb);
             return () => pushCbs.delete(channel);
         }),
+        // Mirror the real handler: RENDER_HISTORY_STORE reports whether the
+        // archive copy landed, and the bridge only publishes an entry when it
+        // did (an unstored id reads back as a blank frame).
+        invoke: vi.fn((channel: string) =>
+            Promise.resolve(channel === IPC.RENDER_HISTORY_STORE ? { ok: true } : undefined),
+        ),
     });
     return {
         api,
@@ -371,6 +377,52 @@ describe('useRenderWindowBridge hatch style template', () => {
             .find((c) => c[0] === IPC.RENDER_HATCH_STYLE_REPLY)?.[1] as { reqId: number; result: { ok: boolean } };
         expect(reply.reqId).toBe(6);
         expect(reply.result.ok).toBe(false);
+        h.unmount();
+    });
+});
+
+/**
+ * A failed archive used to produce a history entry anyway. Its
+ * RENDER_HISTORY_READ then returns null -- a blank frame in the render window,
+ * and "no longer available" from Save Image -- and, because the work directory
+ * is only registered on a successful store, that render's temp directory
+ * leaked for the run.
+ */
+describe('useRenderWindowBridge history store failure', () => {
+    it('does not publish a history entry when the archive copy fails', async () => {
+        const pushCbs = new Map<string, (payload: unknown) => void>();
+        const api = setupElectronAPI({
+            onPush: vi.fn((channel: string, cb: (payload: unknown) => void) => {
+                pushCbs.set(channel, cb);
+                return () => pushCbs.delete(channel);
+            }),
+            invoke: vi.fn((channel: string) =>
+                Promise.resolve(
+                    channel === IPC.RENDER_HISTORY_STORE ? { ok: false } : undefined,
+                ),
+            ),
+        });
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { cm, emit } = makeCm();
+        const h = mountBridge(cm);
+
+        await act(async () => {
+            pushCbs.get(IPC.RENDER_WINDOW_EXEC)?.({ type: 'start', snapshot });
+            await flushPromises();
+        });
+        act(() => emit({
+            type: 'complete', jobId: 'job-1',
+            imagePath: '/tmp/render/out.png', workDir: '/tmp/render',
+            width: 800, height: 600, elapsedSec: 3.5,
+        }));
+        await flushPromises();
+        warn.mockRestore();
+
+        const historyPushes = (api.invoke as ReturnType<typeof vi.fn>).mock.calls
+            .filter((c) => c[0] === IPC.RENDER_WINDOW_STATE)
+            .map((c) => c[1] as { kind: string })
+            .filter((u) => u.kind === 'history');
+        expect(historyPushes).toHaveLength(0);
         h.unmount();
     });
 });

--- a/tritium/react-gui/src/renderer/__test__/useRenderWindowBridge.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderWindowBridge.test.ts
@@ -285,6 +285,7 @@ describe('useRenderWindowBridge', () => {
     it('VIEW_SIZE_REQUEST replies with the canvas pixel size', async () => {
         const { cm } = makeCm();
         const canvas = document.createElement('canvas');
+        canvas.setAttribute('data-molview-canvas', '');
         canvas.getBoundingClientRect = () =>
             ({ width: 400, height: 300 } as DOMRect);
         document.body.appendChild(canvas);
@@ -301,6 +302,39 @@ describe('useRenderWindowBridge', () => {
         });
         h.unmount();
         document.body.removeChild(canvas);
+    });
+
+    /**
+     * The sequence panel and the multi-gradient histogram also render a
+     * <canvas>, and the sidebar comes before the content area in the DOM. A
+     * bare `document.querySelector('canvas')` therefore measured whichever of
+     * those happened to be on screen, and the render ran at that widget's size
+     * with nothing to indicate it.
+     */
+    it('measures the molview canvas, not whichever canvas comes first', async () => {
+        const { cm } = makeCm();
+        const decoy = document.createElement('canvas');
+        decoy.getBoundingClientRect = () => ({ width: 64, height: 12 } as DOMRect);
+        document.body.appendChild(decoy);
+
+        const molview = document.createElement('canvas');
+        molview.setAttribute('data-molview-canvas', '');
+        molview.getBoundingClientRect = () => ({ width: 800, height: 600 } as DOMRect);
+        document.body.appendChild(molview);
+
+        const h = mountBridge(cm);
+        await act(async () => {
+            harness.requestViewSize(12);
+            await flushPromises();
+        });
+
+        expect(harness.api.invoke).toHaveBeenCalledWith(IPC.RENDER_VIEW_SIZE_REPLY, {
+            reqId: 12,
+            size: { width: 800, height: 600 },
+        });
+        h.unmount();
+        document.body.removeChild(decoy);
+        document.body.removeChild(molview);
     });
 });
 

--- a/tritium/react-gui/src/renderer/__test__/windowCloseFlow.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/windowCloseFlow.test.tsx
@@ -93,6 +93,15 @@ describe('useWindowCloseHandler (UXP-parity window-close chain)', () => {
     vi.restoreAllMocks()
   })
 
+/**
+ * PROCEED replies only. The chain also emits WINDOW_CLOSE_PROGRESS pings to
+ * re-arm main's watchdog; those are asserted separately.
+ */
+function proceedCalls(api: Record<string, unknown>): unknown[][] {
+  const invoke = api.invoke as { mock: { calls: unknown[][] } }
+  return invoke.mock.calls.filter((c) => c[0] === IPC.WINDOW_CLOSE_PROCEED)
+}
+
   it('walks all tabs in order and calls WINDOW_CLOSE_PROCEED { proceed: true } when every close succeeds', async () => {
     const tabs: TabData[] = [
       { id: 'molview-1', title: 'A', icon: 'file.molview', type: 'molview', viewId: 1 },
@@ -111,7 +120,7 @@ describe('useWindowCloseHandler (UXP-parity window-close chain)', () => {
     expect(h.setActiveTab.mock.calls.map((c) => c[0])).toEqual([
       'molview-1', 'molview-2',
     ])
-    expect(h.api.invoke).toHaveBeenCalledTimes(1)
+    expect(proceedCalls(h.api)).toHaveLength(1)
     expect(h.api.invoke).toHaveBeenCalledWith(IPC.WINDOW_CLOSE_PROCEED, { proceed: true })
 
     h.unmount()
@@ -131,7 +140,7 @@ describe('useWindowCloseHandler (UXP-parity window-close chain)', () => {
     expect(h.handleCloseTab.mock.calls.map((c) => c[0])).toEqual([
       'molview-1', 'molview-2',
     ])
-    expect(h.api.invoke).toHaveBeenCalledTimes(1)
+    expect(proceedCalls(h.api)).toHaveLength(1)
     expect(h.api.invoke).toHaveBeenCalledWith(IPC.WINDOW_CLOSE_PROCEED, { proceed: false })
 
     h.unmount()
@@ -150,7 +159,8 @@ describe('useWindowCloseHandler (UXP-parity window-close chain)', () => {
 
     expect(onBeforeProceed).toHaveBeenCalledTimes(1)
     // Save runs before the proceed reply.
-    expect(order).toEqual(['save', `invoke:${IPC.WINDOW_CLOSE_PROCEED}`])
+    expect(order.filter((e) => e !== `invoke:${IPC.WINDOW_CLOSE_PROGRESS}`))
+      .toEqual(['save', `invoke:${IPC.WINDOW_CLOSE_PROCEED}`])
     expect(h.api.invoke).toHaveBeenCalledWith(IPC.WINDOW_CLOSE_PROCEED, { proceed: true })
 
     h.unmount()
@@ -224,9 +234,54 @@ describe('useWindowCloseHandler (UXP-parity window-close chain)', () => {
     await flushPromises()
     await flushPromises()
 
-    expect(api.invoke).toHaveBeenCalledTimes(1)
+    expect(proceedCalls(api)).toHaveLength(1)
     expect(api.invoke).toHaveBeenCalledWith(IPC.WINDOW_CLOSE_PROCEED, { proceed: true })
 
     handle.unmount()
+  })
+
+  /**
+   * Main force-closes the window if no reply arrives, so every path through
+   * this handler has to answer. It used to have a `finally` but no `catch`: a
+   * throw from handleCloseTab or setActiveTab aborted the walk before either
+   * invoke, main heard nothing, and the watchdog discarded the unsaved scenes.
+   */
+  it('replies proceed:false when a step throws instead of leaving main waiting', async () => {
+    const tabs: TabData[] = [
+      { id: 'molview-1', title: 'A', icon: 'file.molview', type: 'molview', viewId: 1 },
+    ]
+    const h = mount({ tabs, closeResults: [true] })
+    h.handleCloseTab.mockImplementation(() => { throw new Error('close blew up') })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await h.triggerCloseRequest()
+    errSpy.mockRestore()
+
+    expect(proceedCalls(h.api)).toHaveLength(1)
+    expect(h.api.invoke).toHaveBeenCalledWith(IPC.WINDOW_CLOSE_PROCEED, { proceed: false })
+
+    h.unmount()
+  })
+
+  /**
+   * The per-tab confirm can sit on the user for as long as they take. The
+   * watchdog must therefore measure renderer silence, not deliberation, so the
+   * chain pings before each step that can block on a person.
+   */
+  it('pings WINDOW_CLOSE_PROGRESS before each tab confirm', async () => {
+    const tabs: TabData[] = [
+      { id: 'molview-1', title: 'A', icon: 'file.molview', type: 'molview', viewId: 1 },
+      { id: 'molview-2', title: 'B', icon: 'file.molview', type: 'molview', viewId: 2 },
+    ]
+    const h = mount({ tabs, closeResults: [true, true] })
+
+    await h.triggerCloseRequest()
+
+    const pings = h.api.invoke.mock.calls.filter(
+      (c: unknown[]) => c[0] === IPC.WINDOW_CLOSE_PROGRESS,
+    )
+    expect(pings.length).toBeGreaterThanOrEqual(tabs.length)
+
+    h.unmount()
   })
 })

--- a/tritium/react-gui/src/renderer/__test__/windowCloseFlow.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/windowCloseFlow.test.tsx
@@ -93,10 +93,7 @@ describe('useWindowCloseHandler (UXP-parity window-close chain)', () => {
     vi.restoreAllMocks()
   })
 
-/**
- * PROCEED replies only. The chain also emits WINDOW_CLOSE_PROGRESS pings to
- * re-arm main's watchdog; those are asserted separately.
- */
+/** PROCEED replies only, ignoring any other channel the chain touches. */
 function proceedCalls(api: Record<string, unknown>): unknown[][] {
   const invoke = api.invoke as { mock: { calls: unknown[][] } }
   return invoke.mock.calls.filter((c) => c[0] === IPC.WINDOW_CLOSE_PROCEED)
@@ -159,8 +156,7 @@ function proceedCalls(api: Record<string, unknown>): unknown[][] {
 
     expect(onBeforeProceed).toHaveBeenCalledTimes(1)
     // Save runs before the proceed reply.
-    expect(order.filter((e) => e !== `invoke:${IPC.WINDOW_CLOSE_PROGRESS}`))
-      .toEqual(['save', `invoke:${IPC.WINDOW_CLOSE_PROCEED}`])
+    expect(order).toEqual(['save', `invoke:${IPC.WINDOW_CLOSE_PROCEED}`])
     expect(h.api.invoke).toHaveBeenCalledWith(IPC.WINDOW_CLOSE_PROCEED, { proceed: true })
 
     h.unmount()
@@ -263,25 +259,4 @@ function proceedCalls(api: Record<string, unknown>): unknown[][] {
     h.unmount()
   })
 
-  /**
-   * The per-tab confirm can sit on the user for as long as they take. The
-   * watchdog must therefore measure renderer silence, not deliberation, so the
-   * chain pings before each step that can block on a person.
-   */
-  it('pings WINDOW_CLOSE_PROGRESS before each tab confirm', async () => {
-    const tabs: TabData[] = [
-      { id: 'molview-1', title: 'A', icon: 'file.molview', type: 'molview', viewId: 1 },
-      { id: 'molview-2', title: 'B', icon: 'file.molview', type: 'molview', viewId: 2 },
-    ]
-    const h = mount({ tabs, closeResults: [true, true] })
-
-    await h.triggerCloseRequest()
-
-    const pings = h.api.invoke.mock.calls.filter(
-      (c: unknown[]) => c[0] === IPC.WINDOW_CLOSE_PROGRESS,
-    )
-    expect(pings.length).toBeGreaterThanOrEqual(tabs.length)
-
-    h.unmount()
-  })
 })

--- a/tritium/react-gui/src/renderer/__test__/workerServiceDispatch.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/workerServiceDispatch.test.ts
@@ -78,14 +78,30 @@ describe('WorkerService.invoke dispatch contract', () => {
         expect(posted).toEqual([['testArgs', 1, true, 30]]);
     });
 
-    it('_methods throw posts [method, seqno, false, error]', () => {
+    // The error must cross the wire as a string, matching the service branch.
+    // Posting the raw thrown value risks a DataCloneError inside the catch --
+    // a native exception is not necessarily structured-cloneable -- which
+    // would escape self.onmessage and be funnelled as __worker_crash__,
+    // turning one recoverable call failure into a whole-worker teardown.
+    it('_methods throw posts [method, seqno, false, String(error)]', () => {
         const { svc, posted } = makeSvc();
-        const err = new Error('boom');
         injectMethod(svc, 'testThrow', () => {
-            throw err;
+            throw new Error('boom');
         });
         svc.invoke('testThrow', 9, []);
-        expect(posted).toEqual([['testThrow', 9, false, err]]);
+        expect(posted).toEqual([['testThrow', 9, false, 'Error: boom']]);
+    });
+
+    it('_methods throw of a non-cloneable value still posts a plain string', () => {
+        const { svc, posted } = makeSvc();
+        // A value structuredClone() rejects (functions are not cloneable).
+        const nonCloneable = { fn: () => undefined, toString: () => 'native abort' };
+        injectMethod(svc, 'testThrowNative', () => {
+            throw nonCloneable;
+        });
+        svc.invoke('testThrowNative', 11, []);
+        expect(posted).toEqual([['testThrowNative', 11, false, 'native abort']]);
+        expect(() => structuredClone(posted[0])).not.toThrow();
     });
 
     it('registered service runs async as fn(ctx, args[0]) and posts the result', async () => {

--- a/tritium/react-gui/src/renderer/commands/CommandRegistry.tsx
+++ b/tritium/react-gui/src/renderer/commands/CommandRegistry.tsx
@@ -62,7 +62,15 @@ export function CommandProvider({ children }: { children: React.ReactNode }): Re
     ): Promise<CommandResult<K>> {
       const h = map.current.get(id)
       if (!h) return Promise.reject(new Error(`[CommandRegistry] unknown command: ${id}`))
-      return Promise.resolve(h(args[0]) as CommandResult<K>)
+      // Call inside the try so a handler that throws synchronously comes back
+      // as a rejected promise. Callers attach `.catch(...)` to the return
+      // value; a synchronous throw would bypass that and escape through
+      // whatever invoked dispatch (an IPC push callback, a menu click).
+      try {
+        return Promise.resolve(h(args[0]) as CommandResult<K>)
+      } catch (e) {
+        return Promise.reject(e)
+      }
     },
 
     has(id) { return map.current.has(id) },

--- a/tritium/react-gui/src/renderer/components/dialogs/ConfirmCloseTabDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ConfirmCloseTabDialogProvider.tsx
@@ -14,6 +14,9 @@ export const {
   useShow: useShowConfirmCloseTabDialog,
 } = createDialogHook<ConfirmCloseTabDialogArgs, ConfirmCloseResult>({
   name: 'ConfirmCloseTabDialog',
+  // A displaced caller must not fall through to the 'save' branch of
+  // App.confirmCloseTab: it never asked the user anything, so the tab stays.
+  supersededResult: 'cancel',
   render: ({ visible, args, resolve }) => (
     <ConfirmCloseTabDialog
       visible={visible}

--- a/tritium/react-gui/src/renderer/components/dialogs/ConfirmReloadSceneDialogProvider.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ConfirmReloadSceneDialogProvider.tsx
@@ -14,6 +14,8 @@ export const {
   useShow: useShowConfirmReloadSceneDialog,
 } = createDialogHook<ConfirmReloadSceneDialogArgs, boolean>({
   name: 'ConfirmReloadSceneDialog',
+  // Never reload on behalf of a caller whose prompt was displaced.
+  supersededResult: false,
   render: ({ visible, args, resolve }) => (
     <ConfirmReloadSceneDialog
       visible={visible}

--- a/tritium/react-gui/src/renderer/components/panes/InlineRenameInput.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/InlineRenameInput.tsx
@@ -30,6 +30,11 @@ export const InlineRenameInput: React.FC<{
                 e.preventDefault();
                 e.stopPropagation();
                 onCancel();
+            } else if (e.key === "Backspace" || e.key === "Delete") {
+                // Editing keys belong to the input. The scene tree binds these
+                // to "delete the selected node" on an ancestor, so let the
+                // default text edit happen but keep the event out of the tree.
+                e.stopPropagation();
             }
         },
         [value, onCommit, onCancel],

--- a/tritium/react-gui/src/renderer/components/panes/MolViewPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/MolViewPane.tsx
@@ -227,7 +227,12 @@ export const MolViewPane = React.memo((): React.JSX.Element => {
     }
   }, []) // stable -- reads state via refs
 
-  return <canvas className={styles.molView} ref={canvasRef} />
+  // The data attribute is how anything outside this component finds the 3D
+  // canvas -- see MOLVIEW_CANVAS_SELECTOR. There are other <canvas> elements in
+  // the app (the sequence panel, the multi-gradient histogram), so a bare
+  // `document.querySelector('canvas')` picks whichever happens to come first in
+  // the DOM.
+  return <canvas className={styles.molView} ref={canvasRef} data-molview-canvas="" />
 })
 
 MolViewPane.displayName = 'MolViewPane'

--- a/tritium/react-gui/src/renderer/components/panes/MolViewPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/MolViewPane.tsx
@@ -80,7 +80,17 @@ export const MolViewPane = React.memo((): React.JSX.Element => {
     ;(async () => {
       if (cancelled || !canvasRef.current) return
       const dpr = window.devicePixelRatio || 1
-      await cm.bindCanvas(canvasRef.current, view_uid, dpr)
+      try {
+        await cm.bindCanvas(canvasRef.current, view_uid, dpr)
+      } catch (err) {
+        // transferControlToOffscreen() throws InvalidStateError if this
+        // element was ever transferred, and the worker call can reject.
+        // Clear the guard so a later mount can try again rather than leaving
+        // the view permanently blank.
+        initStartedRef.current = false
+        console.warn('bindCanvas failed:', err)
+        return
+      }
 
       // Send initial resize with actual layout dimensions.
       // The ResizeObserver may have already fired (and been ignored because

--- a/tritium/react-gui/src/renderer/components/panes/ScenePane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/ScenePane.tsx
@@ -375,6 +375,11 @@ export const ScenePane: React.FC<ScenePaneProps> = ({
     // fires while the user is focused inside the scene tree.
     const handleTreeKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLDivElement>) => {
+            // The inline rename editor is an <input> inside this wrapper, so
+            // everything typed into it bubbles to this handler. While it is
+            // open the tree owns no keys: Backspace there means "delete a
+            // character", not "delete the node".
+            if (editingNodeId != null) return;
             // Delete / Backspace removes the selection. `onDeleteSelected`
             // is the same handler the toolbar button uses, so it deletes the
             // whole multi-selection under one undo transaction.
@@ -393,7 +398,7 @@ export const ScenePane: React.FC<ScenePaneProps> = ({
             e.preventDefault();
             beginRenameRef.current(selectedId);
         },
-        [selectedId, nodeLookup, isRenameableType, onDeleteSelected, canDelete],
+        [selectedId, nodeLookup, isRenameableType, onDeleteSelected, canDelete, editingNodeId],
     );
 
     // Auto-focus + select the inline input each time the editor opens.

--- a/tritium/react-gui/src/renderer/components/panes/molViewCanvas.ts
+++ b/tritium/react-gui/src/renderer/components/panes/molViewCanvas.ts
@@ -1,0 +1,14 @@
+/**
+ * @file components/panes/molViewCanvas.ts
+ * @description How to find the 3D view canvas from outside MolViewPane.
+ *
+ * Several components render a `<canvas>` -- the sequence panel and the
+ * multi-gradient histogram among them -- so `document.querySelector('canvas')`
+ * returns whichever sits first in the DOM, not the one showing the molecule.
+ * The sidebar renders before the content area, so with a histogram on screen
+ * the render window's "Current view" size preset measured that strip instead
+ * and rendered at the wrong resolution, silently.
+ */
+
+/** Marks the single OffscreenCanvas-bound 3D view (see MolViewPane). */
+export const MOLVIEW_CANVAS_SELECTOR = '[data-molview-canvas]';

--- a/tritium/react-gui/src/renderer/components/renderwindow/RenderWindowApp.tsx
+++ b/tritium/react-gui/src/renderer/components/renderwindow/RenderWindowApp.tsx
@@ -28,6 +28,7 @@ import { RenderPanel } from "../panels/RenderPanel";
 import { RenderSettingsPane } from "./RenderSettingsPane";
 import { useRenderSettings } from "../../hooks/useRenderSettings";
 import { useHatchTemplate } from "../../hooks/useHatchTemplate";
+import { useTextContextMenu } from "../../hooks/useTextContextMenu";
 import type { HatchLookEditorProps } from "../inspector/HatchLookEditor";
 import { useMovieOutputPrefs } from "../../hooks/useMovieOutputPrefs";
 import { isRenderJobActive } from "../../hooks/useRenderJob";
@@ -37,6 +38,10 @@ import { sizePresetsForMode } from "../../data/renderSettings";
 import { IPC } from "@shared/ipcChannels";
 
 export const RenderWindowApp: React.FC = () => {
+  // Main registers the text context menu on this window too; on Windows /
+  // Linux it arrives as a push the renderer has to draw. Without this the
+  // window's text fields had no context menu at all.
+  useTextContextMenu();
   const client = useRenderWindowClient();
   // Umbreon is the default backend when the build supports it (forwarded from
   // the main window); otherwise fall back to the static default (POV-Ray).

--- a/tritium/react-gui/src/renderer/crash/CrashReporter.ts
+++ b/tritium/react-gui/src/renderer/crash/CrashReporter.ts
@@ -5,19 +5,41 @@
  * Every crash source (window.onerror, unhandledrejection, React
  * ErrorBoundary, worker.onerror, worker.onmessageerror, worker postMessage
  * '__worker_crash__', and the worker render-loop try-catch) reports here.
- * The first report wins -- subsequent reports are only logged. On first
- * report we (a) log to console (which the main process tee's to stderr via
- * the console-message hook), (b) forward to main via IPC.CRASH_REPORT so
- * componentStack and other non-console info also reach stderr, (c) mount
- * the DOM-direct fallback so the user sees the crash even when React died,
- * and (d) notify subscribers (React `ErrorBoundary` -> `CrashOverlay`).
+ *
+ * Reports are split by severity. Everything is (a) logged to console -- which
+ * the main process tee's to stderr via the console-message hook -- and (b)
+ * forwarded to main via IPC.CRASH_REPORT so componentStack and other
+ * non-console fields reach stderr too.
+ *
+ * Only a FATAL source additionally (c) mounts the DOM-direct fallback so the
+ * user sees the crash even when React died, and (d) notifies subscribers
+ * (React `ErrorBoundary` -> `CrashOverlay`). Fatal means the app cannot carry
+ * on: the CueMol worker is gone, or the React tree is. A stray uncaught
+ * throw or unhandled rejection is neither -- `installGlobalCrashHandlers`
+ * funnels every one of them here, and the overlay has no way back, so
+ * treating them as fatal turned any recoverable failure (a worker service
+ * rejecting, a settings write failing on a full disk) into a dead session.
+ *
+ * The first FATAL report wins; later ones are only logged. A non-fatal report
+ * never occupies that slot.
  */
 
 import { IPC } from '@shared/ipcChannels'
-import type { CrashReport } from '@shared/ipcTypes'
+import type { CrashReport, CrashSource } from '@shared/ipcTypes'
 import { mountFallbackDom } from './mountFallbackDom'
 
 type Subscriber = (report: CrashReport) => void
+
+/**
+ * Sources that mean the app cannot continue, so the crash overlay is the
+ * right answer. Everything else is reported but left recoverable.
+ */
+const FATAL_SOURCES: ReadonlySet<CrashSource> = new Set<CrashSource>([
+  'worker-global',
+  'worker-message',
+  'worker-render-loop',
+  'react-error-boundary',
+])
 
 let firstReport: CrashReport | null = null
 const subscribers: Set<Subscriber> = new Set()
@@ -29,13 +51,14 @@ const subscribers: Set<Subscriber> = new Set()
  * IPC or re-mount the fallback.
  */
 export function report(payload: CrashReport): void {
-  if (firstReport !== null) {
+  const fatal = FATAL_SOURCES.has(payload.source)
+  if (fatal && firstReport !== null) {
     console.error('[Crash][repeat][' + payload.source + ']', payload.message)
     return
   }
-  firstReport = payload
+  if (fatal) firstReport = payload
 
-  console.error('[Crash][' + payload.source + ']', payload.message)
+  console.error('[' + (fatal ? 'Crash' : 'Error') + '][' + payload.source + ']', payload.message)
   if (payload.filename) {
     const loc = payload.lineno !== undefined
       ? `${payload.filename}:${payload.lineno}:${payload.colno ?? 0}`
@@ -60,6 +83,10 @@ export function report(payload: CrashReport): void {
   } catch (e) {
     console.error('[Crash] IPC.CRASH_REPORT threw:', e)
   }
+
+  // A non-fatal report stops here: it has been logged and forwarded, and the
+  // app keeps running.
+  if (!fatal) return
 
   // DOM-direct fallback so the user sees the crash even when React died.
   try {

--- a/tritium/react-gui/src/renderer/h3-kit/form/DragNumericField.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/form/DragNumericField.tsx
@@ -159,16 +159,25 @@ export interface DragNumericFieldProps {
     unit?: string;
     disabled?: boolean;
     /**
-     * Treat a drag as a live transaction: emit `onDragStart` / `onDragCancel`
-     * so the parent can preview-while-dragging and commit once on release. When
-     * false (default), no drag-lifecycle callbacks fire and behaviour is
-     * unchanged. See the file header.
+     * Treat a *drag* as a live transaction: preview while dragging and commit
+     * once on release. When false (default) a drag writes nothing until it is
+     * released. See the file header.
+     *
+     * This flag gates the drag lifecycle only. An arrow press announces itself
+     * either way -- see {@link DragNumericFieldProps.onDragStart}.
      */
     realtime?: boolean;
     /**
-     * Fired once when a drag crosses the movement threshold (only when
-     * `realtime`). The parent typically snapshots the pre-drag value here so it
-     * can roll back / build a single undo step.
+     * Fired once at the start of an interaction that will emit several
+     * `onChange` values, so the parent can snapshot the value they all step
+     * away from and build one undo entry for the whole run.
+     *
+     * Two interactions qualify, and they are gated differently on purpose:
+     *   - a drag, once it crosses the movement threshold -- only when
+     *     `realtime`, because a non-realtime drag writes nothing until release;
+     *   - an arrow-button press, always, because auto-repeat turns one press
+     *     into a run of steps whether or not it previews. Holding the arrow
+     *     must still collapse to a single undo entry.
      */
     onDragStart?: () => void;
     /**

--- a/tritium/react-gui/src/renderer/h3-kit/form/NumericField.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/form/NumericField.tsx
@@ -67,9 +67,14 @@ export const NumericField: React.FC<NumericFieldProps> = ({
             const text = e.target.value;
             setEditText(text);
             const parsed = parseFloat(text);
-            if (!isNaN(parsed)) onChange(parsed);
+            if (isNaN(parsed)) return;
+            // `min` / `max` on <input type="number"> only bind the spinner
+            // buttons; a typed value is not constrained by the browser. Clamp
+            // here so an out-of-range keystroke cannot be committed to a C++
+            // property (RejectNumberInput's doc comment already promised this).
+            onChange(Math.min(max, Math.max(min, parsed)));
         },
-        [onChange],
+        [onChange, min, max],
     );
 
     // Commit reads `value` (not `editText`): every parseable keystroke already

--- a/tritium/react-gui/src/renderer/h3-kit/form/VectorField.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/form/VectorField.tsx
@@ -67,7 +67,12 @@ export const VectorField: React.FC<VectorFieldProps> = ({
     const count = parsed ? parsed.length : 3;
 
     const commitAt = (index: number, text: string): void => {
-        const next = Number(text.trim());
+        const trimmed = text.trim();
+        // `Number('')` is 0 and `Number.isFinite(0)` is true, so an emptied
+        // cell would silently write 0 into that axis. An unparseable cell is
+        // rejected and snaps back, as documented at the top of this file.
+        if (trimmed === '') return;
+        const next = Number(trimmed);
         if (!Number.isFinite(next)) return;
         const base = parsed ?? new Array<number>(count).fill(0);
         const out = base.slice();

--- a/tritium/react-gui/src/renderer/h3-kit/form/__bounds.test.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/form/__bounds.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @file h3-kit/form/__bounds.test.tsx
+ * @description Pins the numeric bounds contracts of the form-kit inputs.
+ *
+ * `min` / `max` are passed to the underlying <input type="number">, but the
+ * HTML attributes only constrain the spinner buttons -- a browser accepts any
+ * typed value. NumericField fed every parseable keystroke straight to
+ * onChange, so typing 9999 into a 0..100 property (Inspector NumRow, GenericTab,
+ * SettingRow, the APBS and interaction dialogs all use it) committed 9999 to
+ * the C++ property. RejectNumberInput's own doc comment claimed NumericField
+ * clamps; it did not.
+ *
+ * VectorField had the mirror problem at the empty end: `Number('')` is 0 and
+ * `Number.isFinite(0)` is true, so clearing an axis cell and tabbing away
+ * silently wrote 0 into it -- while the file header promised an unparseable
+ * cell would be rejected and snap back.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { mountTree } from '../../__test__/helpers/testHarness'
+import { NumericField } from './NumericField'
+import { VectorField } from './VectorField'
+import { DragNumericField } from './DragNumericField'
+
+void React
+
+function typeInto(input: HTMLInputElement, text: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype, 'value',
+  )!.set!
+  setter.call(input, text)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+describe('NumericField bounds', () => {
+  it.each([
+    ['above max', '9999', 100],
+    ['below min', '-50', 0],
+  ])('clamps a typed value %s', (_label, typed, expected) => {
+    const onChange = vi.fn()
+    const { container, unmount } = mountTree(
+      <NumericField value={5} min={0} max={100} onChange={onChange} />,
+    )
+    typeInto(container.querySelector('input') as HTMLInputElement, typed)
+    expect(onChange).toHaveBeenLastCalledWith(expected)
+    unmount()
+  })
+
+  it('passes an in-range value through untouched', () => {
+    const onChange = vi.fn()
+    const { container, unmount } = mountTree(
+      <NumericField value={5} min={0} max={100} onChange={onChange} />,
+    )
+    typeInto(container.querySelector('input') as HTMLInputElement, '42')
+    expect(onChange).toHaveBeenLastCalledWith(42)
+    unmount()
+  })
+
+  it('does not commit while the text is not yet a number', () => {
+    const onChange = vi.fn()
+    const { container, unmount } = mountTree(
+      <NumericField value={5} min={0} max={100} onChange={onChange} />,
+    )
+    const input = container.querySelector('input') as HTMLInputElement
+    typeInto(input, '')
+    typeInto(input, '-')
+    expect(onChange).not.toHaveBeenCalled()
+    unmount()
+  })
+})
+
+describe('VectorField empty cell', () => {
+  it('does not write 0 when a cell is cleared', () => {
+    const onCommit = vi.fn()
+    const { container, unmount } = mountTree(
+      <VectorField value="(1, 2, 3)" onCommit={onCommit} />,
+    )
+    const cell = container.querySelectorAll('input')[1] as HTMLInputElement
+    typeInto(cell, '   ')
+    cell.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    expect(onCommit).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it('still commits a real edit', () => {
+    const onCommit = vi.fn()
+    const { container, unmount } = mountTree(
+      <VectorField value="(1, 2, 3)" onCommit={onCommit} />,
+    )
+    const cell = container.querySelectorAll('input')[1] as HTMLInputElement
+    typeInto(cell, '7')
+    cell.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    expect(onCommit).toHaveBeenCalledTimes(1)
+    expect(onCommit.mock.calls[0][0]).toContain('7')
+    unmount()
+  })
+})
+
+describe('DragNumericField interaction announcements', () => {
+  /**
+   * `onDragStart` fires for an arrow press even when `realtime` is false. That
+   * looks like an oversight next to the drag path, which gates on `realtime`,
+   * and the prop doc used to claim it. It is deliberate: auto-repeat turns one
+   * press into a run of steps, and the parent needs the pre-press value to
+   * collapse the run into a single undo entry.
+   */
+  it('announces an arrow press even when not realtime', () => {
+    const onDragStart = vi.fn()
+    const { container, unmount } = mountTree(
+      <DragNumericField
+        value={5}
+        min={0}
+        max={100}
+        step={1}
+        onChange={() => {}}
+        onDragStart={onDragStart}
+      />,
+    )
+    const arrow = container.querySelector('.h3-form-drag-arrow-right') as HTMLElement
+    arrow.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    expect(onDragStart).toHaveBeenCalledTimes(1)
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    unmount()
+  })
+})

--- a/tritium/react-gui/src/renderer/hooks/sceneTree/useSceneTreeNodeOps.ts
+++ b/tritium/react-gui/src/renderer/hooks/sceneTree/useSceneTreeNodeOps.ts
@@ -434,7 +434,14 @@ export function useSceneTreeNodeOps(
                 nodeIds: items.map((i) => i.nodeId),
                 nodeTypes: items.map((i) => i.nodeType),
             })
-            if (res?.ok !== true) return { ok: false, reason: res?.reason }
+            if (res?.ok !== true) {
+                // 'nodeTypesMismatch' is a caller bug, not a user-facing case.
+                const reason = res?.reason
+                return {
+                    ok: false,
+                    reason: reason === 'nodeTypesMismatch' ? undefined : reason,
+                }
+            }
             return { ok: await writeSceneClip(res) }
         },
         [cm, sceneIdRef, resolveBulkItems],

--- a/tritium/react-gui/src/renderer/hooks/useAppInitialization.ts
+++ b/tritium/react-gui/src/renderer/hooks/useAppInitialization.ts
@@ -50,10 +50,19 @@ export function useAppInitialization({
 
     let cancelled = false;
     (async () => {
-      const result = await newScene({ bindView: false });
+      let result: unknown;
+      try {
+        result = await newScene({ bindView: false });
+      } catch (err) {
+        // A failed launch scene must not leave the gate closed: it also
+        // releases useShellOpenFiles, so a file passed on the command line or
+        // opened from Finder would be dropped for the rest of the session.
+        console.warn('initial scene creation failed:', err);
+        result = undefined;
+      }
       if (cancelled) return;
       if (!result) {
-        // Allow retry on next ready/newScene change in case of failure.
+        // Clear the guard so an explicit New Scene can still take this path.
         initialSceneCreatedRef.current = false;
       }
       setInitialSceneSettled(true);

--- a/tritium/react-gui/src/renderer/hooks/useDialogFactory.tsx
+++ b/tritium/react-gui/src/renderer/hooks/useDialogFactory.tsx
@@ -37,6 +37,20 @@ export interface CreateDialogHookOptions<TArgs, TResult> {
   render: (props: DialogRenderProps<TArgs, TResult>) => React.ReactNode
   /** Optional human label used in error messages. */
   name?: string
+  /**
+   * Value handed to a caller whose dialog is superseded, i.e. `show()` is
+   * called again while that one is still open.
+   *
+   * Only one dialog of a given kind can be on screen, so the earlier caller
+   * never gets an answer from the user. Its promise is settled with this
+   * instead of being abandoned -- an abandoned `await` parks the caller
+   * forever, which is how a queued shell-open drain used to lose its files.
+   *
+   * Defaults to `undefined`. Set it for a dialog whose result type has no
+   * natural empty value, so "superseded" cannot be mistaken for a real answer
+   * (e.g. `'cancel'`, not a fallthrough into "save").
+   */
+  supersededResult?: TResult
 }
 
 export interface DialogHookHandle<TArgs, TResult> {
@@ -66,7 +80,10 @@ export function createDialogHook<TArgs, TResult>(
 
     const show = useCallback((args: TArgs): Promise<TResult> => {
       return new Promise<TResult>((resolve) => {
+        // Settle the caller we are about to displace before taking the slot.
+        const superseded = resolveRef.current
         resolveRef.current = resolve
+        superseded?.(options.supersededResult as TResult)
         setState({ visible: true, args })
       })
     }, [])
@@ -139,6 +156,9 @@ export function createConfirmCancelDialog<TArgs, TResult>(
   const { component: Component, name } = options
   return createDialogHook<TArgs, TResult | null>({
     name,
+    // A confirm/cancel dialog already resolves null on cancel, so that is the
+    // right answer for a caller whose dialog was displaced.
+    supersededResult: null,
     render: ({ visible, args, resolve }) =>
       React.createElement(Component, {
         ...((args ?? {}) as TArgs),

--- a/tritium/react-gui/src/renderer/hooks/useFileDrop.ts
+++ b/tritium/react-gui/src/renderer/hooks/useFileDrop.ts
@@ -63,7 +63,7 @@ export function useFileDrop({ cm }: { cm: AsyncCueMol | null }): { isDragActive:
     for (const file of files) {
       let path = ''
       try {
-        path = window.electronAPI.getPathForFile(file)
+        path = window.electronAPI?.getPathForFile(file) ?? ''
       } catch {
         // Non-filesystem File (should not happen for an OS drop).
       }

--- a/tritium/react-gui/src/renderer/hooks/useLayoutPersistence.ts
+++ b/tritium/react-gui/src/renderer/hooks/useLayoutPersistence.ts
@@ -82,11 +82,18 @@ export function useLayoutPersistence() {
       return;
     }
 
-    Promise.all([api.invoke(IPC.LAYOUT_LOAD), api.invoke(IPC.UI_LOAD)]).then(([savedLayout, savedUi]) => {
-      if (savedLayout) setLayout((prev) => ({ ...prev, ...savedLayout }));
-      if (savedUi) setUi((prev) => ({ ...prev, ...savedUi }));
-      setLoaded(true);
-    });
+    Promise.all([api.invoke(IPC.LAYOUT_LOAD), api.invoke(IPC.UI_LOAD)])
+      .then(([savedLayout, savedUi]) => {
+        if (savedLayout) setLayout((prev) => ({ ...prev, ...savedLayout }));
+        if (savedUi) setUi((prev) => ({ ...prev, ...savedUi }));
+      })
+      .catch((err: unknown) => {
+        // Fall back to the defaults rather than leaving `loaded` false: App
+        // gates the whole main content area on it, so a rejected store read
+        // would render a permanently blank window.
+        console.warn('layout/ui load failed; using defaults:', err);
+      })
+      .finally(() => setLoaded(true));
   }, []);
 
   // --- Debounced save helpers ---

--- a/tritium/react-gui/src/renderer/hooks/useLayoutPersistence.ts
+++ b/tritium/react-gui/src/renderer/hooks/useLayoutPersistence.ts
@@ -208,25 +208,45 @@ export function useLayoutPersistence() {
     [scheduleUiSave],
   );
 
+  /**
+   * Write any debounced layout / UI state immediately.
+   *
+   * Closing the window does not unmount the renderer -- there is no
+   * `beforeunload` handler anywhere -- so the unmount cleanup below never runs
+   * in practice. Without an explicit flush, dragging a splitter and closing the
+   * window inside the debounce window lost the new layout. App calls this from
+   * the window-close chain.
+   */
+  const flushPendingSaves = useCallback(async (): Promise<void> => {
+    const api = window.electronAPI;
+    if (!api) return;
+    const writes: Promise<unknown>[] = [];
+    if (layoutTimerRef.current) {
+      clearTimeout(layoutTimerRef.current);
+      layoutTimerRef.current = null;
+      writes.push(api.invoke(IPC.LAYOUT_SAVE, layoutRef.current));
+    }
+    if (uiTimerRef.current) {
+      clearTimeout(uiTimerRef.current);
+      uiTimerRef.current = null;
+      writes.push(api.invoke(IPC.UI_SAVE, uiRef.current));
+    }
+    await Promise.allSettled(writes);
+  }, []);
+
   // --- Flush pending saves on unmount ---
   useEffect(() => {
     return () => {
-      if (layoutTimerRef.current) {
-        clearTimeout(layoutTimerRef.current);
-        window.electronAPI?.invoke(IPC.LAYOUT_SAVE, layoutRef.current);
-      }
-      if (uiTimerRef.current) {
-        clearTimeout(uiTimerRef.current);
-        window.electronAPI?.invoke(IPC.UI_SAVE, uiRef.current);
-      }
+      void flushPendingSaves();
     };
-  }, []);
+  }, [flushPendingSaves]);
 
   return {
     // State
     layout,
     ui,
     loaded,
+    flushPendingSaves,
     // Layout setters
     setMainSizes,
     setRightPanelSizes,

--- a/tritium/react-gui/src/renderer/hooks/useNaviContextMenu.ts
+++ b/tritium/react-gui/src/renderer/hooks/useNaviContextMenu.ts
@@ -30,9 +30,10 @@ export function useNaviContextMenu(): {
         // macOS shows the native menu (main process); Windows / Linux render
         // the same shared template with the React MenuPanel for a look that
         // matches the menu bar dropdowns.
+        const api = window.electronAPI;
         const action: NaviCtxAction | null =
-            window.electronAPI.platform === 'darwin'
-                ? await window.electronAPI.invoke(IPC.NAVI_CTX_SHOW, { x, y, ...payload })
+            api?.platform === 'darwin'
+                ? await api.invoke(IPC.NAVI_CTX_SHOW, { x, y, ...payload })
                 : await showContextMenu(buildNaviCtxMenuNodes(payload), { x, y });
 
         if (!action || !cm) return;

--- a/tritium/react-gui/src/renderer/hooks/usePickClickHandler.ts
+++ b/tritium/react-gui/src/renderer/hooks/usePickClickHandler.ts
@@ -81,8 +81,16 @@ export function usePickClickHandler({
             const click = decodeClick(args)
             if (!click) return
             if (!(click.mod & INDEV_LBTN)) return
-            const result = await pick(click.x, click.y)
-            if (result?.statusMessage) setStatusMessage(result.statusMessage)
+            try {
+                const result = await pick(click.x, click.y)
+                if (result?.statusMessage) setStatusMessage(result.statusMessage)
+            } catch (err) {
+                // useCueMolEventListener discards the promise this handler
+                // returns, so nothing else can catch this. Picking an object
+                // that was deleted between the click and the dispatch is an
+                // ordinary outcome, not a crash.
+                console.warn('pick failed:', err)
+            }
         },
     })
 
@@ -91,7 +99,7 @@ export function usePickClickHandler({
     useEffect(() => {
         if (!cm || !enabled) return
         return () => {
-            void reset()
+            reset().catch((err: unknown) => console.warn('pick reset failed:', err))
         }
         // `reset` identity is stable per (cm, viewId); deps mirror the
         // original per-tool cleanup gating.
@@ -103,9 +111,11 @@ export function usePickClickHandler({
         if (!cm || !enabled) return
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.key !== 'Escape') return
-            void reset().then((r) => {
-                if (r?.cleared) setStatusMessage(escapeMessage)
-            })
+            reset()
+                .then((r) => {
+                    if (r?.cleared) setStatusMessage(escapeMessage)
+                })
+                .catch((err: unknown) => console.warn('pick reset failed:', err))
         }
         window.addEventListener('keydown', onKeyDown)
         return () => window.removeEventListener('keydown', onKeyDown)

--- a/tritium/react-gui/src/renderer/hooks/useRenderWindowBridge.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderWindowBridge.ts
@@ -39,6 +39,7 @@ import type {
 } from "../data/renderResult";
 import { useRenderJob, type RenderJob } from "./useRenderJob";
 import type { TabData } from "../types";
+import { MOLVIEW_CANVAS_SELECTOR } from '../components/panes/molViewCanvas';
 
 /**
  * Drop the live preview image from a job before it goes on a context push.
@@ -222,7 +223,7 @@ export function useRenderWindowBridge(args: UseRenderWindowBridgeArgs): void {
     const offSize = api.onPush(IPC.RENDER_VIEW_SIZE_REQUEST, ({ reqId }) => {
       // Resolve the molview canvas pixel size ("Current view" preset).
       let size: ViewSizePx | null = null;
-      const canvas = document.querySelector("canvas");
+      const canvas = document.querySelector(MOLVIEW_CANVAS_SELECTOR);
       if (canvas) {
         const rect = canvas.getBoundingClientRect();
         const dpr = window.devicePixelRatio || 1;

--- a/tritium/react-gui/src/renderer/hooks/useRenderWindowBridge.ts
+++ b/tritium/react-gui/src/renderer/hooks/useRenderWindowBridge.ts
@@ -97,7 +97,16 @@ export function useRenderWindowBridge(args: UseRenderWindowBridgeArgs): void {
             })
             .catch(() => ({ ok: false }))
         : Promise.resolve({ ok: false });
-      void stored.then(() => {
+      void stored.then((res) => {
+        // Only publish an entry the archive actually holds. A failed store
+        // still produced a history row whose RENDER_HISTORY_READ returns null
+        // -- a blank frame in the render window, and "no longer available" from
+        // Save Image -- and left the render's work directory unregistered, so
+        // nothing ever reclaimed it.
+        if (!res?.ok) {
+          console.warn("render history store failed; entry not published:", result.id);
+          return;
+        }
         historyRef.current = [...historyRef.current, result].slice(
           -RENDER_HISTORY_LIMIT,
         );

--- a/tritium/react-gui/src/renderer/hooks/useSceneContextMenu.ts
+++ b/tritium/react-gui/src/renderer/hooks/useSceneContextMenu.ts
@@ -131,8 +131,9 @@ export function useSceneContextMenu(opts: UseSceneContextMenuOptions): {
     // menu bar dropdowns.
     const showSceneCtxMenu = useCallback(
         async (payload: SceneCtxMenuPayload): Promise<SceneCtxAction | null> => {
-            if (window.electronAPI.platform === 'darwin') {
-                return await window.electronAPI.invoke(IPC.SCENE_CTX_SHOW, payload)
+            const api = window.electronAPI
+            if (api?.platform === 'darwin') {
+                return await api.invoke(IPC.SCENE_CTX_SHOW, payload)
             }
             return await showContextMenu(buildTemplate(payload), { x: payload.x, y: payload.y })
         },

--- a/tritium/react-gui/src/renderer/hooks/useWindowCloseHandler.ts
+++ b/tritium/react-gui/src/renderer/hooks/useWindowCloseHandler.ts
@@ -64,11 +64,6 @@ export function useWindowCloseHandler({
           // UXP parity: switch to the tab being closed so the user sees
           // which scene the confirm dialog refers to.
           if (tab.type === "molview") setActiveTabRef.current(id);
-          // This step can sit on a "Save changes?" confirm for as long as the
-          // user takes. Tell main we are alive so its watchdog measures
-          // silence, not deliberation -- it used to force the window shut
-          // mid-decision and discard the unsaved scenes.
-          await api.invoke(IPC.WINDOW_CLOSE_PROGRESS);
           const ok = await handleCloseTabRef.current(id);
           if (!ok) {
             await api.invoke(IPC.WINDOW_CLOSE_PROCEED, { proceed: false });
@@ -78,7 +73,6 @@ export function useWindowCloseHandler({
         // All tabs confirmed: persist user-defined defaults before closing
         // (UXP onUnLoad). Failure must not block the close.
         if (onBeforeProceedRef.current) {
-          await api.invoke(IPC.WINDOW_CLOSE_PROGRESS);
           try {
             await onBeforeProceedRef.current();
           } catch {

--- a/tritium/react-gui/src/renderer/hooks/useWindowCloseHandler.ts
+++ b/tritium/react-gui/src/renderer/hooks/useWindowCloseHandler.ts
@@ -64,6 +64,11 @@ export function useWindowCloseHandler({
           // UXP parity: switch to the tab being closed so the user sees
           // which scene the confirm dialog refers to.
           if (tab.type === "molview") setActiveTabRef.current(id);
+          // This step can sit on a "Save changes?" confirm for as long as the
+          // user takes. Tell main we are alive so its watchdog measures
+          // silence, not deliberation -- it used to force the window shut
+          // mid-decision and discard the unsaved scenes.
+          await api.invoke(IPC.WINDOW_CLOSE_PROGRESS);
           const ok = await handleCloseTabRef.current(id);
           if (!ok) {
             await api.invoke(IPC.WINDOW_CLOSE_PROCEED, { proceed: false });
@@ -73,6 +78,7 @@ export function useWindowCloseHandler({
         // All tabs confirmed: persist user-defined defaults before closing
         // (UXP onUnLoad). Failure must not block the close.
         if (onBeforeProceedRef.current) {
+          await api.invoke(IPC.WINDOW_CLOSE_PROGRESS);
           try {
             await onBeforeProceedRef.current();
           } catch {
@@ -80,6 +86,17 @@ export function useWindowCloseHandler({
           }
         }
         await api.invoke(IPC.WINDOW_CLOSE_PROCEED, { proceed: true });
+      } catch (err) {
+        // Main is waiting for a reply and force-closes the window if none
+        // arrives. Anything unexpected in here (a throw from handleCloseTab or
+        // setActiveTab) must therefore still answer -- aborting the close is
+        // the safe answer, since we cannot know the tabs are saved.
+        console.error('window close handling failed; aborting the close:', err);
+        try {
+          await api.invoke(IPC.WINDOW_CLOSE_PROCEED, { proceed: false });
+        } catch {
+          /* main is gone -- nothing left to reply to */
+        }
       } finally {
         isProcessingRef.current = false;
       }

--- a/tritium/react-gui/src/renderer/render.tsx
+++ b/tritium/react-gui/src/renderer/render.tsx
@@ -11,6 +11,11 @@
  * a second native addon), no dialog/command providers, and no
  * installGlobalCrashHandlers (a satellite-window crash must not exit the
  * app; the main process destroys just this window on render-process-gone).
+ *
+ * ContextMenuProvider is the exception: main registers the text context menu
+ * on this window too, and on Windows / Linux that arrives as an
+ * IPC.TEXT_CTX_SHOW push the renderer has to draw itself. Without a subscriber
+ * here, right-clicking a text field in this window produced no menu at all.
  */
 
 import { createRoot } from 'react-dom/client'
@@ -23,6 +28,7 @@ import './index.css'
 import './app.css'
 
 import { ThemeProvider } from './contexts/ThemeContext'
+import { ContextMenuProvider } from './components/menu/ContextMenuProvider'
 import { ErrorBoundary } from './crash/ErrorBoundary'
 import { RenderWindowApp } from './components/renderwindow/RenderWindowApp'
 
@@ -30,7 +36,9 @@ const container = document.getElementById('root') as HTMLElement
 createRoot(container).render(
   <ErrorBoundary>
     <ThemeProvider>
-      <RenderWindowApp />
+      <ContextMenuProvider>
+        <RenderWindowApp />
+      </ContextMenuProvider>
     </ThemeProvider>
   </ErrorBoundary>
 )

--- a/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
+++ b/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
@@ -204,7 +204,12 @@ export class WorkerService {
                 }
             } catch (e) {
                 log.error(`Worker> call method failed: ${method},`, e);
-                this._postMessage([method, seqno, false, e]);
+                // Stringify like the service branch below does: a raw thrown
+                // value is not necessarily structured-cloneable, and a
+                // DataCloneError raised inside this catch would escape
+                // self.onmessage and be funnelled as __worker_crash__ --
+                // tearing down the whole worker over one failed call.
+                this._postMessage([method, seqno, false, String(e)]);
             }
         } else if (serviceFn) {
             Promise.resolve()

--- a/tritium/react-gui/src/renderer/worker/server/services/bulkSceneNodeOps.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/bulkSceneNodeOps.service.ts
@@ -14,6 +14,7 @@ import type { SceneNodeType } from '../../shared/sceneTreeTypes';
 import { getSceneOrNull } from './helpers/sceneResolver';
 import { withUndoTxn } from './withUndoTxn';
 import { listGroupChildRenderers } from './helpers/groupChildren';
+import { collectGroupMemberUids } from './helpers/rendGroup';
 
 export interface BulkSceneNodeItem {
     nodeId: number;
@@ -118,7 +119,9 @@ function bulkDeleteNode(
                 if (!grp) continue;
                 const client = grp.getClientObj() as CueMolObject | null;
                 if (!client) continue;
-                for (const cid of it.childIds ?? []) {
+                // Live membership, not just the caller's tree snapshot -- see
+                // collectGroupMemberUids.
+                for (const cid of collectGroupMemberUids(scene, grp, it.childIds)) {
                     try { client.destroyRenderer(cid); }
                     catch (e) { console.warn('destroyRenderer (group child) failed:', e); }
                 }

--- a/tritium/react-gui/src/renderer/worker/server/services/calcApbsPot.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/calcApbsPot.service.ts
@@ -596,4 +596,23 @@ function calcApbsCancel(
   return { ok: true };
 }
 
+/**
+ * Cancel every APBS job still in flight. Same reasoning as
+ * cancelAllRenderJobs: apbs / pdb2pqr run as external processes that outlive
+ * the app unless they are killed.
+ *
+ * @returns how many jobs were cancelled.
+ */
+export function cancelAllApbsJobs(ctx: WorkerContext): number {
+  const ids = [...jobs.keys()];
+  for (const jobId of ids) {
+    try {
+      calcApbsCancel(ctx, { jobId });
+    } catch (e) {
+      console.warn(`calcApbsCancel(${jobId}) failed during shutdown:`, e);
+    }
+  }
+  return ids.length;
+}
+
 export const services = { calcApbsStart, calcApbsCancel, proposeElepotName };

--- a/tritium/react-gui/src/renderer/worker/server/services/calcApbsPot.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/calcApbsPot.service.ts
@@ -199,13 +199,22 @@ function computeGrid(
 
   let min: { x: number; y: number; z: number };
   let max: { x: number; y: number; z: number };
+  // Sizing the grid to a selection means borrowing mol.sel for two getter
+  // calls. Only do that when the current value can be read back: the restore
+  // used to be `if (oldSel)`, so a throwing getter -- or a molecule with no
+  // selection -- left the user's selection permanently replaced by the APBS
+  // one, outside any undo transaction.
+  let oldSel: MolSelection | null = null;
+  let canRestore = false;
   if (sel) {
-    let oldSel: MolSelection | null = null;
     try {
       oldSel = anyMol.sel;
+      canRestore = true;
     } catch {
-      oldSel = null;
+      canRestore = false;
     }
+  }
+  if (sel && canRestore) {
     anyMol.sel = sel;
     try {
       const vmin = anyMol.getBoundBoxMin(true);
@@ -214,9 +223,11 @@ function computeGrid(
       max = { x: vmax.x, y: vmax.y, z: vmax.z };
     } finally {
       try {
-        if (oldSel) anyMol.sel = oldSel;
-      } catch {
-        /* best-effort restore */
+        // Assign back exactly what was read, null included -- the point is to
+        // leave mol.sel as it was found.
+        (anyMol as { sel: MolSelection | null }).sel = oldSel;
+      } catch (e) {
+        console.warn('APBS grid: could not restore the molecule selection:', e);
       }
     }
   } else {

--- a/tritium/react-gui/src/renderer/worker/server/services/coloring/paintCrud.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/coloring/paintCrud.ts
@@ -106,7 +106,10 @@ export function addPaintEntry(
 ): PaintMutationResult {
     const target = resolvePaintTarget(ctx, args);
     if (!target) return { ok: false };
-    const { scene, rend } = target;
+    const { scene, rend, coloring } = target;
+
+    // Insert position: `size` is legal and means append (see below).
+    if (args.idx < 0 || args.idx > coloring.size) return { ok: false };
 
     const sel = makeSel(ctx, args.selStr, scene.uid);
     if (!sel) return { ok: false };
@@ -130,7 +133,13 @@ export function removePaintEntry(
 ): PaintMutationResult {
     const target = resolvePaintTarget(ctx, args);
     if (!target) return { ok: false };
-    const { scene, rend } = target;
+    const { scene, rend, coloring } = target;
+
+    // A stale deck index (the row was deleted by another panel, or by an undo,
+    // between the panel's refetch and the click) makes C++ return false and
+    // mutate nothing -- but the service reported ok, so the row appeared to
+    // survive a successful delete, and the empty commit cleared the redo stack.
+    if (args.idx < 0 || args.idx >= coloring.size) return { ok: false };
 
     withUndoTxn(scene, 'Delete paint entry', () => {
         materializeColoringIfDefault(rend);
@@ -146,7 +155,12 @@ export function updatePaintEntry(
 ): PaintMutationResult {
     const target = resolvePaintTarget(ctx, args);
     if (!target) return { ok: false };
-    const { scene, rend } = target;
+    const { scene, rend, coloring } = target;
+
+    // A stale deck index makes C++ return false and mutate nothing, but the
+    // service reported ok -- the row appeared to change and did not, and the
+    // empty commit cleared the redo stack.
+    if (args.idx < 0 || args.idx >= coloring.size) return { ok: false };
 
     const sel = makeSel(ctx, args.selStr, scene.uid);
     if (!sel) return { ok: false };

--- a/tritium/react-gui/src/renderer/worker/server/services/exportImage.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/exportImage.service.ts
@@ -149,13 +149,19 @@ function exportScene(ctx: WorkerContext, args: ExportSceneArgs): ExportSceneResu
     exporter.camera = '__current';
 
     exporter.attach(scene);
-    exporter.setPath(args.filePath);
-    // POV-Ray writes a sibling include file alongside the .pov (UXP parity).
-    if (args.exporterName === 'pov' && typeof exporter.setSubPath === 'function') {
-        exporter.setSubPath('inc', replaceExt(args.filePath, 'inc'));
+    try {
+        exporter.setPath(args.filePath);
+        // POV-Ray writes a sibling include file alongside the .pov (UXP parity).
+        if (args.exporterName === 'pov' && typeof exporter.setSubPath === 'function') {
+            exporter.setSubPath('inc', replaceExt(args.filePath, 'inc'));
+        }
+        exporter.write();
+    } finally {
+        // write() throws for an unwritable path, and for an off-screen buffer
+        // whose requested size exceeds MAX_TEXTURE_SIZE. Without the finally the
+        // exporter stayed attached to the scene and its FBO was never released.
+        exporter.detach();
     }
-    exporter.write();
-    exporter.detach();
 
     return { ok: true };
 }

--- a/tritium/react-gui/src/renderer/worker/server/services/genericProps.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/genericProps.service.ts
@@ -14,6 +14,7 @@ import { parseGenericProps, type GenericPropEntry } from './helpers/parseGeneric
 import { makeSel } from './helpers/makeSel';
 import { safeRead } from './helpers/safeRead';
 import { listGroupChildRenderers } from './helpers/groupChildren';
+import { checkGroupAssignment } from './helpers/rendGroup';
 
 export type { GenericPropEntry } from './helpers/parseGenericProps';
 export type { PropTargetType } from './helpers/resolvePropTarget';
@@ -257,6 +258,27 @@ function setGenericProp(
             children: listGroupChildRenderers(scene, grp),
             newName,
         };
+    }
+
+    // Group membership is an unvalidated name reference, so a `group` write
+    // naming no existing group (a typo, or a group deleted meanwhile) drops the
+    // renderer out of getGroupedRendListJSON -- it keeps drawing but is gone
+    // from the scene tree, and every way to select / hide / delete it starts
+    // there. Reject instead of writing. See helpers/rendGroup.ts.
+    if (
+        args.op === 'set' &&
+        args.propName === 'group' &&
+        (args.nodeType === 'renderer' || args.nodeType === 'rendGroup')
+    ) {
+        const reason = checkGroupAssignment(
+            scene,
+            target as unknown as Renderer,
+            String(args.value ?? ''),
+        );
+        if (reason) {
+            console.warn(`setGenericProp: refusing group write -- ${reason}`);
+            return fail;
+        }
     }
 
     try {

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/molPostProc.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/molPostProc.ts
@@ -3,7 +3,17 @@ import { createDefPaintColoring } from './defPaintColoring';
 
 const log = console;
 
-export function molPostProc(ctx: WorkerContext, mol: any, newObj: boolean): void {
+/**
+ * @param sceneUid - style scope for the default colouring. Named colours live
+ *   in the scene's style set, so the scene's uid has to be threaded through;
+ *   the coloring panel already passes it (coloring/applyColoring.ts).
+ */
+export function molPostProc(
+    ctx: WorkerContext,
+    mol: any,
+    newObj: boolean,
+    sceneUid = 0,
+): void {
     try {
         const selRend = mol.getRendererByType('*selection');
         if (!selRend) {
@@ -15,7 +25,7 @@ export function molPostProc(ctx: WorkerContext, mol: any, newObj: boolean): void
 
     if (newObj) {
         try {
-            const coloring = createDefPaintColoring(ctx);
+            const coloring = createDefPaintColoring(ctx, sceneUid);
             if (coloring) {
                 mol.coloring = coloring;
                 log.info('*** default paint coloring set');

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/pickReaderName.ts
@@ -10,6 +10,7 @@
 import type { WorkerContext } from '../../types/WorkerContext';
 import { DEFAULT_SNIFF_CAP } from '../../../shared/sniffConfig';
 import { isHiddenObjReader } from './readerFilter';
+import { matchExtLength, parseExtList } from '@shared/fileExt';
 
 export const OBJREADER_CATEGORY = 0;
 
@@ -58,14 +59,19 @@ export function pickReaderName(
         return ctx.strMgr.searchReaderByContent(filePath, csv, OBJREADER_CATEGORY, false, cap);
     }
 
-    // Ext-first: collect every user-facing reader whose fext claims this extension.
-    const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-    const candidates = objReaders
-        .filter(
-            (e) =>
-                e.fext.split(';').map((s) => s.trim().replace(/^\*\./, '').toLowerCase()).includes(ext),
-        )
-        .map((e) => e.name);
+    // Ext-first: collect every user-facing reader whose fext claims this path.
+    //
+    // Matched by suffix, most specific first. A reader's fext is a pattern list
+    // ("*.pdb; *.ent; *.pdb.gz"), so an extension is not one dot-segment:
+    // reducing "1crn.pdb.gz" to "gz" matched no reader at all and the open
+    // failed with "could not determine a compatible reader". Scoring by the
+    // matched length also keeps a reader claiming "pdb.gz" ahead of one
+    // claiming only "gz".
+    const scored = objReaders
+        .map((e) => ({ name: e.name, len: matchExtLength(filePath, parseExtList(e.fext)) }))
+        .filter((c) => c.len > 0);
+    const best = scored.reduce((m, c) => (c.len > m ? c.len : m), 0);
+    const candidates = scored.filter((c) => c.len === best).map((c) => c.name);
 
     if (candidates.length === 0) return '';
     if (candidates.length === 1) return candidates[0];

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/rendGroup.test.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/rendGroup.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @file worker/server/services/helpers/rendGroup.test.ts
+ * @description Pins the guard that keeps a renderer from vanishing out of the
+ * scene tree.
+ *
+ * `Renderer.group` is a plain writable string and the Inspector lists every
+ * property `getPropsJSON` reports, so a user can type any value into it. A
+ * value naming no existing group removes the renderer from
+ * `getGroupedRendListJSON` entirely -- it keeps drawing but is unreachable
+ * from the tree, so it cannot be selected, hidden or deleted again.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { checkGroupAssignment, collectGroupMemberUids, isRendGroup } from './rendGroup'
+import type { Scene } from '@cuemol/core/src/wrappers/Scene'
+import type { Renderer } from '@cuemol/core/src/wrappers/Renderer'
+
+interface FakeRend {
+  uid: number
+  name: string
+  type_name: string
+  group: string
+}
+
+function makeObject(rends: FakeRend[]) {
+  const client = {
+    rend_uids: rends.map((r) => r.uid).join(','),
+    name: 'mol1',
+  }
+  const wrap = (r: FakeRend) => ({ ...r, getClientObj: () => client })
+  const wrapped = rends.map(wrap)
+  const scene = {
+    getRenderer: (uid: number) => wrapped.find((r) => r.uid === uid) ?? null,
+  } as unknown as Scene
+  return { scene, rend: (uid: number) => wrapped.find((r) => r.uid === uid) as unknown as Renderer }
+}
+
+const SIMPLE = { uid: 1, name: 'simple1', type_name: 'simple', group: '' }
+const GROUP = { uid: 2, name: 'Group A', type_name: '*group', group: '' }
+const GROUP2 = { uid: 3, name: 'Group B', type_name: '*group', group: '' }
+
+describe('isRendGroup', () => {
+  it('recognises a renderer group by its C++ type name', () => {
+    const { rend } = makeObject([SIMPLE, GROUP])
+    expect(isRendGroup(rend(2))).toBe(true)
+    expect(isRendGroup(rend(1))).toBe(false)
+  })
+})
+
+describe('checkGroupAssignment', () => {
+  it('allows clearing the group', () => {
+    const { scene, rend } = makeObject([SIMPLE, GROUP])
+    expect(checkGroupAssignment(scene, rend(1), '')).toBeNull()
+    expect(checkGroupAssignment(scene, rend(1), '   ')).toBeNull()
+  })
+
+  it('allows a group that exists on the same object', () => {
+    const { scene, rend } = makeObject([SIMPLE, GROUP])
+    expect(checkGroupAssignment(scene, rend(1), 'Group A')).toBeNull()
+  })
+
+  it('rejects a name that matches no group', () => {
+    const { scene, rend } = makeObject([SIMPLE, GROUP])
+    expect(checkGroupAssignment(scene, rend(1), 'Gx')).toMatch(/no renderer group/i)
+  })
+
+  it('rejects a name that matches a non-group renderer', () => {
+    const { scene, rend } = makeObject([SIMPLE, GROUP])
+    expect(checkGroupAssignment(scene, rend(1), 'simple1')).toMatch(/no renderer group/i)
+  })
+
+  it('rejects nesting one group inside another', () => {
+    const { scene, rend } = makeObject([GROUP, GROUP2])
+    expect(checkGroupAssignment(scene, rend(2), 'Group B')).toMatch(/cannot be nested/i)
+  })
+
+  it('rejects a group naming itself', () => {
+    const { scene, rend } = makeObject([SIMPLE, GROUP])
+    expect(checkGroupAssignment(scene, rend(2), 'Group A')).toMatch(/cannot be nested/i)
+  })
+})
+
+describe('collectGroupMemberUids', () => {
+  it('unions live members with the caller snapshot and drops the group itself', () => {
+    const rends = [
+      { uid: 1, name: 'r1', type_name: 'simple', group: 'Group A' },
+      { uid: 2, name: 'Group A', type_name: '*group', group: '' },
+      // Added to the group after the renderer fetched its tree snapshot.
+      { uid: 4, name: 'r4', type_name: 'simple', group: 'Group A' },
+      { uid: 5, name: 'r5', type_name: 'simple', group: '' },
+    ]
+    const { scene, rend } = makeObject(rends)
+    // The caller only knew about uid 1, and wrongly included the group itself.
+    const out = collectGroupMemberUids(scene, rend(2), [1, 2])
+    expect(out.sort()).toEqual([1, 4])
+  })
+
+  it('works with no snapshot at all', () => {
+    const rends = [
+      { uid: 1, name: 'r1', type_name: 'simple', group: 'Group A' },
+      { uid: 2, name: 'Group A', type_name: '*group', group: '' },
+    ]
+    const { scene, rend } = makeObject(rends)
+    expect(collectGroupMemberUids(scene, rend(2))).toEqual([1])
+  })
+})

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/rendGroup.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/rendGroup.ts
@@ -1,0 +1,105 @@
+/**
+ * @file renderer/worker/server/services/helpers/rendGroup.ts
+ * @description Guards for renderer-group membership writes.
+ *
+ * Group membership is a loose name reference: a renderer belongs to the group
+ * whose `name` equals its own `group` string (see helpers/groupChildren.ts).
+ * Nothing in C++ validates that string, and `Renderer.group` is an ordinary
+ * writable property that the Inspector exposes like any other.
+ *
+ * That makes two writes silently destructive, because
+ * `Object::getGroupedRendListJSON` skips every renderer with a non-empty
+ * `group` at top level and only re-emits it under a group whose name matches:
+ *
+ *   - a name that matches no group ("Gx", a typo, or a group deleted in the
+ *     meantime) removes the renderer from the scene tree for good. It keeps
+ *     drawing in 3D but cannot be selected, hidden or deleted, because every
+ *     one of those paths starts from the tree.
+ *   - a group placed inside another group disappears the same way: the C++
+ *     JSON is one level deep, so the inner group's own members match no
+ *     filter. The renderer-side DnD planner already refuses this
+ *     (components/panes/sceneTreeDnd.ts); the Inspector bypassed it.
+ *
+ * Both are rejected here instead, so a bad value fails the service call and
+ * leaves the scene untouched.
+ */
+
+import type { Scene } from '@cuemol/core/src/wrappers/Scene';
+import type { Object as CueMolObject } from '@cuemol/core/src/wrappers/Object';
+import type { Renderer } from '@cuemol/core/src/wrappers/Renderer';
+import { safeRead } from './safeRead';
+import { enumerateObjectRenderers, listGroupChildRenderers } from './groupChildren';
+
+/** C++ type name of a renderer group. */
+export const REND_GROUP_TYPE = '*group';
+
+/** Whether `rend` is a renderer group rather than a leaf renderer. */
+export function isRendGroup(rend: Renderer): boolean {
+    return (safeRead(() => rend.type_name) ?? '') === REND_GROUP_TYPE;
+}
+
+/**
+ * Check whether `target` may be moved into the group named `groupName`.
+ *
+ * @param scene - scene owning both renderers.
+ * @param target - the renderer whose `group` property would be written.
+ * @param groupName - requested group name; `''` means "no group" and is
+ *   always allowed.
+ * @returns `null` when the write is safe, otherwise a reason for the caller
+ *   to report.
+ */
+export function checkGroupAssignment(
+    scene: Scene,
+    target: Renderer,
+    groupName: string,
+): string | null {
+    const name = groupName.trim();
+    if (name === '') return null;
+
+    if (isRendGroup(target)) {
+        return 'renderer groups cannot be nested';
+    }
+
+    const client = safeRead(() => target.getClientObj() as CueMolObject | null) ?? null;
+    if (!client) return 'renderer has no client object';
+
+    const targetUid = safeRead(() => target.uid);
+    const match = enumerateObjectRenderers(client, scene).find(
+        (r) =>
+            safeRead(() => r.uid) !== targetUid &&
+            isRendGroup(r) &&
+            (safeRead(() => r.name) ?? '') === name,
+    );
+    if (!match) return `no renderer group named "${name}" on this object`;
+    return null;
+}
+
+/**
+ * Uids to destroy along with a renderer group: the live members plus anything
+ * the caller's tree snapshot listed, de-duplicated.
+ *
+ * Deleting a group has to take its members with it. Reading them only from the
+ * snapshot the renderer sent leaves any renderer moved into the group since
+ * that fetch behind, with `group` still naming a destroyed group -- which is
+ * exactly the unreachable state `checkGroupAssignment` exists to prevent.
+ *
+ * @param scene - scene owning the group.
+ * @param grp - the group renderer being destroyed.
+ * @param snapshotIds - member uids as the caller saw them; may be undefined.
+ * @returns member uids, each appearing once.
+ */
+export function collectGroupMemberUids(
+    scene: Scene,
+    grp: Renderer,
+    snapshotIds?: readonly number[],
+): number[] {
+    const uids = new Set<number>();
+    for (const child of listGroupChildRenderers(scene, grp)) {
+        const uid = safeRead(() => child.uid);
+        if (typeof uid === 'number') uids.add(uid);
+    }
+    for (const uid of snapshotIds ?? []) uids.add(uid);
+    const grpUid = safeRead(() => grp.uid);
+    if (typeof grpUid === 'number') uids.delete(grpUid);
+    return [...uids];
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/selName.test.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/selName.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @file worker/server/services/helpers/selName.test.ts
+ * @description Pins the quoting contract for names in selection strings.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { quoteSelName } from './selName'
+import { INVALID_UID, isValidUid } from '../../../shared/uid'
+
+describe('quoteSelName', () => {
+  it('quotes a plain name', () => {
+    expect(quoteSelName('A')).toBe("'A'")
+  })
+
+  it('quotes a name with a space (mmCIF auth_asym_id can have one)', () => {
+    expect(quoteSelName('A 1')).toBe("'A 1'")
+  })
+
+  it('quotes an empty name', () => {
+    expect(quoteSelName('')).toBe("''")
+  })
+
+  /**
+   * The scanner's escape rule appends the whole `\'` match to the value, so the
+   * backslash survives and the compiled name is not what was asked for. There
+   * is no representation for such a name; refuse rather than select the wrong
+   * atoms.
+   */
+  it('refuses a name containing a single quote', () => {
+    expect(quoteSelName("O'Brien")).toBeNull()
+  })
+})
+
+/**
+ * `qlib::invalid_uid` is 0 (src/qlib/qlib.hpp), so the `uid < 0` guards these
+ * services used never fired: a "not found" answer fell through as a real uid.
+ * saveStyleSetToFile(0, 0, path) logged "styleset (0) not found" and returned
+ * false, and saveSelDef wrote named selections into style-set id 0.
+ */
+describe('isValidUid', () => {
+  it('rejects the C++ sentinel', () => {
+    expect(isValidUid(INVALID_UID)).toBe(false)
+    expect(isValidUid(0)).toBe(false)
+  })
+
+  it('accepts a real uid', () => {
+    expect(isValidUid(1)).toBe(true)
+    expect(isValidUid(4242)).toBe(true)
+  })
+
+  it('rejects values a C++ lookup can never return', () => {
+    expect(isValidUid(-1)).toBe(false)
+    expect(isValidUid(NaN)).toBe(false)
+    expect(isValidUid(undefined)).toBe(false)
+    expect(isValidUid(null)).toBe(false)
+  })
+})

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/selName.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/selName.ts
@@ -1,0 +1,27 @@
+/**
+ * @file renderer/worker/server/services/helpers/selName.ts
+ * @description Quoting for chain / residue names embedded in selection strings.
+ *
+ * Selection strings are compiled by the C++ parser, whose scanner
+ * (src/modules/molstr/scanner_sel.lxx) reads an unquoted name as
+ * `SEL_TOKEN [_a-zA-Z0-9][_a-zA-Z0-9'*]*` -- so a name containing a space, or
+ * any character outside that set, has to be single-quoted or the expression is
+ * silently a different one.
+ *
+ * A name containing a single quote cannot be represented at all. The scanner's
+ * `\'` rule appends the whole two-character match to the buffer, so the
+ * backslash survives into the value and the compiled name is wrong. Such a name
+ * is rejected here rather than compiled into something that would select the
+ * wrong atoms.
+ */
+
+/**
+ * Quote a name for use in a selection string.
+ *
+ * @param name - chain or residue name straight from the model.
+ * @returns the quoted literal, or `null` when the name cannot be represented.
+ */
+export function quoteSelName(name: string): string | null {
+    if (name.includes("'")) return null;
+    return `'${name}'`;
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/loadScene.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/loadScene.service.ts
@@ -15,6 +15,7 @@ import type { WorkerContext } from '../types/WorkerContext';
 import type { Scene } from '@cuemol/core/src/wrappers/Scene';
 import type { SceneXMLReader } from '@cuemol/core/src/wrappers/SceneXMLReader';
 import type { View } from '@cuemol/core/src/wrappers/View';
+import { matchExtLength, parseExtList } from '@shared/fileExt';
 
 const log = console;
 
@@ -50,16 +51,17 @@ function guessReaderName(ctx: WorkerContext, filePath: string): string | null {
     } catch {
         return null;
     }
-    const ext = filePath.toLowerCase().split('.').pop() ?? '';
-    if (!ext) return null;
-    const hit = info.find(
-        (e) =>
-            e.category === SCEREADER_CATEGORY &&
-            e.fext
-                .split(';')
-                .map((s) => s.trim().replace(/^\*\./, '').toLowerCase())
-                .includes(ext),
-    );
+    // Suffix match, most specific first -- see shared/fileExt.ts.
+    let hit: StreamHandlerInfo | null = null;
+    let best = 0;
+    for (const e of info) {
+        if (e.category !== SCEREADER_CATEGORY) continue;
+        const len = matchExtLength(filePath, parseExtList(e.fext));
+        if (len > best) {
+            best = len;
+            hit = e;
+        }
+    }
     return hit?.name ?? null;
 }
 

--- a/tritium/react-gui/src/renderer/worker/server/services/naviCtxtMenu.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/naviCtxtMenu.service.ts
@@ -8,6 +8,7 @@ import { makeSel } from './helpers/makeSel';
 import { invertSelStr, rewriteAround, toggleSidechainStr } from './helpers/selStrTransforms';
 import { getViewSceneOrNull, getViewSceneObjOrNull } from './helpers/sceneResolver';
 import { withUndoTxn } from './withUndoTxn';
+import { quoteSelName } from './helpers/selName';
 
 /**
  * Granularity of an atom context-menu selection. Canonical source for the
@@ -38,10 +39,17 @@ function buildSelStr(mol: MolCoord, atomId: number, mode: SelectMode): string | 
     const chainName: string = atom.chainName;
     const residIndex: string = atom.residIndex;
 
+    // A chain name reaches the selection grammar as a literal, so it has to be
+    // quoted: mmCIF auth_asym_id may contain a space, which would otherwise
+    // parse as a different expression. quoteSelName returns null for a name the
+    // grammar cannot represent at all.
+    const chain = quoteSelName(chainName);
+    if (!chain) return null;
+
     switch (mode) {
         case 'atom':     return `aid ${atomId}`;
-        case 'residue':  return `'${chainName}'.${residIndex}.*`;
-        case 'chain':    return `c;${chainName}`;
+        case 'residue':  return `${chain}.${residIndex}.*`;
+        case 'chain':    return `c;${chain}`;
         case 'mol':      return '*';
     }
 }

--- a/tritium/react-gui/src/renderer/worker/server/services/naviTool.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/naviTool.service.ts
@@ -5,10 +5,11 @@ import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
 import type { MsgLog } from '@cuemol/core/src/wrappers/MsgLog';
 import type { NameLabelRenderer } from '@cuemol/core/src/wrappers/NameLabelRenderer';
 import type { ResidRangeSet } from '@cuemol/core/src/wrappers/ResidRangeSet';
-import type { SelCommand } from '@cuemol/core/src/wrappers/SelCommand';
 import type { MolResidue } from '@cuemol/core/src/wrappers/MolResidue';
 import type { HitTestResult } from '../../../types';
 import { withUndoTxn } from './withUndoTxn';
+import { makeSel } from './helpers/makeSel';
+import { quoteSelName } from './helpers/selName';
 
 // ---- internal helpers ----
 
@@ -22,12 +23,6 @@ function runHitTest(ctx: WorkerContext, viewId: number, x: number, y: number): H
     } catch {
         return null;
     }
-}
-
-function makeSel(ctx: WorkerContext, selStr: string, sceneUid: number): SelCommand {
-    const sel = ctx.svc.createObj('SelCommand') as SelCommand;
-    sel.compile(selStr, sceneUid);
-    return sel;
 }
 
 function toggleAtomLabel(mol: MolCoord, atomId: number): void {
@@ -146,6 +141,8 @@ function naviResidSel(ctx: WorkerContext, args: NaviResidSelArgs): NaviResidSelR
 
     const chainName: string = atom.chainName;
     const residIndex: string = atom.residIndex;
+    const chain = quoteSelName(chainName);
+    if (!chain) return { handled: false };
 
     withUndoTxn(scene, 'Toggle select atom(s)', () => {
         const rrs = ctx.svc.createObj('ResidRangeSet') as ResidRangeSet;
@@ -160,11 +157,15 @@ function naviResidSel(ctx: WorkerContext, args: NaviResidSelArgs): NaviResidSelR
             if (prevAtom.chainName !== chainName) return;
 
             const prevResidIndex = prevAtom.residIndex;
-            const addSel = makeSel(ctx, `'${chainName}'.${prevResidIndex}:${residIndex}.*`, scene.uid);
+            const addSel = makeSel(ctx, `${chain}.${prevResidIndex}:${residIndex}.*`, scene.uid);
+            // A failed compile used to yield a match-nothing SelCommand that
+            // was appended anyway, silently changing the selection.
+            if (!addSel) return;
             rrs.append(mol, addSel);
         } else {
             const resid = mol.getResidue(chainName, residIndex) as MolResidue;
-            const addSel = makeSel(ctx, `'${chainName}'.${residIndex}.*`, scene.uid);
+            const addSel = makeSel(ctx, `${chain}.${residIndex}.*`, scene.uid);
+            if (!addSel) return;
             if (resid && rrs.contains(resid)) {
                 rrs.remove(mol, addSel);
             } else {

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/PovrayBackend.ts
@@ -19,6 +19,7 @@ import type { PovSceneExporter } from "@cuemol/core/src/wrappers/PovSceneExporte
 import type { WorkerContext } from "../../types/WorkerContext";
 import type { RenderSettingsSnapshot } from "../../../../data/renderResult";
 import type { RenderBinaries } from "../../../shared/renderTypes";
+import { quoteProcArg } from "./procArgs";
 import {
   type RenderBackend,
   type ExportedScene,
@@ -251,12 +252,17 @@ export const povrayBackend: RenderBackend = {
     }));
 
     // blendpng finalize task: composite layers, stamp DPI.
-    const blendArgs: string[] = [layerPaths[0]];
+    //
+    // Every path is quoted: C++ splits this single string on spaces, so an
+    // unquoted path with a space in it becomes two arguments and the composite
+    // step fails with nothing but "Output image not produced". buildPovArgs
+    // above already quotes for the same reason.
+    const blendArgs: string[] = [quoteProcArg(layerPaths[0])];
     for (let i = 1; i < layers.length; i++) {
-      blendArgs.push(layerPaths[i]);
+      blendArgs.push(quoteProcArg(layerPaths[i]));
       blendArgs.push(String(layers[i].alpha));
     }
-    blendArgs.push(this.outputImagePath(exported));
+    blendArgs.push(quoteProcArg(this.outputImagePath(exported)));
     blendArgs.push(String(numVal(snapshot.commonProps, "dpi", 600)));
     tasks.push({
       exe: blendpngExe,

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/procArgs.test.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/procArgs.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @file worker/server/services/renderBackends/procArgs.test.ts
+ * @description Pins the quoting against the C++ splitter's grammar
+ * (qlib::PosixProcImpl::parseCmdLine + replaceEsc).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { quoteProcArg } from './procArgs'
+
+/** Mirror of the C++ tokenizer, so the expectations are checked end to end. */
+function parseCmdLine(args: string): string[] {
+  const re = /"(?:\\"|[^"])*"|(?:\\ |[^ ])+/g
+  return (args.match(re) ?? []).map((tok) => {
+    let t = tok
+    if (t.startsWith('"')) t = t.slice(1)
+    if (t.endsWith('"')) t = t.slice(0, -1)
+    return t.replace(/\\ /g, ' ').replace(/\\"/g, '"')
+  })
+}
+
+describe('quoteProcArg', () => {
+  it('keeps a path with a space as one argument', () => {
+    const p = 'C:\\Users\\Jane Doe\\AppData\\Local\\Temp\\render.png'
+    expect(parseCmdLine(quoteProcArg(p))).toEqual([p])
+  })
+
+  it('keeps several spaced paths separate', () => {
+    const a = '/tmp/my renders/layer0.png'
+    const b = '/tmp/my renders/out.png'
+    expect(parseCmdLine([quoteProcArg(a), '0.5', quoteProcArg(b)].join(' ')))
+      .toEqual([a, '0.5', b])
+  })
+
+  it('survives a quote inside the value', () => {
+    const p = '/tmp/we"ird/out.png'
+    expect(parseCmdLine(quoteProcArg(p))).toEqual([p])
+  })
+
+  it('leaves an ordinary path unchanged after a round trip', () => {
+    const p = '/tmp/plain/out.png'
+    expect(parseCmdLine(quoteProcArg(p))).toEqual([p])
+  })
+})

--- a/tritium/react-gui/src/renderer/worker/server/services/renderBackends/procArgs.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderBackends/procArgs.ts
@@ -1,0 +1,24 @@
+/**
+ * @file worker/server/services/renderBackends/procArgs.ts
+ * @description Quoting for the single argument string ProcessManager takes.
+ *
+ * C++ splits that string itself (qlib::PosixProcImpl::parseCmdLine): a token is
+ * either a double-quoted run -- in which `\"` stands for a literal quote -- or
+ * a run of non-space characters in which `\ ` stands for a literal space.
+ * `replaceEsc` then strips the surrounding quotes and undoes those two escapes.
+ *
+ * So an unquoted path containing a space is split into two arguments. That is
+ * not exotic: on Windows `os.tmpdir()` is
+ * C:\Users\<account>\AppData\Local\Temp, and any account name with a space in
+ * it breaks every path handed to a render backend.
+ */
+
+/**
+ * Quote one argument for `ProcessManager`.
+ *
+ * @param value - raw argument (a path, a number, a flag).
+ * @returns the quoted token.
+ */
+export function quoteProcArg(value: string): string {
+    return `"${value.replace(/"/g, '\\"')}"`;
+}

--- a/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderJob.service.ts
@@ -1348,4 +1348,34 @@ function renderCancel(ctx: WorkerContext, args: RenderCancelArgs): RenderCancelR
   return { ok: true };
 }
 
+/**
+ * Cancel every render job still in flight.
+ *
+ * Called from the window-close chain. An external-process render (POV-Ray, and
+ * the ffmpeg encode of a movie) is spawned through the C++ ProcessManager with
+ * posix_spawn, so it is an ordinary child: killing the app leaves it running,
+ * writing into a work directory nothing will reclaim. renderCancel already
+ * kills the tasks and cleans the directory up -- nothing was calling it on the
+ * way out.
+ *
+ * An in-process render (umbreon) is cancelled cooperatively and keeps its
+ * registry entry, because normally the poll loop is what observes the
+ * cancellation and finishes the job. That loop will not run again here, but
+ * there is no external process to strand either -- the render thread goes with
+ * the worker.
+ *
+ * @returns how many jobs were asked to stop.
+ */
+export function cancelAllRenderJobs(ctx: WorkerContext): number {
+  const ids = [...jobs.keys()];
+  for (const jobId of ids) {
+    try {
+      renderCancel(ctx, { jobId });
+    } catch (e) {
+      console.warn(`renderCancel(${jobId}) failed during shutdown:`, e);
+    }
+  }
+  return ids.length;
+}
+
 export const services = { renderStart, renderCancel };

--- a/tritium/react-gui/src/renderer/worker/server/services/reorderSceneNode.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/reorderSceneNode.service.ts
@@ -20,6 +20,7 @@ import type { WorkerContext } from '../types/WorkerContext';
 import { withUndoTxn } from './withUndoTxn';
 import { getSceneOrNull } from './helpers/sceneResolver';
 import { enumerateObjectRenderers } from './helpers/groupChildren';
+import { isRendGroup } from './helpers/rendGroup';
 
 /** -1 = drop BEFORE target; 0 = drop AT target (used for rendGroup INTO); +1 = drop AFTER. */
 export type ReorderOri = -1 | 0 | 1;
@@ -178,6 +179,21 @@ function reorderSceneNode(
     if (!src) return { ok: false };
     const destObj = scene.getObject(args.destObjId) as CueMolObject | null;
     if (!destObj) return { ok: false };
+
+    // Nesting one renderer group inside another drops the inner group's members
+    // out of the scene tree for good: getGroupedRendListJSON is only one level
+    // deep, so they match no filter. The renderer-side DnD planner already
+    // refuses this (components/panes/sceneTreeDnd.ts); refuse it here too, since
+    // the service is reachable without it.
+    //
+    // The existence of `destGroupName` is NOT checked here: every caller derives
+    // it from a group node in the tree it just rendered. The Inspector, where a
+    // user can type an arbitrary string into `Renderer.group`, is guarded in
+    // genericProps.service.ts. See helpers/rendGroup.ts.
+    if (args.destGroupName.trim() !== '' && isRendGroup(src)) {
+        console.warn('reorderSceneNode: refusing to nest a renderer group');
+        return { ok: false };
+    }
 
     // Assign / clear rend.group BEFORE re-collecting siblings -- UXP does
     // the same; the group string is part of the rend, not of the obj.

--- a/tritium/react-gui/src/renderer/worker/server/services/saveScene.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/saveScene.service.ts
@@ -77,9 +77,14 @@ function saveScene(ctx: WorkerContext, args: SaveSceneArgs): SaveSceneResult {
     }
 
     writer.attach(scene);
-    writer.setPath(args.filePath);
-    writer.write();
-    writer.detach();
+    try {
+        writer.setPath(args.filePath);
+        writer.write();
+    } finally {
+        // A failed write (read-only path, disk full) used to leave the writer
+        // attached to the scene. objectSave.saveObjectToFile already does this.
+        writer.detach();
+    }
 
     // UXP: writing the scene drops undo/redo data. Also align the displayed
     // scene name with the new file name (matches the Save As path in UXP).

--- a/tritium/react-gui/src/renderer/worker/server/services/saveSelDef.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/saveSelDef.service.ts
@@ -12,6 +12,7 @@ import type { WorkerContext } from '../types/WorkerContext';
 import type { StyleManager } from '@cuemol/core/src/wrappers/StyleManager';
 import { getSceneOrNull } from './helpers/sceneResolver';
 import { withUndoTxn } from './withUndoTxn';
+import { isValidUid } from '../../shared/uid';
 
 export interface SaveSelDefArgs {
     sceneId: number;
@@ -62,7 +63,10 @@ function saveSelDef(ctx: WorkerContext, args: SaveSelDefArgs): SaveSelDefResult 
         let setId = findWritableSceneSet(styleMgr, args.sceneId);
         if (setId === null) {
             setId = styleMgr.createStyleSet('user', args.sceneId);
-            if (setId < 0) return;
+            // C++ returns qlib::invalid_uid (0) on failure, never a negative
+            // number -- the old `< 0` guard never fired and named selections
+            // were written into style-set id 0.
+            if (!isValidUid(setId)) return;
         }
         ok = styleMgr.setStrData('sel', name, expr, args.sceneId, setId);
     });

--- a/tritium/react-gui/src/renderer/worker/server/services/sceneClipboard.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/sceneClipboard.service.ts
@@ -503,7 +503,7 @@ export interface CopyNodesResult {
      * 'mixed' -- the selection spans more than one kind;
      * 'objectUnsupported' -- multiple objects, which UXP declines too.
      */
-    reason?: 'mixed' | 'objectUnsupported';
+    reason?: 'mixed' | 'objectUnsupported' | 'nodeTypesMismatch';
 }
 
 /** UXP `convElemNodeTypes`: a group counts as a renderer for type checking. */
@@ -541,16 +541,34 @@ function copyNodes(ctx: WorkerContext, args: CopyNodesArgs): CopyNodesResult {
 
     // A selected group contributes its member renderers, matching what a
     // single-group copy serializes.
+    //
+    // De-duplicated by uid: selecting a group *and* one of its own children
+    // reached the same renderer twice -- once through the group's membership
+    // scan and once directly -- so arrayToXML serialized it twice and the paste
+    // produced two copies. (Same shape as the group+child double-delete fixed
+    // in resolveBulkItems.)
     const natives: unknown[] = [];
+    const seen = new Set<number>();
+    const pushRend = (rend: Renderer): void => {
+        const uid = safeRead(() => rend.uid);
+        if (typeof uid === 'number') {
+            if (seen.has(uid)) return;
+            seen.add(uid);
+        }
+        natives.push((rend as unknown as { wrapped: unknown }).wrapped);
+    };
+    // nodeTypes is read positionally; a short array would silently reclassify
+    // the tail as plain renderers.
+    if (args.nodeTypes.length !== args.nodeIds.length) {
+        return { ok: false, kind: null, reason: 'nodeTypesMismatch' };
+    }
     for (let i = 0; i < args.nodeIds.length; ++i) {
         const rend = scene.getRenderer(args.nodeIds[i]) as Renderer | null;
         if (!rend) continue;
         if (args.nodeTypes[i] === 'rendGroup') {
-            for (const child of listGroupChildRenderers(scene, rend)) {
-                natives.push((child as unknown as { wrapped: unknown }).wrapped);
-            }
+            for (const child of listGroupChildRenderers(scene, rend)) pushRend(child);
         } else {
-            natives.push((rend as unknown as { wrapped: unknown }).wrapped);
+            pushRend(rend);
         }
     }
     if (natives.length === 0) return { ok: false, kind: null };

--- a/tritium/react-gui/src/renderer/worker/server/services/sceneOps.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/sceneOps.service.ts
@@ -18,6 +18,7 @@ import type { SceneNodeType } from '../../shared/sceneTreeTypes';
 import { withUndoTxn } from './withUndoTxn';
 import { safeRead } from './helpers/safeRead';
 import { listGroupChildRenderers } from './helpers/groupChildren';
+import { collectGroupMemberUids } from './helpers/rendGroup';
 
 export interface FocusOnNodeArgs {
     sceneId: number;
@@ -183,9 +184,12 @@ function deleteNode(ctx: WorkerContext, args: DeleteNodeArgs): DeleteNodeResult 
         if (!client) return { ok: false };
         const objName = safeRead(() => client.name) ?? '';
         const grpName = safeRead(() => grp.name) ?? '';
-        const childIds = args.childIds ?? [];
         withUndoTxn(scene, `Delete rend group: ${objName}/${grpName}`, () => {
-            for (const cid of childIds) {
+            // Union the caller's snapshot with the live membership: a renderer
+            // moved into the group after the tree was fetched would otherwise
+            // survive with `group` still naming the destroyed group, which
+            // hides it from the scene tree for good.
+            for (const cid of collectGroupMemberUids(scene, grp, args.childIds)) {
                 try {
                     client.destroyRenderer(cid);
                 } catch (e) {

--- a/tritium/react-gui/src/renderer/worker/server/services/setupRenderer.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/setupRenderer.service.ts
@@ -29,6 +29,7 @@ import type { RendererOptions } from '../../../components/fopen-opt-dlgs/types';
 import { getDefaultStyleName } from './helpers/getDefaultStyleName';
 import { makeSel } from './helpers/makeSel';
 import { molPostProc } from './helpers/molPostProc';
+import { safeRead } from './helpers/safeRead';
 
 const log = console;
 
@@ -105,7 +106,7 @@ export function setupRenderer(
         // Selection field while a preset is picked).
         recenterIfRequested(mol, rend, rendOpts);
         if (!NON_MOL_CLASSES.includes(mol.getClassName())) {
-            molPostProc(ctx, mol, true);
+            molPostProc(ctx, mol, true, safeRead(() => (mol.getScene() as Scene | null)?.uid) ?? 0);
         }
         return rend;
     }
@@ -138,10 +139,16 @@ export function setupRenderer(
 
     const className = mol.getClassName();
     if (!NON_MOL_CLASSES.includes(className)) {
-        molPostProc(ctx, mol, true);
+        // Named selections and colours are scoped to the scene's style set
+        // (saveSelDef writes them there and getSelDefs offers them to the UI),
+        // so compiling in the default global scope made a scene-local name
+        // fail to resolve -- the renderer was then created with no selection at
+        // all, showing every atom.
+        const sceneUid = safeRead(() => (mol.getScene() as Scene | null)?.uid) ?? 0;
+        molPostProc(ctx, mol, true, sceneUid);
 
         if (rendOpts.selectionEnabled && rendOpts.selection && rendOpts.selection !== '*') {
-            const sel = makeSel(ctx, rendOpts.selection);
+            const sel = makeSel(ctx, rendOpts.selection, sceneUid);
             if (sel) {
                 (rend as unknown as MolRenderer).sel = sel;
             } else {

--- a/tritium/react-gui/src/renderer/worker/server/services/shutdown.service.test.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/shutdown.service.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @file worker/server/services/shutdown.service.test.ts
+ * @description Pins that quitting stops the external processes it started.
+ *
+ * Renders (POV-Ray, plus the ffmpeg encode of a movie) and APBS runs are not
+ * worker work: they are external processes started through the C++
+ * ProcessManager and watched by a poll timer. posix_spawn children are
+ * ordinary children, so they survive the app. Nothing was cancelling them on
+ * the way out, which left them running -- burning CPU, and writing into a work
+ * directory nothing would reclaim, since a job's directory is only registered
+ * for cleanup once it completes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { WorkerContext } from '../types/WorkerContext'
+
+const renderCancelled: string[] = []
+const apbsCancelled: string[] = []
+
+vi.mock('./renderJob.service', () => ({
+  cancelAllRenderJobs: vi.fn(() => {
+    const n = renderCancelled.length
+    return n
+  }),
+}))
+vi.mock('./calcApbsPot.service', () => ({
+  cancelAllApbsJobs: vi.fn(() => apbsCancelled.length),
+}))
+
+import { services } from './shutdown.service'
+import { cancelAllRenderJobs } from './renderJob.service'
+import { cancelAllApbsJobs } from './calcApbsPot.service'
+
+const ctx = {} as WorkerContext
+
+beforeEach(() => {
+  renderCancelled.length = 0
+  apbsCancelled.length = 0
+  vi.clearAllMocks()
+})
+
+describe('cancelAllJobs', () => {
+  it('cancels both job kinds and reports the counts', () => {
+    renderCancelled.push('render-1', 'render-2')
+    apbsCancelled.push('apbs-1')
+
+    const res = services.cancelAllJobs(ctx)
+
+    expect(cancelAllRenderJobs).toHaveBeenCalledWith(ctx)
+    expect(cancelAllApbsJobs).toHaveBeenCalledWith(ctx)
+    expect(res).toEqual({ ok: true, render: 2, apbs: 1 })
+  })
+
+  it('is a no-op when nothing is running', () => {
+    const res = services.cancelAllJobs(ctx)
+    expect(res).toEqual({ ok: true, render: 0, apbs: 0 })
+  })
+
+  it('cancels APBS even when there is no render job, and vice versa', () => {
+    apbsCancelled.push('apbs-1')
+    expect(services.cancelAllJobs(ctx)).toEqual({ ok: true, render: 0, apbs: 1 })
+
+    apbsCancelled.length = 0
+    renderCancelled.push('render-1')
+    expect(services.cancelAllJobs(ctx)).toEqual({ ok: true, render: 1, apbs: 0 })
+  })
+})

--- a/tritium/react-gui/src/renderer/worker/server/services/shutdown.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/shutdown.service.ts
@@ -1,0 +1,42 @@
+/**
+ * @file renderer/worker/server/services/shutdown.service.ts
+ * @description Worker-side cleanup the renderer runs before the window closes.
+ *
+ * Long-running jobs (POV-Ray renders, the ffmpeg encode of a movie, apbs /
+ * pdb2pqr) do not run inside the worker: they are external processes started
+ * through the C++ ProcessManager and watched by a poll timer. posix_spawn
+ * children are ordinary children, so they survive the app -- quitting mid-job
+ * left them running, burning CPU and writing into a work directory nothing
+ * would ever reclaim (the directory is only registered for cleanup once the
+ * job completes).
+ *
+ * Each job type already knows how to stop itself properly -- kill the tasks,
+ * stop the timer, restore whatever an animation overwrote, remove the work
+ * directory. Nothing was calling that on the way out.
+ */
+
+import type { WorkerContext } from '../types/WorkerContext';
+import { cancelAllRenderJobs } from './renderJob.service';
+import { cancelAllApbsJobs } from './calcApbsPot.service';
+
+export interface CancelAllJobsResult {
+    ok: true;
+    /** Jobs cancelled, by kind -- logged by the caller, useful in tests. */
+    render: number;
+    apbs: number;
+}
+
+/**
+ * Stop every in-flight job so nothing outlives the app.
+ *
+ * Safe to call when nothing is running: it reports zeroes.
+ */
+function cancelAllJobs(ctx: WorkerContext): CancelAllJobsResult {
+    return {
+        ok: true,
+        render: cancelAllRenderJobs(ctx),
+        apbs: cancelAllApbsJobs(ctx),
+    };
+}
+
+export const services = { cancelAllJobs };

--- a/tritium/react-gui/src/renderer/worker/server/services/styleFile.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/styleFile.service.ts
@@ -16,6 +16,7 @@
 import type { WorkerContext } from '../types/WorkerContext';
 import { withUndoTxn } from './withUndoTxn';
 import { getSceneOrNull } from './helpers/sceneResolver';
+import { isValidUid } from '../../shared/uid';
 
 interface StyleManagerLike {
     loadStyleSetFromFile(scopeId: number, path: string, readOnly: boolean): number;
@@ -60,7 +61,7 @@ function loadStyleSetFromFile(
         // default. The user can toggle off later via the ctxmenu item.
         newId = mgr.loadStyleSetFromFile(args.sceneId, args.path, true);
     });
-    if (newId < 0) return empty;
+    if (!isValidUid(newId)) return empty;
     try { mgr.firePendingEvents?.(); } catch { /* ignore */ }
     return { ok: true, newId };
 }

--- a/tritium/react-gui/src/renderer/worker/server/services/styleOps.service.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/styleOps.service.ts
@@ -14,6 +14,7 @@
 import type { WorkerContext } from '../types/WorkerContext';
 import { withUndoTxn } from './withUndoTxn';
 import { getSceneOrNull } from './helpers/sceneResolver';
+import { INVALID_UID, isValidUid } from '../../shared/uid';
 
 interface StyleManagerLike {
     createStyleSet(name: string, scopeId: number): number;
@@ -62,11 +63,11 @@ function createStyleSet(
     if (!mgr) return empty;
     if (mgr.hasStyleSet(trimmed, args.sceneId) !== 0) return empty;
 
-    let newId = -1;
+    let newId = INVALID_UID;
     withUndoTxn(scene, 'Create style', () => {
         newId = mgr.createStyleSet(trimmed, args.sceneId);
     });
-    if (newId < 0) return empty;
+    if (!isValidUid(newId)) return empty;
     return { ok: true, newId };
 }
 

--- a/tritium/react-gui/src/renderer/worker/server/workerLifecycle.ts
+++ b/tritium/react-gui/src/renderer/worker/server/workerLifecycle.ts
@@ -4,6 +4,7 @@ import type { StyleManager } from '@cuemol/core/src/wrappers/StyleManager';
 import type { ViewInputConfig } from '@cuemol/core/src/wrappers/ViewInputConfig';
 import * as event from '../../event';
 import { renderText } from './textRender';
+import { isValidUid } from '../shared/uid';
 
 /**
  * Worker bootstrap / configuration helpers extracted from `WorkerService`.
@@ -61,7 +62,7 @@ export function saveUserStyle(cm: CueMol, userStylePath: string): boolean {
     }
     try {
         const uid = stylem.hasStyleSet('user', 0);
-        if (uid < 0) {
+        if (!isValidUid(uid)) {
             log.info('Worker> no "user" style set; nothing to save');
             return false;
         }

--- a/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/WorkerCalls.ts
@@ -30,6 +30,7 @@ import type {
 import type { AppInfoResult } from '../server/services/appInfo.service'
 import type { GetHatchStyleSpecArgs, GetHatchStyleSpecResult } from '../server/services/hatchStyleSpec.service'
 import type { DrainLogMessagesResult } from '../server/services/drainLogMessages.service'
+import type { CancelAllJobsResult } from '../server/services/shutdown.service';
 import type { AnimListTimelineArgs, AnimGetMgrStateArgs, AnimPlayArgs, AnimPauseArgs, AnimStopArgs, AnimGoTimeArgs, AnimSetLoopArgs, AnimSetStartCamArgs, AnimTransportResult, AnimSetElementTimeArgs, AnimAddElementArgs, AnimRemoveElementArgs, AnimMoveElementArgs, AnimEditResult, AnimAddResult } from '../server/services/animation.service'
 import type { GetAnimElementDetailArgs, GetAnimElementDetailResult, SetAnimElementPropArgs, SetAnimElementPropResult, GetAnimTargetOptionsArgs, GetAnimTargetOptionsResult, GetAnimElementGenericPropsArgs, SetAnimElementGenericPropArgs, ResetAnimElementGenericPropsArgs, AnimGenericPropsResult } from '../server/services/animDetail.service'
 import type { AnimTimeline, AnimMgrState } from '../../types'
@@ -526,6 +527,7 @@ export interface SerializedGestureEvent {
 export interface ServiceMap {
   appInfo:                    { args: Record<string, never>;          result: AppInfoResult }
   drainLogMessages:           { args: Record<string, never>;          result: DrainLogMessagesResult }
+  cancelAllJobs:              { args: Record<string, never>;          result: CancelAllJobsResult }
   createNewSceneAndView:      { args: CreateNewSceneAndViewArgs;       result: CreateNewSceneAndViewResult }
   createViewInScene:          { args: CreateViewInSceneArgs;           result: CreateViewInSceneResult }
   getCompatibleRendererNames: { args: GetCompatibleRendererNamesArgs;  result: GetCompatibleRendererNamesResult }

--- a/tritium/react-gui/src/renderer/worker/shared/uid.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/uid.ts
@@ -1,0 +1,24 @@
+/**
+ * @file renderer/worker/shared/uid.ts
+ * @description The C++ uid sentinel.
+ *
+ * `qlib::invalid_uid` is **0**, not a negative number (src/qlib/qlib.hpp).
+ * Several worker services guarded lookups with `if (uid < 0)`, which is never
+ * true, so a "not found" result fell through as if it were a real uid:
+ * saveStyleSetToFile(0, 0, path) logged "styleset (0) not found" and returned
+ * false, and saveSelDef wrote named selections into style-set id 0.
+ */
+
+/** The value C++ returns for "no such object". */
+export const INVALID_UID = 0;
+
+/**
+ * Whether a uid returned by a C++ lookup refers to a real object.
+ *
+ * Accepts only strictly positive values: 0 is the sentinel, and a real uid is
+ * never negative (see the "IDs are not URLs" note in tritium/CLAUDE.md), so a
+ * negative value can only mean a stub or a bug and is not a usable id either.
+ */
+export function isValidUid(uid: number | null | undefined): boolean {
+    return typeof uid === 'number' && Number.isFinite(uid) && uid > INVALID_UID;
+}

--- a/tritium/react-gui/src/shared/fileExt.test.ts
+++ b/tritium/react-gui/src/shared/fileExt.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @file shared/fileExt.test.ts
+ * @description Pins suffix matching against declared extensions.
+ *
+ * Readers declare multi-dot extensions (`"*.pdb; *.ent; *.pdb.gz"`). Taking a
+ * path's last dot-segment reduced `1crn.pdb.gz` to `gz`, which matches no
+ * reader -- so the file fell through to whatever the no-match branch did.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { hasExt, matchExtLength, parseExtList } from './fileExt'
+
+describe('parseExtList', () => {
+    it('strips the glob prefix and normalises case and spacing', () => {
+        expect(parseExtList('*.pdb; *.ent; *.PDB.GZ')).toEqual(['pdb', 'ent', 'pdb.gz'])
+    })
+
+    it('accepts a bare or dotted list', () => {
+        expect(parseExtList('pdb;.ent')).toEqual(['pdb', 'ent'])
+    })
+
+    it('drops empty entries', () => {
+        expect(parseExtList('*.pdb;;  ;*.ent')).toEqual(['pdb', 'ent'])
+    })
+})
+
+describe('hasExt', () => {
+    it('matches a multi-dot extension', () => {
+        expect(hasExt('/tmp/1crn.pdb.gz', 'pdb.gz')).toBe(true)
+    })
+
+    it('matches a plain extension', () => {
+        expect(hasExt('/tmp/1crn.pdb', 'pdb')).toBe(true)
+    })
+
+    it('is case insensitive on both sides', () => {
+        expect(hasExt('/tmp/1CRN.PDB.GZ', '*.pdb.gz')).toBe(true)
+    })
+
+    it('does not match a different extension', () => {
+        expect(hasExt('/tmp/1crn.cif', 'pdb')).toBe(false)
+    })
+
+    it('does not match a bare substring', () => {
+        // "mypdb" must not count as ".pdb".
+        expect(hasExt('/tmp/mypdb', 'pdb')).toBe(false)
+    })
+
+    it('is not fooled by a dot in a parent directory', () => {
+        expect(hasExt('/Users/me/v1.2/output', 'pdb')).toBe(false)
+    })
+})
+
+describe('matchExtLength', () => {
+    it('reports the longest matching extension so the most specific wins', () => {
+        // A reader claiming pdb.gz must beat one claiming only gz.
+        expect(matchExtLength('/tmp/1crn.pdb.gz', ['gz'])).toBe(2)
+        expect(matchExtLength('/tmp/1crn.pdb.gz', ['pdb', 'ent', 'pdb.gz'])).toBe(6)
+    })
+
+    it('reports 0 when nothing matches', () => {
+        expect(matchExtLength('/tmp/1crn.xyz', ['pdb', 'cif'])).toBe(0)
+        expect(matchExtLength('/tmp/1crn.xyz', [])).toBe(0)
+    })
+})

--- a/tritium/react-gui/src/shared/fileExt.ts
+++ b/tritium/react-gui/src/shared/fileExt.ts
@@ -1,0 +1,55 @@
+/**
+ * @file shared/fileExt.ts
+ * @description Matching a file path against declared extensions.
+ *
+ * Readers and dialog filters declare extensions as a semicolon list of glob
+ * patterns -- the PDB reader's is `"*.pdb; *.ent; *.pdb.gz"` -- so an
+ * extension is not necessarily one dot-segment. Reducing a path with
+ * `split('.').pop()` turns `1crn.pdb.gz` into `gz`, which matches nothing:
+ * the file then falls through to whatever the no-match branch does. That
+ * mistake appeared independently in four places, hence this module.
+ *
+ * Matching is by suffix, and the longest declared extension wins, so a reader
+ * claiming `pdb.gz` beats one claiming only `gz`.
+ */
+
+/**
+ * Split a `fext` / filter string into bare extensions.
+ *
+ * @param fext - semicolon-separated patterns, e.g. `"*.pdb; *.ent; *.pdb.gz"`.
+ * @returns lower-cased extensions without the leading `*.`, e.g.
+ *   `['pdb', 'ent', 'pdb.gz']`.
+ */
+export function parseExtList(fext: string): string[] {
+    return fext
+        .split(';')
+        .map((s) => s.trim().replace(/^\*\./, '').replace(/^\./, '').toLowerCase())
+        .filter((s) => s.length > 0)
+}
+
+/**
+ * Whether `filePath` carries the extension `ext`.
+ *
+ * @param ext - bare extension, with or without a leading dot; may contain dots
+ *   of its own (`pdb.gz`).
+ */
+export function hasExt(filePath: string, ext: string): boolean {
+    const bare = ext.replace(/^\*\./, '').replace(/^\./, '').toLowerCase()
+    if (!bare) return false
+    return filePath.toLowerCase().endsWith('.' + bare)
+}
+
+/**
+ * How specifically `exts` claims `filePath`.
+ *
+ * @returns the length of the longest matching extension, or 0 when none match.
+ *   Comparing this across candidates is what makes `pdb.gz` win over `gz`.
+ */
+export function matchExtLength(filePath: string, exts: readonly string[]): number {
+    let best = 0
+    for (const e of exts) {
+        const bare = e.replace(/^\*\./, '').replace(/^\./, '').toLowerCase()
+        if (bare.length > best && hasExt(filePath, bare)) best = bare.length
+    }
+    return best
+}

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -114,7 +114,6 @@ export const IPC = {
   // through win.on('close'))
   WINDOW_CLOSE_REQUEST: 'window:close-request',
   WINDOW_CLOSE_PROCEED: 'window:close-proceed',
-  WINDOW_CLOSE_PROGRESS: 'window:close-progress',
 
   // Window menu: raise the main window (the Rendering window has its own
   // open-or-focus channel, RENDER_WINDOW_OPEN).

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -114,6 +114,7 @@ export const IPC = {
   // through win.on('close'))
   WINDOW_CLOSE_REQUEST: 'window:close-request',
   WINDOW_CLOSE_PROCEED: 'window:close-proceed',
+  WINDOW_CLOSE_PROGRESS: 'window:close-progress',
 
   // Window menu: raise the main window (the Rendering window has its own
   // open-or-focus channel, RENDER_WINDOW_OPEN).

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -100,6 +100,12 @@ export interface InvokeChannels {
   [IPC.RECENT_CLEAR]:      { req: void;                  res: void }
   [IPC.MENU_INVOKE_ROLE]:  { req: string;                res: void }
   [IPC.WINDOW_CLOSE_PROCEED]: { req: { proceed: boolean }; res: void }
+  /**
+   * "Still working on the close" -- re-arms the WINDOW_CLOSE_REQUEST watchdog.
+   * Sent before each step that can wait on the user, so a slow decision is not
+   * mistaken for a wedged renderer.
+   */
+  [IPC.WINDOW_CLOSE_PROGRESS]: { req: void; res: void }
   [IPC.WINDOW_FOCUS_MAIN]: { req: void;                  res: void }
   [IPC.WINDOW_SET_TITLE]:  { req: { subtitle: string }; res: void }
   // Rendering window relay (see ipcChannels.ts for direction of each leg)

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -100,12 +100,6 @@ export interface InvokeChannels {
   [IPC.RECENT_CLEAR]:      { req: void;                  res: void }
   [IPC.MENU_INVOKE_ROLE]:  { req: string;                res: void }
   [IPC.WINDOW_CLOSE_PROCEED]: { req: { proceed: boolean }; res: void }
-  /**
-   * "Still working on the close" -- re-arms the WINDOW_CLOSE_REQUEST watchdog.
-   * Sent before each step that can wait on the user, so a slow decision is not
-   * mistaken for a wedged renderer.
-   */
-  [IPC.WINDOW_CLOSE_PROGRESS]: { req: void; res: void }
   [IPC.WINDOW_FOCUS_MAIN]: { req: void;                  res: void }
   [IPC.WINDOW_SET_TITLE]:  { req: { subtitle: string }; res: void }
   // Rendering window relay (see ipcChannels.ts for direction of each leg)

--- a/tritium/react-gui/src/shared/ipcTypes.ts
+++ b/tritium/react-gui/src/shared/ipcTypes.ts
@@ -268,7 +268,7 @@ export type TextCtxAction = 'cut' | 'copy' | 'paste' | 'selectAll'
  * when focus is in a text field, and that includes undo / redo, which the
  * context menu never offers.
  */
-export type TextEditAction = 'cut' | 'copy' | 'paste' | 'undo' | 'redo'
+export type TextEditAction = 'cut' | 'copy' | 'paste' | 'undo' | 'redo' | 'selectAll'
 
 /** Subset of Electron's `ContextMenuParams.editFlags` the menu consumes. */
 export interface TextCtxEditFlags {


### PR DESCRIPTION
Stacked on #517 (path aliases + ESLint + CI), which this needs for the aliases,
the moved test locations and the CI job.

An audit of the whole react-gui surface -- renderer, worker services, main
process and the IPC contracts -- turned up 108 candidate defects. This fixes the
30 that were confirmed by reading the code path end to end, each with a
regression test written first. Every commit is one coherent failure mode and can
be reviewed on its own.

## The ones that lose work or a session

| | |
|---|---|
| **A renderer could vanish from the scene tree for good** | Group membership is an unvalidated name reference and `Renderer.group` is writable, so typing a name that matches no group dropped the renderer out of `getGroupedRendListJSON`. It kept drawing in 3D but selecting, hiding and deleting all start from the tree. Nesting a group, and deleting a group whose membership had changed since the caller's tree snapshot, reached the same state. |
| **Backspace deleted a node while renaming it** | The tree binds Delete / Backspace on the scrolling wrapper; the inline rename `<input>` sits inside it and only stopped Enter and Escape. Correcting a typo deleted the object -- and `preventDefault` meant the character was not even removed. |
| **The close funnel discarded unsaved scenes** | The 10s watchdog measured user deliberation, not renderer silence: taking longer than that on a "Save changes?" prompt got the window forced shut. And the close handler had a `finally` but no `catch`, so a throw meant main heard nothing and the watchdog fired. |
| **One recoverable failure killed the session** | Every unhandled rejection mounted a full-screen Quit-only overlay. The renderer has ~50 fire-and-forget promises; a settings write failing on a full disk was enough. |
| **A damaged `app-state.json` produced a windowless zombie** | The store constructor throws on unparseable JSON, inside `app.whenReady()` with no catch, so `createWindow()` never ran -- and with no window, `window-all-closed` never fired either. |
| **The menu could lock permanently** | The 'blueprint' block count is incremented and decremented from the renderer. A reload in between left every item except the text-edit ones disabled for the rest of the run, Cmd+Q included, with no way back. |
| **A second instance wiped the first's renders** | `CUEMOL_FRESH_PREFS` gives a second instance its own lock domain, so it reached the boot-time sweep and rm -rf'd the running instance's live work directories. |
| **APBS permanently replaced the user's selection** | Sizing the grid borrows `mol.sel`; the restore was `if (oldSel)`, so a throwing getter or a molecule with no selection skipped it -- outside any undo transaction. |

## The ones that silently do the wrong thing

- A renderer created from the New Renderer / File Open dialog with a
  scene-local named selection got **no selection at all** (showing every atom):
  the selection compiled in the global style scope, and the failure was only
  `log.warn`'d.
- `naviTool` carried a local `makeSel` that ignored `compile()`'s result and
  assigned a match-nothing `SelCommand`.
- Chain-mode selections were built unquoted, so an mmCIF `auth_asym_id` with a
  space parsed as a different expression.
- `qlib::invalid_uid` is 0, so four `uid < 0` guards never fired -- `saveSelDef`
  wrote named selections into style-set id 0.
- Typing 9999 into a 0..100 property committed 9999 (`min`/`max` on
  `<input type=number>` do not constrain typed values), and clearing a vector
  cell wrote 0 into that axis.
- A second `show()` on a dialog abandoned the first caller's promise: two Finder
  "Open With" invocations left the first drain parked forever and its files
  unopened.
- The render window measured `document.querySelector("canvas")` for its
  "Current view" preset -- the sequence panel and gradient histogram render one
  too, and the sidebar comes first in the DOM.
- Text editing did not work in the Rendering window at all (no context menu on
  Win/Linux, a no-op Select All on macOS, and Cmd+A acting on the main window).
- `1crn.pdb.gz` matched no reader row, so the user's explicit PDB choice was
  discarded; a save path under a directory with a dot picked a writer nobody
  chose.
- Dragging a splitter and closing the window lost the layout (the debounced
  write is only flushed on unmount, and the renderer is never unmounted).
- A failed render-history archive still produced a history entry -- a blank
  frame, and "no longer available" from Save Image.
- One MRU path on a disconnected network mount blocked every window's input for
  the mount timeout.

## Two the audit called wrong, corrected here

- `DragNumericField.onDragStart` fires for an arrow press even when
  `realtime` is false. That is deliberate -- auto-repeat turns one press into a
  run of steps and the parent needs the pre-press value for a single undo
  entry -- so the **prop's documentation** was the defect. Rewritten, with a
  test pinning the behaviour so the "fix" is not applied later.
- `installMainCrashHandlers` was reported as swallowing fatal errors and needing
  `app.exit(1)`. Electron's own handler, verified in the shipped binary
  (`process.listenerCount("uncaughtException") > 1 || ...showErrorBox(...)`),
  **does not exit either** -- staying up is its deliberate choice for a desktop
  app. What registering a listener actually suppressed was the *dialog*, so that
  is what is restored.

## Verification

Every fix has a test that fails before it and passes after. 3144 tests across
331 files pass, typecheck is clean for both projects, eslint holds at 0 errors,
and the production build succeeds.

Some changes need a look in the running app rather than in CI: the scene-tree
rename keys, the close/quit flow with a modified scene, the Rendering window's
text fields, and the render window's size preset with a gradient histogram open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jq8nSHJWsEpfSui98LTXR