### PR TITLE
refactor(react-gui): finish moving every dialog onto the shared shell (Phase 3-2)

### DIFF
--- a/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/dialogOutsideClick.test.tsx
@@ -13,6 +13,10 @@
  * dialog's outer JSX is exercised (its hooks/state run) but the body
  * children never mount. We assert the captured props on the recorded
  * call.
+ *
+ * Every dialog in the app now renders its frame through DialogShell, so
+ * there is one block: if the shell stops forwarding any of these, all of
+ * them regress here at once.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -67,42 +71,12 @@ function lastDialogProps(): Record<string, unknown> {
   return dialogPropsList[dialogPropsList.length - 1]
 }
 
-describe('Modal dialog: backdrop click + close button are disabled', () => {
-  beforeEach(() => {
-    dialogPropsList.length = 0
-  })
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  it('FileOpenOptionDialog passes canOutsideClickClose={false}', () => {
-    const handle = mountTree(
-      React.createElement(FileOpenOptionDialog, {
-        visible: true,
-        filePath: '/tmp/foo.pdb',
-        sceneId: 0,
-        rendererTypes: ['*default'],
-        objType: '',
-        readerName: 'pdb',
-        onConfirm: () => {},
-        onCancel: () => {},
-      }),
-    )
-    expect(lastDialogProps().canOutsideClickClose).toBe(false)
-    expect(lastDialogProps().isCloseButtonShown).toBe(false)
-    handle.unmount()
-  })
-})
-
 /**
- * The 9 molecule-edit dialogs render their frame through the shared
- * `DialogShell`. This block pins the DialogShell-owned frame contract on
- * each of them (not just the two boolean props above, but also the
- * light-theme `portalClassName === ''` value -- NOT `undefined` -- the
- * title, and a token-driven `style.width`). It guards the shell extraction:
- * if DialogShell stops forwarding any of these, every dialog regresses here.
+ * Pins the DialogShell-owned frame contract on every dialog: the two boolean
+ * props, the light-theme `portalClassName === ''` value (NOT `undefined`), the
+ * title, and a `style.width` that is a token rung rather than a number.
  */
