### PR TITLE
refactor(react-gui): split the last three components (Phase 3-3)

### DIFF
--- a/tritium/react-gui/src/renderer/components/multigrad/MultiGradSection.tsx
+++ b/tritium/react-gui/src/renderer/components/multigrad/MultiGradSection.tsx
@@ -40,60 +40,22 @@ import type { AsyncCueMol } from '../../worker/client/AsyncCueMol'
 import type { MultiGradWriteNode } from '../../worker/server/services/rendererColoring.service'
 import { fireService } from '../../utils/fireService'
 import { useMultiGradState } from '../../hooks/useMultiGradState'
-import { useMultiGradHistogram } from '../../hooks/useMultiGradHistogram'
+import { useGradientViewDomain } from './section/useGradientViewDomain'
+import {
+    PENDING_SAFETY_MS,
+    ZOOM_STEP,
+    resolveDisplayHex,
+    toWriteNodes,
+    type MultiGradStop,
+} from './section/gradientStops'
 import { GradientStopBar, type GradientCommitGesture } from '@renderer/h3-kit/gradient'
 import {
     type GradientStop,
-    type ValueDomain,
     MIN_STOP_SPACING,
     keepRatioRescale,
-    minHistogramBinWidth,
     moveStopFree,
-    zoomDomain,
 } from '@renderer/h3-kit/gradient'
 import { MULTIGRAD_PRESETS, buildPresetNodes } from '@renderer/worker/shared/multiGradPresets'
