### PR TITLE
ci: fetch autoconf 2.13 from the third-party source mirror

### DIFF
--- a/build_scripts/deplibs.env
+++ b/build_scripts/deplibs.env
@@ -55,3 +55,16 @@ MESHMS_GIT_REF=main
 # === UXP GUI prebuilt platform (owned by build_uxpgui) ===
 UXP_VERSION=v0.0.1
 UXP_TGZ=RB_20231106.tar.gz
+
+# === Third-party source mirror (hosted by CueMol/build_scripts, fixed tag) ===
+# Upstream tarballs whose origin hosts are unreliable are mirrored into a
+# fixed-tag release of CueMol/build_scripts, so CI never fetches them from the
+# origin host. The tag is immutable (unlike DEPLIBS_VERSION); assets are
+# refreshed by the "Mirror third-party sources" workflow in that repository.
+THIRDPARTY_MIRROR_URL=https://github.com/CueMol/build_scripts/releases/download/thirdparty-mirror
+
+# autoconf 2.13 is built from source by download_deplibs and provides autoconf213,
+# required by the macOS UXP GUI build. Upstream is ftp.gnu.org, which is often
+# unreachable; the checksum below is GNU's published sha256 for the tarball.
+AUTOCONF213_VER=2.13
+AUTOCONF213_SHA256=f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e

--- a/build_scripts/download_deplibs/action.yml
+++ b/build_scripts/download_deplibs/action.yml
@@ -23,16 +23,25 @@ runs:
       cd ${GITHUB_WORKSPACE}
       bash build_scripts/download_deplibs/run.sh $BASEDIR ${{ runner.os }} ${{ runner.arch }}
 
+  # The tarball comes from the third-party source mirror in CueMol/build_scripts
+  # rather than ftp.gnu.org, which is frequently unreachable and used to take the
+  # whole macOS matrix down with it.
   - name: Install autoconf 2.13 (macOS)
     if: ${{ runner.os == 'macOS' }}
     shell: bash
     run: |
-      curl -fsSL https://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz | tar xz
-      cd autoconf-2.13
-      ./configure --prefix=$HOME/autoconf-2.13 --program-suffix=213
+      set -eux
+      . "${GITHUB_WORKSPACE}/build_scripts/deplibs.env"
+      TGZ="autoconf-${AUTOCONF213_VER}.tar.gz"
+      cd "${RUNNER_TEMP}"
+      curl -fsSL --retry 3 --connect-timeout 20 -o "$TGZ" "${THIRDPARTY_MIRROR_URL}/${TGZ}"
+      echo "${AUTOCONF213_SHA256}  $TGZ" | shasum -a 256 -c -
+      tar xzf "$TGZ"
+      cd "autoconf-${AUTOCONF213_VER}"
+      ./configure --prefix=$HOME/autoconf-${AUTOCONF213_VER} --program-suffix=213
       make
       make install
-      echo "$HOME/autoconf-2.13/bin" >> $GITHUB_PATH
+      echo "$HOME/autoconf-${AUTOCONF213_VER}/bin" >> $GITHUB_PATH
 
   - name: Check autoconf 2.13 (macOS)
     if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked on [CueMol/build_scripts#11](https://github.com/CueMol/build_scripts/pull/11).**
> Draft until that PR is merged and its **Mirror third-party sources** workflow
> has run to create the `thirdparty-mirror` release. CI here will 404 before then.

## Why

The macOS jobs rebuild autoconf 2.13 from `ftp.gnu.org` on **every** run
(`build_scripts/download_deplibs/action.yml`). That host is frequently
unreachable — it is timing out right now — and when it is down the whole macOS
matrix fails before it even reaches the UXP GUI build.

## What

The tarball now comes from the fixed-tag `thirdparty-mirror` release in
`CueMol/build_scripts`, which this repo already depends on for the deplibs
bundle. The tag never changes, so the URL is independent of `DEPLIBS_VERSION`.

```
-  curl -fsSL https://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz | tar xz
+  . "${GITHUB_WORKSPACE}/build_scripts/deplibs.env"
+  curl -fsSL --retry 3 --connect-timeout 20 -o "$TGZ" "${THIRDPARTY_MIRROR_URL}/${TGZ}"
+  echo "${AUTOCONF213_SHA256}  $TGZ" | shasum -a 256 -c -
```

Two things ride along with the URL swap:

- **sha256 verification.** Going through a mirror is a good reason to stop
  trusting the transport alone. `AUTOCONF213_SHA256` in `deplibs.env` is GNU's
  published value and is checked before the tarball is unpacked.
- **Extract under `$RUNNER_TEMP`.** The old step ran with the cwd at
  `$GITHUB_WORKSPACE`, so it unpacked `autoconf-2.13/` straight into the
  repository checkout on every run.

Version and checksum live in `build_scripts/deplibs.env` alongside every other
pinned version, in the existing `KEY=VALUE` format that both the bash `.` loader
and `deplibs_env.bat`'s `for /f ... delims==` parser read (no `=` in any value).

The follow-up `Check autoconf 2.13 (macOS)` step is unchanged and remains the
acceptance test.

## Verification done

Ran the new step end-to-end locally on macOS with `HOME`, `GITHUB_WORKSPACE`,
`RUNNER_TEMP` and `GITHUB_PATH` pointed at a sandbox, substituting the upstream
GNU mirror for the not-yet-published release URL:

- `autoconf-2.13.tar.gz: OK` from `shasum -a 256 -c -`
- `configure` / `make` / `make install` succeed; `autoconf213 --version` prints
  `Autoconf version 2.13`
- the fake workspace is left clean — nothing extracted into it
- a deliberately wrong checksum aborts the step (exit 1) instead of building on

`deplibs.env` still sources cleanly in bash with the new keys resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSg2nE7PweWBCJ7G6DxMgw