### PR TITLE
test(react-gui): Phase 1-1 -- worker-service test harness

### DIFF
--- a/tritium/CLAUDE.md
+++ b/tritium/CLAUDE.md
@@ -452,9 +452,34 @@ vi.spyOn(globalThis, 'setTimeout').mockImplementation((cb: any) => { timerCb = c
 act(() => { timerCb!(); });
 ```
 
-### Worker-service tests with wrapper setter spying
+### Worker-service tests: use the harness (`renderer/worker/testing/`)
 
-Worker services often assign values to C++ wrapper setters (`(rend as MolRenderer).sel = sel`, `mol.name = ...`, `cmd.target_object = mol`). To pin this contract in vitest without a real native addon, mock the wrapper as a plain object literal whose accessor records the assignment:
+`@renderer/worker/testing` (test files only -- ESLint rejects it elsewhere) provides fake wrapper objects and a `WorkerContext` factory, so a service test does not hand-roll `makeCtx` / `makeScene` / accessor spies:
+
+```ts
+import { fakeObject, fakeScene, fakeView, makeWorkerCtx } from '@renderer/worker/testing'
+
+const log: string[] = []                              // ordered mutation log
+const scene = fakeScene({ uid: 100, views: [fakeView({ uid: 7 })], log })
+const mol = fakeObject({ className: 'MolCoord', scene, log })
+const { ctx, cmdMgr } = makeWorkerCtx({ scenes: [scene] })
+
+setupRenderer(ctx, mol as unknown, opts)              // service under test
+
+const rend = mol.renderers[0]                          // what createRenderer attached
+expect(rend.sets.sel).toHaveBeenCalledWith(sel)        // accessor-write spy
+expect(log).toEqual(['mol.createRenderer(simple)', 'rend.name=simple1', 'rend.applyStyles(DefaultStyle)'])
+expect(scene.undo.committed).toEqual(['Label'])       // undo bookkeeping
+expect(cmdMgr.getCmd).not.toHaveBeenCalled()          // manager spies
+```
+
+- `fakeRenderer` / `fakeObject` / `fakeView` / `fakeCamera` / `fakeScene` mirror the wrapper shapes structurally: accessor writes are spied (`fake.sets.<prop>`) and readable back, mutating methods are `vi.fn`s (override with `mol.createRenderer.mockReturnValueOnce(null)`), and `scene.getSceneDataJSON()` / `getCameraInfoJSON()` are synthesised in the C++ shapes below (groups via `childNodes`) so tests never hand-write those documents.
+- `makeWorkerCtx({ scenes, readers, readerInfo, cmds, styleNames, createObj, getService })` resolves the fakes through `sceMgr` / `strMgr` / `cmdMgr` / `styleMgr` / `svc`; unknown commands and `createObj` throw with a hint, so a missing fake fails loudly.
+- Members a service needs that the fakes lack go in `extra` (or add them to the fake when a second test needs them). New service tests use the harness; existing hand-rolled fixtures are migrated when their test is next touched.
+
+### Worker-service tests with wrapper setter spying (one-off shapes)
+
+For a wrapper the harness does not model, mock it as a plain object literal whose accessor records the assignment (this is what the harness does internally):
 
 ```ts
 const setSel = vi.fn()

--- a/tritium/react-gui/eslint.config.mjs
+++ b/tritium/react-gui/eslint.config.mjs
@@ -33,7 +33,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
  * renderer bundle -- is rejected.
  */
 const NO_TEST_HELPERS = {
-  group: ['**/__test__/**', '**/testHarness*'],
+  group: ['**/__test__/**', '**/testHarness*', '**/worker/testing', '**/worker/testing/**'],
   message: 'Test helpers must not be imported from production code.',
 }
 
@@ -200,7 +200,7 @@ export default tseslint.config(
 
   // --- Tests may reach anywhere ---
   {
-    files: ['src/**/*.test.{ts,tsx}', 'src/**/__test__/**'],
+    files: ['src/**/*.test.{ts,tsx}', 'src/**/__test__/**', 'src/renderer/worker/testing/**'],
     rules: {
       '@typescript-eslint/no-restricted-imports': 'off',
       '@typescript-eslint/no-floating-promises': 'off',

--- a/tritium/react-gui/src/renderer/__test__/setupRendererService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/setupRendererService.test.ts
@@ -17,7 +17,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { WorkerContext } from '../worker/server/types/WorkerContext'
 import type { RendererOptions } from '../components/fopen-opt-dlgs/types'
 
 vi.mock('../worker/server/services/helpers/makeSel', () => ({
@@ -33,63 +32,22 @@ vi.mock('../worker/server/services/helpers/getDefaultStyleName', () => ({
 import { setupRenderer } from '../worker/server/services/setupRenderer.service'
 import { makeSel } from '../worker/server/services/helpers/makeSel'
 import { molPostProc } from '../worker/server/services/helpers/molPostProc'
+import { fakeObject, fakeScene, fakeView, makeWorkerCtx } from '@renderer/worker/testing'
 
-function makeFixture(opts: {
-    className: string
-    scene?: {
-        view_uids?: string
-        getView?: (uid: number) => { setViewCenter: (pos: unknown) => void } | null
-    }
-    hasGetCenter?: boolean
-}) {
-    const calls: string[] = []
-    const setSel = vi.fn((v: unknown) => { calls.push(`sel=${JSON.stringify(v)}`) })
-    const setName = vi.fn((v: string) => { calls.push(`name=${v}`) })
-    const applyStyles = vi.fn((s: string) => { calls.push(`applyStyles(${s})`) })
-
-    const getCenter = vi.fn(() => ({ __pos: true }))
-    const rendBase: Record<string, unknown> = {
-        get name() { return '' },
-        set name(v: string) { setName(v) },
-        get sel() { return undefined },
-        set sel(v: unknown) { setSel(v) },
-        applyStyles,
-    }
-    if (opts.hasGetCenter !== false) {
-        rendBase.getCenter = getCenter
-    }
-    const rend = rendBase
-
-    const createRenderer = vi.fn((type: string) => {
-        calls.push(`createRenderer(${type})`)
-        return rend
+/**
+ * One object in one scene. Renderers the service creates through
+ * `mol.createRenderer` / `createPresetRenderer` land in `mol.renderers`,
+ * so a test reads the created renderer back from there.
+ */
+function makeFixture(opts: { className: string; viewIds?: number[]; hasGetCenter?: boolean }) {
+    const log: string[] = []
+    const scene = fakeScene({ uid: 100, views: (opts.viewIds ?? []).map((uid) => fakeView({ uid })), log })
+    const mol = fakeObject({
+        className: opts.className, scene, log,
+        rendererDefaults: { hasCenter: opts.hasGetCenter !== false },
     })
-    const createPresetRenderer = vi.fn((preset: string, grp: string, prefix: string) => {
-        calls.push(`createPresetRenderer(${preset},${grp},${prefix})`)
-        return rend
-    })
-
-    const scene = opts.scene ?? { view_uids: '' }
-
-    const mol = {
-        createRenderer,
-        createPresetRenderer,
-        getClassName: () => opts.className,
-        getScene: () => scene,
-    }
-
-    const getCmd = vi.fn(() => {
-        throw new Error('getCmd should NOT be called in the direct-API path')
-    })
-
-    const ctx = {
-        cmdMgr: { getCmd },
-    } as unknown as WorkerContext
-
-    return {
-        ctx, mol, rend, scene, calls, setSel, setName, applyStyles, getCenter,
-        createRenderer, createPresetRenderer, getCmd,
-    }
+    const { ctx, cmdMgr } = makeWorkerCtx({ scenes: [scene] })
+    return { ctx, mol, scene, log, getCmd: cmdMgr.getCmd, rend: () => mol.renderers[0] }
 }
 
 const baseOpts: RendererOptions = {
@@ -107,102 +65,88 @@ describe('setupRenderer — direct API (no NewRendererCommand)', () => {
     })
 
     it('uses mol.createRenderer(type), never asks cmdMgr for new_renderer', () => {
-        const { ctx, mol, createRenderer, getCmd } = makeFixture({ className: 'MolCoord' })
+        const { ctx, mol, getCmd } = makeFixture({ className: 'MolCoord' })
         setupRenderer(ctx, mol as unknown, baseOpts)
-        expect(createRenderer).toHaveBeenCalledWith('simple')
+        expect(mol.createRenderer).toHaveBeenCalledWith('simple')
         expect(getCmd).not.toHaveBeenCalled()
     })
 
     it('returns null and skips downstream work when createRenderer returns null', () => {
         const { ctx, mol } = makeFixture({ className: 'MolCoord' })
-        ;(mol.createRenderer as ReturnType<typeof vi.fn>).mockReturnValueOnce(null)
+        mol.createRenderer.mockReturnValueOnce(null)
         const result = setupRenderer(ctx, mol as unknown, baseOpts)
         expect(result).toBeNull()
         expect(molPostProc).not.toHaveBeenCalled()
     })
 
     it('sets renderer name, applies default style, then runs molPostProc (in that order)', () => {
-        const { ctx, mol, calls } = makeFixture({ className: 'MolCoord' })
+        const { ctx, mol, log } = makeFixture({ className: 'MolCoord' })
         setupRenderer(ctx, mol as unknown, baseOpts)
         // createRenderer first, then name, then applyStyles. molPostProc runs after.
-        expect(calls).toEqual([
-            'createRenderer(simple)',
-            'name=simple1',
-            'applyStyles(DefaultStyle)',
+        expect(log).toEqual([
+            'mol.createRenderer(simple)',
+            'rend.name=simple1',
+            'rend.applyStyles(DefaultStyle)',
         ])
         expect(molPostProc).toHaveBeenCalledTimes(1)
     })
 
     it('centerView=true recenters all views via scene.view_uids -> scene.getView -> setViewCenter', () => {
-        const setViewCenter = vi.fn()
-        const getView = vi.fn((_uid: number) => ({ setViewCenter }))
-        const { ctx, mol, getCenter } = makeFixture({
-            className: 'MolCoord',
-            scene: { view_uids: '10, 11', getView },
-        })
+        const { ctx, mol, scene, rend } = makeFixture({ className: 'MolCoord', viewIds: [10, 11] })
         setupRenderer(ctx, mol as unknown, { ...baseOpts, centerView: true })
-        expect(getCenter).toHaveBeenCalled()
-        expect(getView).toHaveBeenCalledWith(10)
-        expect(getView).toHaveBeenCalledWith(11)
-        expect(setViewCenter).toHaveBeenCalledTimes(2)
-        expect(setViewCenter).toHaveBeenCalledWith({ __pos: true })
+        expect(rend().getCenter).toHaveBeenCalled()
+        expect(scene.getView).toHaveBeenCalledWith(10)
+        expect(scene.getView).toHaveBeenCalledWith(11)
+        for (const view of scene.views) {
+            expect(view.setViewCenter).toHaveBeenCalledTimes(1)
+            expect(view.setViewCenter).toHaveBeenCalledWith({ __pos: true })
+        }
     })
 
     it('centerView=false does not touch the views', () => {
-        const setViewCenter = vi.fn()
-        const getView = vi.fn(() => ({ setViewCenter }))
-        const { ctx, mol, getCenter } = makeFixture({
-            className: 'MolCoord',
-            scene: { view_uids: '10', getView },
-        })
+        const { ctx, mol, scene, rend } = makeFixture({ className: 'MolCoord', viewIds: [10] })
         setupRenderer(ctx, mol as unknown, { ...baseOpts, centerView: false })
-        expect(getCenter).not.toHaveBeenCalled()
-        expect(setViewCenter).not.toHaveBeenCalled()
+        expect(rend().getCenter).not.toHaveBeenCalled()
+        expect(scene.views[0].setViewCenter).not.toHaveBeenCalled()
     })
 
     it('centerView=true but renderer lacks getCenter() -> skips silently', () => {
-        const setViewCenter = vi.fn()
-        const getView = vi.fn(() => ({ setViewCenter }))
-        const { ctx, mol } = makeFixture({
-            className: 'MolCoord',
-            hasGetCenter: false,
-            scene: { view_uids: '10', getView },
-        })
+        const { ctx, mol, scene } = makeFixture({ className: 'MolCoord', hasGetCenter: false, viewIds: [10] })
         expect(() =>
             setupRenderer(ctx, mol as unknown, { ...baseOpts, centerView: true })
         ).not.toThrow()
-        expect(setViewCenter).not.toHaveBeenCalled()
+        expect(scene.views[0].setViewCenter).not.toHaveBeenCalled()
     })
 
     // --- Selection gate (preserved from the prior contract) ---
 
     it('selectionEnabled=false skips sel even when selection is non-default', () => {
-        const { ctx, mol, setSel } = makeFixture({ className: 'MolCoord' })
+        const { ctx, mol, rend } = makeFixture({ className: 'MolCoord' })
         setupRenderer(ctx, mol as unknown, { ...baseOpts, selectionEnabled: false, selection: 'protein' })
         expect(makeSel).not.toHaveBeenCalled()
-        expect(setSel).not.toHaveBeenCalled()
+        expect(rend().sets.sel).not.toHaveBeenCalled()
     })
 
     it('selectionEnabled=true with concrete selection assigns sel via makeSel', () => {
-        const { ctx, mol, setSel } = makeFixture({ className: 'MolCoord' })
+        const { ctx, mol, rend } = makeFixture({ className: 'MolCoord' })
         setupRenderer(ctx, mol as unknown, { ...baseOpts, selectionEnabled: true, selection: 'protein' })
         expect(makeSel).toHaveBeenCalledTimes(1)
-        expect(setSel).toHaveBeenCalledTimes(1)
-        expect(setSel).toHaveBeenCalledWith({ __sel: true })
+        expect(rend().sets.sel).toHaveBeenCalledTimes(1)
+        expect(rend().sets.sel).toHaveBeenCalledWith({ __sel: true })
     })
 
     it('selectionEnabled=true with selection="*" still skips sel (full-molecule shorthand)', () => {
-        const { ctx, mol, setSel } = makeFixture({ className: 'MolCoord' })
+        const { ctx, mol, rend } = makeFixture({ className: 'MolCoord' })
         setupRenderer(ctx, mol as unknown, { ...baseOpts, selectionEnabled: true, selection: '*' })
         expect(makeSel).not.toHaveBeenCalled()
-        expect(setSel).not.toHaveBeenCalled()
+        expect(rend().sets.sel).not.toHaveBeenCalled()
     })
 
     it('NON_MOL class skips sel + molPostProc even when selectionEnabled=true', () => {
-        const { ctx, mol, setSel } = makeFixture({ className: 'DensityMap' })
+        const { ctx, mol, rend } = makeFixture({ className: 'DensityMap' })
         setupRenderer(ctx, mol as unknown, { ...baseOpts, selectionEnabled: true, selection: 'protein' })
         expect(makeSel).not.toHaveBeenCalled()
-        expect(setSel).not.toHaveBeenCalled()
+        expect(rend().sets.sel).not.toHaveBeenCalled()
         expect(molPostProc).not.toHaveBeenCalled()
     })
 })
@@ -221,16 +165,16 @@ describe('setupRenderer — preset renderer group (presetName set)', () => {
     it('creates via createPresetRenderer(preset, name, name); no createRenderer / name / applyStyles / getCmd', () => {
         const f = makeFixture({ className: 'MolCoord' })
         const result = setupRenderer(f.ctx, f.mol as unknown, presetOpts)
-        expect(f.createPresetRenderer).toHaveBeenCalledWith(
+        expect(f.mol.createPresetRenderer).toHaveBeenCalledWith(
             'Default1RendPreset', 'default1_1', 'default1_1',
         )
-        expect(f.createRenderer).not.toHaveBeenCalled()
+        expect(f.mol.createRenderer).not.toHaveBeenCalled()
         // C++ setName(grp_name) already named the group; children carry
         // their styles from the preset definition.
-        expect(f.setName).not.toHaveBeenCalled()
-        expect(f.applyStyles).not.toHaveBeenCalled()
+        expect(f.rend().sets.name).not.toHaveBeenCalled()
+        expect(f.rend().applyStyles).not.toHaveBeenCalled()
         expect(f.getCmd).not.toHaveBeenCalled()
-        expect(result).toBe(f.rend)
+        expect(result).toBe(f.rend())
     })
 
     it('runs molPostProc for a mol class but never assigns sel (RendGroup has none)', () => {
@@ -240,7 +184,7 @@ describe('setupRenderer — preset renderer group (presetName set)', () => {
         })
         expect(molPostProc).toHaveBeenCalledTimes(1)
         expect(makeSel).not.toHaveBeenCalled()
-        expect(f.setSel).not.toHaveBeenCalled()
+        expect(f.rend().sets.sel).not.toHaveBeenCalled()
     })
 
     it('skips molPostProc for a NON_MOL class', () => {
@@ -250,20 +194,15 @@ describe('setupRenderer — preset renderer group (presetName set)', () => {
     })
 
     it('centerView=true recenters through the group getCenter (member average)', () => {
-        const setViewCenter = vi.fn()
-        const getView = vi.fn(() => ({ setViewCenter }))
-        const f = makeFixture({
-            className: 'MolCoord',
-            scene: { view_uids: '10', getView },
-        })
+        const f = makeFixture({ className: 'MolCoord', viewIds: [10] })
         setupRenderer(f.ctx, f.mol as unknown, { ...presetOpts, centerView: true })
-        expect(f.getCenter).toHaveBeenCalled()
-        expect(setViewCenter).toHaveBeenCalledWith({ __pos: true })
+        expect(f.rend().getCenter).toHaveBeenCalled()
+        expect(f.scene.views[0].setViewCenter).toHaveBeenCalledWith({ __pos: true })
     })
 
     it('returns null (no molPostProc) when createPresetRenderer throws', () => {
         const f = makeFixture({ className: 'MolCoord' })
-        ;(f.mol.createPresetRenderer as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        f.mol.createPresetRenderer.mockImplementationOnce(() => {
             throw new Error('Unknown renderer preset')
         })
         const result = setupRenderer(f.ctx, f.mol as unknown, presetOpts)

--- a/tritium/react-gui/src/renderer/worker/testing/fakes.test.ts
+++ b/tritium/react-gui/src/renderer/worker/testing/fakes.test.ts
@@ -54,6 +54,24 @@ describe('object / renderer wiring', () => {
         expect('getCenter' in rend).toBe(false);
     });
 
+    it('createView attaches a view the scene resolves, and clearAllData spares it', () => {
+        const scene = fakeScene({ objects: [fakeObject({ name: 'mol' })], cameras: [fakeCamera({ name: 'cam' })] });
+        const view = scene.createView();
+        expect(scene.getView(view.uid)).toBe(view);
+        expect(view.getScene()).toBe(scene);
+        expect(scene.view_uids).toBe(String(view.uid));
+
+        // Mirrors C++ Scene::clearAllData: objects, renderers, cameras and the
+        // undo history go; the view table survives.
+        scene.startUndoTxn('edit');
+        scene.commitUndoTxn();
+        scene.clearAllData();
+        expect(scene.objects).toHaveLength(0);
+        expect(scene.cameras).toHaveLength(0);
+        expect(scene.undo.committed).toHaveLength(0);
+        expect(scene.views).toEqual([view]);
+    });
+
     it('a mol-like class gets fitView, a map does not', () => {
         expect(typeof fakeObject({ className: 'PDBMol' }).fitView).toBe('function');
         expect('fitView' in fakeObject({ className: 'DensityMap' })).toBe(false);

--- a/tritium/react-gui/src/renderer/worker/testing/fakes.test.ts
+++ b/tritium/react-gui/src/renderer/worker/testing/fakes.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @file renderer/worker/testing/fakes.test.ts
+ * @description Pins the harness contracts other tests lean on: accessor
+ * spies, the C++ JSON shapes, undo bookkeeping and manager resolution.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { parseSceneTreeJSON } from '../shared/sceneTreeTypes';
+import {
+    fakeCamera, fakeObject, fakeRenderer, fakeScene, fakeView, makeWorkerCtx, resetFakeUids,
+} from './index';
+
+beforeEach(() => resetFakeUids());
+
+describe('accessor spies', () => {
+    it('record the assignment, store the value and log it in order', () => {
+        const log: string[] = [];
+        const rend = fakeRenderer({ name: 'r0', log });
+        rend.name = 'r1';
+        rend.sel = { __sel: true };
+        expect(rend.sets.name).toHaveBeenCalledWith('r1');
+        expect(rend.name).toBe('r1');
+        expect(rend.sets.sel).toHaveBeenCalledTimes(1);
+        expect(log).toEqual(['rend.name=r1', 'rend.sel={"__sel":true}']);
+    });
+
+    it('setProp / resetProp drive the generic-prop store', () => {
+        const rend = fakeRenderer({ props: { alpha: 0.5 } });
+        expect(rend.isPropDefault('alpha')).toBe(false);
+        rend.setProp('width', 2);
+        expect(rend.getProp('width')).toBe(2);
+        rend.resetProp('alpha');
+        expect(rend.hasProp('alpha')).toBe(false);
+    });
+});
+
+describe('object / renderer wiring', () => {
+    it('createRenderer attaches the renderer so scene lookups find it', () => {
+        const log: string[] = [];
+        const mol = fakeObject({ name: 'mol', log });
+        const scene = fakeScene({ objects: [mol] });
+        const rend = mol.createRenderer('cartoon')!;
+        expect(mol.getRendererByType('cartoon')).toBe(rend);
+        expect(scene.getRenderer(rend.uid)).toBe(rend);
+        expect(rend.getClientObj()).toBe(mol);
+        expect(rend.getScene()).toBe(scene);
+        expect(mol.rend_uids).toBe(String(rend.uid));
+        expect(log).toEqual(['mol.createRenderer(cartoon)']);
+    });
+
+    it('rendererDefaults shape the renderers an object creates', () => {
+        const mol = fakeObject({ rendererDefaults: { hasCenter: false } });
+        const rend = mol.createRenderer('simple')!;
+        expect('getCenter' in rend).toBe(false);
+    });
+
+    it('a mol-like class gets fitView, a map does not', () => {
+        expect(typeof fakeObject({ className: 'PDBMol' }).fitView).toBe('function');
+        expect('fitView' in fakeObject({ className: 'DensityMap' })).toBe(false);
+    });
+});
+
+describe('getSceneDataJSON / getCameraInfoJSON', () => {
+    it('produce the documented C++ shapes, groups via childNodes', () => {
+        const grp = fakeRenderer({ uid: 30, type: '*group', name: 'g' });
+        const member = fakeRenderer({ uid: 31, type: 'cartoon', name: 'c', group: 'g' });
+        const top = fakeRenderer({ uid: 32, type: 'simple', name: 's' });
+        const mol = fakeObject({ uid: 3, name: 'mol', renderers: [grp, member, top] });
+        const scene = fakeScene({ uid: 100, name: 'sc', objects: [mol], cameras: [fakeCamera({ name: 'cam', visSize: 2 })] });
+
+        const raw = JSON.parse(scene.getSceneDataJSON()) as Array<Record<string, unknown>>;
+        expect(raw[0]).toMatchObject({ ID: 100, name: 'sc', type: '' });
+        expect(raw[1]).toMatchObject({ ID: 3, name: 'mol', type: 'MolCoord', visible: true });
+        const rends = raw[1].rends as Array<Record<string, unknown>>;
+        // A grouped member is not at the top level; it hangs off the group.
+        expect(rends.map((r) => r.ID)).toEqual([30, 32]);
+        expect((rends[0].childNodes as Array<Record<string, unknown>>).map((r) => r.ID)).toEqual([31]);
+        expect('childNodes' in rends[1]).toBe(false);
+
+        expect(JSON.parse(scene.getCameraInfoJSON())).toEqual([{ name: 'cam', vis_size: 2, src: '' }]);
+    });
+
+    it('is accepted by the production parser', () => {
+        const mol = fakeObject({ uid: 3, name: 'mol', renderers: [fakeRenderer({ uid: 31, type: 'cartoon', name: 'c' })] });
+        const tree = parseSceneTreeJSON(fakeScene({ uid: 100, objects: [mol] }).getSceneDataJSON());
+        expect(tree?.children[0].children[0]).toMatchObject({ id: 31, type: 'renderer', className: 'cartoon' });
+    });
+});
+
+describe('undo bookkeeping', () => {
+    it('tracks started / committed / rolled-back labels', () => {
+        const scene = fakeScene();
+        scene.startUndoTxn('A');
+        scene.commitUndoTxn();
+        scene.startUndoTxn('B');
+        scene.rollbackUndoTxn();
+        expect(scene.undo).toEqual({ started: ['A', 'B'], committed: ['A'], rolledBack: ['B'], open: null });
+        expect(scene.isUndoable()).toBe(true);
+    });
+});
+
+describe('makeWorkerCtx', () => {
+    it('resolves scenes, views, objects and renderers from the fakes', () => {
+        const rend = fakeRenderer({ uid: 31 });
+        const mol = fakeObject({ uid: 3, renderers: [rend] });
+        const view = fakeView({ uid: 7 });
+        const scene = fakeScene({ uid: 100, objects: [mol], views: [view] });
+        const { ctx, sceMgr } = makeWorkerCtx({ scenes: [scene] });
+        expect(ctx.sceMgr.getScene(100)).toBe(scene);
+        expect(ctx.sceMgr.getScene(1)).toBeNull();
+        expect(ctx.sceMgr.getView(7)).toBe(view);
+        expect(view.getScene()).toBe(scene);
+        expect(sceMgr.getObject(3)).toBe(mol);
+        expect(sceMgr.getRenderer(31)).toBe(rend);
+        expect(sceMgr.scene_uids).toBe('100');
+    });
+
+    it('serves readers, reader info, commands, styles and services from the tables', () => {
+        const reader = { read: () => undefined };
+        const cmd = { run: () => undefined };
+        const { ctx } = makeWorkerCtx({
+            readers: { pdb: reader },
+            readerInfo: [{ name: 'pdb', fext: '*.pdb', category: 0 }, { name: 'qsc_xml', fext: '*.qsc', category: 2 }],
+            cmds: { load_object: cmd },
+            styleNames: { 0: ['DefaultCPKColoring'] },
+            getService: (name) => (name === 'MolAnlManager' ? { anl: true } : undefined),
+        });
+        expect(ctx.strMgr.createHandler('pdb', 0)).toBe(reader);
+        expect(ctx.strMgr.createHandler('nope', 0)).toBeNull();
+        expect(JSON.parse(ctx.strMgr.getInfoJSON2())).toHaveLength(2);
+        expect(ctx.cmdMgr.getCmd('load_object')).toBe(cmd);
+        expect(() => ctx.cmdMgr.getCmd('new_renderer')).toThrow(/no fake command/);
+        expect(JSON.parse(ctx.styleMgr.getStyleNamesJSON(0))).toEqual([{ name: 'DefaultCPKColoring' }]);
+        expect(ctx.svc.getService('MolAnlManager')).toEqual({ anl: true });
+        expect(ctx.svc.getService('Other')).toBeNull();
+        expect(() => ctx.svc.createObj('Vector')).toThrow(/createObj/);
+    });
+});

--- a/tritium/react-gui/src/renderer/worker/testing/fakes.ts
+++ b/tritium/react-gui/src/renderer/worker/testing/fakes.ts
@@ -1,0 +1,578 @@
+/**
+ * @file renderer/worker/testing/fakes.ts
+ * @description In-memory stand-ins for the C++ wrapper objects a worker
+ * service touches (Scene / Object / Renderer / View / Camera).
+ *
+ * Test-only: production code must never import this directory (ESLint
+ * forbids it). Each fake mirrors the *shape* the generated wrappers expose
+ * (accessor properties, sync methods, the JSON documents `getSceneDataJSON`
+ * and `getCameraInfoJSON` return) closely enough that a service runs
+ * unmodified against it, while recording what the service did:
+ *
+ *   - every accessor write is spied (`fake.sets.name`, `fake.sets.sel`, ...)
+ *     and the assigned value is readable back through the accessor;
+ *   - mutating methods are `vi.fn`s, so a test can assert on them or
+ *     override them (`mol.createRenderer.mockReturnValueOnce(null)`);
+ *   - an optional shared `log` receives one entry per mutation, in order,
+ *     for tests that pin call ordering ("name before applyStyles").
+ *
+ * Fakes are plain objects; cast at the service call site
+ * (`scene as unknown as Scene`). Keep them structural -- add a member when a
+ * service needs it rather than modelling the whole wrapper.
+ */
+
+import { vi, type Mock } from 'vitest';
+
+/** Ordered mutation log shared by every fake created with the same array. */
+export type CallLog = string[];
+
+let nextUid = 1000;
+
+/** Hand out a fresh uid; deterministic within a test (see resetFakeUids). */
+export function allocUid(): number {
+    return nextUid++;
+}
+
+/** Restart the uid counter (call from beforeEach when uids appear in assertions). */
+export function resetFakeUids(): void {
+    nextUid = 1000;
+}
+
+function fmt(v: unknown): string {
+    if (v === null || v === undefined) return String(v);
+    if (typeof v === 'object') {
+        try {
+            return JSON.stringify(v);
+        } catch {
+            return '[object]';
+        }
+    }
+    return String(v);
+}
+
+/**
+ * Install spied accessors on `target`: reading returns the stored value,
+ * writing records the call in `sets[key]`, stores the value and appends
+ * `<tag>.<key>=<value>` to the log.
+ */
+function spyProps(
+    target: Record<string, unknown>,
+    initial: Record<string, unknown>,
+    sets: Record<string, Mock>,
+    log: CallLog | undefined,
+    tag: string,
+): void {
+    const values: Record<string, unknown> = { ...initial };
+    for (const key of Object.keys(initial)) {
+        const spy = vi.fn();
+        sets[key] = spy;
+        Object.defineProperty(target, key, {
+            enumerable: true,
+            configurable: true,
+            get: () => values[key],
+            set: (v: unknown) => {
+                spy(v);
+                values[key] = v;
+                log?.push(`${tag}.${key}=${fmt(v)}`);
+            },
+        });
+    }
+}
+
+interface FakeBaseOptions {
+    uid?: number;
+    name?: string;
+    /** Shared ordered mutation log. */
+    log?: CallLog;
+    /** Prefix used in log entries (defaults to the fake kind). */
+    tag?: string;
+    /** Extra members merged onto the fake (duck-typed subclass methods). */
+    extra?: Record<string, unknown>;
+}
+
+// --- Renderer ---
+
+export interface FakeRendererOptions extends FakeBaseOptions {
+    /** `type_name` (e.g. 'simple', 'cartoon', '*group'). Default 'simple'. */
+    type?: string;
+    /** `getClassName()`; default 'Renderer' ('RendGroup' for '*group'). */
+    className?: string;
+    /** Initial generic-prop store read by getProp / written by setProp. */
+    props?: Record<string, unknown>;
+    group?: string;
+    visible?: boolean;
+    locked?: boolean;
+    ui_order?: number;
+    /** Whether `getCenter()` / `has_center` exist (some types lack a center). */
+    hasCenter?: boolean;
+}
+
+export interface FakeRenderer {
+    [key: string]: unknown;
+    uid: number;
+    type_name: string;
+    name: string;
+    group: string;
+    visible: boolean;
+    locked: boolean;
+    ui_order: number;
+    sel: unknown;
+    coloring: unknown;
+    material: unknown;
+    alpha: number;
+    /** Accessor-write spies keyed by property name. */
+    sets: Record<string, Mock>;
+    /** Live generic-prop store behind getProp / setProp. */
+    props: Record<string, unknown>;
+    getUID: () => number;
+    getClassName: () => string;
+    getProp: Mock<(key: string) => unknown>;
+    setProp: Mock<(key: string, value: unknown) => void>;
+    hasProp: (key: string) => boolean;
+    resetProp: Mock<(key: string) => void>;
+    isPropDefault: (key: string) => boolean;
+    applyStyles: Mock<(styles: string) => void>;
+    reapplyStyle: Mock<() => void>;
+    getClientObj: () => FakeObject | null;
+    getClientObjID: () => number;
+    getScene: () => FakeScene | null;
+    /** Parent object; set by fakeObject when the renderer is attached. */
+    owner: FakeObject | null;
+}
+
+/** Create a fake renderer. Attach it to an object via fakeObject({ renderers }) or mol.attachRenderer. */
+export function fakeRenderer(opts: FakeRendererOptions = {}): FakeRenderer {
+    const type = opts.type ?? 'simple';
+    const tag = opts.tag ?? 'rend';
+    const log = opts.log;
+    const sets: Record<string, Mock> = {};
+    const props: Record<string, unknown> = { ...(opts.props ?? {}) };
+    const rend: Record<string, unknown> = {
+        uid: opts.uid ?? allocUid(),
+        type_name: type,
+        sets,
+        props,
+        owner: null,
+        getUID: () => rend.uid as number,
+        getClassName: () => opts.className ?? (type === '*group' ? 'RendGroup' : 'Renderer'),
+        getProp: vi.fn((key: string) => props[key]),
+        setProp: vi.fn((key: string, value: unknown) => {
+            props[key] = value;
+            log?.push(`${tag}.setProp(${key},${fmt(value)})`);
+        }),
+        hasProp: (key: string) => key in props,
+        resetProp: vi.fn((key: string) => {
+            delete props[key];
+            log?.push(`${tag}.resetProp(${key})`);
+        }),
+        isPropDefault: (key: string) => !(key in props),
+        applyStyles: vi.fn((styles: string) => {
+            log?.push(`${tag}.applyStyles(${styles})`);
+        }),
+        reapplyStyle: vi.fn(),
+        getClientObj: () => rend.owner as FakeObject | null,
+        getClientObjID: () => (rend.owner as FakeObject | null)?.uid ?? 0,
+        getScene: () => (rend.owner as FakeObject | null)?.getScene() ?? null,
+    };
+    if (opts.hasCenter !== false) {
+        rend.has_center = true;
+        rend.getCenter = vi.fn(() => ({ __pos: true }));
+    }
+    spyProps(rend, {
+        name: opts.name ?? type,
+        group: opts.group ?? '',
+        visible: opts.visible ?? true,
+        locked: opts.locked ?? false,
+        ui_order: opts.ui_order ?? 0,
+        sel: undefined,
+        coloring: undefined,
+        material: '',
+        alpha: 1,
+    }, sets, log, tag);
+    Object.assign(rend, opts.extra ?? {});
+    return rend as unknown as FakeRenderer;
+}
+
+// --- Object (MolCoord, DensityMap, ...) ---
+
+export interface FakeObjectOptions extends FakeBaseOptions {
+    /** `getClassName()`; default 'MolCoord'. */
+    className?: string;
+    renderers?: FakeRenderer[];
+    scene?: FakeScene | null;
+    visible?: boolean;
+    locked?: boolean;
+    ui_collapsed?: boolean;
+    ui_order?: number;
+    /** Defaults applied to renderers created through createRenderer / createPresetRenderer. */
+    rendererDefaults?: Omit<FakeRendererOptions, 'type' | 'name'>;
+}
+
+export interface FakeObject {
+    [key: string]: unknown;
+    uid: number;
+    name: string;
+    visible: boolean;
+    locked: boolean;
+    ui_collapsed: boolean;
+    ui_order: number;
+    sel: unknown;
+    coloring: unknown;
+    sets: Record<string, Mock>;
+    /** Live renderer list in attach order (= `rend_uids` order). */
+    renderers: FakeRenderer[];
+    /** Owning scene; set by fakeScene({ objects }) / scene.addObject. */
+    scene: FakeScene | null;
+    readonly rend_uids: string;
+    getUID: () => number;
+    getClassName: () => string;
+    getScene: () => FakeScene | null;
+    getRendCount: () => number;
+    getRenderer: (uid: number) => FakeRenderer | null;
+    getRendererByType: (type: string) => FakeRenderer | null;
+    getRendererByName: (name: string) => FakeRenderer | null;
+    getRendererByNameType: (name: string, type: string) => FakeRenderer | null;
+    attachRenderer: (rend: FakeRenderer) => void;
+    createRenderer: Mock<(type: string) => FakeRenderer | null>;
+    createPresetRenderer: Mock<(preset: string, grpName: string, prefix: string) => FakeRenderer | null>;
+    destroyRenderer: Mock<(uid: number) => boolean>;
+}
+
+/** Create a fake object (molecule, map, ...). Mol-like classes also get `fitView`. */
+export function fakeObject(opts: FakeObjectOptions = {}): FakeObject {
+    const className = opts.className ?? 'MolCoord';
+    const tag = opts.tag ?? 'mol';
+    const log = opts.log;
+    const sets: Record<string, Mock> = {};
+    const renderers: FakeRenderer[] = [];
+    const obj: Record<string, unknown> = {
+        uid: opts.uid ?? allocUid(),
+        sets,
+        renderers,
+        scene: opts.scene ?? null,
+        getUID: () => obj.uid as number,
+        getClassName: () => className,
+        getScene: () => obj.scene as FakeScene | null,
+        getRendCount: () => renderers.length,
+        getRenderer: (uid: number) => renderers.find((r) => r.uid === uid) ?? null,
+        getRendererByType: (type: string) => renderers.find((r) => r.type_name === type) ?? null,
+        getRendererByName: (name: string) => renderers.find((r) => r.name === name) ?? null,
+        getRendererByNameType: (name: string, type: string) =>
+            renderers.find((r) => r.name === name && r.type_name === type) ?? null,
+        attachRenderer: (rend: FakeRenderer) => {
+            rend.owner = obj as unknown as FakeObject;
+            renderers.push(rend);
+        },
+        createRenderer: vi.fn((type: string) => {
+            const rend = fakeRenderer({ ...(opts.rendererDefaults ?? {}), type, name: type, log });
+            (obj.attachRenderer as (r: FakeRenderer) => void)(rend);
+            log?.push(`${tag}.createRenderer(${type})`);
+            return rend;
+        }),
+        createPresetRenderer: vi.fn((preset: string, grpName: string, prefix: string) => {
+            const grp = fakeRenderer({ ...(opts.rendererDefaults ?? {}), type: '*group', name: grpName, log });
+            (obj.attachRenderer as (r: FakeRenderer) => void)(grp);
+            log?.push(`${tag}.createPresetRenderer(${preset},${grpName},${prefix})`);
+            return grp;
+        }),
+        destroyRenderer: vi.fn((uid: number) => {
+            const i = renderers.findIndex((r) => r.uid === uid);
+            if (i < 0) return false;
+            renderers.splice(i, 1);
+            log?.push(`${tag}.destroyRenderer(${uid})`);
+            return true;
+        }),
+    };
+    Object.defineProperty(obj, 'rend_uids', {
+        enumerable: true,
+        get: () => renderers.map((r) => r.uid).join(','),
+    });
+    if (className === 'MolCoord' || className.endsWith('Mol')) {
+        obj.fitView = vi.fn();
+    }
+    spyProps(obj, {
+        name: opts.name ?? className.toLowerCase(),
+        visible: opts.visible ?? true,
+        locked: opts.locked ?? false,
+        ui_collapsed: opts.ui_collapsed ?? false,
+        ui_order: opts.ui_order ?? 0,
+        sel: undefined,
+        coloring: undefined,
+    }, sets, log, tag);
+    Object.assign(obj, opts.extra ?? {});
+    for (const r of opts.renderers ?? []) (obj.attachRenderer as (r: FakeRenderer) => void)(r);
+    return obj as unknown as FakeObject;
+}
+
+// --- View ---
+
+export interface FakeViewOptions extends FakeBaseOptions {
+    scene?: FakeScene | null;
+    /** Value returned by getViewCenter(). */
+    center?: unknown;
+    perspective?: boolean;
+    centerMark?: string;
+}
+
+export interface FakeView {
+    [key: string]: unknown;
+    uid: number;
+    name: string;
+    perspective: boolean;
+    centerMark: string;
+    sets: Record<string, Mock>;
+    scene: FakeScene | null;
+    getUID: () => number;
+    getScene: () => FakeScene | null;
+    getViewCenter: Mock<() => unknown>;
+    setViewCenter: Mock<(pos: unknown) => void>;
+}
+
+/** Create a fake view. Attach it to a scene via fakeScene({ views }). */
+export function fakeView(opts: FakeViewOptions = {}): FakeView {
+    const tag = opts.tag ?? 'view';
+    const sets: Record<string, Mock> = {};
+    let center: unknown = opts.center ?? { __center: true };
+    const view: Record<string, unknown> = {
+        uid: opts.uid ?? allocUid(),
+        sets,
+        scene: opts.scene ?? null,
+        getUID: () => view.uid as number,
+        getScene: () => view.scene as FakeScene | null,
+        getViewCenter: vi.fn(() => center),
+        setViewCenter: vi.fn((pos: unknown) => {
+            center = pos;
+            opts.log?.push(`${tag}.setViewCenter(${fmt(pos)})`);
+        }),
+    };
+    spyProps(view, {
+        name: opts.name ?? 'view',
+        perspective: opts.perspective ?? true,
+        centerMark: opts.centerMark ?? 'none',
+    }, sets, opts.log, tag);
+    Object.assign(view, opts.extra ?? {});
+    return view as unknown as FakeView;
+}
+
+// --- Camera ---
+
+export interface FakeCameraOptions {
+    name: string;
+    /** Source file path; '' for a camera saved from a live view. */
+    src?: string;
+    /** Number of saved vis-flag entries (`vis_size`). */
+    visSize?: number;
+    extra?: Record<string, unknown>;
+}
+
+export interface FakeCamera {
+    [key: string]: unknown;
+    name: string;
+    src: string;
+    vis_size: number;
+}
+
+/** Create a fake camera; it appears in the owning scene's getCameraInfoJSON(). */
+export function fakeCamera(opts: FakeCameraOptions): FakeCamera {
+    return { name: opts.name, src: opts.src ?? '', vis_size: opts.visSize ?? 0, ...(opts.extra ?? {}) };
+}
+
+// --- Scene ---
+
+export interface FakeSceneOptions extends FakeBaseOptions {
+    objects?: FakeObject[];
+    views?: FakeView[];
+    cameras?: FakeCamera[];
+    bgcolor?: unknown;
+    use_colproof?: boolean;
+    icc_filename?: string;
+}
+
+/** Undo-transaction record kept by a fake scene. */
+export interface FakeUndoLog {
+    /** Labels passed to startUndoTxn, in order. */
+    started: string[];
+    /** Labels of transactions that reached commitUndoTxn. */
+    committed: string[];
+    /** Labels of transactions that were rolled back. */
+    rolledBack: string[];
+    /** Label of the transaction currently open, or null. */
+    open: string | null;
+}
+
+export interface FakeScene {
+    [key: string]: unknown;
+    uid: number;
+    name: string;
+    bgcolor: unknown;
+    use_colproof: boolean;
+    icc_filename: string;
+    sets: Record<string, Mock>;
+    objects: FakeObject[];
+    views: FakeView[];
+    cameras: FakeCamera[];
+    undo: FakeUndoLog;
+    readonly obj_uids: string;
+    readonly view_uids: string;
+    getUID: () => number;
+    setName: Mock<(name: string) => void>;
+    getObject: Mock<(uid: number) => FakeObject | null>;
+    getObjectByName: (name: string) => FakeObject | null;
+    getRenderer: Mock<(uid: number) => FakeRenderer | null>;
+    getRendByName: (name: string) => FakeRenderer | null;
+    getView: Mock<(uid: number) => FakeView | null>;
+    getViewCount: () => number;
+    addObject: Mock<(obj: FakeObject) => void>;
+    destroyObject: Mock<(uid: number) => boolean>;
+    getSceneDataJSON: Mock<() => string>;
+    getCameraInfoJSON: Mock<() => string>;
+    hasCamera: (name: string) => boolean;
+    getCamera: (name: string) => FakeCamera | null;
+    setCamera: Mock<(name: string, cam: FakeCamera) => void>;
+    destroyCamera: Mock<(name: string) => boolean>;
+    saveViewToCam: Mock<(viewId: number, name: string) => boolean>;
+    loadViewFromCam: Mock<(viewId: number, name: string) => boolean>;
+    startUndoTxn: Mock<(label: string) => void>;
+    commitUndoTxn: Mock<() => void>;
+    rollbackUndoTxn: Mock<() => void>;
+    isUndoable: () => boolean;
+    isRedoable: () => boolean;
+    getUndoSize: () => number;
+}
+
+/**
+ * Renderer entry of the getSceneDataJSON document, in the C++ shape: a
+ * group carries `childNodes` (its members, which are excluded from the top
+ * level); a plain renderer omits the field.
+ */
+function rendNode(r: FakeRenderer, all: FakeRenderer[]): Record<string, unknown> {
+    const node: Record<string, unknown> = {
+        ID: r.uid, name: r.name, type: r.type_name,
+        visible: r.visible, locked: r.locked, ui_order: r.ui_order,
+    };
+    if (r.type_name === '*group') {
+        node.childNodes = all.filter((c) => c !== r && c.group === r.name).map((c) => rendNode(c, all));
+    }
+    return node;
+}
+
+/**
+ * Create a fake scene. `getSceneDataJSON()` / `getCameraInfoJSON()` are
+ * synthesised live from `objects` / `cameras` in the documented C++ shapes
+ * (`[sceneNode, ...objectNodes]`, groups via `childNodes`,
+ * `[{ name, vis_size, src }]`), so a test never hand-writes those documents.
+ */
+export function fakeScene(opts: FakeSceneOptions = {}): FakeScene {
+    const tag = opts.tag ?? 'scene';
+    const log = opts.log;
+    const sets: Record<string, Mock> = {};
+    const objects: FakeObject[] = [];
+    const views: FakeView[] = [];
+    const cameras: FakeCamera[] = [...(opts.cameras ?? [])];
+    const undo: FakeUndoLog = { started: [], committed: [], rolledBack: [], open: null };
+    const allRenderers = (): FakeRenderer[] => objects.flatMap((o) => o.renderers);
+    const scene: Record<string, unknown> = {
+        uid: opts.uid ?? allocUid(),
+        sets,
+        objects,
+        views,
+        cameras,
+        undo,
+        getUID: () => scene.uid as number,
+        setName: vi.fn((name: string) => {
+            (scene as unknown as FakeScene).name = name;
+        }),
+        getObject: vi.fn((uid: number) => objects.find((o) => o.uid === uid) ?? null),
+        getObjectByName: (name: string) => objects.find((o) => o.name === name) ?? null,
+        getRenderer: vi.fn((uid: number) => allRenderers().find((r) => r.uid === uid) ?? null),
+        getRendByName: (name: string) => allRenderers().find((r) => r.name === name) ?? null,
+        getView: vi.fn((uid: number) => views.find((v) => v.uid === uid) ?? null),
+        getViewCount: () => views.length,
+        addObject: vi.fn((obj: FakeObject) => {
+            obj.scene = scene as unknown as FakeScene;
+            objects.push(obj);
+            log?.push(`${tag}.addObject(${obj.name})`);
+        }),
+        destroyObject: vi.fn((uid: number) => {
+            const i = objects.findIndex((o) => o.uid === uid);
+            if (i < 0) return false;
+            objects.splice(i, 1);
+            log?.push(`${tag}.destroyObject(${uid})`);
+            return true;
+        }),
+        getSceneDataJSON: vi.fn(() => {
+            const all = allRenderers();
+            return JSON.stringify([
+                { ID: scene.uid, name: (scene as unknown as FakeScene).name, type: '' },
+                ...objects.map((o) => ({
+                    ID: o.uid, name: o.name, type: o.getClassName(),
+                    visible: o.visible, locked: o.locked,
+                    ui_collapsed: o.ui_collapsed, ui_order: o.ui_order,
+                    rends: o.renderers.filter((r) => r.group === '').map((r) => rendNode(r, all)),
+                })),
+            ]);
+        }),
+        getCameraInfoJSON: vi.fn(() =>
+            JSON.stringify(cameras.map((c) => ({ name: c.name, vis_size: c.vis_size, src: c.src }))),
+        ),
+        hasCamera: (name: string) => cameras.some((c) => c.name === name),
+        getCamera: (name: string) => cameras.find((c) => c.name === name) ?? null,
+        setCamera: vi.fn((name: string, cam: FakeCamera) => {
+            const i = cameras.findIndex((c) => c.name === name);
+            if (i >= 0) cameras[i] = cam;
+            else cameras.push(cam);
+            log?.push(`${tag}.setCamera(${name})`);
+        }),
+        destroyCamera: vi.fn((name: string) => {
+            const i = cameras.findIndex((c) => c.name === name);
+            if (i < 0) return false;
+            cameras.splice(i, 1);
+            log?.push(`${tag}.destroyCamera(${name})`);
+            return true;
+        }),
+        saveViewToCam: vi.fn(() => true),
+        loadViewFromCam: vi.fn(() => true),
+        startUndoTxn: vi.fn((label: string) => {
+            undo.started.push(label);
+            undo.open = label;
+            log?.push(`${tag}.startUndoTxn(${label})`);
+        }),
+        commitUndoTxn: vi.fn(() => {
+            if (undo.open !== null) undo.committed.push(undo.open);
+            undo.open = null;
+            log?.push(`${tag}.commitUndoTxn`);
+        }),
+        rollbackUndoTxn: vi.fn(() => {
+            if (undo.open !== null) undo.rolledBack.push(undo.open);
+            undo.open = null;
+            log?.push(`${tag}.rollbackUndoTxn`);
+        }),
+        isUndoable: () => undo.committed.length > 0,
+        isRedoable: () => false,
+        getUndoSize: () => undo.committed.length,
+    };
+    Object.defineProperty(scene, 'obj_uids', {
+        enumerable: true,
+        get: () => objects.map((o) => o.uid).join(','),
+    });
+    Object.defineProperty(scene, 'view_uids', {
+        enumerable: true,
+        get: () => views.map((v) => v.uid).join(','),
+    });
+    spyProps(scene, {
+        name: opts.name ?? 'scene',
+        bgcolor: opts.bgcolor ?? null,
+        use_colproof: opts.use_colproof ?? false,
+        icc_filename: opts.icc_filename ?? '',
+    }, sets, log, tag);
+    Object.assign(scene, opts.extra ?? {});
+    for (const o of opts.objects ?? []) {
+        o.scene = scene as unknown as FakeScene;
+        objects.push(o);
+    }
+    for (const v of opts.views ?? []) {
+        v.scene = scene as unknown as FakeScene;
+        views.push(v);
+    }
+    return scene as unknown as FakeScene;
+}

--- a/tritium/react-gui/src/renderer/worker/testing/fakes.ts
+++ b/tritium/react-gui/src/renderer/worker/testing/fakes.ts
@@ -422,6 +422,8 @@ export interface FakeScene {
     getRendByName: (name: string) => FakeRenderer | null;
     getView: Mock<(uid: number) => FakeView | null>;
     getViewCount: () => number;
+    createView: Mock<() => FakeView>;
+    clearAllData: Mock<() => void>;
     addObject: Mock<(obj: FakeObject) => void>;
     destroyObject: Mock<(uid: number) => boolean>;
     getSceneDataJSON: Mock<() => string>;
@@ -488,6 +490,24 @@ export function fakeScene(opts: FakeSceneOptions = {}): FakeScene {
         getRendByName: (name: string) => allRenderers().find((r) => r.name === name) ?? null,
         getView: vi.fn((uid: number) => views.find((v) => v.uid === uid) ?? null),
         getViewCount: () => views.length,
+        createView: vi.fn(() => {
+            const view = fakeView({ log, tag: 'view' });
+            view.scene = scene as unknown as FakeScene;
+            views.push(view);
+            log?.push(`${tag}.createView`);
+            return view;
+        }),
+        clearAllData: vi.fn(() => {
+            // Mirrors C++ Scene::clearAllData: objects, renderers, cameras and
+            // undo history go; the view table survives.
+            objects.length = 0;
+            cameras.length = 0;
+            undo.started.length = 0;
+            undo.committed.length = 0;
+            undo.rolledBack.length = 0;
+            undo.open = null;
+            log?.push(`${tag}.clearAllData`);
+        }),
         addObject: vi.fn((obj: FakeObject) => {
             obj.scene = scene as unknown as FakeScene;
             objects.push(obj);

--- a/tritium/react-gui/src/renderer/worker/testing/index.ts
+++ b/tritium/react-gui/src/renderer/worker/testing/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @file renderer/worker/testing/index.ts
+ * @description Worker-service test harness: fake wrapper objects plus a
+ * `WorkerContext` factory. Import from '@renderer/worker/testing' in
+ * `*.test.ts` only -- ESLint rejects it anywhere else.
+ */
+
+export {
+    allocUid, resetFakeUids,
+    fakeRenderer, fakeObject, fakeView, fakeCamera, fakeScene,
+} from './fakes';
+export type {
+    CallLog,
+    FakeRenderer, FakeRendererOptions,
+    FakeObject, FakeObjectOptions,
+    FakeView, FakeViewOptions,
+    FakeCamera, FakeCameraOptions,
+    FakeScene, FakeSceneOptions, FakeUndoLog,
+} from './fakes';
+export { makeWorkerCtx } from './makeWorkerCtx';
+export type { WorkerCtxOptions, FakeWorkerCtx, FakeReaderInfo, FakeSceneManager } from './makeWorkerCtx';

--- a/tritium/react-gui/src/renderer/worker/testing/makeWorkerCtx.ts
+++ b/tritium/react-gui/src/renderer/worker/testing/makeWorkerCtx.ts
@@ -1,0 +1,168 @@
+/**
+ * @file renderer/worker/testing/makeWorkerCtx.ts
+ * @description Build a `WorkerContext` over fake managers for a worker
+ * service test.
+ *
+ * Test-only (see fakes.ts). The managers resolve the fakes handed in
+ * (`sceMgr.getScene(uid)` finds a scene in `scenes`, `strMgr.createHandler`
+ * returns the reader registered under that name, ...) and are `vi.fn`s, so
+ * a test can both assert on them and override a single call. Anything a
+ * service needs beyond that is passed through `extra`.
+ */
+
+import { vi, type Mock } from 'vitest';
+import type { WorkerContext } from '../server/types/WorkerContext';
+import type { FakeObject, FakeRenderer, FakeScene, FakeView } from './fakes';
+
+/** One entry of `StreamManager.getInfoJSON2(category)`. */
+export interface FakeReaderInfo {
+    name: string;
+    /** Space-separated glob list, e.g. '*.pdb *.ent'. */
+    fext: string;
+    /** StreamManager category (OBJECT_READER = 0, SCENE_READER = 2, ...). */
+    category: number;
+    /** Optional human-readable description. */
+    descr?: string;
+}
+
+export interface WorkerCtxOptions {
+    scenes?: FakeScene[];
+    /** Views resolvable through sceMgr.getView; defaults to every scene's views. */
+    views?: FakeView[];
+    /** Backs `ctx.svc.createObj(className)`; throws when absent. */
+    createObj?: (className: string) => unknown;
+    /** Backs `ctx.svc.getService(name)`; null when absent. */
+    getService?: (name: string) => unknown;
+    /** Command objects returned by `cmdMgr.getCmd(name)`; unknown names throw. */
+    cmds?: Record<string, unknown>;
+    /** Handlers returned by `strMgr.createHandler(name, category)`; unknown names return null. */
+    readers?: Record<string, unknown>;
+    /** Entries served by `strMgr.getInfoJSON2()` (callers filter on `category`). */
+    readerInfo?: FakeReaderInfo[];
+    /** Style names served by `styleMgr.getStyleNamesJSON(sceneId)`, keyed by scene uid (0 = global). */
+    styleNames?: Record<number, string[]>;
+    /** Extra members merged onto each manager (duck-typed methods a service needs). */
+    extra?: {
+        svc?: Record<string, unknown>;
+        sceMgr?: Record<string, unknown>;
+        cmdMgr?: Record<string, unknown>;
+        strMgr?: Record<string, unknown>;
+        styleMgr?: Record<string, unknown>;
+    };
+}
+
+export interface FakeSceneManager {
+    [key: string]: unknown;
+    getScene: Mock<(uid: number) => FakeScene | null>;
+    getView: Mock<(uid: number) => FakeView | null>;
+    getObject: Mock<(uid: number) => FakeObject | null>;
+    getRenderer: Mock<(uid: number) => FakeRenderer | null>;
+    readonly scene_uids: string;
+    activeSceneID: number;
+    createScene: Mock<() => FakeScene>;
+    destroyScene: Mock<(uid: number) => boolean>;
+    /** Live scene list (createScene appends here). */
+    scenes: FakeScene[];
+}
+
+export interface FakeWorkerCtx {
+    ctx: WorkerContext;
+    sceMgr: FakeSceneManager;
+    cmdMgr: { [key: string]: unknown; getCmd: Mock<(name: string) => unknown> };
+    strMgr: {
+        [key: string]: unknown;
+        getInfoJSON2: Mock<() => string>;
+        createHandler: Mock<(name: string, category: number) => unknown>;
+    };
+    styleMgr: {
+        [key: string]: unknown;
+        getStyleNamesJSON: Mock<(sceneId: number) => string>;
+        hasStyleSet: Mock<(name: string, sceneId: number) => number>;
+    };
+    svc: {
+        [key: string]: unknown;
+        createObj: Mock<(className: string) => unknown>;
+        getService: Mock<(name: string) => unknown>;
+    };
+}
+
+/**
+ * Create a `WorkerContext` backed by fakes.
+ *
+ * @param opts - Fakes and lookup tables the managers resolve against.
+ * @returns The context plus each fake manager for assertions / overrides.
+ */
+export function makeWorkerCtx(opts: WorkerCtxOptions = {}): FakeWorkerCtx {
+    const scenes: FakeScene[] = [...(opts.scenes ?? [])];
+    const views = (): FakeView[] => opts.views ?? scenes.flatMap((s) => s.views);
+    const allObjects = (): FakeObject[] => scenes.flatMap((s) => s.objects);
+
+    const sceMgr: Record<string, unknown> = {
+        scenes,
+        activeSceneID: scenes[0]?.uid ?? 0,
+        getScene: vi.fn((uid: number) => scenes.find((s) => s.uid === uid) ?? null),
+        getView: vi.fn((uid: number) => views().find((v) => v.uid === uid) ?? null),
+        getObject: vi.fn((uid: number) => allObjects().find((o) => o.uid === uid) ?? null),
+        getRenderer: vi.fn((uid: number) =>
+            allObjects().flatMap((o) => o.renderers).find((r) => r.uid === uid) ?? null),
+        createScene: vi.fn(() => {
+            throw new Error('makeWorkerCtx: pass extra.sceMgr.createScene to create scenes');
+        }),
+        destroyScene: vi.fn((uid: number) => {
+            const i = scenes.findIndex((s) => s.uid === uid);
+            if (i < 0) return false;
+            scenes.splice(i, 1);
+            return true;
+        }),
+        ...(opts.extra?.sceMgr ?? {}),
+    };
+    Object.defineProperty(sceMgr, 'scene_uids', {
+        enumerable: true,
+        get: () => scenes.map((s) => s.uid).join(','),
+    });
+
+    const cmds = opts.cmds ?? {};
+    const cmdMgr = {
+        getCmd: vi.fn((name: string) => {
+            if (!(name in cmds)) throw new Error(`makeWorkerCtx: no fake command '${name}' (pass it via cmds)`);
+            return cmds[name];
+        }),
+        ...(opts.extra?.cmdMgr ?? {}),
+    };
+
+    const readers = opts.readers ?? {};
+    const readerInfo = opts.readerInfo ?? [];
+    const strMgr = {
+        getInfoJSON2: vi.fn(() => JSON.stringify(readerInfo)),
+        createHandler: vi.fn((name: string) => readers[name] ?? null),
+        searchReaderByContent: vi.fn(() => ''),
+        ...(opts.extra?.strMgr ?? {}),
+    };
+
+    const styleNames = opts.styleNames ?? {};
+    const styleMgr = {
+        getStyleNamesJSON: vi.fn((sceneId: number) =>
+            JSON.stringify((styleNames[sceneId] ?? []).map((name) => ({ name })))),
+        hasStyleSet: vi.fn(() => 0),
+        ...(opts.extra?.styleMgr ?? {}),
+    };
+
+    const svc = {
+        createObj: vi.fn((className: string) => {
+            if (!opts.createObj) throw new Error(`makeWorkerCtx: createObj('${className}') has no fake (pass createObj)`);
+            return opts.createObj(className);
+        }),
+        getService: vi.fn((name: string) => opts.getService?.(name) ?? null),
+        ...(opts.extra?.svc ?? {}),
+    };
+
+    const ctx = { svc, sceMgr, cmdMgr, strMgr, styleMgr } as unknown as WorkerContext;
+    return {
+        ctx,
+        sceMgr: sceMgr as unknown as FakeSceneManager,
+        cmdMgr: cmdMgr as FakeWorkerCtx['cmdMgr'],
+        strMgr: strMgr as FakeWorkerCtx['strMgr'],
+        styleMgr: styleMgr as FakeWorkerCtx['styleMgr'],
+        svc: svc as FakeWorkerCtx['svc'],
+    };
+}


### PR DESCRIPTION
## Summary

Phase 1-1 of the react-gui refactoring plan: a shared harness for worker-service tests, so the 82 tests that currently hand-roll `makeCtx` / `makeScene` / accessor-spy fixtures have one place to get them from (and so the service-folder moves in Phase 5 can rewrite tests against a stable API).

`renderer/worker/testing/` (test files only -- ESLint rejects it from production code, and the production bundle is verified not to contain it):

- `fakeScene` / `fakeObject` / `fakeRenderer` / `fakeView` / `fakeCamera`: structural stand-ins for the generated wrappers. Accessor writes are spied (`rend.sets.sel`) and readable back; mutating methods are `vi.fn`s (`mol.createRenderer.mockReturnValueOnce(null)`); an optional shared `log` records mutations in order; `scene.undo` tracks started / committed / rolled-back labels.
- `scene.getSceneDataJSON()` / `getCameraInfoJSON()` are synthesised live from the fakes in the documented C++ shapes (`[sceneNode, ...objectNodes]`, groups via `childNodes`, members excluded from the top level) -- `fakes.test.ts` checks the production `parseSceneTreeJSON` accepts them.
- `makeWorkerCtx({ scenes, readers, readerInfo, cmds, styleNames, createObj, getService })` builds a `WorkerContext` whose managers resolve those fakes; an unknown command / `createObj` throws with a hint.

`setupRendererService.test.ts` is migrated as the worked example (55-line fixture -> 12 lines, every assertion kept); `tritium/CLAUDE.md` documents the harness as the default for new service tests. Existing fixtures are migrated opportunistically when their test is next touched, per the plan.

No production code changes.

## Verification

- `bash build_scripts/check_tritium_react_gui/run.sh`: typecheck OK, ESLint 124 problems (0 errors, 124 warnings) (baseline 0 errors / 124 warnings), `lint:comments` OK, vitest Test Files 334 passed (334) / Tests 3177 passed (3177)
- `npx electron-vite build` OK; `out/renderer/assets/*.js` contains no `worker/testing` module

Independent of #521 / #522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jq8nSHJWsEpfSui98LTXR


---

## Added after manual verification

Commit `ed3adcb4`: the fake scene gains `createView` and `clearAllData`, both needed by the scene-loading services (a scene-open path creates a view after reading; a reload clears first). `clearAllData` mirrors the C++ version -- objects, renderers, cameras and undo history go, the view table survives.