-describe('Molecule-edit dialogs: DialogShell frame contract', () => {
+describe('DialogShell frame contract', () => {
   beforeEach(() => {
     dialogPropsList.length = 0
   })
@@ -247,6 +221,15 @@ describe('Molecule-edit dialogs: DialogShell frame contract', () => {
       title: 'Edit visibility flags: cam1',
       render: () => React.createElement(EditCameraVisFlagsDialog, {
         visible: true, cameraName: 'cam1', entries: [], onConfirm: () => {}, onCancel: () => {},
+      }),
+    },
+    {
+      name: 'FileOpenOptionDialog',
+      title: 'Open File Options',
+      render: () => React.createElement(FileOpenOptionDialog, {
+        visible: true, filePath: '/tmp/foo.pdb', sceneId: 0,
+        rendererTypes: ['*default'], objType: '', readerName: 'pdb',
+        onConfirm: () => {}, onCancel: () => {},
       }),
     },
     {

--- a/tritium/react-gui/src/renderer/components/dialogs/AboutDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/AboutDialog.tsx
@@ -31,7 +31,7 @@ export function AboutDialog({ visible, onClose }: Props): React.JSX.Element {
       onCancel={onClose}
       // A splash image bled to the frame edge, not a form: the shared gutter
       // and section gap would inset it.
-      plainBody
+      bodyClassName="h3-dialog-plain-body"
       footerActions={<Button intent="primary" onClick={onClose}>OK</Button>}
     >
       <>

--- a/tritium/react-gui/src/renderer/components/dialogs/ApplyRendStyleDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ApplyRendStyleDialog.tsx
@@ -1,18 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import {
-    Button,
-    ButtonGroup,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    Divider,
-    Menu,
-    MenuDivider,
-    MenuItem,
-    Popover,
-} from '@blueprintjs/core'
+import { Button, ButtonGroup, Divider, Menu, MenuDivider, MenuItem, Popover } from '@blueprintjs/core'
 import { AppIcon } from '@renderer/h3-kit/primitives'
-import { useTheme } from '../../contexts/ThemeContext'
+import { DialogShell } from './DialogShell';
 
 /**
  * "Edit Renderer Style" dialog -- UXP `apply_rend_style.xul` /
@@ -66,8 +55,6 @@ export function ApplyRendStyleDialog({
     onConfirm,
     onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
 
     const [styles, setStyles] = useState<string[]>(() => [...initialStyles])
     const [selectedIdx, setSelectedIdx] = useState<number>(
@@ -170,135 +157,118 @@ export function ApplyRendStyleDialog({
     )
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="Apply Renderer Style"
-            style={{ width: 420 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="2xl"
+            onCancel={onCancel}
+            onOk={() => onConfirm({ styleNames: styles })}
         >
-            <DialogBody>
-                <div style={{ marginBottom: 8 }}>
-                    <strong>Renderer: </strong>
-                    {rendName} ({rendTypeName})
-                </div>
+            <div style={{ marginBottom: 8 }}>
+                <strong>Renderer: </strong>
+                {rendName} ({rendTypeName})
+            </div>
 
-                <div style={{ marginBottom: 4 }}>Styles:</div>
-                <div
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                        fontSize: 'var(--fs-base)',
-                        color: 'var(--text-secondary)',
-                    }}
-                >
-                    (low priority)
-                </div>
-                <div
-                    role="listbox"
-                    aria-label="Applied styles"
-                    style={{
-                        border: '1px solid var(--border)',
-                        borderRadius: 3,
-                        minHeight: 120,
-                        maxHeight: 220,
-                        overflowY: 'auto',
-                        padding: 2,
-                        background: 'var(--bg-surface)',
-                    }}
-                >
-                    {styles.length === 0 ? (
+            <div style={{ marginBottom: 4 }}>Styles:</div>
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    fontSize: 'var(--fs-base)',
+                    color: 'var(--text-secondary)',
+                }}
+            >
+                (low priority)
+            </div>
+            <div
+                role="listbox"
+                aria-label="Applied styles"
+                style={{
+                    border: '1px solid var(--border)',
+                    borderRadius: 3,
+                    minHeight: 120,
+                    maxHeight: 220,
+                    overflowY: 'auto',
+                    padding: 2,
+                    background: 'var(--bg-surface)',
+                }}
+            >
+                {styles.length === 0 ? (
+                    <div
+                        style={{
+                            padding: '8px 4px',
+                            color: 'var(--text-secondary)',
+                            fontStyle: 'italic',
+                        }}
+                    >
+                        (no styles applied)
+                    </div>
+                ) : (
+                    styles.map((name, idx) => (
                         <div
+                            key={`${name}-${idx}`}
+                            role="option"
+                            aria-selected={idx === selectedIdx}
+                            onClick={() => setSelectedIdx(idx)}
                             style={{
-                                padding: '8px 4px',
-                                color: 'var(--text-secondary)',
-                                fontStyle: 'italic',
+                                padding: '3px 6px',
+                                cursor: 'pointer',
+                                background:
+                                    idx === selectedIdx
+                                        ? 'var(--accent)'
+                                        : 'transparent',
+                                color:
+                                    idx === selectedIdx
+                                        ? 'white'
+                                        : 'var(--text-primary)',
+                                borderRadius: 2,
                             }}
                         >
-                            (no styles applied)
+                            {name}
                         </div>
-                    ) : (
-                        styles.map((name, idx) => (
-                            <div
-                                key={`${name}-${idx}`}
-                                role="option"
-                                aria-selected={idx === selectedIdx}
-                                onClick={() => setSelectedIdx(idx)}
-                                style={{
-                                    padding: '3px 6px',
-                                    cursor: 'pointer',
-                                    background:
-                                        idx === selectedIdx
-                                            ? 'var(--accent)'
-                                            : 'transparent',
-                                    color:
-                                        idx === selectedIdx
-                                            ? 'white'
-                                            : 'var(--text-primary)',
-                                    borderRadius: 2,
-                                }}
-                            >
-                                {name}
-                            </div>
-                        ))
-                    )}
-                </div>
-                <div
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                        fontSize: 'var(--fs-base)',
-                        color: 'var(--text-secondary)',
-                    }}
-                >
-                    (high priority)
-                </div>
+                    ))
+                )}
+            </div>
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'flex-end',
+                    fontSize: 'var(--fs-base)',
+                    color: 'var(--text-secondary)',
+                }}
+            >
+                (high priority)
+            </div>
 
-                <Divider style={{ margin: '8px 0' }} />
+            <Divider style={{ margin: '8px 0' }} />
 
-                <ButtonGroup>
-                    <Popover content={addMenu} placement="bottom-start">
-                        <Button
-                            icon={<AppIcon name="ui.add" aria-hidden />}
-                            text="Add"
-                            disabled={totalAvailable === 0}
-                        />
-                    </Popover>
+            <ButtonGroup>
+                <Popover content={addMenu} placement="bottom-start">
                     <Button
-                        icon={<AppIcon name="ui.trash" aria-hidden />}
-                        text="Delete"
-                        disabled={!canDelete}
-                        onClick={handleDelete}
+                        icon={<AppIcon name="ui.add" aria-hidden />}
+                        text="Add"
+                        disabled={totalAvailable === 0}
                     />
-                    <Button
-                        icon={<AppIcon name="ui.caretUp" aria-hidden />}
-                        text="Up"
-                        disabled={!canMoveUp}
-                        onClick={() => handleMove(-1)}
-                    />
-                    <Button
-                        icon={<AppIcon name="ui.caretDown" aria-hidden />}
-                        text="Down"
-                        disabled={!canMoveDown}
-                        onClick={() => handleMove(1)}
-                    />
-                </ButtonGroup>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button
-                            intent="primary"
-                            onClick={() => onConfirm({ styleNames: styles })}
-                        >
-                            OK
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                </Popover>
+                <Button
+                    icon={<AppIcon name="ui.trash" aria-hidden />}
+                    text="Delete"
+                    disabled={!canDelete}
+                    onClick={handleDelete}
+                />
+                <Button
+                    icon={<AppIcon name="ui.caretUp" aria-hidden />}
+                    text="Up"
+                    disabled={!canMoveUp}
+                    onClick={() => handleMove(-1)}
+                />
+                <Button
+                    icon={<AppIcon name="ui.caretDown" aria-hidden />}
+                    text="Down"
+                    disabled={!canMoveDown}
+                    onClick={() => handleMove(1)}
+                />
+            </ButtonGroup>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/ChangeChainIdDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ChangeChainIdDialog.tsx
@@ -15,7 +15,7 @@
 
 import React, { useCallback, useRef, useState } from 'react'
 import { Alert } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { useDarkPortalClass } from '@renderer/h3-kit/primitives'
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
 import { useMolEditCommit } from '@renderer/hooks/cuemol/useMolEditCommit'
 import { FieldSection, TextField } from '../../h3-kit/form'
@@ -40,8 +40,8 @@ interface Props {
 export function ChangeChainIdDialog({
     visible, sceneId, onConfirm, onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
+    // The confirm Alert is its own portal, so it needs the theme class too.
+    const portalClassName = useDarkPortalClass()
     const { cm } = useCueMol()
 
     const [objId, setObjId] = useState<number | undefined>(undefined)
@@ -139,7 +139,7 @@ export function ChangeChainIdDialog({
                     intent="primary"
                     confirmButtonText="Yes"
                     cancelButtonText="No"
-                    className={isDark ? 'bp5-dark' : undefined}
+                    className={portalClassName}
                     onConfirm={() => {
                         const p = pendingCommit
                         setPendingCommit(null)

--- a/tritium/react-gui/src/renderer/components/dialogs/ChangeResidueIndexDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ChangeResidueIndexDialog.tsx
@@ -17,7 +17,7 @@
 
 import React, { useCallback, useRef, useState } from 'react'
 import { Alert } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { useDarkPortalClass } from '@renderer/h3-kit/primitives'
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
 import { useMolEditCommit } from '@renderer/hooks/cuemol/useMolEditCommit'
 import { Field, FieldSection, SegmentField, SwitchField, TextField } from '../../h3-kit/form'
@@ -47,8 +47,8 @@ const MODE_OPTIONS: { label: string; value: ResIndexMode }[] = [
 export function ChangeResidueIndexDialog({
     visible, sceneId, onConfirm, onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
+    // The confirm Alert is its own portal, so it needs the theme class too.
+    const portalClassName = useDarkPortalClass()
     const { cm } = useCueMol()
 
     const [objId, setObjId] = useState<number | undefined>(undefined)
@@ -135,7 +135,7 @@ export function ChangeResidueIndexDialog({
                     intent="primary"
                     confirmButtonText="Yes"
                     cancelButtonText="No"
-                    className={isDark ? 'bp5-dark' : undefined}
+                    className={portalClassName}
                     onConfirm={() => {
                         const p = pendingCommit
                         setPendingCommit(null)

--- a/tritium/react-gui/src/renderer/components/dialogs/CreateRendStyleDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/CreateRendStyleDialog.tsx
@@ -1,13 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
-import {
-    Button,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    FormGroup,
-    InputGroup,
-} from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { FormGroup, InputGroup } from '@blueprintjs/core'
+import { DialogShell } from './DialogShell';
 
 /**
  * "Create Renderer Style" dialog -- UXP `rendstyle_create.xul` /
@@ -51,8 +44,6 @@ export function CreateRendStyleDialog({
     onConfirm,
     onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
     const inputRef = useRef<HTMLInputElement | null>(null)
     const [selUid, setSelUid] = useState<number>(defaultSelectedUid)
     const [name, setName] = useState<string>('')
@@ -84,111 +75,98 @@ export function CreateRendStyleDialog({
     }
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="Create Renderer Style"
-            style={{ width: 380 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="lg"
+            onCancel={onCancel}
+            onOk={handleOk}
+            okDisabled={!canSubmit}
         >
-            <DialogBody>
-                <div style={{ marginBottom: 8 }}>
-                    <strong>Original rend: </strong>
-                    {rendName} ({rendTypeName})
-                </div>
+            <div style={{ marginBottom: 8 }}>
+                <strong>Original rend: </strong>
+                {rendName} ({rendTypeName})
+            </div>
 
-                <FormGroup label="Target Style set:" labelFor="create-style-set-list">
-                    <div
-                        id="create-style-set-list"
-                        role="listbox"
-                        aria-label="Style sets"
-                        style={{
-                            border: '1px solid var(--border)',
-                            borderRadius: 3,
-                            minHeight: 100,
-                            maxHeight: 180,
-                            overflowY: 'auto',
-                            padding: 2,
-                            background: 'var(--bg-surface)',
-                        }}
-                    >
-                        {styleSets.length === 0 ? (
-                            <div
-                                style={{
-                                    padding: '8px 4px',
-                                    color: 'var(--text-secondary)',
-                                    fontStyle: 'italic',
-                                }}
-                            >
-                                (no writable style sets)
-                            </div>
-                        ) : (
-                            styleSets.map((s) => {
-                                const label = s.name === '' ? '(anonymous)' : s.name
-                                const selected = s.uid === selUid
-                                return (
-                                    <div
-                                        key={s.uid}
-                                        role="option"
-                                        aria-selected={selected}
-                                        onClick={() => setSelUid(s.uid)}
-                                        style={{
-                                            padding: '3px 6px',
-                                            cursor: 'pointer',
-                                            background: selected
-                                                ? 'var(--accent)'
-                                                : 'transparent',
-                                            color: selected
-                                                ? 'white'
-                                                : 'var(--text-primary)',
-                                            borderRadius: 2,
-                                        }}
-                                    >
-                                        {label}
-                                    </div>
-                                )
-                            })
-                        )}
-                    </div>
-                </FormGroup>
-
-                <FormGroup label="Style name:" labelFor="create-style-name">
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                        <InputGroup
-                            id="create-style-name"
-                            inputRef={(el) => {
-                                inputRef.current = el
-                            }}
-                            value={name}
-                            onChange={(e) => setName(e.target.value)}
-                            onKeyDown={handleKeyDown}
-                            fill
-                            autoComplete="off"
-                            placeholder="base name"
-                        />
-                        <span
+            <FormGroup label="Target Style set:" labelFor="create-style-set-list">
+                <div
+                    id="create-style-set-list"
+                    role="listbox"
+                    aria-label="Style sets"
+                    style={{
+                        border: '1px solid var(--border)',
+                        borderRadius: 3,
+                        minHeight: 100,
+                        maxHeight: 180,
+                        overflowY: 'auto',
+                        padding: 2,
+                        background: 'var(--bg-surface)',
+                    }}
+                >
+                    {styleSets.length === 0 ? (
+                        <div
                             style={{
+                                padding: '8px 4px',
                                 color: 'var(--text-secondary)',
-                                whiteSpace: 'nowrap',
+                                fontStyle: 'italic',
                             }}
                         >
-                            {rendTypeName}
-                        </span>
-                    </div>
-                </FormGroup>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk} disabled={!canSubmit}>
-                            OK
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                            (no writable style sets)
+                        </div>
+                    ) : (
+                        styleSets.map((s) => {
+                            const label = s.name === '' ? '(anonymous)' : s.name
+                            const selected = s.uid === selUid
+                            return (
+                                <div
+                                    key={s.uid}
+                                    role="option"
+                                    aria-selected={selected}
+                                    onClick={() => setSelUid(s.uid)}
+                                    style={{
+                                        padding: '3px 6px',
+                                        cursor: 'pointer',
+                                        background: selected
+                                            ? 'var(--accent)'
+                                            : 'transparent',
+                                        color: selected
+                                            ? 'white'
+                                            : 'var(--text-primary)',
+                                        borderRadius: 2,
+                                    }}
+                                >
+                                    {label}
+                                </div>
+                            )
+                        })
+                    )}
+                </div>
+            </FormGroup>
+
+            <FormGroup label="Style name:" labelFor="create-style-name">
+                <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                    <InputGroup
+                        id="create-style-name"
+                        inputRef={(el) => {
+                            inputRef.current = el
+                        }}
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        fill
+                        autoComplete="off"
+                        placeholder="base name"
+                    />
+                    <span
+                        style={{
+                            color: 'var(--text-secondary)',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        {rendTypeName}
+                    </span>
+                </div>
+            </FormGroup>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/DialogShell.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/DialogShell.tsx
@@ -30,7 +30,7 @@ import { useDarkPortalClass } from '@renderer/h3-kit/primitives'
  */
 export type DialogWidth =
     | 'xs' | 'sm' | 'md' | 'lg' | 'xl'
-    | '2xl' | '3xl' | '4xl' | '5xl'
+    | '2xl' | '3xl' | '4xl' | '5xl' | '6xl'
 
 const WIDTH_VAR: Record<DialogWidth, string> = {
     xs: 'var(--dialog-w-xs)',
@@ -42,6 +42,7 @@ const WIDTH_VAR: Record<DialogWidth, string> = {
     '3xl': 'var(--dialog-w-3xl)',
     '4xl': 'var(--dialog-w-4xl)',
     '5xl': 'var(--dialog-w-5xl)',
+    '6xl': 'var(--dialog-w-6xl)',
 }
 
 export interface DialogShellProps {
@@ -89,14 +90,20 @@ export interface DialogShellProps {
      * out is its own action.
      */
     canEscapeKeyClose?: boolean
+    /** Extra class on the dialog frame, for a dialog with chrome of its own. */
+    className?: string
     /**
-     * The body lays itself out: no padding and no `.h3-dialog-form` column.
-     * For content that is not a form -- the About splash is a full-bleed image
-     * -- where the shared gap and gutter would box it in. The frame concerns
-     * (portal class, outside click, close button, width) still apply, which is
-     * the reason to be here at all.
+     * Replaces the shared body wrapper: the dialog lays its own body out, and
+     * this class says how. For content that is not a form -- the About splash
+     * bleeds an image to the frame edge, the file-open dialogs draw their own
+     * banded sections -- where the `.h3-dialog-form` column's gutter and gap
+     * would box it in. The frame concerns (portal class, outside click, close
+     * button, width) still apply, which is the reason to be here at all.
+     *
+     * `errorMsg` renders only inside the shared wrapper, so a dialog using this
+     * owns its own error line too.
      */
-    plainBody?: boolean
+    bodyClassName?: string
 }
 
 /**
@@ -121,7 +128,8 @@ export function DialogShell({
     footerActions,
     extra,
     canEscapeKeyClose = true,
-    plainBody = false,
+    className,
+    bodyClassName,
 }: DialogShellProps): React.JSX.Element {
     const portalClassName = useDarkPortalClass()
 
@@ -130,14 +138,15 @@ export function DialogShell({
             isOpen={visible}
             onClose={onCancel}
             title={title}
+            className={className}
             style={{ width: WIDTH_VAR[width] }}
             portalClassName={portalClassName}
             canOutsideClickClose={false}
             canEscapeKeyClose={canEscapeKeyClose}
             isCloseButtonShown={false}
         >
-            {plainBody ? (
-                <DialogBody style={{ padding: 0 }}>{children}</DialogBody>
+            {bodyClassName !== undefined ? (
+                <DialogBody className={bodyClassName}>{children}</DialogBody>
             ) : (
                 <DialogBody>
                     <div className="h3-dialog-form">

--- a/tritium/react-gui/src/renderer/components/dialogs/EditInteractionListDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/EditInteractionListDialog.tsx
@@ -7,8 +7,8 @@
  */
 
 import React, { useEffect, useState } from 'react'
-import { Dialog, DialogBody, DialogFooter, Button } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { Button } from '@blueprintjs/core';
+import { DialogShell } from './DialogShell';
 import { AppIcon } from '@renderer/h3-kit/primitives'
 import type { AtomIntrDefEntry } from '../../worker/server/services/atomIntrEdit.service'
 
@@ -34,8 +34,6 @@ export function EditInteractionListDialog({
     onConfirm,
     onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
 
     // Working copy of remaining rows, re-seeded on each open.
     const [rows, setRows] = useState<AtomIntrDefEntry[]>(() => entries.map((e) => ({ ...e })))
@@ -52,66 +50,52 @@ export function EditInteractionListDialog({
     }
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title={`Edit interaction list: ${rendName}`}
-            style={{ width: 460 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="4xl"
+            onCancel={onCancel}
+            onOk={handleOk}
         >
-            <DialogBody>
-                <div
-                    role="table"
-                    aria-label="Interaction definitions"
-                    style={{
-                        border: '1px solid var(--border)',
-                        borderRadius: 3,
-                        maxHeight: 320,
-                        overflowY: 'auto',
-                        background: 'var(--bg-surface)',
-                    }}
-                >
-                    {rows.length === 0 ? (
-                        <div style={{ padding: 8, color: 'var(--text-secondary)', fontStyle: 'italic' }}>
-                            (no interactions)
+            <div
+                role="table"
+                aria-label="Interaction definitions"
+                style={{
+                    border: '1px solid var(--border)',
+                    borderRadius: 3,
+                    maxHeight: 320,
+                    overflowY: 'auto',
+                    background: 'var(--bg-surface)',
+                }}
+            >
+                {rows.length === 0 ? (
+                    <div style={{ padding: 8, color: 'var(--text-secondary)', fontStyle: 'italic' }}>
+                        (no interactions)
+                    </div>
+                ) : (
+                    rows.map((r) => (
+                        <div
+                            role="row"
+                            key={r.id}
+                            style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 8px' }}
+                        >
+                            <span style={{ width: 64, color: 'var(--text-secondary)' }}>
+                                {MODE_LABEL[r.mode] ?? '?'}
+                            </span>
+                            <span style={{ flex: 1, fontFamily: 'var(--font-mono)' }}>
+                                {r.atoms.join('  -  ')}
+                            </span>
+                            <Button
+                                minimal
+                                small
+                                aria-label={`Delete interaction ${r.id}`}
+                                icon={<AppIcon name="ui.remove" size="md" aria-hidden />}
+                                onClick={() => removeRow(r.id)}
+                            />
                         </div>
-                    ) : (
-                        rows.map((r) => (
-                            <div
-                                role="row"
-                                key={r.id}
-                                style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '2px 8px' }}
-                            >
-                                <span style={{ width: 64, color: 'var(--text-secondary)' }}>
-                                    {MODE_LABEL[r.mode] ?? '?'}
-                                </span>
-                                <span style={{ flex: 1, fontFamily: 'var(--font-mono)' }}>
-                                    {r.atoms.join('  -  ')}
-                                </span>
-                                <Button
-                                    minimal
-                                    small
-                                    aria-label={`Delete interaction ${r.id}`}
-                                    icon={<AppIcon name="ui.remove" size="md" aria-hidden />}
-                                    onClick={() => removeRow(r.id)}
-                                />
-                            </div>
-                        ))
-                    )}
-                </div>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk}>
-                            OK
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                    ))
+                )}
+            </div>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/ExportPngOptionsDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/ExportPngOptionsDialog.tsx
@@ -16,8 +16,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Button, Dialog, DialogBody, DialogFooter } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { DialogShell } from './DialogShell';
 import { Field, FieldSection, NumericField, SelectField, SwitchField } from '../../h3-kit/form'
 import {
     DPI_OPTIONS,
@@ -53,8 +52,6 @@ const UNIT_OPTIONS: { value: PngUnit; label: string }[] = [
 export function ExportPngOptionsDialog({
     visible, initialWidth, initialHeight, onConfirm, onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
 
     // Pixels are the source of truth.
     const [pxW, setPxW] = useState(initialWidth)
@@ -110,88 +107,69 @@ export function ExportPngOptionsDialog({
     const stepForUnit = unit === 'px' ? 1 : 0.1
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="PNG options"
-            style={{ width: 360 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="md"
+            onCancel={onCancel}
+            onOk={handleOk}
+            okDisabled={pxW <= 0 || pxH <= 0}
         >
-            <DialogBody>
-                <div className="h3-dialog-form">
-                    <FieldSection title="Image size">
-                        <Field label="Resolution (DPI)">
-                            <SelectField
-                                value={String(dpi)}
-                                onChange={(v) => setDpi(Number(v))}
-                            >
-                                {DPI_OPTIONS.map((d) => (
-                                    <option key={d} value={d}>{d}</option>
-                                ))}
-                            </SelectField>
-                        </Field>
-                        <Field label="Unit">
-                            <SelectField
-                                value={unit}
-                                onChange={(v) => setUnit(v as PngUnit)}
-                            >
-                                {UNIT_OPTIONS.map((u) => (
-                                    <option key={u.value} value={u.value}>{u.label}</option>
-                                ))}
-                            </SelectField>
-                        </Field>
-                        <Field label="Width">
-                            <NumericField
-                                value={widthDisplay}
-                                onChange={handleWidth}
-                                min={0}
-                                max={100000}
-                                step={stepForUnit}
-                                slider={false}
-                            />
-                        </Field>
-                        <Field label="Height">
-                            <NumericField
-                                value={heightDisplay}
-                                onChange={handleHeight}
-                                min={0}
-                                max={100000}
-                                step={stepForUnit}
-                                slider={false}
-                                disabled={retainAspect}
-                            />
-                        </Field>
-                        <Field label="Retain aspect ratio" inline>
-                            <SwitchField checked={retainAspect} onChange={handleRetain} />
-                        </Field>
-                    </FieldSection>
-
-                    <FieldSection title="Output">
-                        <Field label={`Pixel size: ${pxW} x ${pxH}`}>
-                            <span />
-                        </Field>
-                        <Field label="Transparent PNG" inline>
-                            <SwitchField checked={alpha} onChange={setAlpha} />
-                        </Field>
-                    </FieldSection>
-                </div>
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button
-                            intent="primary"
-                            onClick={handleOk}
-                            disabled={pxW <= 0 || pxH <= 0}
+                <FieldSection title="Image size">
+                    <Field label="Resolution (DPI)">
+                        <SelectField
+                            value={String(dpi)}
+                            onChange={(v) => setDpi(Number(v))}
                         >
-                            OK
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                            {DPI_OPTIONS.map((d) => (
+                                <option key={d} value={d}>{d}</option>
+                            ))}
+                        </SelectField>
+                    </Field>
+                    <Field label="Unit">
+                        <SelectField
+                            value={unit}
+                            onChange={(v) => setUnit(v as PngUnit)}
+                        >
+                            {UNIT_OPTIONS.map((u) => (
+                                <option key={u.value} value={u.value}>{u.label}</option>
+                            ))}
+                        </SelectField>
+                    </Field>
+                    <Field label="Width">
+                        <NumericField
+                            value={widthDisplay}
+                            onChange={handleWidth}
+                            min={0}
+                            max={100000}
+                            step={stepForUnit}
+                            slider={false}
+                        />
+                    </Field>
+                    <Field label="Height">
+                        <NumericField
+                            value={heightDisplay}
+                            onChange={handleHeight}
+                            min={0}
+                            max={100000}
+                            step={stepForUnit}
+                            slider={false}
+                            disabled={retainAspect}
+                        />
+                    </Field>
+                    <Field label="Retain aspect ratio" inline>
+                        <SwitchField checked={retainAspect} onChange={handleRetain} />
+                    </Field>
+                </FieldSection>
+
+                <FieldSection title="Output">
+                    <Field label={`Pixel size: ${pxW} x ${pxH}`}>
+                        <span />
+                    </Field>
+                    <Field label="Transparent PNG" inline>
+                        <SwitchField checked={alpha} onChange={setAlpha} />
+                    </Field>
+                </FieldSection>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/NewRendererDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/NewRendererDialog.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Button, Dialog, DialogBody, DialogFooter } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { DialogShell } from './DialogShell'
 import { RendererOptionsPane } from '../fopen-opt-dlgs/panes/RendererOptionsPane'
 import { useRendererOptions } from '../fopen-opt-dlgs/useRendererOptions'
 import type { PresetTypeEntry, RendererOptions } from '../fopen-opt-dlgs/types'
@@ -62,8 +61,6 @@ export function NewRendererDialog({
     onConfirm,
     onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
 
     const { options, setOptions, onRendererNameUserEdit, commitHistory } =
         useRendererOptions({
@@ -98,16 +95,17 @@ export function NewRendererDialog({
         : 'New Renderer'
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title={title}
+            width="6xl"
+            onCancel={onCancel}
+            onOk={handleOk}
+            okLabel="Create"
+            okDisabled={!canSubmit}
             className="fod-dialog"
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            bodyClassName="fod-body"
         >
-            <DialogBody className="fod-body">
                 <div className="fod-file-info">
                     <span className="fod-file-name" title={objName}>{objName || '(no object)'}</span>
                     {objClassName && (
@@ -124,17 +122,6 @@ export function NewRendererDialog({
                     isMolFormat={isMol}
                     onRendererNameUserEdit={onRendererNameUserEdit}
                 />
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel}>Cancel</Button>
-                        <Button intent="primary" onClick={handleOk} disabled={!canSubmit}>
-                            Create
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/StyleEditorDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/StyleEditorDialog.tsx
@@ -9,8 +9,8 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react'
-import { Dialog, DialogBody, DialogFooter, Button, Tabs, Tab, InputGroup } from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { Button, Tabs, Tab, InputGroup } from '@blueprintjs/core'
+import { DialogShell } from './DialogShell';
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
 import { ColorPickerProvider } from '@renderer/h3-kit/colorpicker'
 import { ColorField } from '../../h3-kit/form'
@@ -71,8 +71,6 @@ export function StyleEditorDialog({
     styleName,
     onClose,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
     const { cm } = useCueMol()
 
     const [contents, setContents] = useState<GetStyleSetContentsResult | null>(null)
@@ -230,36 +228,33 @@ export function StyleEditorDialog({
     )
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onClose}
+        <DialogShell
+            visible={visible}
             title={`Style editor: ${styleName}`}
-            style={{ width: 500 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="5xl"
+            onCancel={onClose}
+            // Nothing to commit: the tabs write as they are edited, so the one
+            // button dismisses rather than confirming.
+            footerActions={
+                <Button intent="primary" onClick={onClose}>
+                    Close
+                </Button>
+            }
         >
+            {/* Only the body reads the picker context; the footer does not, so
+                the provider does not have to straddle the frame. */}
             <ColorPickerProvider cm={cm} sceneId={sceneId}>
-                <DialogBody>
-                    {ro && (
-                        <div style={{ color: 'var(--text-secondary)', marginBottom: 8 }}>
-                            (read-only style set)
-                        </div>
-                    )}
-                    <Tabs id="style-editor-tabs" selectedTabId={tab} onChange={(t) => setTab(String(t))}>
-                        <Tab id="color" title="Color" panel={colorPanel} />
-                        <Tab id="selection" title="Selection" panel={selPanel} />
-                        <Tab id="styles" title="Styles" panel={stylePanel} />
-                    </Tabs>
-                </DialogBody>
-                <DialogFooter
-                    actions={
-                        <Button intent="primary" onClick={onClose}>
-                            Close
-                        </Button>
-                    }
-                />
+                {ro && (
+                    <div style={{ color: 'var(--text-secondary)', marginBottom: 8 }}>
+                        (read-only style set)
+                    </div>
+                )}
+                <Tabs id="style-editor-tabs" selectedTabId={tab} onChange={(t) => setTab(String(t))}>
+                    <Tab id="color" title="Color" panel={colorPanel} />
+                    <Tab id="selection" title="Selection" panel={selPanel} />
+                    <Tab id="styles" title="Styles" panel={stylePanel} />
+                </Tabs>
             </ColorPickerProvider>
-        </Dialog>
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/dialogs/SymmetryChangeDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/dialogs/SymmetryChangeDialog.tsx
@@ -14,18 +14,8 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react'
-import {
-    Button,
-    Checkbox,
-    Dialog,
-    DialogBody,
-    DialogFooter,
-    FormGroup,
-    HTMLSelect,
-    InputGroup,
-    NumericInput,
-} from '@blueprintjs/core'
-import { useTheme } from '../../contexts/ThemeContext'
+import { Checkbox, FormGroup, HTMLSelect, InputGroup, NumericInput } from '@blueprintjs/core'
+import { DialogShell } from './DialogShell';
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
 import type {
     SpaceGroupEntry,
@@ -163,8 +153,6 @@ const DEFAULT_INFO: SymmetryInfo = {
 export function SymmetryChangeDialog({
     visible, sceneId, objId, onConfirm, onCancel,
 }: Props): React.JSX.Element {
-    const { theme } = useTheme()
-    const isDark = theme === 'dark'
     const { cm } = useCueMol()
 
     const [lattice, setLattice] = useState<CrystalSystem>('TRICLINIC')
@@ -332,96 +320,79 @@ export function SymmetryChangeDialog({
     const ready = loaded && sgItems.length > 0
 
     return (
-        <Dialog
-            isOpen={visible}
-            onClose={onCancel}
+        <DialogShell
+            visible={visible}
             title="Symmetry"
-            style={{ width: 440 }}
-            portalClassName={isDark ? 'bp5-dark' : ''}
-            canOutsideClickClose={false}
-            isCloseButtonShown={false}
+            width="3xl"
+            onCancel={onCancel}
+            onOk={handleOk}
+            okDisabled={!ready}
+            submitting={submitting}
         >
-            <DialogBody>
-                <fieldset style={{ padding: '8px 12px', marginBottom: 12 }}>
-                    <legend style={{ padding: '0 4px' }}>Symmetry</legend>
+            <fieldset style={{ padding: '8px 12px', marginBottom: 12 }}>
+                <legend style={{ padding: '0 4px' }}>Symmetry</legend>
 
-                    <FormGroup label="Crystal system:" inline>
-                        <HTMLSelect
-                            className="h3-form-select"
-                            value={lattice}
-                            disabled={submitting}
-                            onChange={(e) => setLattice(e.currentTarget.value as CrystalSystem)}
-                            options={LATTICE_OPTIONS}
-                        />
-                    </FormGroup>
-
-                    <FormGroup label="Space Group:" inline>
-                        <HTMLSelect
-                            className="h3-form-select"
-                            value={nsg}
-                            disabled={submitting || sgItems.length === 0}
-                            onChange={(e) => setNsg(Number(e.currentTarget.value))}
-                            options={sgItems.map((i) => ({ value: i.id, label: i.cname }))}
-                        />
-                    </FormGroup>
-
-                    <Checkbox
-                        label="Biomolecules only"
-                        checked={false}
-                        disabled
-                    />
-
-                    <FormGroup label="Space Group Number:" inline>
-                        <InputGroup
-                            value={String(nsg)}
-                            readOnly
-                            style={{ width: 80 }}
-                        />
-                    </FormGroup>
-                </fieldset>
-
-                <fieldset style={{ padding: '8px 12px' }}>
-                    <legend style={{ padding: '0 4px' }}>Cell dimension</legend>
-
-                    <Checkbox
-                        label="Restrict by symmetry"
-                        checked={restrict}
+                <FormGroup label="Crystal system:" inline>
+                    <HTMLSelect
+                        className="h3-form-select"
+                        value={lattice}
                         disabled={submitting}
-                        onChange={(e) => setRestrict(e.currentTarget.checked)}
-                        style={{ marginBottom: 8 }}
+                        onChange={(e) => setLattice(e.currentTarget.value as CrystalSystem)}
+                        options={LATTICE_OPTIONS}
                     />
+                </FormGroup>
 
-                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 16 }}>
-                        {numericFor('a', 'a=')}
-                        {numericFor('alpha', String.fromCharCode(0x03b1) + '=')}
-                        {numericFor('b', 'b=')}
-                        {numericFor('beta', String.fromCharCode(0x03b2) + '=')}
-                        {numericFor('c', 'c=')}
-                        {numericFor('gamma', String.fromCharCode(0x03b3) + '=')}
-                    </div>
-                </fieldset>
+                <FormGroup label="Space Group:" inline>
+                    <HTMLSelect
+                        className="h3-form-select"
+                        value={nsg}
+                        disabled={submitting || sgItems.length === 0}
+                        onChange={(e) => setNsg(Number(e.currentTarget.value))}
+                        options={sgItems.map((i) => ({ value: i.id, label: i.cname }))}
+                    />
+                </FormGroup>
 
-                {errorMsg !== null && (
-                    <div style={{ color: 'var(--accent-red)', marginTop: 8 }}>
-                        {errorMsg}
-                    </div>
-                )}
-            </DialogBody>
-            <DialogFooter
-                actions={
-                    <>
-                        <Button onClick={onCancel} disabled={submitting}>Cancel</Button>
-                        <Button
-                            intent="primary"
-                            onClick={handleOk}
-                            disabled={!ready || submitting}
-                            loading={submitting}
-                        >
-                            OK
-                        </Button>
-                    </>
-                }
-            />
-        </Dialog>
+                <Checkbox
+                    label="Biomolecules only"
+                    checked={false}
+                    disabled
+                />
+
+                <FormGroup label="Space Group Number:" inline>
+                    <InputGroup
+                        value={String(nsg)}
+                        readOnly
+                        style={{ width: 80 }}
+                    />
+                </FormGroup>
+            </fieldset>
+
+            <fieldset style={{ padding: '8px 12px' }}>
+                <legend style={{ padding: '0 4px' }}>Cell dimension</legend>
+
+                <Checkbox
+                    label="Restrict by symmetry"
+                    checked={restrict}
+                    disabled={submitting}
+                    onChange={(e) => setRestrict(e.currentTarget.checked)}
+                    style={{ marginBottom: 8 }}
+                />
+
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 16 }}>
+                    {numericFor('a', 'a=')}
+                    {numericFor('alpha', String.fromCharCode(0x03b1) + '=')}
+                    {numericFor('b', 'b=')}
+                    {numericFor('beta', String.fromCharCode(0x03b2) + '=')}
+                    {numericFor('c', 'c=')}
+                    {numericFor('gamma', String.fromCharCode(0x03b3) + '=')}
+                </div>
+            </fieldset>
+
+            {errorMsg !== null && (
+                <div style={{ color: 'var(--accent-red)', marginTop: 8 }}>
+                    {errorMsg}
+                </div>
+            )}
+        </DialogShell>
     )
 }

--- a/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialog.tsx
+++ b/tritium/react-gui/src/renderer/components/fopen-opt-dlgs/FileOpenOptionDialog.tsx
@@ -18,9 +18,9 @@
  */
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Dialog, DialogBody, DialogFooter, Button, Collapse } from '@blueprintjs/core';
+import { Collapse } from '@blueprintjs/core';
+import { DialogShell } from '../dialogs/DialogShell';
 import { AppIcon } from '@renderer/h3-kit/primitives';
-import { useTheme } from '../../contexts/ThemeContext';
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol';
 
 import {
@@ -112,7 +112,6 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
   onConfirm,
   onCancel,
 }) => {
-  const { theme } = useTheme();
   const { cm } = useCueMol();
   const formatKind = formatKindForReader(readerName);
   const formatName = formatLabel(formatKind);
@@ -305,16 +304,16 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
   const isModified = hasFormatOptions && isFormatOptionsModified(formatOptions, formatDefaults);
 
   return (
-    <Dialog
-      isOpen={visible}
-      onClose={onCancel}
+    <DialogShell
+      visible={visible}
       title="Open File Options"
+      width="6xl"
+      onCancel={onCancel}
+      onOk={handleConfirm}
+      okLabel="Open"
       className="fod-dialog"
-      portalClassName={theme === 'dark' ? 'bp5-dark' : ''}
-      canOutsideClickClose={false}
-      isCloseButtonShown={false}
-    >
-      <DialogBody className="fod-body">
+      bodyClassName="fod-body"
+  >
         {/* File info row */}
         <div className="fod-file-info">
           <AppIcon name="ui.document" size="md" className="fod-file-icon" aria-hidden />
@@ -406,16 +405,6 @@ export const FileOpenOptionDialog: React.FC<FileOpenOptionDialogProps> = ({
             </Collapse>
           </div>
         )}
-      </DialogBody>
-
-      <DialogFooter
-        actions={
-          <>
-            <Button onClick={onCancel}>Cancel</Button>
-            <Button intent="primary" onClick={handleConfirm}>Open</Button>
-          </>
-        }
-      />
-    </Dialog>
+    </DialogShell>
   );
 };

--- a/tritium/react-gui/src/renderer/styles/_dialog.css
+++ b/tritium/react-gui/src/renderer/styles/_dialog.css
@@ -99,6 +99,13 @@
 /* form-kit dialog body: a vertical stack of FieldSections that shares one
    section gap (the canonical place to own section spacing -- consumers never
    set it per-section). Use for dialogs composed from h3-kit/form widgets. */
+/* Body of a dialog whose content is not a form and lays itself out (the About
+   splash bleeds its image to the frame edge). DialogShell's `bodyClassName`
+   selects this instead of the .h3-dialog-form column. */
+.h3-dialog-plain-body {
+  padding: 0;
+}
+
 .h3-dialog-form {
   display: flex;
   flex-direction: column;

--- a/tritium/react-gui/src/renderer/styles/_file-open-dialog.css
+++ b/tritium/react-gui/src/renderer/styles/_file-open-dialog.css
@@ -1,8 +1,7 @@
 /* File Open Option Dialog styles */
 
-.fod-dialog {
-  width: 480px;
-}
+/* Width comes from the shell's `--dialog-w-*` ladder (the 6xl rung), so it is
+   set in one place for every dialog rather than here for these two. */
 
 .fod-body {
   display: flex;

--- a/tritium/react-gui/src/renderer/styles/_variables.css
+++ b/tritium/react-gui/src/renderer/styles/_variables.css
@@ -280,6 +280,7 @@
   --dialog-w-3xl: 440px;  /* symmetry editor */
   --dialog-w-4xl: 460px;  /* interaction list editor */
   --dialog-w-5xl: 500px;  /* style editor */
+  --dialog-w-6xl: 480px;  /* file-open option dialogs */
 
   /* ── Listbox / list-tree rows (single source for styles/_list-kit.css) ──
      Row height reuses --row-h (22px). hover/selected reuse --bg-hover /


### PR DESCRIPTION
#533 の続きで、**残り 8 ダイアログを全て `DialogShell` に移しました**。これで **アプリ内の 32 ダイアログすべて**が共有の枠を通ります。

## 5 つは素直なケース

`ApplyRendStyle` / `CreateRendStyle` / `EditInteractionList` / `ExportPngOptions` / `SymmetryChange`。インライン px 幅（420 / 380 / 460 / 360 / 440）が `--dialog-w-*` の段になり、`SymmetryChange` の `submitting` はシェルの同名 prop にそのまま乗りました。`ExportPngOptions` は自前で `.h3-dialog-form` を持っていたので、シェルのものと二重にならないよう内側を外しました。

## 残り 3 つ — 調べたら想定より小さかった

**`StyleEditor`** は計画で「`tabs` スロットが要る」としていましたが、**不要でした**。Blueprint の `Tabs` は他と同じ本文コンテンツです。実際に必要だったのは `ColorPickerProvider` が body と footer を跨ぐのをやめることで、これは可能でした — context を読むのは body だけで、Close ボタンは読んでいません。

**`NewRenderer` / `FileOpenOption`** は `fod-dialog` / `fod-body` クラスを持ちます（本文がフォームの列ではなく帯状のセクションのため）。そこでシェルに**「ダイアログが自分の枠クラスと body クラスを名乗る」口**を足しました。これは #533 で足した `plainBody` boolean を吸収します — About は `h3-dialog-plain-body` を名乗る形になり、padding はインライン style から他のダイアログ metrics と同じ場所（`_dialog.css`）へ移りました。

## 幅の梯子が守られました

`.fod-dialog` は `width: 480px` を直接持っていました。これは幅の梯子がまさに防ぐためにあるものなので、**480 を `6xl` の段にして CSS の宣言を削除**しました。ダイアログの幅は全部が同じ 1 箇所で選ばれます。

## `ThemeContext` を読むダイアログがゼロになりました

`ChangeChainId` / `ChangeResidueIndex` が最後の 2 つでした（`extra` で渡す確認 `Alert` が別 portal なのでクラスが要る）。これらも kit の `useDarkPortalClass` を使うようにしています。**手でテーマを導出しているダイアログはもうありません。**

## parity test が 1 ブロックに畳まれました

全ダイアログがシェルを通るようになったので、手書きの個別チェックは消え、**32 ダイアログ × 1 つの契約**になりました。幅が「トークンの段であって数値でないこと」も assert しているので、誰かが px を書き戻すと落ちます。

## 検証

- typecheck (web + node) OK
- vitest **361 files / 3419 tests all pass**
- ESLint **0 errors / 75 warnings**（ベースライン）、stylelint 14（ベースライン）、lint:comments OK
- `task build_tritium` OK / `task run_tritium` で `shader program created OK` まで到達

**目視確認のお願い**: 移した 8 ダイアログを dark / light 両方で。特に **File Open Options と New Renderer の幅・帯状セクションが従来どおりか**（480px の出所が変わっています）、**Style editor のタブと色ピッカーが動くか**、`About` の画像が全幅のままか。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jq8nSHJWsEpfSui98LTXR
