### PR TITLE
refactor(react-gui): move eleven dialogs onto the shared shell (Phase 3-2)

### DIFF
--- a/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
@@ -42,6 +42,8 @@ import { ConfirmCloseTabDialog } from '../components/dialogs/ConfirmCloseTabDial
 import { ConfirmReloadSceneDialog } from '../components/dialogs/ConfirmReloadSceneDialog'
 import { ErrorAlertDialog } from '../components/dialogs/ErrorAlertDialog'
 import { ObjectPickerDialog } from '../components/dialogs/ObjectPickerDialog'
+import { TextPromptDialog } from '../components/dialogs/TextPromptDialog'
+import { EditCameraVisFlagsDialog } from '../components/dialogs/EditCameraVisFlagsDialog'
 import { GetPdbDialog } from '../components/dialogs/GetPdbDialog'
 import { NewTabDialog } from '../components/dialogs/NewTabDialog'
 import { QscWriterOptionDialog } from '../components/dialogs/QscWriterOptionDialog'
@@ -71,48 +73,6 @@ describe('Modal dialog: backdrop click + close button are disabled', () => {
   })
   afterEach(() => {
     vi.restoreAllMocks()
-  })
-
-  it('GetPdbDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(GetPdbDialog, {
-        visible: true,
-        onConfirm: () => {},
-        onCancel: () => {},
-      }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
-  })
-
-  it('NewTabDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(NewTabDialog, {
-        visible: true,
-        currentSceneName: null,
-        defaultSceneName: 'Scene_1',
-        defaultViewName: 'View_1',
-        onConfirm: () => {},
-        onCancel: () => {},
-      }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
-  })
-
-  it('QscWriterOptionDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(QscWriterOptionDialog, {
-        visible: true,
-        onConfirm: () => {},
-        onCancel: () => {},
-      }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
   })
 
   it('FileOpenOptionDialog passes canOutsideClickClose={false}', () => {
@@ -250,6 +210,43 @@ describe('Molecule-edit dialogs: DialogShell frame contract', () => {
       render: () => React.createElement(StreamProgressDialog, {
         visible: true, title: 'Downloading', bytesReceived: 0,
         status: 'downloading' as const, onCancel: () => {},
+      }),
+    },
+    {
+      name: 'GetPdbDialog',
+      title: 'Get PDB',
+      render: () => React.createElement(GetPdbDialog, {
+        visible: true, onConfirm: () => {}, onCancel: () => {},
+      }),
+    },
+    {
+      name: 'NewTabDialog',
+      title: 'New Tab/Window',
+      render: () => React.createElement(NewTabDialog, {
+        visible: true, currentSceneName: 's', defaultSceneName: 'Scene_1',
+        defaultViewName: 'View_1', onConfirm: () => {}, onCancel: () => {},
+      }),
+    },
+    {
+      name: 'TextPromptDialog',
+      title: 'Rename',
+      render: () => React.createElement(TextPromptDialog, {
+        visible: true, title: 'Rename', label: 'Name', defaultValue: 'x',
+        onResult: () => {},
+      }),
+    },
+    {
+      name: 'QscWriterOptionDialog',
+      title: 'Scene options',
+      render: () => React.createElement(QscWriterOptionDialog, {
+        visible: true, onConfirm: () => {}, onCancel: () => {},
+      }),
+    },
+    {
+      name: 'EditCameraVisFlagsDialog',
+      title: 'Edit visibility flags: cam1',
+      render: () => React.createElement(EditCameraVisFlagsDialog, {
+        visible: true, cameraName: 'cam1', entries: [], onConfirm: () => {}, onCancel: () => {},
       }),
     },
     {

--- a/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
@@ -39,6 +39,9 @@ vi.mock('@renderer/hooks/cuemol/useCueMol', () => ({
 
 import { AboutDialog } from '../components/dialogs/AboutDialog'
 import { ConfirmCloseTabDialog } from '../components/dialogs/ConfirmCloseTabDialog'
+import { ConfirmReloadSceneDialog } from '../components/dialogs/ConfirmReloadSceneDialog'
+import { ErrorAlertDialog } from '../components/dialogs/ErrorAlertDialog'
+import { ObjectPickerDialog } from '../components/dialogs/ObjectPickerDialog'
 import { GetPdbDialog } from '../components/dialogs/GetPdbDialog'
 import { NewTabDialog } from '../components/dialogs/NewTabDialog'
 import { QscWriterOptionDialog } from '../components/dialogs/QscWriterOptionDialog'
@@ -68,28 +71,6 @@ describe('Modal dialog: backdrop click + close button are disabled', () => {
   })
   afterEach(() => {
     vi.restoreAllMocks()
-  })
-
-  it('AboutDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(AboutDialog, { visible: true, onClose: () => {} }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
-  })
-
-  it('ConfirmCloseTabDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(ConfirmCloseTabDialog, {
-        visible: true,
-        sceneName: 'Scene_1',
-        onResult: () => {},
-      }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
   })
 
   it('GetPdbDialog passes canOutsideClickClose={false}', () => {
@@ -126,21 +107,6 @@ describe('Modal dialog: backdrop click + close button are disabled', () => {
       React.createElement(QscWriterOptionDialog, {
         visible: true,
         onConfirm: () => {},
-        onCancel: () => {},
-      }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
-  })
-
-  it('StreamProgressDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(StreamProgressDialog, {
-        visible: true,
-        title: 'Loading',
-        bytesReceived: 0,
-        status: 'downloading',
         onCancel: () => {},
       }),
     )
@@ -241,6 +207,51 @@ describe('Molecule-edit dialogs: DialogShell frame contract', () => {
         visible: true, sceneId: 0, onConfirm: () => {}, onCancel: () => {},
       }),
     },
+    // Moved onto the shell from a hand-rolled frame. ErrorAlertDialog is the
+    // one that changes behaviour: it was the only dialog in the app still
+    // showing a window-chrome (X) button, which the stylesheet already assumed
+    // was gone everywhere.
+    {
+      name: 'AboutDialog',
+      title: 'About CueMol3',
+      render: () => React.createElement(AboutDialog, { visible: true, onClose: () => {} }),
+    },
+    {
+      name: 'ConfirmCloseTabDialog',
+      title: 'Unsaved Changes',
+      render: () => React.createElement(ConfirmCloseTabDialog, {
+        visible: true, sceneName: 's', onResult: () => {},
+      }),
+    },
+    {
+      name: 'ConfirmReloadSceneDialog',
+      title: 'Reload Scene',
+      render: () => React.createElement(ConfirmReloadSceneDialog, {
+        visible: true, sceneName: 's', onResult: () => {},
+      }),
+    },
+    {
+      name: 'ErrorAlertDialog',
+      title: 'Open failed',
+      render: () => React.createElement(ErrorAlertDialog, {
+        visible: true, title: 'Open failed', message: 'no reader', onClose: () => {},
+      }),
+    },
+    {
+      name: 'ObjectPickerDialog',
+      title: 'Save Object As',
+      render: () => React.createElement(ObjectPickerDialog, {
+        visible: true, objects: [{ id: 1, name: 'mol1' }], onResult: () => {},
+      }),
+    },
+    {
+      name: 'StreamProgressDialog',
+      title: 'Downloading',
+      render: () => React.createElement(StreamProgressDialog, {
+        visible: true, title: 'Downloading', bytesReceived: 0,
+        status: 'downloading' as const, onCancel: () => {},
+      }),
+    },
     {
       name: 'InteractionAnalysisDialog',
       title: 'Interaction analysis',
@@ -266,4 +277,40 @@ describe('Molecule-edit dialogs: DialogShell frame contract', () => {
       handle.unmount()
     })
   }
+})
+
+/*
+ * The two escape hatches the conversion needed. Both are load-bearing: without
+ * the first, Escape abandons a download while it keeps running; without the
+ * second, the About splash gets the shared form gutter and stops being
+ * full-bleed.
+ */
+describe('DialogShell escape hatches', () => {
+  beforeEach(() => {
+    dialogPropsList.length = 0
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('lets Escape close a dialog by default', () => {
+    const handle = mountTree(
+      React.createElement(ConfirmReloadSceneDialog, {
+        visible: true, sceneName: 's', onResult: () => {},
+      }),
+    )
+    expect(lastDialogProps().canEscapeKeyClose).toBe(true)
+    handle.unmount()
+  })
+
+  it('refuses Escape while a download is in flight', () => {
+    const handle = mountTree(
+      React.createElement(StreamProgressDialog, {
+        visible: true, title: 'Downloading', bytesReceived: 0,
+        status: 'downloading' as const, onCancel: () => {},
+      }),
+    )
+    expect(lastDialogProps().canEscapeKeyClose).toBe(false)
+    handle.unmount()
+  })
 })

--- a/tritium/react-gui/src/renderer/components/dialogs/AboutDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/AboutDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { Dialog, DialogBody, DialogFooter, Button } from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Button } from '@blueprintjs/core';
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol';
+import { DialogShell } from './DialogShell';
 import aboutPng from '../../assets/about.png';
 import { APP_PRODUCT_NAME } from '@shared/appInfo';
 
@@ -11,7 +11,6 @@ interface Props {
 }
 
 export function AboutDialog({ visible, onClose }: Props): React.JSX.Element {
-  const { theme } = useTheme();
   const { cm } = useCueMol();
   const [version, setVersion] = useState('');
   const [build, setBuild] = useState('');
@@ -24,19 +23,18 @@ export function AboutDialog({ visible, onClose }: Props): React.JSX.Element {
     }).catch(() => {});
   }, [visible, cm]);
 
-  const isDark = theme === 'dark';
-
   return (
-    <Dialog
-      isOpen={visible}
-      onClose={onClose}
+    <DialogShell
+      visible={visible}
       title={`About ${APP_PRODUCT_NAME}`}
-      style={{ width: 300, paddingBottom: 0 }}
-      portalClassName={isDark ? 'bp5-dark' : ''}
-      canOutsideClickClose={false}
-      isCloseButtonShown={false}
+      width="xs"
+      onCancel={onClose}
+      // A splash image bled to the frame edge, not a form: the shared gutter
+      // and section gap would inset it.
+      plainBody
+      footerActions={<Button intent="primary" onClick={onClose}>OK</Button>}
     >
-      <DialogBody style={{ padding: 0 }}>
+      <>
         <img
           src={aboutPng}
           alt="CueMol3"
@@ -82,12 +80,7 @@ export function AboutDialog({ visible, onClose }: Props): React.JSX.Element {
             ©1998-2026 Contributors. All Rights Reserved.
           </div>
         </div>
-      </DialogBody>
-      <DialogFooter
-        actions={
-          <Button intent="primary" onClick={onClose}>OK</Button>
-        }
-      />
-    </Dialog>
+      </>
+    </DialogShell>
   );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/ConfirmCloseTabDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ConfirmCloseTabDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button, Dialog, DialogBody, DialogFooter } from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Button } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 
 export type ConfirmCloseResult = 'save' | 'discard' | 'cancel';
 
