### PR TITLE
refactor(react-gui): separate the animation inspector's form and its generic tab (Phase 3-3)

### DIFF
--- a/tritium/react-gui/src/renderer/components/inspector/AnimElementInspector.tsx
+++ b/tritium/react-gui/src/renderer/components/inspector/AnimElementInspector.tsx
@@ -38,7 +38,7 @@ import {
 } from "../../h3-kit/form";
 import { GenericTab } from "./GenericTab";
 import { InspectorResetAllButton } from "./InspectorResetAllButton";
-import { modifiedKeys } from "./propModel";
+import { useAnimGenericProps } from "./anim/useAnimGenericProps";
 import type { AsyncCueMol } from "../../worker/client/AsyncCueMol";
 import type {
   AnimElementDetail,
@@ -48,7 +48,6 @@ import type {
   AnimMolOption,
   SetAnimElementPropArgs,
 } from "../../worker/server/services/animDetail.service";
-import type { GenericPropEntry } from '@renderer/worker/shared/genericProps';
 import { SEM_ANIM, SEM_OBJECT, SEM_RENDERER, SEM_CAMERA, SEM_ANY } from "../../event";
 import { useCueMolEventListener } from "@renderer/hooks/cuemol/useCueMolEventListener";
 
@@ -61,68 +60,14 @@ interface AnimElementInspectorProps {
   /** Report the element name/type so the inspector header can show them. */
   onHeaderChange: (name: string, type: string) => void;
 }
-
-const TYPE_LABEL: Record<string, string> = {
-  SimpleSpin: "Simple spin",
-  CamMotion: "Camera motion",
-  ShowHideAnim: "Show / Hide",
-  SlideInOutAnim: "Slide",
-  MolAnim: "Mol morphing",
-  NoopAnimObj: "No operation",
-  unknown: "Animation element",
-};
-
-/** Draft of the numeric / text fields (controlled while editing). */
-interface FormState {
-  name: string;
-  quadricPct: number;
-  startMs: number;
-  durationMs: number;
-  angle: number;
-  tgtAlpha: number;
-  direction: number;
-  distance: number;
-  startValue: number;
-  endValue: number;
-}
-
-function detailToForm(d: AnimElementDetail): FormState {
-  const c = d.common;
-  const t = d.typeProps;
-  return {
-    name: c.name,
-    quadricPct: c.quadric * 100,
-    startMs: c.startMs,
-    durationMs: c.endMs - c.startMs,
-    angle: t.angle ?? 0,
-    tgtAlpha: t.tgtAlpha ?? 1,
-    direction: t.direction ?? 0,
-    distance: t.distance ?? 1,
-    startValue: t.startValue ?? 0,
-    endValue: t.endValue ?? 1,
-  };
-}
-
-/** Normalize an angle into [0, 360] by wrapping (UXP parity, not clamping). */
-function wrapAngle(a: number): number {
-  let v = a;
-  while (v < 0) v += 360;
-  while (v > 360) v -= 360;
-  return v;
-}
-
-/** Which axis preset (if any) the current vector matches. */
-function axisPreset(x: number, y: number, z: number): string {
-  if (x === 1 && y === 0 && z === 0) return "x";
-  if (x === 0 && y === 1 && z === 0) return "y";
-  if (x === 0 && y === 0 && z === 1) return "z";
-  return "cart";
-}
-
-/** Compact axis-component display: round to 4 dp and drop trailing zeros. */
-function fmtAxis(n: number): string {
-  return String(Math.round(n * 1e4) / 1e4);
-}
+import {
+  TYPE_LABEL,
+  axisPreset,
+  detailToForm,
+  fmtAxis,
+  wrapAngle,
+  type FormState,
+} from "./anim/animElementForm";
 
 /**
  * Per-element detail editor (right InspectorPanel `animElement` branch).
@@ -148,8 +93,6 @@ export const AnimElementInspector: React.FC<AnimElementInspectorProps> = ({
   // Active tab: the bespoke per-type editor ("properties") or the full generic
   // property table ("generic"), mirroring the renderer node inspector.
   const [mode, setMode] = useState<"properties" | "generic">("properties");
-  const [genericEntries, setGenericEntries] = useState<GenericPropEntry[]>([]);
-  const [genericLoading, setGenericLoading] = useState(false);
 
   const cmRef = useRef(cm);
   cmRef.current = cm;
@@ -161,16 +104,18 @@ export const AnimElementInspector: React.FC<AnimElementInspectorProps> = ({
   onGoneRef.current = onGone;
   const onHeaderRef = useRef(onHeaderChange);
   onHeaderRef.current = onHeaderChange;
+
+  const {
+    genericEntries, genericLoading, refetchGeneric,
+    handleGenericSet, handleGenericReset, handleResetAll, canResetAll,
+  } = useAnimGenericProps({ cmRef, sceneIdRef, uidRef, onGoneRef });
+
   // Drop a stale response that resolves after a newer fetch/commit.
   const fetchToken = useRef(0);
   // Drop a stale target-options response (rapid scene / scene-tree changes).
   const optionsToken = useRef(0);
   // True while a draft (numeric/text) field is mid-edit -- blocks re-seed.
   const editingRef = useRef(false);
-  // Generic-tab fetch token + live mirrors read inside event handlers.
-  const genericToken = useRef(0);
-  const genericEntriesRef = useRef(genericEntries);
-  genericEntriesRef.current = genericEntries;
 
   const adopt = useCallback((d: AnimElementDetail) => {
     setDetail(d);
@@ -196,29 +141,6 @@ export const AnimElementInspector: React.FC<AnimElementInspectorProps> = ({
   }, [adopt]);
 
   /** Refetch the full generic property list (generic tab). */
-  const refetchGeneric = useCallback(() => {
-    const c = cmRef.current;
-    const sid = sceneIdRef.current;
-    const u = uidRef.current;
-    if (!c) return;
-    setGenericLoading(true);
-    const token = ++genericToken.current;
-    c.invokeService("getAnimElementGenericProps", { sceneId: sid, uid: u })
-      .then((res) => {
-        if (token !== genericToken.current) return;
-        setGenericLoading(false);
-        if (!res || res.gone) {
-          onGoneRef.current(sid);
-          return;
-        }
-        setGenericEntries(res.entries ?? []);
-      })
-      .catch((e: unknown) => {
-        setGenericLoading(false);
-        console.warn("getAnimElementGenericProps failed:", e);
-      });
-  }, []);
-
   // SEM_ANIM keeps both views in sync. The generic table is refetched in both
   // modes: the mode bar's Reset-all button derives its enabled state from
   // genericEntries, so they must stay live on the Properties tab too.
@@ -327,70 +249,6 @@ export const AnimElementInspector: React.FC<AnimElementInspectorProps> = ({
   }, []);
 
   /** Adopt the fresh generic list returned by a write (token-gated). */
-  const adoptGeneric = useCallback(
-    (
-      res: { ok: boolean; gone?: boolean; entries?: GenericPropEntry[] } | undefined,
-      token: number,
-    ) => {
-      if (token !== genericToken.current) return;
-      if (!res || res.gone) {
-        onGoneRef.current(sceneIdRef.current);
-        return;
-      }
-      setGenericEntries(res.entries ?? []);
-    },
-    [],
-  );
-  const handleGenericSet = useCallback(
-    (key: string, valueType: string, value: string | number | boolean) => {
-      const c = cmRef.current;
-      if (!c) return;
-      const token = ++genericToken.current;
-      c.invokeService("setAnimElementGenericProp", {
-        sceneId: sceneIdRef.current,
-        uid: uidRef.current,
-        propName: key,
-        op: "set",
-        valueType,
-        value,
-      })
-        .then((res) => adoptGeneric(res, token))
-        .catch((e: unknown) => console.warn("setAnimElementGenericProp failed:", e));
-    },
-    [adoptGeneric],
-  );
-  const handleGenericReset = useCallback(
-    (key: string) => {
-      const c = cmRef.current;
-      if (!c) return;
-      const token = ++genericToken.current;
-      c.invokeService("setAnimElementGenericProp", {
-        sceneId: sceneIdRef.current,
-        uid: uidRef.current,
-        propName: key,
-        op: "reset",
-        valueType: "",
-      })
-        .then((res) => adoptGeneric(res, token))
-        .catch((e: unknown) => console.warn("setAnimElementGenericProp (reset) failed:", e));
-    },
-    [adoptGeneric],
-  );
-  const handleResetAll = useCallback(() => {
-    const c = cmRef.current;
-    if (!c) return;
-    const keys = modifiedKeys(genericEntriesRef.current);
-    if (keys.length === 0) return;
-    const token = ++genericToken.current;
-    c.invokeService("resetAnimElementGenericProps", {
-      sceneId: sceneIdRef.current,
-      uid: uidRef.current,
-      propNames: keys,
-    })
-      .then((res) => adoptGeneric(res, token))
-      .catch((e: unknown) => console.warn("resetAnimElementGenericProps failed:", e));
-  }, [adoptGeneric]);
-
   // Properties / Generic switcher, shown above the body in both modes.
   const modeBar = (
     <div className="inspector-mode-bar mode-bar">
@@ -405,7 +263,7 @@ export const AnimElementInspector: React.FC<AnimElementInspectorProps> = ({
       {/* Available in both modes (they edit the same properties), matching
           InspectorPanel's mode bar. */}
       <InspectorResetAllButton
-        canResetAll={modifiedKeys(genericEntries).length > 0}
+        canResetAll={canResetAll}
         onResetAll={handleResetAll}
       />
     </div>

--- a/tritium/react-gui/src/renderer/components/inspector/anim/animElementForm.test.ts
+++ b/tritium/react-gui/src/renderer/components/inspector/anim/animElementForm.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @file components/inspector/anim/animElementForm.test.ts
+ * @description Contract for the animation inspector's conversions.
+ *
+ * These decide what the fields show and which axis preset the dropdown lands
+ * on -- both silent when wrong: a mis-wrapped angle looks like a valid value,
+ * and a missed preset just shows "Cartesian" for a vector that is exactly an
+ * axis. The boundaries are what these pin.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { axisPreset, fmtAxis, wrapAngle } from './animElementForm';
+
+describe('wrapAngle', () => {
+    it('leaves an angle already in range alone', () => {
+        expect(wrapAngle(0)).toBe(0);
+        expect(wrapAngle(180)).toBe(180);
+        expect(wrapAngle(360)).toBe(360);
+    });
+
+    it('brings a negative angle up into range', () => {
+        expect(wrapAngle(-90)).toBe(270);
+        expect(wrapAngle(-360)).toBe(0);
+        // More than one turn below: the loop has to run twice.
+        expect(wrapAngle(-450)).toBe(270);
+    });
+
+    it('brings an angle past a full turn back down', () => {
+        expect(wrapAngle(450)).toBe(90);
+        // The upper bound is inclusive -- `> 360`, not `>= 360` -- so a full
+        // turn stays 360 rather than snapping to 0. Dragging up through the
+        // top of the range therefore reads continuously instead of jumping
+        // back to zero, and 360 and 0 are the same rotation anyway.
+        expect(wrapAngle(720)).toBe(360);
+        expect(wrapAngle(725)).toBe(5);
+    });
+});
+
+describe('axisPreset', () => {
+    it('names each cardinal axis', () => {
+        expect(axisPreset(1, 0, 0)).toBe('x');
+        expect(axisPreset(0, 1, 0)).toBe('y');
+        expect(axisPreset(0, 0, 1)).toBe('z');
+    });
+
+    it('falls back to cartesian for anything else', () => {
+        expect(axisPreset(1, 1, 0)).toBe('cart');
+        expect(axisPreset(0, 0, 0)).toBe('cart');
+        // A scaled axis is not the preset: the dropdown would misreport the
+        // vector's length as unit.
+        expect(axisPreset(2, 0, 0)).toBe('cart');
+        expect(axisPreset(-1, 0, 0)).toBe('cart');
+    });
+});
+
+describe('fmtAxis', () => {
+    it('rounds to four decimals and drops trailing zeros', () => {
+        expect(fmtAxis(1)).toBe('1');
+        expect(fmtAxis(0.5)).toBe('0.5');
+        expect(fmtAxis(0.123456)).toBe('0.1235');
+        // The IEEE-754 noise a drag produces must not reach the field.
+        expect(fmtAxis(0.30000000000000004)).toBe('0.3');
+    });
+});

--- a/tritium/react-gui/src/renderer/components/inspector/anim/animElementForm.ts
+++ b/tritium/react-gui/src/renderer/components/inspector/anim/animElementForm.ts
@@ -1,0 +1,74 @@
+/**
+ * @file components/inspector/anim/animElementForm.ts
+ * @description The animation element inspector's form shape and the
+ * conversions around it.
+ *
+ * The editor keeps its own `FormState` rather than editing the fetched detail
+ * in place, because the fields are text while the element stores numbers: a
+ * half-typed value has to survive on screen without being written. These turn
+ * one into the other, and none of them needs React.
+ */
+
+import type { AnimElementDetail } from '@renderer/worker/server/services/animDetail.service';
+
+export const TYPE_LABEL: Record<string, string> = {
+  SimpleSpin: "Simple spin",
+  CamMotion: "Camera motion",
+  ShowHideAnim: "Show / Hide",
+  SlideInOutAnim: "Slide",
+  MolAnim: "Mol morphing",
+  NoopAnimObj: "No operation",
+  unknown: "Animation element",
+};
+
+/** Draft of the numeric / text fields (controlled while editing). */
+export interface FormState {
+  name: string;
+  quadricPct: number;
+  startMs: number;
+  durationMs: number;
+  angle: number;
+  tgtAlpha: number;
+  direction: number;
+  distance: number;
+  startValue: number;
+  endValue: number;
+}
+
+export function detailToForm(d: AnimElementDetail): FormState {
+  const c = d.common;
+  const t = d.typeProps;
+  return {
+    name: c.name,
+    quadricPct: c.quadric * 100,
+    startMs: c.startMs,
+    durationMs: c.endMs - c.startMs,
+    angle: t.angle ?? 0,
+    tgtAlpha: t.tgtAlpha ?? 1,
+    direction: t.direction ?? 0,
+    distance: t.distance ?? 1,
+    startValue: t.startValue ?? 0,
+    endValue: t.endValue ?? 1,
+  };
+}
+
+/** Normalize an angle into [0, 360] by wrapping (UXP parity, not clamping). */
+export function wrapAngle(a: number): number {
+  let v = a;
+  while (v < 0) v += 360;
+  while (v > 360) v -= 360;
+  return v;
+}
+
+/** Which axis preset (if any) the current vector matches. */
+export function axisPreset(x: number, y: number, z: number): string {
+  if (x === 1 && y === 0 && z === 0) return "x";
+  if (x === 0 && y === 1 && z === 0) return "y";
+  if (x === 0 && y === 0 && z === 1) return "z";
+  return "cart";
+}
+
+/** Compact axis-component display: round to 4 dp and drop trailing zeros. */
+export function fmtAxis(n: number): string {
+  return String(Math.round(n * 1e4) / 1e4);
+}

--- a/tritium/react-gui/src/renderer/components/inspector/anim/useAnimGenericProps.ts
+++ b/tritium/react-gui/src/renderer/components/inspector/anim/useAnimGenericProps.ts
@@ -1,0 +1,137 @@
+/**
+ * @file components/inspector/anim/useAnimGenericProps.ts
+ * @description The animation inspector's Generic tab: the element's raw
+ * properties, read and written by name.
+ *
+ * It is fetched in BOTH modes, not only while the Generic tab is showing: the
+ * mode bar's Reset-all button derives its enabled state from these entries, so
+ * the Properties tab needs them live too.
+ *
+ * The element identity arrives as refs rather than values because every
+ * callback here has to stay reference-stable -- they are handed to rows that
+ * would otherwise re-render on each keystroke -- while still addressing the
+ * currently inspected element.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol';
+import type { GenericPropEntry } from '@renderer/worker/shared/genericProps';
+import { modifiedKeys } from '../propModel';
+
+export interface UseAnimGenericPropsOptions {
+    cmRef: React.MutableRefObject<AsyncCueMol | null>;
+    sceneIdRef: React.MutableRefObject<number>;
+    uidRef: React.MutableRefObject<number>;
+    /** Called when the element turns out to be gone (deleted). */
+    onGoneRef: React.MutableRefObject<(sceneId: number) => void>;
+}
+
+export function useAnimGenericProps({
+    cmRef, sceneIdRef, uidRef, onGoneRef,
+}: UseAnimGenericPropsOptions) {
+    const [genericEntries, setGenericEntries] = useState<GenericPropEntry[]>([]);
+    const [genericLoading, setGenericLoading] = useState(false);
+    // Stale-response guard: every request takes the next number and a reply
+    // is dropped unless it is still the latest.
+    const genericToken = useRef(0);
+    const genericEntriesRef = useRef(genericEntries);
+    genericEntriesRef.current = genericEntries;
+
+  const refetchGeneric = useCallback(() => {
+    const c = cmRef.current;
+    const sid = sceneIdRef.current;
+    const u = uidRef.current;
+    if (!c) return;
+    setGenericLoading(true);
+    const token = ++genericToken.current;
+    c.invokeService("getAnimElementGenericProps", { sceneId: sid, uid: u })
+      .then((res) => {
+        if (token !== genericToken.current) return;
+        setGenericLoading(false);
+        if (!res || res.gone) {
+          onGoneRef.current(sid);
+          return;
+        }
+        setGenericEntries(res.entries ?? []);
+      })
+      .catch((e: unknown) => {
+        setGenericLoading(false);
+        console.warn("getAnimElementGenericProps failed:", e);
+      });
+  }, [cmRef, sceneIdRef, uidRef, onGoneRef]);
+
+  const adoptGeneric = useCallback(
+    (
+      res: { ok: boolean; gone?: boolean; entries?: GenericPropEntry[] } | undefined,
+      token: number,
+    ) => {
+      if (token !== genericToken.current) return;
+      if (!res || res.gone) {
+        onGoneRef.current(sceneIdRef.current);
+        return;
+      }
+      setGenericEntries(res.entries ?? []);
+    },
+    [onGoneRef, sceneIdRef],
+  );
+  const handleGenericSet = useCallback(
+    (key: string, valueType: string, value: string | number | boolean) => {
+      const c = cmRef.current;
+      if (!c) return;
+      const token = ++genericToken.current;
+      c.invokeService("setAnimElementGenericProp", {
+        sceneId: sceneIdRef.current,
+        uid: uidRef.current,
+        propName: key,
+        op: "set",
+        valueType,
+        value,
+      })
+        .then((res) => adoptGeneric(res, token))
+        .catch((e: unknown) => console.warn("setAnimElementGenericProp failed:", e));
+    },
+    [adoptGeneric, cmRef, sceneIdRef, uidRef],
+  );
+  const handleGenericReset = useCallback(
+    (key: string) => {
+      const c = cmRef.current;
+      if (!c) return;
+      const token = ++genericToken.current;
+      c.invokeService("setAnimElementGenericProp", {
+        sceneId: sceneIdRef.current,
+        uid: uidRef.current,
+        propName: key,
+        op: "reset",
+        valueType: "",
+      })
+        .then((res) => adoptGeneric(res, token))
+        .catch((e: unknown) => console.warn("setAnimElementGenericProp (reset) failed:", e));
+    },
+    [adoptGeneric, cmRef, sceneIdRef, uidRef],
+  );
+  const handleResetAll = useCallback(() => {
+    const c = cmRef.current;
+    if (!c) return;
+    const keys = modifiedKeys(genericEntriesRef.current);
+    if (keys.length === 0) return;
+    const token = ++genericToken.current;
+    c.invokeService("resetAnimElementGenericProps", {
+      sceneId: sceneIdRef.current,
+      uid: uidRef.current,
+      propNames: keys,
+    })
+      .then((res) => adoptGeneric(res, token))
+      .catch((e: unknown) => console.warn("resetAnimElementGenericProps failed:", e));
+  }, [adoptGeneric, cmRef, sceneIdRef, uidRef]);
+
+    return {
+        genericEntries,
+        genericLoading,
+        refetchGeneric,
+        handleGenericSet,
+        handleGenericReset,
+        handleResetAll,
+        /** True while any property differs from its default. */
+        canResetAll: modifiedKeys(genericEntries).length > 0,
+    };
+}


### PR DESCRIPTION
> #537 (SequencePanel) / #538 (useRenderSettings) と独立しています。ファイルの重複はありません。

## なぜ

`AnimElementInspector.tsx` は **742 行**で、3 つのものを抱えていました — 要素が保持する数値とそれを編集するテキストフィールドの間の変換、Generic タブの生プロパティ表、そして型付きエディタ本体。

## 1. `anim/animElementForm.ts` (74 行、React なし)

エディタが取得した detail を直接編集せず**自前の `FormState` を持つ**のは、**フィールドがテキストで要素が数値を保持する**からです — 打ちかけの値が書き込まれずに画面上に残る必要があります。これらの変換はその継ぎ目にあたるので、テストする価値があります。

## テストが私の想定を訂正しました

**`wrapAngle(720)` は 0 ではなく 360 を返します。** ループが `>= 360` ではなく `> 360` なので、ちょうど 1 回転は 1 回転のまま残ります。これは見落としではありません — **ドラッグでレンジ上端を越えたときに 0 へ飛び戻らず連続して読める**うえ、360 と 0 は同じ回転です。テストは私が想定した挙動ではなく**実在する挙動を、その理由とともに** pin しています。

残り 5 件は軸プリセット（**スケールされた軸はプリセットではない** — でないとドロップダウンがベクトルを単位長だと誤報する）と、ドラッグの IEEE-754 ノイズをフィールドに入れない 4 桁丸めです。

## 2. `anim/useAnimGenericProps.ts` (137 行)

Generic タブです。**知らないとバグに見えること**をヘッダに明記しました: 生プロパティ表は **両モードで fetch されます**。モードバーの Reset-all ボタンの有効判定がその entries から導かれるので、Properties タブでも live である必要があるためです。

## また 5 件の exhaustive-deps 漏れ

直近 3 本の分割と同じ形です。要素の identity を運ぶ ref 群が closure 捕捉から引数になったため、それを読むコールバックが依存に挙げる必要が生じました。ref オブジェクトは安定なので、名前を挙げても全コールバックは参照安定のまま — それが ref である理由そのものです。

## 検証

- typecheck (web + node) OK
- vitest **362 files / 3425 tests all pass**（+1 file / +6 tests）
- ESLint **0 errors / 72 warnings**（ベースライン）、lint:comments OK
- `task build_tritium` OK / `task run_tritium` で `shader program created OK` まで到達

**目視確認のお願い**: Animation panel で要素を選び、右の Inspector で。**Properties タブ**（開始/継続時間、回転角、軸プリセット x/y/z と Cartesian の切替、対象 renderer/camera/mol の選択）、**Generic タブ**への切替、**Reset-all ボタンが Properties タブにいる間も正しく有効/無効になること**（これが両モードで fetch している理由）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jq8nSHJWsEpfSui98LTXR