-
-/** Stop displayed by this section: bar geometry + the CueMol color string. */
-interface MultiGradStop extends GradientStop {
-    /** CueMol color string (may be a named color); hex is display-only. */
-    color?: string
-}
-
-/** Convert display stops back to the service write shape. */
-function toWriteNodes(stops: readonly MultiGradStop[]): MultiGradWriteNode[] {
-    return stops.map((s) => ({ value: s.value, color: s.color ?? s.hex }))
-}
-
-/** Basic named colors for optimistic swatch display (preset colors etc.). */
-const NAMED_HEX: Record<string, string> = {
-    red: '#FF0000', yellow: '#FFFF00', white: '#FFFFFF',
-    green: '#00FF00', blue: '#0000FF', black: '#000000',
-    cyan: '#00FFFF', magenta: '#FF00FF', orange: '#FFA500',
-}
-
-/**
- * Best-effort display hex for a CueMol color string, used only for the
- * optimistic override; the canonical hex from C++ replaces it on refetch.
- */
-function resolveDisplayHex(color: string, fallback: string): string {
-    const c = color.trim()
-    if (/^#[0-9a-fA-F]{6}$/.test(c)) return c.toUpperCase()
-    if (/^#[0-9a-fA-F]{3}$/.test(c)) {
-        return (
-            '#' + c.slice(1).split('').map((ch) => ch + ch).join('')
-        ).toUpperCase()
-    }
-    return NAMED_HEX[c.toLowerCase()] ?? fallback
-}
-
-/** Span factor per - / + click. */
-const ZOOM_STEP = 1.5
-/** Fraction of the current span shifted per < / > click. */
-const PAN_STEP = 0.25
-
-/** Drop a stuck optimistic override after this long without a refetch. */
-const PENDING_SAFETY_MS = 1500
-
 interface MultiGradSectionProps {
     cm: AsyncCueMol | null
     sceneId: number | undefined
@@ -114,7 +76,6 @@ export const MultiGradSection: React.FC<MultiGradSectionProps> = ({
     const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
     const [keepRatio, setKeepRatio] = useState(false)
     /** Explicit view domain from zoom/pan; null = follow the fit domain. */
-    const [viewOverride, setViewOverride] = useState<ValueDomain | null>(null)
     /** Measured stop-bar width (px) for histogram bin sizing. */
     const [stripWidth, setStripWidth] = useState(0)
     /** Local override while a drag preview / pending commit is live. */
@@ -168,83 +129,11 @@ export const MultiGradSection: React.FC<MultiGradSectionProps> = ({
     }, [canonicalStops.length, selectedIndex])
 
     const displayStops = previewStops ?? canonicalStops
-
-    // --- display domain (independent of the stop range) ---
-
-    // Fit domain (the -/+/Fit baseline): the stop range when nodes exist;
-    // otherwise the central-95% histogram range (raw map min/max is
-    // usually blown up by outliers), then the raw map range, then a
-    // synthetic fallback.
-    const fitDomain = useMemo<ValueDomain>(() => {
-        if (canonicalStops.length >= 2) {
-            const min = canonicalStops[0].value
-            const max = canonicalStops[canonicalStops.length - 1].value
-            if (max > min) return { min, max }
-        }
-        const p = state?.mapPercentiles
-        if (p && p.hi > p.lo) return { min: p.lo, max: p.hi }
-        const stats = state?.mapStats
-        if (stats && stats.max > stats.min) {
-            return { min: stats.min, max: stats.max }
-        }
-        if (canonicalStops.length === 1) {
-            const v = canonicalStops[0].value
-            return { min: v - 0.5, max: v + 0.5 }
-        }
-        return { min: 0, max: 1 }
-    }, [canonicalStops, state?.mapPercentiles, state?.mapStats])
-
-    const activeDomain = viewOverride ?? fitDomain
-
-    // Freeze the domain while an override is live so a mid-drag canonical
-    // refetch (whose values follow the drag) cannot rescale the bar.
-    const frozenDomainRef = useRef(activeDomain)
-    if (previewStops === null) frozenDomainRef.current = activeDomain
-    const viewDomain = previewStops !== null
-        ? frozenDomainRef.current
-        : activeDomain
-
-    const handleZoom = useCallback((factor: number) => {
-        setViewOverride((prev) => zoomDomain(prev ?? frozenDomainRef.current, factor))
-    }, [])
-
-    const handlePan = useCallback((direction: -1 | 1) => {
-        setViewOverride((prev) => {
-            const base = prev ?? frozenDomainRef.current
-            // Derive max from min + span (rather than shifting both ends)
-            // so repeated pans cannot drift the span through floating-
-            // point accumulation, which would silently change the zoom.
-            const span = base.max - base.min
-            const min = base.min + span * PAN_STEP * direction
-            return { min, max: min + span }
-        })
-    }, [])
-
-    // Floor on the bin width, from the map's own statistics: zooming in
-    // past it cannot reveal more structure, so the bars widen instead of
-    // splitting into empty comb teeth.
-    const minBinWidth = useMemo(() => {
-        const s = state?.mapStats
-        if (!s) return 0
-        return minHistogramBinWidth({
-            sigma: s.sigma,
-            min: s.min,
-            max: s.max,
-            voxelCount: state?.mapVoxelCount ?? null,
-            peakCount: state?.mapPeakCount ?? null,
-            quantStep: s.quantStep,
-        })
-    }, [state?.mapStats, state?.mapVoxelCount, state?.mapPeakCount])
-
-    const histogram = useMultiGradHistogram({
-        cm,
-        sceneId,
-        rendId,
-        domain: viewDomain,
-        widthPx: stripWidth,
-        minBinWidth,
-        paused: previewStops !== null,
-        enabled: state?.capable === true,
+    const {
+        viewDomain, histogram,
+        handleZoom, handlePan, setViewOverride, isViewOverridden, frozenDomainRef,
+    } = useGradientViewDomain({
+        cm, sceneId, rendId, state, canonicalStops, previewStops, stripWidth,
     })
 
     // --- write paths ---
@@ -352,7 +241,7 @@ export const MultiGradSection: React.FC<MultiGradSectionProps> = ({
                 : 'Change multi gradient color'
             commitNodes(stops as MultiGradStop[], label, original)
         },
-        [commitNodes],
+        [commitNodes, frozenDomainRef, setViewOverride],
     )
 
     const handleAbort = useCallback(() => {
@@ -579,7 +468,7 @@ export const MultiGradSection: React.FC<MultiGradSectionProps> = ({
                     text="Fit"
                     aria-label="Fit view range"
                     title="Fit the gradient range (or the map's central 95%)"
-                    disabled={viewOverride === null}
+                    disabled={!isViewOverridden}
                     onClick={() => setViewOverride(null)}
                 />
             </div>

--- a/tritium/react-gui/src/renderer/components/multigrad/section/gradientStops.ts
+++ b/tritium/react-gui/src/renderer/components/multigrad/section/gradientStops.ts
@@ -1,0 +1,54 @@
+/**
+ * @file components/multigrad/section/gradientStops.ts
+ * @description The section's stop shape and the colour it shows for one.
+ *
+ * A stop carries two colours for one reason: `color` is the CueMol string the
+ * renderer stores (which may be a name), `hex` is what the swatch draws. They
+ * diverge only between an optimistic edit and the refetch that replaces it,
+ * which is what `resolveDisplayHex` covers -- a best-effort read of the name
+ * so the swatch does not blank out for the frame in between.
+ */
+
+import type { GradientStop } from '@renderer/h3-kit/gradient';
+import type { MultiGradWriteNode } from '@renderer/worker/server/services/rendererColoring.service';
+
+/** Stop displayed by this section: bar geometry + the CueMol color string. */
+export interface MultiGradStop extends GradientStop {
+    /** CueMol color string (may be a named color); hex is display-only. */
+    color?: string
+}
+
+/** Convert display stops back to the service write shape. */
+export function toWriteNodes(stops: readonly MultiGradStop[]): MultiGradWriteNode[] {
+    return stops.map((s) => ({ value: s.value, color: s.color ?? s.hex }))
+}
+
+/** Basic named colors for optimistic swatch display (preset colors etc.). */
+const NAMED_HEX: Record<string, string> = {
+    red: '#FF0000', yellow: '#FFFF00', white: '#FFFFFF',
+    green: '#00FF00', blue: '#0000FF', black: '#000000',
+    cyan: '#00FFFF', magenta: '#FF00FF', orange: '#FFA500',
+}
+
+/**
+ * Best-effort display hex for a CueMol color string, used only for the
+ * optimistic override; the canonical hex from C++ replaces it on refetch.
+ */
+export function resolveDisplayHex(color: string, fallback: string): string {
+    const c = color.trim()
+    if (/^#[0-9a-fA-F]{6}$/.test(c)) return c.toUpperCase()
+    if (/^#[0-9a-fA-F]{3}$/.test(c)) {
+        return (
+            '#' + c.slice(1).split('').map((ch) => ch + ch).join('')
+        ).toUpperCase()
+    }
+    return NAMED_HEX[c.toLowerCase()] ?? fallback
+}
+
+/** Span factor per - / + click. */
+export const ZOOM_STEP = 1.5
+/** Fraction of the current span shifted per < / > click. */
+export const PAN_STEP = 0.25
+
+/** Drop a stuck optimistic override after this long without a refetch. */
+export const PENDING_SAFETY_MS = 1500

--- a/tritium/react-gui/src/renderer/components/multigrad/section/useGradientViewDomain.ts
+++ b/tritium/react-gui/src/renderer/components/multigrad/section/useGradientViewDomain.ts
@@ -1,0 +1,140 @@
+/**
+ * @file components/multigrad/section/useGradientViewDomain.ts
+ * @description The value range the gradient strip is looking at, and the
+ * zoom / pan that moves it.
+ *
+ * The view domain is deliberately independent of the stop range: a user
+ * zooming in to place a stop precisely must not have the view snap back every
+ * time the stops move. `fitDomain` is the baseline the Fit button returns to,
+ * and it prefers the central-95% histogram range over the raw map min/max,
+ * because a single outlier voxel otherwise compresses every stop into a
+ * sliver at one end.
+ *
+ * The domain is frozen for the duration of a drag (`previewStops !== null`):
+ * the stops are moving, and letting the axis move with them would make the
+ * marker appear to stand still.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol';
+import {
+    minHistogramBinWidth,
+    zoomDomain,
+    type ValueDomain,
+} from '@renderer/h3-kit/gradient';
+import { useMultiGradHistogram } from '@renderer/hooks/useMultiGradHistogram';
+import type { GetMultiGradStateResult } from '@renderer/worker/server/services/rendererColoring.service';
+import { PAN_STEP, type MultiGradStop } from './gradientStops';
+
+export interface UseGradientViewDomainOptions {
+    cm: AsyncCueMol | null;
+    sceneId: number | undefined;
+    rendId: number | null;
+    state: GetMultiGradStateResult | null;
+    canonicalStops: MultiGradStop[];
+    /** Non-null while a drag is previewing; freezes the axis. */
+    previewStops: MultiGradStop[] | null;
+    /** Measured strip width, for the histogram's bin count. */
+    stripWidth: number;
+}
+
+export function useGradientViewDomain({
+    cm, sceneId, rendId, state, canonicalStops, previewStops, stripWidth,
+}: UseGradientViewDomainOptions) {
+    // User zoom / pan; null means "follow the fit domain".
+    const [viewOverride, setViewOverride] = useState<ValueDomain | null>(null);
+
+    // Fit domain (the -/+/Fit baseline): the stop range when nodes exist;
+    // otherwise the central-95% histogram range (raw map min/max is
+    // usually blown up by outliers), then the raw map range, then a
+    // synthetic fallback.
+    const fitDomain = useMemo<ValueDomain>(() => {
+        if (canonicalStops.length >= 2) {
+            const min = canonicalStops[0].value
+            const max = canonicalStops[canonicalStops.length - 1].value
+            if (max > min) return { min, max }
+        }
+        const p = state?.mapPercentiles
+        if (p && p.hi > p.lo) return { min: p.lo, max: p.hi }
+        const stats = state?.mapStats
+        if (stats && stats.max > stats.min) {
+            return { min: stats.min, max: stats.max }
+        }
+        if (canonicalStops.length === 1) {
+            const v = canonicalStops[0].value
+            return { min: v - 0.5, max: v + 0.5 }
+        }
+        return { min: 0, max: 1 }
+    }, [canonicalStops, state?.mapPercentiles, state?.mapStats])
+
+    const activeDomain = viewOverride ?? fitDomain
+
+    // Freeze the domain while an override is live so a mid-drag canonical
+    // refetch (whose values follow the drag) cannot rescale the bar.
+    const frozenDomainRef = useRef(activeDomain)
+    if (previewStops === null) frozenDomainRef.current = activeDomain
+    const viewDomain = previewStops !== null
+        ? frozenDomainRef.current
+        : activeDomain
+
+    const handleZoom = useCallback((factor: number) => {
+        setViewOverride((prev) => zoomDomain(prev ?? frozenDomainRef.current, factor))
+    }, [])
+
+    const handlePan = useCallback((direction: -1 | 1) => {
+        setViewOverride((prev) => {
+            const base = prev ?? frozenDomainRef.current
+            // Derive max from min + span (rather than shifting both ends)
+            // so repeated pans cannot drift the span through floating-
+            // point accumulation, which would silently change the zoom.
+            const span = base.max - base.min
+            const min = base.min + span * PAN_STEP * direction
+            return { min, max: min + span }
+        })
+    }, [])
+
+    // Floor on the bin width, from the map's own statistics: zooming in
+    // past it cannot reveal more structure, so the bars widen instead of
+    // splitting into empty comb teeth.
+    const minBinWidth = useMemo(() => {
+        const s = state?.mapStats
+        if (!s) return 0
+        return minHistogramBinWidth({
+            sigma: s.sigma,
+            min: s.min,
+            max: s.max,
+            voxelCount: state?.mapVoxelCount ?? null,
+            peakCount: state?.mapPeakCount ?? null,
+            quantStep: s.quantStep,
+        })
+    }, [state?.mapStats, state?.mapVoxelCount, state?.mapPeakCount])
+
+    const histogram = useMultiGradHistogram({
+        cm,
+        sceneId,
+        rendId,
+        domain: viewDomain,
+        widthPx: stripWidth,
+        minBinWidth,
+        paused: previewStops !== null,
+        enabled: state?.capable === true,
+    })
+
+    return {
+        fitDomain,
+        activeDomain,
+        viewDomain,
+        histogram,
+        handleZoom,
+        handlePan,
+        setViewOverride,
+        /** True while the view is zoomed / panned off the fit baseline. */
+        isViewOverridden: viewOverride !== null,
+        /**
+         * The domain as it was when the current drag began. A commit compares
+         * the new stop range against it to decide whether the view has to
+         * follow, so it needs the same frozen value the strip is drawing.
+         */
+        frozenDomainRef,
+    };
+}

--- a/tritium/react-gui/src/renderer/components/panes/DensityMapPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/DensityMapPane.tsx
@@ -41,9 +41,9 @@ import {
 } from '@blueprintjs/core'
 import { AppIcon } from '@renderer/h3-kit/primitives'
 import { PaneSectionHeader } from './PaneSectionHeader'
+import { DragRow, type MapPropWriteOpts } from './densityMap/DragRow'
 import { useDensityMapPanel } from '../../hooks/useDensityMapPanel'
-import { useRealtimeDragProp } from '@renderer/hooks/react/useRealtimeDragProp'
-import { FieldGrid, FieldGridRow, DragNumericField } from '../../h3-kit/form'
+import { FieldGrid } from '../../h3-kit/form'
 import type {
     MapRendererEntry,
     MapRendererPropName,
@@ -66,86 +66,7 @@ import { useActiveScene } from '../../state/workspace'
  */
 const CHECK_SPACER = <span style={{ display: 'inline-block', width: 16 }} aria-hidden />
 
-/** Stored-value write options threaded to `setMapRendererProp`. */
-interface MapPropWriteOpts {
-    mode?: 'preview' | 'commit' | 'abort'
-    originalValue?: number
-    originalWasDefault?: boolean
-}
-
-/**
- * Labeled drag-to-snap numeric row for the density-map panel. Holds a local
- * draft in displayed units (stored * scale) for live feedback and commits the
- * stored value on drag end / Enter so a drag is one undo step (via
- * `useRealtimeDragProp`).
- *
- * With `realtime`, the renderer updates live during the drag: the worker
- * previews each frame without undo and commits a single step on release.
- * `onWrite` mirrors `setMapRendererProp`'s contract (stored value + optional
- * mode / originalValue).
- */
-const DragRow: React.FC<{
-    label: string
-    value: number
-    min: number
-    max: number
-    step: number
-    unit?: string
-    scale?: number
-    disabled?: boolean
-    realtime?: boolean
-    /** The prop's default flag (flag-based), frozen at drag start for restore. */
-    committedIsDefault?: boolean
-    onWrite: (stored: number, opts?: MapPropWriteOpts) => void
-}> = ({
-    label,
-    value,
-    min,
-    max,
-    step,
-    unit,
-    scale = 1,
-    disabled,
-    realtime,
-    committedIsDefault,
-    onWrite,
-}) => {
-    const dragProps = useRealtimeDragProp({
-        committed: value * scale,
-        committedIsDefault,
-        realtime,
-        onPreview: (v) => onWrite(v / scale, { mode: 'preview' }),
-        onCommit: (original, v, wasDefault) => {
-            const stored = v / scale
-            if (stored === original / scale) return
-            // Realtime: restore the pre-drag value (and default flag) before the
-            // single undo step. Non-realtime: plain commit (current behavior).
-            if (realtime)
-                onWrite(stored, {
-                    mode: 'commit',
-                    originalValue: original / scale,
-                    originalWasDefault: wasDefault,
-                })
-            else onWrite(stored)
-        },
-        onAbort: (original, wasDefault) =>
-            onWrite(original / scale, { mode: 'abort', originalWasDefault: wasDefault }),
-    })
-    return (
-        <FieldGridRow label={label}>
-            <DragNumericField
-                {...dragProps}
-                min={min}
-                max={max}
-                step={step}
-                unit={unit}
-                disabled={disabled}
-            />
-        </FieldGridRow>
-    )
-}
-
-interface DensityMapPaneProps {
+/** Stored-value write options threaded to `setMapRendererProp`. */interface DensityMapPaneProps {
     collapsed?: boolean
     onToggleCollapse?: () => void
 }

--- a/tritium/react-gui/src/renderer/components/panes/SelectionPane.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/SelectionPane.tsx
@@ -25,6 +25,7 @@
 import React, { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { Button, Popover } from '@blueprintjs/core';
 import { PaneSectionHeader } from './PaneSectionHeader';
+import { useSelectionValidation } from './selection/useSelectionValidation';
 import { AppIcon, Tooltip } from '@renderer/h3-kit/primitives';
 import { ObjectSelect, objectFilters } from '../../h3-kit/ObjectSelect';
 import { fireService } from '../../utils/fireService';
@@ -52,10 +53,8 @@ interface SelectionPaneProps {
 
 /* --- Constants --- */
 
-const VALIDATE_DEBOUNCE_MS = 500;
 // Mirror MolSelList/selHistory.SKIP: values that pushHistory ignores.
 // Skipping the validate round-trip for these as well matches MolSelList.
-const VALIDATE_SKIP = new Set(['', '*', 'none']);
 
 /* --- Component --- */
 
@@ -82,7 +81,6 @@ export const SelectionPane: React.FC<SelectionPaneProps> = ({ collapsed, onToggl
     // not clobber a persisted pending edit (only a genuine mol.sel change does).
     const syncedSelRef = useRef<string>(seededForScene() ? loadSnapshot()!.syncedSel : '');
 
-    const [isValid, setIsValid] = useState(true);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
     const [historyItems, setHistoryItems] = useState<string[]>(() => getHistory());
 
@@ -232,35 +230,7 @@ export const SelectionPane: React.FC<SelectionPaneProps> = ({ collapsed, onToggl
         () => applySelection(textDraft, true),
         [applySelection, textDraft],
     );
-
-    // ---- Live validation (debounced) of the text field ----
-    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    useEffect(() => {
-        if (!cm || activeSceneId === undefined) {
-            setIsValid(true);
-            return;
-        }
-        if (debounceRef.current !== null) clearTimeout(debounceRef.current);
-        const trimmed = textDraft.trim();
-        if (VALIDATE_SKIP.has(trimmed)) {
-            setIsValid(true);
-            return;
-        }
-        let cancelled = false;
-        debounceRef.current = setTimeout(() => {
-            cm.invokeService('validateSelection', { selStr: trimmed, sceneId: activeSceneId })
-                .then((res) => {
-                    if (!cancelled) setIsValid(res.ok);
-                })
-                .catch(() => {
-                    if (!cancelled) setIsValid(true);
-                });
-        }, VALIDATE_DEBOUNCE_MS);
-        return () => {
-            cancelled = true;
-            if (debounceRef.current !== null) clearTimeout(debounceRef.current);
-        };
-    }, [cm, textDraft, activeSceneId]);
+    const isValid = useSelectionValidation({ cm, sceneId: activeSceneId, text: textDraft });
 
     // Center the active view on the applied selection.
     const canCenter = canApply && activeMolViewId !== undefined;

--- a/tritium/react-gui/src/renderer/components/panes/densityMap/DragRow.tsx
+++ b/tritium/react-gui/src/renderer/components/panes/densityMap/DragRow.tsx
@@ -1,0 +1,94 @@
+/**
+ * @file components/panes/densityMap/DragRow.tsx
+ * @description A labelled drag-number row for a map renderer property.
+ *
+ * The map panel writes properties by name rather than through the inspector's
+ * `GenericPropEntry` plumbing, so it cannot use the inspector's `NumRow`: that
+ * one takes an entry and reports back through it. This row takes the value and
+ * a writer, and threads the same realtime lifecycle (preview per frame, one
+ * commit on release, rollback on abort) through `useRealtimeDragProp`.
+ */
+
+import React from 'react';
+import { useRealtimeDragProp } from '@renderer/hooks/react/useRealtimeDragProp';
+import { FieldGridRow, DragNumericField } from '@renderer/h3-kit/form';
+
+void React; // classic JSX runtime (vitest)
+
+export interface MapPropWriteOpts {
+    mode?: 'preview' | 'commit' | 'abort'
+    originalValue?: number
+    originalWasDefault?: boolean
+}
+
+/**
+ * Labeled drag-to-snap numeric row for the density-map panel. Holds a local
+ * draft in displayed units (stored * scale) for live feedback and commits the
+ * stored value on drag end / Enter so a drag is one undo step (via
+ * `useRealtimeDragProp`).
+ *
+ * With `realtime`, the renderer updates live during the drag: the worker
+ * previews each frame without undo and commits a single step on release.
+ * `onWrite` mirrors `setMapRendererProp`'s contract (stored value + optional
+ * mode / originalValue).
+ */
+export const DragRow: React.FC<{
+    label: string
+    value: number
+    min: number
+    max: number
+    step: number
+    unit?: string
+    scale?: number
+    disabled?: boolean
+    realtime?: boolean
+    /** The prop's default flag (flag-based), frozen at drag start for restore. */
+    committedIsDefault?: boolean
+    onWrite: (stored: number, opts?: MapPropWriteOpts) => void
+}> = ({
+    label,
+    value,
+    min,
+    max,
+    step,
+    unit,
+    scale = 1,
+    disabled,
+    realtime,
+    committedIsDefault,
+    onWrite,
+}) => {
+    const dragProps = useRealtimeDragProp({
+        committed: value * scale,
+        committedIsDefault,
+        realtime,
+        onPreview: (v) => onWrite(v / scale, { mode: 'preview' }),
+        onCommit: (original, v, wasDefault) => {
+            const stored = v / scale
+            if (stored === original / scale) return
+            // Realtime: restore the pre-drag value (and default flag) before the
+            // single undo step. Non-realtime: plain commit (current behavior).
+            if (realtime)
+                onWrite(stored, {
+                    mode: 'commit',
+                    originalValue: original / scale,
+                    originalWasDefault: wasDefault,
+                })
+            else onWrite(stored)
+        },
+        onAbort: (original, wasDefault) =>
+            onWrite(original / scale, { mode: 'abort', originalWasDefault: wasDefault }),
+    })
+    return (
+        <FieldGridRow label={label}>
+            <DragNumericField
+                {...dragProps}
+                min={min}
+                max={max}
+                step={step}
+                unit={unit}
+                disabled={disabled}
+            />
+        </FieldGridRow>
+    )
+}

--- a/tritium/react-gui/src/renderer/components/panes/selection/useSelectionValidation.ts
+++ b/tritium/react-gui/src/renderer/components/panes/selection/useSelectionValidation.ts
@@ -1,0 +1,70 @@
+/**
+ * @file components/panes/selection/useSelectionValidation.ts
+ * @description Live validity of the selection expression being typed.
+ *
+ * The field shows an invalid state, so the answer has to be current -- but a
+ * selection compiles in C++, and asking on every keystroke would compile a
+ * dozen half-written expressions per word. Hence the debounce, and the
+ * cancelled flag: a reply that arrives after the text moved on would mark the
+ * wrong expression.
+ *
+ * The empty string, `*` and `none` are answered without asking. They are
+ * always valid, and they are what the field holds most of the time.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol';
+
+/** Wait this long after the last keystroke before compiling. */
+export const VALIDATE_DEBOUNCE_MS = 500;
+
+/** Expressions that need no round trip to be known valid. */
+const VALIDATE_SKIP = new Set(['', '*', 'none']);
+
+export interface UseSelectionValidationOptions {
+    cm: AsyncCueMol | null;
+    sceneId: number | undefined;
+    /** The text currently in the field. */
+    text: string;
+}
+
+/**
+ * True while the expression is valid (or not worth asking about). Optimistic:
+ * a failed round trip reports valid rather than marking a field the user
+ * cannot fix.
+ */
+export function useSelectionValidation({
+    cm, sceneId, text,
+}: UseSelectionValidationOptions): boolean {
+    const [isValid, setIsValid] = useState(true);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (!cm || sceneId === undefined) {
+            setIsValid(true);
+            return;
+        }
+        if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+        const trimmed = text.trim();
+        if (VALIDATE_SKIP.has(trimmed)) {
+            setIsValid(true);
+            return;
+        }
+        let cancelled = false;
+        debounceRef.current = setTimeout(() => {
+            cm.invokeService('validateSelection', { selStr: trimmed, sceneId })
+                .then((res) => {
+                    if (!cancelled) setIsValid(res.ok);
+                })
+                .catch(() => {
+                    if (!cancelled) setIsValid(true);
+                });
+        }, VALIDATE_DEBOUNCE_MS);
+        return () => {
+            cancelled = true;
+            if (debounceRef.current !== null) clearTimeout(debounceRef.current);
+        };
+    }, [cm, text, sceneId]);
+
+    return isValid;
+}


### PR DESCRIPTION
Phase 3-3 の残り 3 本です。前回までの反省（先行 PR が merge されるたびに後続の rebase + CI 再実行が要る）から、**独立した 3 つを 1 PR にまとめました**。commit は 2 つに分かれており、それぞれ独立して読めます。

## 1. `MultiGradSection` 668 → 557 + 2 ファイル (`6c6b0ce9`)

このファイルで一番大きかったのは**編集ではなく「ストリップがどの値域を見ているか」を決める部分**でした。

その値域は**意図的にストップの範囲と別**です。ストップを正確に置くためにズームしたユーザーが、ストップを動かすたびに view が戻されては困るからです。したがって view は fit ベースラインの上のオーバーライドで、**ベースラインは生の map min/max ではなくヒストグラムの中央 95% を優先します** — 外れ値のボクセル 1 つで全ストップが端の細片に潰れるため。そして**ドラッグ中は値域を凍結**します（ストップが動いているときに軸も動くと、マーカーが止まって見える）。

この 3 つのルールが hook の中身であり、名前を付ける価値がある理由です。section に残ったのは編集そのもの — どのストップが選択されているか、ドラッグが何を書くか、ツールバーが何をするか。

ストップの形も一緒に出しました。**ストップが色を 2 つ持つ**のは、`color` が renderer の保持する CueMol 文字列（名前かもしれない）で `hex` が swatch の描画色だからです。両者が食い違うのは楽観的更新と refetch の間だけで、それが `resolveDisplayHex` の存在理由です。

## 2. `DensityMapPane` 490 → 411、`SelectionPane` 439 → 409 (`2d892c6d`)

**`DragRow` は inspector の `NumRow` に見えて、そうはできません。** map パネルはプロパティを名前で書きますが、`NumRow` は `GenericPropEntry` を受け取ってそれ経由で報告します。**計画はこの 2 つを統合する想定でしたが、できません** — その理由を次に読む人が見る場所に書きました。realtime のライフサイクル（フレームごとの preview、リリース時の 1 commit、abort でロールバック）は同じです。

**`SelectionPane` のライブ検証**は debounce と cancelled フラグで、**両方が効いています**: selection は C++ でコンパイルされるので、キーストロークごとに聞くと 1 単語あたり書きかけの式を十数回コンパイルすることになります。また、テキストが先に進んだ後に届いた返答は**別の式を判定してしまいます**。空文字 / `*` / `none` は往復せず即座に valid（常に valid で、フィールドがほとんどの時間その値を持つため）。失敗時は楽観的に valid を返します — ユーザーが直しようのないフィールドを invalid 表示するより良いので。

**この 2 本は exhaustive-deps の warning を 1 件も増やしませんでした。** この一連の分割で初めてです — 切り出した部品が setter ではなく値を受け取るためです。

## 検証

- typecheck (web + node) OK
- vitest **363 files / 3431 tests all pass**
- ESLint **0 errors / 72 warnings**（ベースライン）、stylelint 14（ベースライン）、lint:comments OK
- `task build_tritium` OK / `task run_tritium` で `shader program created OK` まで到達

**目視確認のお願い**: **Color pane の Multi-gradient** — ズーム（−/＋）とパン（＜/＞）、**Fit ボタンの有効/無効**、**ドラッグ中に軸が動かないこと**、ストップ移動後に必要なら view が追従すること。**Density map pane** の各スライダ（Transp / Level / Extent）のドラッグとステッパー。**Selection pane** で不正な式を打ったときの invalid 表示と、`*` を打ったときに即座に valid になること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jq8nSHJWsEpfSui98LTXR