@@ -11,35 +11,27 @@ interface Props {
 }
 
 export function ConfirmCloseTabDialog({ visible, sceneName, onResult }: Props): React.JSX.Element {
-  const { theme } = useTheme();
-  const isDark = theme === 'dark';
-
   const displayName = sceneName ? `"${sceneName}"` : '(unnamed)';
 
   return (
-    <Dialog
-      isOpen={visible}
-      onClose={() => onResult('cancel')}
+    <DialogShell
+      visible={visible}
       title="Unsaved Changes"
-      style={{ width: 400, paddingBottom: 0 }}
-      portalClassName={isDark ? 'bp5-dark' : ''}
-      canOutsideClickClose={false}
-      isCloseButtonShown={false}
+      width="xl"
+      onCancel={() => onResult('cancel')}
+      // Three outcomes, not two: the shared Cancel / OK pair cannot express
+      // "discard" sitting between them.
+      footerActions={
+        <>
+          <Button onClick={() => onResult('cancel')}>Cancel</Button>
+          <Button intent="danger" onClick={() => onResult('discard')}>Don&apos;t Save</Button>
+          <Button intent="primary" onClick={() => onResult('save')}>Save</Button>
+        </>
+      }
     >
-      <DialogBody>
-        <p style={{ margin: 0 }}>
-          Scene {displayName} is not saved. Save changes?
-        </p>
-      </DialogBody>
-      <DialogFooter
-        actions={
-          <>
-            <Button onClick={() => onResult('cancel')}>Cancel</Button>
-            <Button intent="danger" onClick={() => onResult('discard')}>Don&apos;t Save</Button>
-            <Button intent="primary" onClick={() => onResult('save')}>Save</Button>
-          </>
-        }
-      />
-    </Dialog>
+      <p style={{ margin: 0 }}>
+        Scene {displayName} is not saved. Save changes?
+      </p>
+    </DialogShell>
   );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/ConfirmReloadSceneDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ConfirmReloadSceneDialog.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Button, Dialog, DialogBody, DialogFooter } from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { DialogShell } from './DialogShell';
 
 interface Props {
   visible: boolean;
@@ -13,35 +12,22 @@ interface Props {
  * Mirrors UXP `Qm2Main.onReloadScene`'s modified-scene confirmation.
  */
 export function ConfirmReloadSceneDialog({ visible, sceneName, onResult }: Props): React.JSX.Element {
-  const { theme } = useTheme();
-  const isDark = theme === 'dark';
-
   const displayName = sceneName ? `"${sceneName}"` : '(unnamed)';
 
   return (
-    <Dialog
-      isOpen={visible}
-      onClose={() => onResult(false)}
+    <DialogShell
+      visible={visible}
       title="Reload Scene"
-      style={{ width: 400, paddingBottom: 0 }}
-      portalClassName={isDark ? 'bp5-dark' : ''}
-      canOutsideClickClose={false}
-      isCloseButtonShown={false}
+      width="xl"
+      onCancel={() => onResult(false)}
+      onOk={() => onResult(true)}
+      okLabel="Reload"
+      okIntent="danger"
     >
-      <DialogBody>
-        <p style={{ margin: 0 }}>
-          Scene {displayName} has unsaved changes. Reload from disk and discard
-          changes?
-        </p>
-      </DialogBody>
-      <DialogFooter
-        actions={
-          <>
-            <Button onClick={() => onResult(false)}>Cancel</Button>
-            <Button intent="danger" onClick={() => onResult(true)}>Reload</Button>
-          </>
-        }
-      />
-    </Dialog>
+      <p style={{ margin: 0 }}>
+        Scene {displayName} has unsaved changes. Reload from disk and discard
+        changes?
+      </p>
+    </DialogShell>
   );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/DialogShell.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/DialogShell.tsx
@@ -21,7 +21,7 @@
 
 import React from 'react'
 import { Button, Dialog, DialogBody, DialogFooter, type Intent } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { useDarkPortalClass } from '@renderer/h3-kit/primitives'
 
 /**
  * Named rungs of the dialog-frame width ladder. Each maps to a
@@ -82,14 +82,29 @@ export interface DialogShellProps {
      * confirm `Alert` for the two Alert-gated molecule-edit dialogs).
      */
     extra?: React.ReactNode
+    /**
+     * Lets Escape close the dialog. Default `true` (Blueprint's own default,
+     * routed through `onCancel`). A dialog whose work must be stopped rather
+     * than dismissed -- a download in flight -- sets this false so the only way
+     * out is its own action.
+     */
+    canEscapeKeyClose?: boolean
+    /**
+     * The body lays itself out: no padding and no `.h3-dialog-form` column.
+     * For content that is not a form -- the About splash is a full-bleed image
+     * -- where the shared gap and gutter would box it in. The frame concerns
+     * (portal class, outside click, close button, width) still apply, which is
+     * the reason to be here at all.
+     */
+    plainBody?: boolean
 }
 
 /**
  * Renders the shared dialog frame around `children`.
  *
- * @remarks `isDark` is derived locally so consumers never thread theme state.
- * `portalClassName` keeps the `''` (not `undefined`) light-theme value the
- * outside-click test pins.
+ * @remarks The theme is read from the document by the kit, so consumers never
+ * thread theme state. `portalClassName` keeps the `''` (not `undefined`)
+ * light-theme value the outside-click test pins.
  */
 export function DialogShell({
     visible,
@@ -105,9 +120,10 @@ export function DialogShell({
     children,
     footerActions,
     extra,
+    canEscapeKeyClose = true,
+    plainBody = false,
 }: DialogShellProps): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
+    const portalClassName = useDarkPortalClass()
 
     return (
         <Dialog
@@ -115,18 +131,23 @@ export function DialogShell({
             onClose={onCancel}
             title={title}
             style={{ width: WIDTH_VAR[width] }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
+            portalClassName={portalClassName}
             canOutsideClickClose={false}
+            canEscapeKeyClose={canEscapeKeyClose}
             isCloseButtonShown={false}
         >
-            <DialogBody>
-                <div className="h3-dialog-form">
-                    {children}
-                    {errorMsg !== null && errorMsg !== undefined && (
-                        <div className="h3-dialog-error">{errorMsg}</div>
-                    )}
-                </div>
-            </DialogBody>
+            {plainBody ? (
+                <DialogBody style={{ padding: 0 }}>{children}</DialogBody>
+            ) : (
+                <DialogBody>
+                    <div className="h3-dialog-form">
+                        {children}
+                        {errorMsg !== null && errorMsg !== undefined && (
+                            <div className="h3-dialog-error">{errorMsg}</div>
+                        )}
+                    </div>
+                </DialogBody>
+            )}
             <DialogFooter
                 actions={
                     footerActions ?? (

--- a/tritium/react-gui/src/renderer/components/dialogs/EditCameraVisFlagsDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/EditCameraVisFlagsDialog.tsx
@@ -8,8 +8,8 @@
  */
 
 import React, { useEffect, useState } from 'react'
-import { Dialog, DialogBody, DialogFooter, Button, Checkbox } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { Checkbox } from '@blueprintjs/core'
+import { DialogShell } from './DialogShell';
 import type { VisFlagEntry } from '../../worker/server/services/cameraVisFlags.service'
 
 export interface EditCameraVisFlagsDialogResult {
@@ -31,8 +31,6 @@ export function EditCameraVisFlagsDialog({
     onConfirm,
     onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
 
     // Editable copy, re-seeded from the latest props on each open.
     const [rows, setRows] = useState<VisFlagEntry[]>(() => entries.map((e) => ({ ...e })))
@@ -44,98 +42,84 @@ export function EditCameraVisFlagsDialog({
         setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title={`Edit visibility flags: ${cameraName}`}
-            style={{ width: 420 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="2xl"
+            onCancel={onCancel}
+            onOk={() => onConfirm({ entries: rows })}
         >
-            <DialogBody>
+            <div
+                role="table"
+                aria-label="Visibility flags"
+                style={{
+                    border: '1px solid var(--border)',
+                    borderRadius: 3,
+                    maxHeight: 320,
+                    overflowY: 'auto',
+                    background: 'var(--bg-surface)',
+                }}
+            >
                 <div
-                    role="table"
-                    aria-label="Visibility flags"
+                    role="row"
                     style={{
-                        border: '1px solid var(--border)',
-                        borderRadius: 3,
-                        maxHeight: 320,
-                        overflowY: 'auto',
-                        background: 'var(--bg-surface)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        padding: '4px 8px',
+                        borderBottom: '1px solid var(--border)',
+                        color: 'var(--text-secondary)',
+                        fontWeight: 'var(--fw-semibold)',
                     }}
                 >
-                    <div
-                        role="row"
-                        style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            padding: '4px 8px',
-                            borderBottom: '1px solid var(--border)',
-                            color: 'var(--text-secondary)',
-                            fontWeight: 'var(--fw-semibold)',
-                        }}
-                    >
-                        <span style={{ width: 40 }}>Inc</span>
-                        <span style={{ flex: 1 }}>Object / Renderer</span>
-                        <span style={{ width: 48 }}>Vis</span>
-                    </div>
-                    {rows.length === 0 ? (
-                        <div style={{ padding: 8, color: 'var(--text-secondary)', fontStyle: 'italic' }}>
-                            (no scene elements)
-                        </div>
-                    ) : (
-                        rows.map((r, i) => (
-                            <div
-                                role="row"
-                                key={r.tgtId}
-                                style={{ display: 'flex', alignItems: 'center', padding: '2px 8px' }}
-                            >
-                                <span style={{ width: 40 }}>
-                                    <Checkbox
-                                        checked={r.included}
-                                        onChange={(e) =>
-                                            setRow(i, { included: (e.target as HTMLInputElement).checked })
-                                        }
-                                        aria-label={`Include ${r.tgtName}`}
-                                        style={{ margin: 0 }}
-                                    />
-                                </span>
-                                <span
-                                    style={{
-                                        flex: 1,
-                                        color: r.isObj ? 'var(--text-primary)' : 'var(--text-secondary)',
-                                    }}
-                                >
-                                    {r.tgtName}
-                                    {r.isObj ? '' : ' (renderer)'}
-                                </span>
-                                <span style={{ width: 48 }}>
-                                    <Checkbox
-                                        checked={r.visible}
-                                        disabled={!r.included}
-                                        onChange={(e) =>
-                                            setRow(i, { visible: (e.target as HTMLInputElement).checked })
-                                        }
-                                        aria-label={`Visible ${r.tgtName}`}
-                                        style={{ margin: 0 }}
-                                    />
-                                </span>
-                            </div>
-                        ))
-                    )}
+                    <span style={{ width: 40 }}>Inc</span>
+                    <span style={{ flex: 1 }}>Object / Renderer</span>
+                    <span style={{ width: 48 }}>Vis</span>
                 </div>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={() => onConfirm({ entries: rows })}>
-                            OK
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                {rows.length === 0 ? (
+                    <div style={{ padding: 8, color: 'var(--text-secondary)', fontStyle: 'italic' }}>
+                        (no scene elements)
+                    </div>
+                ) : (
+                    rows.map((r, i) => (
+                        <div
+                            role="row"
+                            key={r.tgtId}
+                            style={{ display: 'flex', alignItems: 'center', padding: '2px 8px' }}
+                        >
+                            <span style={{ width: 40 }}>
+                                <Checkbox
+                                    checked={r.included}
+                                    onChange={(e) =>
+                                        setRow(i, { included: (e.target as HTMLInputElement).checked })
+                                    }
+                                    aria-label={`Include ${r.tgtName}`}
+                                    style={{ margin: 0 }}
+                                />
+                            </span>
+                            <span
+                                style={{
+                                    flex: 1,
+                                    color: r.isObj ? 'var(--text-primary)' : 'var(--text-secondary)',
+                                }}
+                            >
+                                {r.tgtName}
+                                {r.isObj ? '' : ' (renderer)'}
+                            </span>
+                            <span style={{ width: 48 }}>
+                                <Checkbox
+                                    checked={r.visible}
+                                    disabled={!r.included}
+                                    onChange={(e) =>
+                                        setRow(i, { visible: (e.target as HTMLInputElement).checked })
+                                    }
+                                    aria-label={`Visible ${r.tgtName}`}
+                                    style={{ margin: 0 }}
+                                />
+                            </span>
+                        </div>
+                    ))
+                )}
+            </div>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/ErrorAlertDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ErrorAlertDialog.tsx
@@ -6,8 +6,8 @@
  */
 
 import React from 'react';
-import { Dialog, DialogBody, DialogFooter, Button } from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Button } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 
 export interface ErrorAlertDialogArgs {
     title: string;
@@ -22,26 +22,21 @@ interface Props {
 }
 
 export function ErrorAlertDialog({ visible, title, message, onClose }: Props): React.JSX.Element {
-    const { theme } = useTheme();
-    const isDark = theme === 'dark';
-
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onClose}
+        <DialogShell
+            visible={visible}
             title={title}
-            style={{ width: 420 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
+            width="2xl"
+            onCancel={onClose}
+            // Acknowledge-only: one button, focused so Enter dismisses without
+            // reaching for the mouse.
+            footerActions={
+                <Button intent="primary" onClick={onClose} autoFocus>OK</Button>
+            }
         >
-            <DialogBody>
-                <div style={{ whiteSpace: 'pre-wrap', color: 'var(--text-primary)' }}>
-                    {message}
-                </div>
-            </DialogBody>
-            <DialogFooter
-                actions={<Button intent="primary" onClick={onClose} autoFocus>OK</Button>}
-            />
-        </Dialog>
+            <div style={{ whiteSpace: 'pre-wrap', color: 'var(--text-primary)' }}>
+                {message}
+            </div>
+        </DialogShell>
     );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/GetPdbDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/GetPdbDialog.tsx
@@ -1,15 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-    Button,
-    Checkbox,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    FormGroup,
-    Radio,
-    RadioGroup,
-} from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Checkbox, FormGroup, Radio, RadioGroup } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 import { ComboBoxField } from '../../h3-kit/form';
 import { getHistory } from './pdbIdHistory';
 
@@ -33,8 +24,6 @@ interface Props {
 const PDBID_RE = /^[0-9][0-9a-z]{3}$/i;
 
 export function GetPdbDialog({ visible, onConfirm, onCancel }: Props): React.JSX.Element {
-    const { theme } = useTheme();
-    const isDark = theme === 'dark';
 
     const [pdbid, setPdbid] = useState('');
 
@@ -87,93 +76,81 @@ export function GetPdbDialog({ visible, onConfirm, onCancel }: Props): React.JSX
     };
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="Get PDB"
-            style={{ width: 380 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="lg"
+            onCancel={onCancel}
+            onOk={handleOk}
+            okLabel="Download"
+            okDisabled={!canSubmit}
         >
-            <DialogBody>
-                <FormGroup label="PDB Accession Code:" labelFor="get-pdb-id">
-                    {/* Editable combobox: text + themed, click-to-open history
-                        dropdown. The chevron and dark-mode popover are handled
-                        by ComboBoxField (h3-kit), so this dialog adds none of
-                        that styling. */}
-                    <ComboBoxField
-                        id="get-pdb-id"
-                        value={pdbid}
-                        onChange={setPdbid}
-                        options={historyItems}
-                        onOpen={refreshHistory}
-                        placeholder="e.g., 1mbn"
-                        autoFocus
-                        invalid={pdbid.length > 0 && !idValid}
-                        onKeyDown={handleKeyDown}
-                        emptyText="No history"
-                        triggerLabel="Show PDB ID history"
-                        triggerTitle="Recent PDB IDs"
-                        aria-label="PDB Accession Code"
-                    />
-                </FormGroup>
+            <FormGroup label="PDB Accession Code:" labelFor="get-pdb-id">
+                {/* Editable combobox: text + themed, click-to-open history
+                    dropdown. The chevron and dark-mode popover are handled
+                    by ComboBoxField (h3-kit), so this dialog adds none of
+                    that styling. */}
+                <ComboBoxField
+                    id="get-pdb-id"
+                    value={pdbid}
+                    onChange={setPdbid}
+                    options={historyItems}
+                    onOpen={refreshHistory}
+                    placeholder="e.g., 1mbn"
+                    autoFocus
+                    invalid={pdbid.length > 0 && !idValid}
+                    onKeyDown={handleKeyDown}
+                    emptyText="No history"
+                    triggerLabel="Show PDB ID history"
+                    triggerTitle="Recent PDB IDs"
+                    aria-label="PDB Accession Code"
+                />
+            </FormGroup>
 
-                <fieldset style={{ marginTop: 12, padding: '8px 12px' }}>
-                    <legend style={{ padding: '0 4px' }}>Coordinates</legend>
-                    <Checkbox
-                        label="Fetch coord file"
-                        checked={coordEnabled}
-                        onChange={(e) => setCoordEnabled(e.currentTarget.checked)}
-                    />
-                    <div style={{ paddingLeft: 24 }}>
-                        <RadioGroup
-                            inline={false}
-                            selectedValue={coordServer}
-                            onChange={(e) => setCoordServer(e.currentTarget.value as CoordServerType)}
-                            disabled={!coordEnabled}
-                        >
-                            <Radio value="RCSB_CIF" label="RCSB (mmCIF)" />
-                            <Radio value="RCSB_PDB" label="RCSB (PDB)" />
-                        </RadioGroup>
-                    </div>
-                </fieldset>
+            <fieldset style={{ marginTop: 12, padding: '8px 12px' }}>
+                <legend style={{ padding: '0 4px' }}>Coordinates</legend>
+                <Checkbox
+                    label="Fetch coord file"
+                    checked={coordEnabled}
+                    onChange={(e) => setCoordEnabled(e.currentTarget.checked)}
+                />
+                <div style={{ paddingLeft: 24 }}>
+                    <RadioGroup
+                        inline={false}
+                        selectedValue={coordServer}
+                        onChange={(e) => setCoordServer(e.currentTarget.value as CoordServerType)}
+                        disabled={!coordEnabled}
+                    >
+                        <Radio value="RCSB_CIF" label="RCSB (mmCIF)" />
+                        <Radio value="RCSB_PDB" label="RCSB (PDB)" />
+                    </RadioGroup>
+                </div>
+            </fieldset>
 
-                <fieldset style={{ marginTop: 8, padding: '8px 12px' }}>
-                    <legend style={{ padding: '0 4px' }}>Density maps</legend>
-                    <Checkbox
-                        label="Fetch 2Fo-Fc map"
-                        checked={map2fofcEnabled}
-                        onChange={(e) => setMap2fofcEnabled(e.currentTarget.checked)}
-                    />
-                    <Checkbox
-                        label="Fetch Fo-Fc map"
-                        checked={mapFofcEnabled}
-                        onChange={(e) => setMapFofcEnabled(e.currentTarget.checked)}
-                    />
-                    <div style={{ paddingLeft: 24 }}>
-                        <RadioGroup
-                            inline={false}
-                            selectedValue={mapServer}
-                            onChange={(e) => setMapServer(e.currentTarget.value as MapServerType)}
-                            disabled={!mapServerEnabled}
-                        >
-                            <Radio value="RCSB_CIF" label="RCSB (cif.gz)" />
-                            <Radio value="EBI_MTZ" label="EBI (MTZ)" />
-                        </RadioGroup>
-                    </div>
-                </fieldset>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk} disabled={!canSubmit}>
-                            Download
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+            <fieldset style={{ marginTop: 8, padding: '8px 12px' }}>
+                <legend style={{ padding: '0 4px' }}>Density maps</legend>
+                <Checkbox
+                    label="Fetch 2Fo-Fc map"
+                    checked={map2fofcEnabled}
+                    onChange={(e) => setMap2fofcEnabled(e.currentTarget.checked)}
+                />
+                <Checkbox
+                    label="Fetch Fo-Fc map"
+                    checked={mapFofcEnabled}
+                    onChange={(e) => setMapFofcEnabled(e.currentTarget.checked)}
+                />
+                <div style={{ paddingLeft: 24 }}>
+                    <RadioGroup
+                        inline={false}
+                        selectedValue={mapServer}
+                        onChange={(e) => setMapServer(e.currentTarget.value as MapServerType)}
+                        disabled={!mapServerEnabled}
+                    >
+                        <Radio value="RCSB_CIF" label="RCSB (cif.gz)" />
+                        <Radio value="EBI_MTZ" label="EBI (MTZ)" />
+                    </RadioGroup>
+                </div>
+            </fieldset>
+        </DialogShell>
     );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/NewTabDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/NewTabDialog.tsx
@@ -1,16 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import {
-    Button,
-    Checkbox,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    FormGroup,
-    InputGroup,
-    Radio,
-    RadioGroup,
-} from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Checkbox, FormGroup, InputGroup, Radio, RadioGroup } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 
 export type NewTabMode = 'new-scene' | 'new-view';
 
@@ -37,8 +27,6 @@ export function NewTabDialog({
     onConfirm,
     onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme();
-    const isDark = theme === 'dark';
 
     const [mode, setMode] = useState<NewTabMode>('new-scene');
     const [sceneName, setSceneName] = useState(defaultSceneName);
@@ -69,66 +57,54 @@ export function NewTabDialog({
         : 'New View (no current scene)';
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="New Tab/Window"
-            style={{ width: 360, paddingBottom: 0 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="md"
+            onCancel={onCancel}
+            onOk={handleOk}
         >
-            <DialogBody>
-                <p style={{ marginBottom: 10, marginTop: 0 }}>Create new tab for:</p>
-                <RadioGroup selectedValue={mode} onChange={handleModeChange}>
-                    <Radio value="new-scene" label="New Scene" />
-                    <div style={{ paddingLeft: 24, marginBottom: 8 }}>
-                        <FormGroup label="Name:" inline labelFor="new-tab-scene-name" style={{ marginBottom: 0 }}>
-                            <InputGroup
-                                id="new-tab-scene-name"
-                                value={sceneName}
-                                onChange={(e) => setSceneName(e.target.value)}
-                                disabled={mode !== 'new-scene'}
-                                style={{ width: 200 }}
-                            />
-                        </FormGroup>
-                    </div>
-
-                    <Radio
-                        value="new-view"
-                        label={newViewLabel}
-                        disabled={!currentSceneName}
-                    />
-                    <div style={{ paddingLeft: 24, marginBottom: 8 }}>
-                        <FormGroup label="Name:" inline labelFor="new-tab-view-name" style={{ marginBottom: 0 }}>
-                            <InputGroup
-                                id="new-tab-view-name"
-                                value={viewName}
-                                onChange={(e) => setViewName(e.target.value)}
-                                disabled={mode !== 'new-view'}
-                                style={{ width: 200 }}
-                            />
-                        </FormGroup>
-                    </div>
-
-                    <div style={{ paddingLeft: 24 }}>
-                        <Checkbox
-                            label="Inherit view props"
-                            checked={inherit}
-                            onChange={(e) => setInherit(e.currentTarget.checked)}
-                            disabled={mode !== 'new-view'}
+            <p style={{ marginBottom: 10, marginTop: 0 }}>Create new tab for:</p>
+            <RadioGroup selectedValue={mode} onChange={handleModeChange}>
+                <Radio value="new-scene" label="New Scene" />
+                <div style={{ paddingLeft: 24, marginBottom: 8 }}>
+                    <FormGroup label="Name:" inline labelFor="new-tab-scene-name" style={{ marginBottom: 0 }}>
+                        <InputGroup
+                            id="new-tab-scene-name"
+                            value={sceneName}
+                            onChange={(e) => setSceneName(e.target.value)}
+                            disabled={mode !== 'new-scene'}
+                            style={{ width: 200 }}
                         />
-                    </div>
-                </RadioGroup>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk}>OK</Button>
-                    </>
-                }
-            />
-        </Dialog>
+                    </FormGroup>
+                </div>
+
+                <Radio
+                    value="new-view"
+                    label={newViewLabel}
+                    disabled={!currentSceneName}
+                />
+                <div style={{ paddingLeft: 24, marginBottom: 8 }}>
+                    <FormGroup label="Name:" inline labelFor="new-tab-view-name" style={{ marginBottom: 0 }}>
+                        <InputGroup
+                            id="new-tab-view-name"
+                            value={viewName}
+                            onChange={(e) => setViewName(e.target.value)}
+                            disabled={mode !== 'new-view'}
+                            style={{ width: 200 }}
+                        />
+                    </FormGroup>
+                </div>
+
+                <div style={{ paddingLeft: 24 }}>
+                    <Checkbox
+                        label="Inherit view props"
+                        checked={inherit}
+                        onChange={(e) => setInherit(e.currentTarget.checked)}
+                        disabled={mode !== 'new-view'}
+                    />
+                </div>
+            </RadioGroup>
+        </DialogShell>
     );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/ObjectPickerDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ObjectPickerDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Dialog, DialogBody, DialogFooter, Radio, RadioGroup } from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Radio, RadioGroup } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 
 export interface ObjectPickerEntry {
   id: number;
@@ -19,9 +19,6 @@ interface Props {
  * two or more objects.
  */
 export function ObjectPickerDialog({ visible, objects, onResult }: Props): React.JSX.Element {
-  const { theme } = useTheme();
-  const isDark = theme === 'dark';
-
   const [selected, setSelected] = useState<number | null>(objects[0]?.id ?? null);
 
   // The provider reuses one component instance across invocations -- re-seed
@@ -31,38 +28,24 @@ export function ObjectPickerDialog({ visible, objects, onResult }: Props): React
   }, [visible, objects]);
 
   return (
-    <Dialog
-      isOpen={visible}
-      onClose={() => onResult(null)}
+    <DialogShell
+      visible={visible}
       title="Save Object As"
-      style={{ width: 400, paddingBottom: 0 }}
-      portalClassName={isDark ? 'bp5-dark' : ''}
+      width="xl"
+      onCancel={() => onResult(null)}
+      onOk={() => onResult(selected)}
+      okLabel={"Save As\u2026"}
+      okDisabled={selected === null}
     >
-      <DialogBody>
-        <RadioGroup
-          label="Select an object to save:"
-          selectedValue={selected ?? undefined}
-          onChange={(e) => setSelected(Number((e.target as HTMLInputElement).value))}
-        >
-          {objects.map((o) => (
-            <Radio key={o.id} label={o.name} value={o.id} />
-          ))}
-        </RadioGroup>
-      </DialogBody>
-      <DialogFooter
-        actions={
-          <>
-            <Button onClick={() => onResult(null)}>Cancel</Button>
-            <Button
-              intent="primary"
-              disabled={selected === null}
-              onClick={() => onResult(selected)}
-            >
-              Save As&hellip;
-            </Button>
-          </>
-        }
-      />
-    </Dialog>
+      <RadioGroup
+        label="Select an object to save:"
+        selectedValue={selected ?? undefined}
+        onChange={(e) => setSelected(Number((e.target as HTMLInputElement).value))}
+      >
+        {objects.map((o) => (
+          <Radio key={o.id} label={o.name} value={o.id} />
+        ))}
+      </RadioGroup>
+    </DialogShell>
   );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/QscWriterOptionDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/QscWriterOptionDialog.tsx
@@ -1,14 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    FormGroup,
-    HTMLSelect,
-    Switch,
-} from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { FormGroup, HTMLSelect, Switch } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 
 export type QscVersion = 'QDF0' | 'QDF1';
 export type QscCompress = 'xzip' | 'gzip' | 'none';
@@ -38,8 +30,6 @@ const COMPRESS_OPTIONS: { value: QscCompress; label: string }[] = [
 ];
 
 export function QscWriterOptionDialog({ visible, onConfirm, onCancel }: Props): React.JSX.Element {
-    const { theme } = useTheme();
-    const isDark = theme === 'dark';
 
     const [embedAll, setEmbedAll] = useState(false);
     const [version, setVersion] = useState<QscVersion>('QDF1');
@@ -79,60 +69,48 @@ export function QscWriterOptionDialog({ visible, onConfirm, onCancel }: Props): 
     };
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="Scene options"
-            style={{ width: 360 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="md"
+            onCancel={onCancel}
+            onOk={handleOk}
         >
-            <DialogBody>
-                <Switch
-                    label="Embed possible"
-                    checked={embedAll}
-                    onChange={(e) => setEmbedAll(e.currentTarget.checked)}
-                />
-
-                <fieldset style={{ marginTop: 8, padding: '8px 12px' }}>
-                    <legend style={{ padding: '0 4px' }}>Format</legend>
-
-                    <FormGroup label="Compatibility" inline>
-                        <HTMLSelect
-                            className="h3-form-select"
-                            value={version}
-                            onChange={(e) => setVersion(e.currentTarget.value as QscVersion)}
-                            options={VERSION_OPTIONS}
-                        />
-                    </FormGroup>
-
-                    <FormGroup label="Compression" inline disabled={advancedDisabled}>
-                        <HTMLSelect
-                            className="h3-form-select"
-                            value={compress}
-                            disabled={advancedDisabled}
-                            onChange={(e) => setCompress(e.currentTarget.value as QscCompress)}
-                            options={COMPRESS_OPTIONS}
-                        />
-                    </FormGroup>
-
-                    <Switch
-                        label="Enable text encoding"
-                        checked={base64}
-                        disabled={advancedDisabled}
-                        onChange={(e) => setBase64(e.currentTarget.checked)}
-                    />
-                </fieldset>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk}>OK</Button>
-                    </>
-                }
+            <Switch
+                label="Embed possible"
+                checked={embedAll}
+                onChange={(e) => setEmbedAll(e.currentTarget.checked)}
             />
-        </Dialog>
+
+            <fieldset style={{ marginTop: 8, padding: '8px 12px' }}>
+                <legend style={{ padding: '0 4px' }}>Format</legend>
+
+                <FormGroup label="Compatibility" inline>
+                    <HTMLSelect
+                        className="h3-form-select"
+                        value={version}
+                        onChange={(e) => setVersion(e.currentTarget.value as QscVersion)}
+                        options={VERSION_OPTIONS}
+                    />
+                </FormGroup>
+
+                <FormGroup label="Compression" inline disabled={advancedDisabled}>
+                    <HTMLSelect
+                        className="h3-form-select"
+                        value={compress}
+                        disabled={advancedDisabled}
+                        onChange={(e) => setCompress(e.currentTarget.value as QscCompress)}
+                        options={COMPRESS_OPTIONS}
+                    />
+                </FormGroup>
+
+                <Switch
+                    label="Enable text encoding"
+                    checked={base64}
+                    disabled={advancedDisabled}
+                    onChange={(e) => setBase64(e.currentTarget.checked)}
+                />
+            </fieldset>
+        </DialogShell>
     );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/StreamProgressDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/StreamProgressDialog.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
-import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    ProgressBar,
-} from '@blueprintjs/core';
-import { useTheme } from '../../contexts/ThemeContext';
+import { Button, ProgressBar } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 
 export type StreamProgressStatus = 'downloading' | 'canceling';
 
@@ -27,34 +21,27 @@ function formatBytes(n: number): string {
 export function StreamProgressDialog({
     visible, title, bytesReceived, status, onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme();
-    const isDark = theme === 'dark';
-
     return (
-        <Dialog
-            isOpen={visible}
+        <DialogShell
+            visible={visible}
             title={title}
-            style={{ width: 320 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
+            width="sm"
+            onCancel={onCancel}
+            // A download in flight has to be stopped, not dismissed: Escape
+            // would leave the transfer running behind a closed dialog.
             canEscapeKeyClose={false}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            footerActions={
+                <Button onClick={onCancel} disabled={status === 'canceling'}>
+                    Cancel
+                </Button>
+            }
         >
-            <DialogBody>
-                <ProgressBar intent="primary" />
-                <div style={{ marginTop: 8, color: 'var(--text-secondary)' }}>
-                    {status === 'canceling'
-                        ? 'Canceling…'
-                        : `Read ${formatBytes(bytesReceived)}`}
-                </div>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <Button onClick={onCancel} disabled={status === 'canceling'}>
-                        Cancel
-                    </Button>
-                }
-            />
-        </Dialog>
+            <ProgressBar intent="primary" />
+            <div style={{ color: 'var(--text-secondary)' }}>
+                {status === 'canceling'
+                    ? 'Canceling\u2026'
+                    : `Read ${formatBytes(bytesReceived)}`}
+            </div>
+        </DialogShell>
     );
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/TextPromptDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/TextPromptDialog.tsx
@@ -1,13 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    FormGroup,
-    InputGroup,
-} from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { FormGroup, InputGroup } from '@blueprintjs/core'
+import { DialogShell } from './DialogShell';
 
 /**
  * Single-line text input dialog -- replacement for Electron's disabled
@@ -36,8 +29,6 @@ export function TextPromptDialog({
     confirmLabel,
     onResult,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
     const inputRef = useRef<HTMLInputElement | null>(null)
     const [value, setValue] = useState(defaultValue)
 
@@ -69,40 +60,28 @@ export function TextPromptDialog({
     }
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={() => onResult(null)}
+        <DialogShell
+            visible={visible}
             title={title}
-            style={{ width: 360 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="md"
+            onCancel={() => onResult(null)}
+            onOk={handleOk}
+            okLabel={confirmLabel ?? 'OK'}
+            okDisabled={!canSubmit}
         >
-            <DialogBody>
-                <FormGroup label={label} labelFor="text-prompt-input">
-                    <InputGroup
-                        id="text-prompt-input"
-                        inputRef={(el) => {
-                            inputRef.current = el
-                        }}
-                        value={value}
-                        onChange={(e) => setValue(e.target.value)}
-                        onKeyDown={handleKeyDown}
-                        fill
-                        autoComplete="off"
-                    />
-                </FormGroup>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={() => onResult(null)}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk} disabled={!canSubmit}>
-                            {confirmLabel ?? 'OK'}
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+            <FormGroup label={label} labelFor="text-prompt-input">
+                <InputGroup
+                    id="text-prompt-input"
+                    inputRef={(el) => {
+                        inputRef.current = el
+                    }}
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    fill
+                    autoComplete="off"
+                />
+            </FormGroup>
+        </DialogShell>
     )
 }


### PR DESCRIPTION
## なぜ

`DialogShell` は「ダイアログの枠が何であるか」— portal の theme クラス、背景クリックで閉じない、ウィンドウ枠の X ボタンを出さない、幅の段、body ラッパ、footer — を所有するために存在しますが、**19 のダイアログがその枠を手書きで再実装**していました。同じ 5 つの prop と同じ `theme === 'dark' ? 'bp5-dark' : ''` を各々コピーしている状態です。

そのうち **11 を移しました**。

| commit | ダイアログ |
|---|---|
| `412c3900` | `ConfirmCloseTab` / `ConfirmReloadScene` / `ErrorAlert` / `ObjectPicker` / `About` / `StreamProgress` |
| `dd5efd59` | `GetPdb` / `NewTab` / `TextPrompt` / `QscWriterOption` / `EditCameraVisFlags` |

1 バッチ目は「本文が一文か単一コントロールで、枠がほぼ全てだったもの」、2 バッチ目は「エスケープハッチを 1 つも必要としない素直なケース」です。

## `DialogShell` に足した口は 2 つだけ

どちらも足す理由が個別にあり、prop の docstring にその理由を書いています。

- **`canEscapeKeyClose`** — 進行中のダウンロードは「中断」すべきで「消す」べきではない。Escape で閉じると転送が閉じたダイアログの裏で走り続けます
- **`plainBody`** — About はフォームではなく全幅の画像なので、共有の内側余白とセクション間 gap から外します

`ConfirmCloseTab`（3 択で Cancel/OK の対に収まらない）と `ErrorAlert`（1 ボタン + `autoFocus` で Enter 確定）は既存の `footerActions` をそのまま使いました。

## 挙動が 1 つ変わります

**`ErrorAlertDialog` は、アプリ内で唯一まだウィンドウ枠の X ボタンが出ていたダイアログ**でした。`canOutsideClickClose` は設定していたのに `isCloseButtonShown` を設定しておらず、一方でスタイルシートは以前から「どのダイアログにも X は無い」前提（`_dialog.css` のヘッダコメント）で書かれています。他と揃えました。

## その他

- インラインの px 幅（380 / 360 / 420）が `--dialog-w-*` の段に置き換わり、**枠で数値を選ぶ場所が消えました**
- `DialogShell` 自身が `ThemeContext` を読むのをやめ、#530 で kit に入れた `useDarkPortalClass` を使うようにしました

## 残り 8 ダイアログ

`NewRenderer` と `FileOpenOption` は `fod-dialog` / `fod-body` クラスを共有しているので、「ダイアログが自分の枠クラスを名乗る」口を足して一緒に移します（前者は形としては素直なのに、これだけの理由で残しました）。他に `StyleEditor`（Blueprint `Tabs`）、`ApplyRendStyle` / `CreateRendStyle` / `EditInteractionList` / `ExportPngOptions` / `SymmetryChange`。

## 検証

- typecheck (web + node) OK
- vitest **361 files / 3419 tests all pass**
- parity test `dialogOutsideClick.test.tsx` を **16 → 23 ケース**に拡張。手書きだった個別チェックは shell 契約を pin するブロックに吸収し、幅が「トークンの段であって数値でないこと」も押さえています。新設の 2 つの口（`canEscapeKeyClose` / `plainBody`）も個別に pin
- ESLint **0 errors / 75 warnings**（ベースライン）、stylelint 14（ベースライン）、lint:comments OK
- `task build_tritium` OK / `task run_tritium` で `shader program created OK` まで到達

**目視確認のお願い**: 移した 11 ダイアログを dark / light 両方で開き、幅・余白・ボタン配置が従来どおりか。特に **About の画像が全幅のままか**、**ダウンロード中に Escape が効かないか**、**エラーダイアログに X が出なくなったこと**を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jq8nSHJWsEpfSui98LTXR
