### PR TITLE
fix(app): show each window once it has something worth showing

### DIFF
--- a/tritium/react-gui/src/main/handlers/windowActions.test.ts
+++ b/tritium/react-gui/src/main/handlers/windowActions.test.ts
@@ -30,6 +30,8 @@ vi.mock('../ipc/handleInvoke', () => ({
     },
 }));
 
+vi.mock('../windows/reveal', () => ({ revealWindow: vi.fn() }));
+
 vi.mock('../quitState', () => ({
     setAppQuitting: vi.fn(),
     setCloseConfirmed: vi.fn(),
@@ -39,6 +41,7 @@ vi.mock('../quitState', () => ({
 
 import { app, BrowserWindow } from 'electron';
 import { IPC } from '@shared/ipcChannels';
+import { revealWindow } from '../windows/reveal';
 import { registerWindowHandlers } from './windowActions';
 
 /** A window stub with just the surface these handlers touch. */
@@ -104,5 +107,29 @@ describe('MENU_INVOKE_ROLE', () => {
         invokeRole({ sender: {} }, 'quit');
 
         expect(app.quit).not.toHaveBeenCalled();
+    });
+});
+
+describe('WINDOW_REVEAL', () => {
+    it('reveals the window the signal came from', () => {
+        handlers.clear();
+        vi.clearAllMocks();
+        registerWindowHandlers(makeWindow() as never);
+        const sender = makeWindow();
+        vi.mocked(BrowserWindow.fromWebContents).mockReturnValueOnce(sender as never);
+
+        handlers.get(IPC.WINDOW_REVEAL)!({ sender: {} });
+
+        expect(revealWindow).toHaveBeenCalledWith(sender);
+    });
+
+    it('does nothing for a sender with no window', () => {
+        handlers.clear();
+        vi.clearAllMocks();
+        registerWindowHandlers(makeWindow() as never);
+
+        handlers.get(IPC.WINDOW_REVEAL)!({ sender: {} });
+
+        expect(revealWindow).not.toHaveBeenCalled();
     });
 });

--- a/tritium/react-gui/src/main/handlers/windowActions.ts
+++ b/tritium/react-gui/src/main/handlers/windowActions.ts
@@ -13,6 +13,7 @@ import { app, BrowserWindow } from 'electron';
 import { IPC } from '@shared/ipcChannels';
 import { APP_PRODUCT_NAME } from '@shared/appInfo';
 import { handleInvoke } from '../ipc/handleInvoke';
+import { revealWindow } from '../windows/reveal';
 import {
   setAppQuitting,
   setCloseConfirmed,
@@ -22,6 +23,13 @@ import {
 
 /** Register the window-scoped channels. */
 export function registerWindowHandlers(mainWindow: BrowserWindow): void {
+  // The renderer's first real frame is up: the window it came from was
+  // created hidden and is waiting on exactly this (see windows/reveal.ts).
+  handleInvoke(IPC.WINDOW_REVEAL, (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) revealWindow(win);
+  });
+
   handleInvoke(IPC.WINDOW_CLOSE_PROCEED, (_event, { proceed }) => {
     setCloseInFlight(mainWindow, false)
     if (proceed) {

--- a/tritium/react-gui/src/main/quitFunnel.test.ts
+++ b/tritium/react-gui/src/main/quitFunnel.test.ts
@@ -146,6 +146,9 @@ class BrowserWindow {
     l.push(cb)
     this.listeners.set(event, l)
   })
+  // createWindow() holds the window off screen until the renderer signals
+  // (windows/reveal.ts), which subscribes with once().
+  once = this.on
   constructor() {
     constructedWin = this as unknown as FakeWindow
   }

--- a/tritium/react-gui/src/main/windows/mainWindow.ts
+++ b/tritium/react-gui/src/main/windows/mainWindow.ts
@@ -20,6 +20,7 @@ import { setAppQuitting, setCloseConfirmed, setForceQuit } from '../quitState'
 import { chromeWindowOptions, forwardConsoleMessages, hideMenuBar } from './windowChrome'
 import { isVisibleOnAnyDisplay, trackWindowState } from './windowState'
 import { handleWindowClose } from './closeFunnel'
+import { holdUntilRevealed } from './reveal'
 import { createOrFocusRenderWindow, getRenderWindow } from './renderWindow'
 
 let mainWindow: BrowserWindow | null = null
@@ -112,11 +113,11 @@ export function createWindow(): void {
 
   hideMenuBar(win)
 
-  if (saved?.isMaximized) {
-    win.maximize()
-  }
-
-  win.on('ready-to-show', () => {
+  // Shown when the renderer reports its first real frame (reveal.ts).
+  // Restoring the maximized state waits for the same moment: `maximize()`
+  // shows a window that is being held back.
+  holdUntilRevealed(win, () => {
+    if (saved?.isMaximized) win.maximize()
     win.show()
     win.focus()
   })

--- a/tritium/react-gui/src/main/windows/renderWindow.ts
+++ b/tritium/react-gui/src/main/windows/renderWindow.ts
@@ -12,6 +12,7 @@ import {
 import { registerTextContextMenu } from '../textContextMenu'
 import { chromeWindowOptions, forwardConsoleMessages, hideMenuBar } from './windowChrome'
 import { isVisibleOnAnyDisplay, trackWindowState } from './windowState'
+import { holdUntilRevealed } from './reveal'
 
 let renderWindow: BrowserWindow | null = null
 
@@ -84,9 +85,10 @@ export function createOrFocusRenderWindow(mainWindow: BrowserWindow): void {
 
   hideMenuBar(win)
 
-  win.on('ready-to-show', () => {
-    if (!win.isDestroyed()) win.show()
-  })
+  // Shown when its page reports the first frame with the main window's
+  // answers in it (reveal.ts), not on Electron's first-paint event, which for
+  // this page is an empty root element.
+  holdUntilRevealed(win, () => win.show())
 
   // Adopt the main window's UI zoom. Zoom level is per-webContents and resets
   // on load, so it is applied after the page is up rather than at creation;

--- a/tritium/react-gui/src/main/windows/reveal.test.ts
+++ b/tritium/react-gui/src/main/windows/reveal.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @file main/windows/reveal.test.ts
+ * @description The three ways a held-back window ends up on screen.
+ *
+ * A window is created hidden and shown when its renderer says so. That signal
+ * can come, can come late, or can never come; the fallback armed by
+ * `ready-to-show` covers the last, and a second signal or a signal for a
+ * window that closed meanwhile must do nothing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { holdUntilRevealed, revealWindow, REVEAL_FALLBACK_MS } from './reveal';
+
+type Listener = () => void;
+
+function makeWindow() {
+    const once = new Map<string, Listener[]>();
+    let destroyed = false;
+    return {
+        isDestroyed: () => destroyed,
+        once: vi.fn((event: string, cb: Listener) => {
+            once.set(event, [...(once.get(event) ?? []), cb]);
+        }),
+        fire(event: string) {
+            const cbs = once.get(event) ?? [];
+            once.delete(event);
+            for (const cb of cbs) cb();
+        },
+        destroy() {
+            destroyed = true;
+            this.fire('closed');
+        },
+    };
+}
+
+describe('holdUntilRevealed', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('reveals on the signal, exactly once', () => {
+        const win = makeWindow();
+        const reveal = vi.fn();
+        holdUntilRevealed(win as never, reveal);
+        expect(reveal).not.toHaveBeenCalled();
+
+        revealWindow(win as never);
+        revealWindow(win as never);
+        expect(reveal).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reveal on ready-to-show, which fires before the page has content', () => {
+        const win = makeWindow();
+        const reveal = vi.fn();
+        holdUntilRevealed(win as never, reveal);
+
+        win.fire('ready-to-show');
+        expect(reveal).not.toHaveBeenCalled();
+    });
+
+    it('falls back to revealing a while after ready-to-show when no signal comes', () => {
+        const win = makeWindow();
+        const reveal = vi.fn();
+        holdUntilRevealed(win as never, reveal);
+
+        win.fire('ready-to-show');
+        vi.advanceTimersByTime(REVEAL_FALLBACK_MS - 1);
+        expect(reveal).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(reveal).toHaveBeenCalledTimes(1);
+
+        // The late signal finds nothing left to do.
+        revealWindow(win as never);
+        expect(reveal).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets the signal cancel the fallback', () => {
+        const win = makeWindow();
+        const reveal = vi.fn();
+        holdUntilRevealed(win as never, reveal);
+
+        win.fire('ready-to-show');
+        revealWindow(win as never);
+        vi.advanceTimersByTime(REVEAL_FALLBACK_MS);
+        expect(reveal).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing for a window that closed while waiting', () => {
+        const win = makeWindow();
+        const reveal = vi.fn();
+        holdUntilRevealed(win as never, reveal);
+
+        win.fire('ready-to-show');
+        win.destroy();
+        revealWindow(win as never);
+        vi.advanceTimersByTime(REVEAL_FALLBACK_MS);
+        expect(reveal).not.toHaveBeenCalled();
+    });
+
+    it('ignores a signal from a window it is not holding', () => {
+        expect(() => revealWindow(makeWindow() as never)).not.toThrow();
+    });
+});

--- a/tritium/react-gui/src/main/windows/reveal.ts
+++ b/tritium/react-gui/src/main/windows/reveal.ts
@@ -1,0 +1,54 @@
+/**
+ * @file main/windows/reveal.ts
+ * @description When a held-back window goes on screen.
+ *
+ * Both windows are created hidden (`show: false` in windowChrome) and revealed
+ * on the renderer's say-so -- `IPC.WINDOW_REVEAL`, sent once the first frame
+ * worth looking at has painted. Electron's own `ready-to-show` fires on the
+ * document's first paint, which for these pages is an empty root element:
+ * React has not mounted yet, let alone fetched what the widgets show. So
+ * revealing there put an unfurnished window on screen and let the user watch
+ * it fill in, and the same for the main window at launch.
+ *
+ * `ready-to-show` still arms a fallback, so a renderer that never sends the
+ * signal -- crashed during boot, or running without Electron's bridge -- is
+ * shown anyway: late, rather than never.
+ */
+
+import type { BrowserWindow } from 'electron'
+
+/**
+ * How long after the page's first paint to wait for the renderer's signal.
+ * The main window's takes ~750 ms on this machine (its first scene has to be
+ * created by the worker first); the margin is for slower ones.
+ */
+export const REVEAL_FALLBACK_MS = 3000
+
+const pending = new Map<BrowserWindow, () => void>()
+
+/**
+ * Keep `win` hidden until `revealWindow(win)` or the fallback, whichever
+ * comes first; `reveal` runs exactly once, and not at all for a window that
+ * closed while waiting.
+ */
+export function holdUntilRevealed(win: BrowserWindow, reveal: () => void): void {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const fire = (): void => {
+    if (!pending.delete(win)) return
+    if (timer) clearTimeout(timer)
+    if (!win.isDestroyed()) reveal()
+  }
+  pending.set(win, fire)
+  win.once('ready-to-show', () => {
+    if (pending.has(win)) timer = setTimeout(fire, REVEAL_FALLBACK_MS)
+  })
+  win.once('closed', () => {
+    pending.delete(win)
+    if (timer) clearTimeout(timer)
+  })
+}
+
+/** The renderer's signal. A window not being held (already shown) ignores it. */
+export function revealWindow(win: BrowserWindow): void {
+  pending.get(win)?.()
+}

--- a/tritium/react-gui/src/main/windows/windowChrome.ts
+++ b/tritium/react-gui/src/main/windows/windowChrome.ts
@@ -31,6 +31,11 @@ export function chromeWindowOptions(
 ): BrowserWindowConstructorOptions {
   const icon = getDevIconPath()
   return {
+    // Created off screen; revealed when the renderer says its first real
+    // frame is up (see reveal.ts). Electron shows a window as soon as it is
+    // constructed unless told otherwise, so both windows used to appear empty
+    // and then be furnished in front of the user.
+    show: false,
     backgroundColor: CHROME_BG,
     // Window / taskbar icon for an unpackaged run on Windows and Linux
     // (undefined once packaged, and ignored on macOS -- see appIcon.ts).

--- a/tritium/react-gui/src/main/windows/windowVisibility.test.ts
+++ b/tritium/react-gui/src/main/windows/windowVisibility.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @file main/windows/windowVisibility.test.ts
+ * @description Neither window goes on screen before its renderer says so.
+ *
+ * Both windows had a `ready-to-show` handler and `show` left at its default,
+ * so each appeared the moment it was constructed -- empty -- and was then
+ * furnished in front of the user. Holding them back on `ready-to-show` alone
+ * would not have helped: that event fires on the document's first paint,
+ * which for these pages is an empty root element. The reveal is the
+ * renderer's call (reveal.ts); this pins that creation defers to it.
+ *
+ * The main window had a second way of revealing itself: `maximize()` shows a
+ * window that is being held back, so restoring the maximized state has to
+ * wait for the reveal too.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { FakeWindow, state } = vi.hoisted(() => {
+    type Listener = (...args: unknown[]) => void;
+    const state = { constructed: null as InstanceType<typeof FakeWindow> | null, saved: null as unknown };
+    class FakeWindow {
+        listeners = new Map<string, Listener[]>();
+        maximize = vi.fn();
+        show = vi.fn();
+        focus = vi.fn();
+        setMenuBarVisibility = vi.fn();
+        loadURL = vi.fn();
+        loadFile = vi.fn();
+        isDestroyed = vi.fn(() => false);
+        isMaximized = vi.fn(() => false);
+        getBounds = vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 }));
+        webContents = {
+            on: vi.fn(),
+            send: vi.fn(),
+            openDevTools: vi.fn(),
+            getZoomLevel: vi.fn(() => 0),
+            setZoomLevel: vi.fn(),
+        };
+        on = vi.fn((event: string, cb: Listener) => {
+            this.listeners.set(event, [...(this.listeners.get(event) ?? []), cb]);
+        });
+        once = this.on;
+        constructor(public options: Record<string, unknown>) {
+            state.constructed = this;
+        }
+        fire(event: string): void {
+            for (const cb of this.listeners.get(event) ?? []) cb();
+        }
+    }
+    return { FakeWindow, state };
+});
+
+vi.mock('electron', () => ({
+    app: { isPackaged: false, name: 'CueMol3', exit: vi.fn(), quit: vi.fn() },
+    BrowserWindow: FakeWindow,
+    screen: {
+        getAllDisplays: () => [{ workArea: { x: 0, y: 0, width: 3000, height: 2000 } }],
+        getDisplayMatching: () => ({ workArea: { x: 0, y: 0, width: 3000, height: 2000 } }),
+    },
+}));
+vi.mock('../stateStore', () => ({
+    loadWindowBounds: () => state.saved,
+    saveWindowBounds: vi.fn(),
+    loadRenderWindowBounds: () => null,
+    saveRenderWindowBounds: vi.fn(),
+}));
+vi.mock('../ipcHandlers', () => ({ registerIpcHandlers: vi.fn() }));
+vi.mock('../renderWindowIpc', () => ({ registerRenderWindowIpc: vi.fn() }));
+vi.mock('../menu', () => ({ createMenu: vi.fn(), resetMenuBlockReason: vi.fn() }));
+vi.mock('../textContextMenu', () => ({ registerTextContextMenu: vi.fn() }));
+vi.mock('../cuemolClipboard', () => ({ registerCuemolClipboardIpc: vi.fn() }));
+vi.mock('../helpers/appIcon', () => ({ getDevIconPath: () => undefined }));
+
+import { chromeWindowOptions } from './windowChrome';
+import { createWindow } from './mainWindow';
+import { createOrFocusRenderWindow } from './renderWindow';
+import { revealWindow } from './reveal';
+
+const constructed = () => state.constructed!;
+
+describe('window visibility', () => {
+    beforeEach(() => {
+        state.constructed = null;
+        state.saved = null;
+        vi.clearAllMocks();
+    });
+    // createWindow() is a no-op while a main window exists; closing the one
+    // a test made lets the next test make its own.
+    afterEach(() => {
+        state.constructed?.fire('closed');
+    });
+
+    it('dresses every window to start hidden', () => {
+        expect(chromeWindowOptions().show).toBe(false);
+        expect(chromeWindowOptions({ worker: true }).show).toBe(false);
+    });
+
+    it('shows the main window on the renderer\'s signal, not on ready-to-show', () => {
+        createWindow();
+        const win = constructed();
+        expect(win.options['show']).toBe(false);
+
+        win.fire('ready-to-show');
+        expect(win.show).not.toHaveBeenCalled();
+
+        revealWindow(win as never);
+        expect(win.show).toHaveBeenCalledTimes(1);
+        expect(win.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores the maximized state at reveal time, not at construction', () => {
+        state.saved = { x: 0, y: 0, width: 1400, height: 900, isMaximized: true };
+        createWindow();
+        const win = constructed();
+        expect(win.maximize).not.toHaveBeenCalled();
+
+        revealWindow(win as never);
+        expect(win.maximize).toHaveBeenCalledTimes(1);
+        expect(win.show).toHaveBeenCalledTimes(1);
+        // maximize() itself shows the window, so it must run before show()
+        // or the window would appear un-maximized for a frame.
+        expect(win.maximize.mock.invocationCallOrder[0]).toBeLessThan(
+            win.show.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('shows the Rendering window on its renderer\'s signal', () => {
+        const parent = new FakeWindow({});
+        state.constructed = null;
+        createOrFocusRenderWindow(parent as never);
+        const win = constructed();
+        expect(win.options['show']).toBe(false);
+
+        win.fire('ready-to-show');
+        expect(win.show).not.toHaveBeenCalled();
+
+        revealWindow(win as never);
+        expect(win.show).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/workerServiceDispatch.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/workerServiceDispatch.test.ts
@@ -209,3 +209,47 @@ describe('WorkerService.invoke no-reply contract', () => {
         expect(posted).toEqual([]);
     });
 });
+
+/*
+ * The canvas size travels with the bind. The transferred canvas arrives at
+ * its attribute size, and a first frame drawn at that size was stretched
+ * over the whole pane until the first `resized` message landed -- a huge,
+ * blocky centre mark for a moment at launch.
+ */
+describe('WorkerService.bindCanvas sizing', () => {
+    function makeGfx() {
+        const calls: string[] = [];
+        return {
+            calls,
+            bindCanvas: vi.fn(() => { calls.push('bind'); }),
+            setLogicalSize: vi.fn(() => { calls.push('size'); }),
+            activateView: vi.fn(() => { calls.push('activate'); }),
+        };
+    }
+
+    it('sizes the backing store and the logical size before activating the view', () => {
+        const { svc } = makeSvc();
+        const gfx = makeGfx();
+        (svc as unknown as { _gfx_mgr: unknown })._gfx_mgr = gfx;
+        const canvas = { width: 300, height: 150 };
+
+        expect(svc.bindCanvas(canvas, 7, 2, 400, 300)).toBe(true);
+
+        expect(canvas).toEqual({ width: 800, height: 600 });
+        expect(gfx.setLogicalSize).toHaveBeenCalledWith(400, 300);
+        expect(gfx.calls).toEqual(['bind', 'size', 'activate']);
+    });
+
+    it('leaves the canvas alone when it had no size yet', () => {
+        const { svc } = makeSvc();
+        const gfx = makeGfx();
+        (svc as unknown as { _gfx_mgr: unknown })._gfx_mgr = gfx;
+        const canvas = { width: 300, height: 150 };
+
+        svc.bindCanvas(canvas, 7, 2, 0, 0);
+
+        expect(canvas).toEqual({ width: 300, height: 150 });
+        expect(gfx.setLogicalSize).not.toHaveBeenCalled();
+        expect(gfx.calls).toEqual(['bind', 'activate']);
+    });
+});

--- a/tritium/react-gui/src/renderer/contexts/ThemeContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/ThemeContext.tsx
@@ -51,6 +51,11 @@ interface ThemeContextValue {
   toggleTheme: () => void;
   /** Set a specific theme. */
   setTheme: (t: Theme) => void;
+  /**
+   * Whether the persisted choice has been read. Until then `theme` is the
+   * default, and a window shown on it would flip colours a moment later.
+   */
+  loaded: boolean;
 }
 
 // ------------------------------------------------------------
@@ -83,6 +88,7 @@ interface ThemeProviderProps {
 
 export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const [theme, setThemeState] = useState<Theme>("dark");
+  const [loaded, setLoaded] = useState(false);
 
   // -- Load persisted theme on mount -----------------------
   useEffect(() => {
@@ -98,6 +104,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
       } catch {
         // Electron not available (Vite dev server) -- keep default.
       }
+      if (!cancelled) setLoaded(true);
     })();
 
     return () => {
@@ -126,8 +133,8 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   }, []);
 
   const value = useMemo<ThemeContextValue>(
-    () => ({ theme, toggleTheme, setTheme }),
-    [theme, toggleTheme, setTheme],
+    () => ({ theme, toggleTheme, setTheme, loaded }),
+    [theme, toggleTheme, setTheme, loaded],
   );
 
   /*

--- a/tritium/react-gui/src/renderer/features/molview/MolViewPane.tsx
+++ b/tritium/react-gui/src/renderer/features/molview/MolViewPane.tsx
@@ -57,17 +57,16 @@ export const MolViewPane = React.memo((): React.JSX.Element => {
 
   /**
    * One-time initialization effect: binds the canvas to the OffscreenCanvas
-   * in the Web Worker using the view that was already created in App.tsx,
-   * then triggers an explicit initial resize.
+   * in the Web Worker using the view that was already created in App.tsx.
    *
-   * Why the explicit resize?
-   *   `transferControlToOffscreen()` captures the canvas at whatever pixel size
-   *   it has at call time (often 0×0 due to `height: 0px` in CSS + flex).
-   *   The ResizeObserver may have already fired once at that point, but
-   *   `getActiveViewId()` was null so the event was ignored.
-   *   After this effect completes, the size no longer changes and the
-   *   ResizeObserver will not re-fire -- so we must push the correct
-   *   dimensions to the worker explicitly here.
+   * The canvas's laid-out size goes with the bind, so the worker sizes the
+   * backing store before it draws the first frame. `transferControlToOffscreen()`
+   * hands over the canvas at its attribute size, and a frame drawn at that
+   * size is stretched over the pane until a resize arrives. The ResizeObserver
+   * below cannot supply one: it may already have fired (and been ignored,
+   * `getActiveViewId()` being null then) and will not fire again for a size
+   * that has not changed. The explicit resize after the bind remains for the
+   * case where the canvas had no size yet when it was bound.
    */
   useEffect(() => {
     if (!cueMolReady || !cm || !canvasRef.current) return
@@ -80,8 +79,10 @@ export const MolViewPane = React.memo((): React.JSX.Element => {
     ;(async () => {
       if (cancelled || !canvasRef.current) return
       const dpr = window.devicePixelRatio || 1
+      const bound = canvasRef.current.getBoundingClientRect()
+      const sizeAtBind = bound.width > 0 && bound.height > 0
       try {
-        await cm.bindCanvas(canvasRef.current, view_uid, dpr)
+        await cm.bindCanvas(canvasRef.current, view_uid, dpr, bound.width, bound.height)
       } catch (err) {
         // transferControlToOffscreen() throws InvalidStateError if this
         // element was ever transferred, and the worker call can reject.
@@ -92,21 +93,21 @@ export const MolViewPane = React.memo((): React.JSX.Element => {
         return
       }
 
-      // Send initial resize with actual layout dimensions.
-      // The ResizeObserver may have already fired (and been ignored because
-      // getActiveViewId() returned undefined), so we must explicitly sync.
-      if (canvasRef.current) {
-        const { width, height } = canvasRef.current.getBoundingClientRect()
-        if (width > 0 && height > 0) {
-          cm.resized(view_uid, width, height, dpr)
-          // Startup diagnostic (Output panel): the backing store is CSS x dpr,
-          // so a higher dpr acts as supersampling. Helps explain edge crispness
-          // differences across displays / platforms.
-          appendLogRef.current(
-            `[view] devicePixelRatio=${dpr}, css=${Math.round(width)}x${Math.round(height)}, ` +
-            `backing=${Math.round(width * dpr)}x${Math.round(height * dpr)} px`,
-          )
-        }
+      // The canvas had no size when it was bound: send it now. (Sending it
+      // again when it did have one would clear the freshly drawn frame.)
+      let { width, height } = bound
+      if (!sizeAtBind && canvasRef.current) {
+        ;({ width, height } = canvasRef.current.getBoundingClientRect())
+        if (width > 0 && height > 0) cm.resized(view_uid, width, height, dpr)
+      }
+      // Startup diagnostic (Output panel): the backing store is CSS x dpr,
+      // so a higher dpr acts as supersampling. Helps explain edge crispness
+      // differences across displays / platforms.
+      if (width > 0 && height > 0) {
+        appendLogRef.current(
+          `[view] devicePixelRatio=${dpr}, css=${Math.round(width)}x${Math.round(height)}, ` +
+          `backing=${Math.round(width * dpr)}x${Math.round(height * dpr)} px`,
+        )
       }
     })()
     return () => { cancelled = true }

--- a/tritium/react-gui/src/renderer/features/render/renderwindow/RenderWindowApp.tsx
+++ b/tritium/react-gui/src/renderer/features/render/renderwindow/RenderWindowApp.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useHoldReveal, useRevealWindow } from "@renderer/shell/reveal/useRevealWindow";
 import { Allotment } from "allotment";
 import { Alert } from "@blueprintjs/core";
 import "allotment/dist/style.css";
@@ -231,16 +232,31 @@ export const RenderWindowApp: React.FC = () => {
   // render starts from the projection the user is looking at. Re-read on every
   // target change; a manual edit stands until the target changes again.
   const targetViewId = client.targetViewId;
+  const [cameraPending, setCameraPending] = useState(false);
+  useHoldReveal(cameraPending);
   useEffect(() => {
     if (targetViewId === null) return;
     let cancelled = false;
-    void clientRef.current.getViewCamera(targetViewId).then((camera) => {
-      if (!cancelled && camera) settingsRef.current.applyViewCamera(camera);
-    });
+    setCameraPending(true);
+    void clientRef.current
+      .getViewCamera(targetViewId)
+      .then((camera) => {
+        if (!cancelled && camera) settingsRef.current.applyViewCamera(camera);
+      })
+      .finally(() => {
+        if (!cancelled) setCameraPending(false);
+      });
     return () => {
       cancelled = true;
+      setCameraPending(false);
     };
   }, [targetViewId]);
+
+  // The window is created hidden. It goes on screen once the main window's
+  // context has arrived (target views, mode) and every load that started on
+  // mount -- the camera above, the history image, a hatch template -- is in,
+  // so the first frame the user sees is the furnished one.
+  useRevealWindow(client.state.synced);
 
   // Surface a failed render / encode in a message box (the log is collapsed).
   // Keyed off the job's startedAt so each failure alerts once.

--- a/tritium/react-gui/src/renderer/features/render/useHatchTemplate.ts
+++ b/tritium/react-gui/src/renderer/features/render/useHatchTemplate.ts
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useRef, useState } from "react";
+import { useHoldReveal } from "@renderer/shell/reveal/useRevealWindow";
 import { parseHatchSpec, type HatchSpec } from "@renderer/data/hatchSpec";
 import type { HatchStyleSpecReply } from "@shared/types/renderWindow";
 
@@ -45,6 +46,8 @@ export function useHatchTemplate({
   fetchRef.current = fetchSpec;
   const loadedRef = useRef(onLoaded);
   loadedRef.current = onLoaded;
+  // A template loading on open keeps the window off screen until it is in.
+  useHoldReveal(status === "loading");
 
   useEffect(() => {
     if (!enabled || !style) {

--- a/tritium/react-gui/src/renderer/features/render/useRenderWindowClient.ts
+++ b/tritium/react-gui/src/renderer/features/render/useRenderWindowClient.ts
@@ -23,6 +23,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { IPC } from "@shared/ipcChannels";
 import type { RenderFramePreviewWire, RenderTargetViewWire, RenderWindowCommand, RenderWindowModeRequest, RenderWindowStateUpdate, RenderViewCamera, HatchStyleSpecReply, ViewSizePx, RelayKind, RelayReq, RelayRes } from "@shared/types/renderWindow";
 import type { RenderJob } from "./useRenderJob";
+import { useHoldReveal } from "@renderer/shell/reveal/useRevealWindow";
 import type {
   RenderResult,
   RenderSettingsSnapshot,
@@ -55,6 +56,8 @@ async function relayGet<K extends RelayKind>(
 
 
 export interface RenderWindowClientState {
+  /** Whether the first context push from the main window has arrived. */
+  synced: boolean;
   /** Mirrored render job (progress/log), or null when idle. */
   job: RenderJob | null;
   /**
@@ -86,6 +89,7 @@ const INITIAL_STATE: RenderWindowClientState = {
   history: [],
   historyIndex: -1,
   preview: null,
+  synced: false,
   views: [],
   activeViewId: null,
   umbreonAvailable: false,
@@ -176,6 +180,7 @@ export function useRenderWindowClient(): {
             ...prev,
             // Wire types are structural mirrors of the renderer types; cast
             // once at this boundary.
+            synced: true,
             job: update.job as RenderJob | null,
             views: update.views,
             activeViewId: update.activeViewId,
@@ -316,6 +321,10 @@ export function useRenderWindowClient(): {
   const shownResult = state.history[state.historyIndex] ?? null;
   const shownId = shownResult?.id ?? null;
   const [shownImage, setShownImage] = useState<string | null>(null);
+  // The window stays hidden while the image is on its way (the history's
+  // newest render is shown on open, and it is the largest thing on screen).
+  const [imagePending, setImagePending] = useState(false);
+  useHoldReveal(imagePending);
   useEffect(() => {
     if (shownId === null) {
       setShownImage(null);
@@ -323,6 +332,7 @@ export function useRenderWindowClient(): {
     }
     let cancelled = false;
     setShownImage(null);
+    setImagePending(true);
     void window.electronAPI
       ?.invoke(IPC.RENDER_HISTORY_READ, { resultId: shownId })
       .then((res) => {
@@ -330,9 +340,13 @@ export function useRenderWindowClient(): {
       })
       .catch(() => {
         if (!cancelled) setShownImage(null);
+      })
+      .finally(() => {
+        if (!cancelled) setImagePending(false);
       });
     return () => {
       cancelled = true;
+      setImagePending(false);
     };
   }, [shownId]);
 

--- a/tritium/react-gui/src/renderer/shell/AppBoot.tsx
+++ b/tritium/react-gui/src/renderer/shell/AppBoot.tsx
@@ -12,7 +12,9 @@ import React, { useCallback, useEffect } from 'react'
 import { IPC } from '@shared/ipcChannels'
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
 import { useWorkspaceDispatch, useWorkspaceTabs } from '@renderer/state/workspace'
-import { useLayoutDispatch } from '@renderer/state/layout'
+import { useLayout, useLayoutDispatch } from '@renderer/state/layout'
+import { useTheme } from '@renderer/contexts/ThemeContext'
+import { useRevealWindow } from '@renderer/shell/reveal/useRevealWindow'
 import { useAppInitialization } from '@renderer/hooks/useAppInitialization'
 import { useNewSceneAction } from '@renderer/hooks/useNewSceneAction'
 import { useShellOpenFiles } from '@renderer/features/file-io/useShellOpenFiles'
@@ -27,6 +29,8 @@ export const AppBoot: React.FC = () => {
   const { activateTab, closeTab, tabsRef } = useWorkspaceDispatch()
   const { tabs, activeTabId } = useWorkspaceTabs()
   const { flushPendingSaves } = useLayoutDispatch()
+  const { loaded: layoutLoaded } = useLayout()
+  const { loaded: themeLoaded } = useTheme()
 
   // Persist user-defined style defaults (atom labels, view-input scalars) to
   // the user style file when the window closes -- UXP `Qm2Main.onUnLoad`
@@ -68,6 +72,12 @@ export const AppBoot: React.FC = () => {
   // + view + register tab" action the New Tab dialog uses.
   const newScene = useNewSceneAction({ cm })
   const { initialSceneSettled } = useAppInitialization({ cueMolReady, newScene })
+
+  // The window is created hidden. It goes on screen once the persisted
+  // layout and theme are applied and the first scene's tab is in -- before
+  // that the user watched the splitters appear, the colours flip and the
+  // welcome pane give way to the molview.
+  useRevealWindow(layoutLoaded && themeLoaded && initialSceneSettled)
 
   // OS shell / command-line file open (UXP openFromShell parity).
   useShellOpenFiles({ cm, cueMolReady, initialSceneSettled })

--- a/tritium/react-gui/src/renderer/shell/reveal/revealGate.ts
+++ b/tritium/react-gui/src/renderer/shell/reveal/revealGate.ts
@@ -1,0 +1,50 @@
+/**
+ * @file renderer/shell/reveal/revealGate.ts
+ * @description What is still keeping this window off screen.
+ *
+ * The window is created hidden and main shows it when this renderer asks
+ * (IPC.WINDOW_REVEAL, sent by useRevealWindow). "Ready" is not one fact the
+ * shell can state: a pane that loads its content asynchronously on mount --
+ * the render history image, a hatch template -- knows about its own load and
+ * nothing else does. Such a pane takes a hold for as long as it is loading,
+ * and the reveal waits for the count to reach zero.
+ *
+ * Module state rather than context: a window has exactly one of these, and
+ * the holders sit at different depths of two different trees.
+ */
+
+type Listener = () => void;
+
+let holds = 0;
+const listeners = new Set<Listener>();
+
+/** Keep the window off screen until the returned release is called. */
+export function holdReveal(): () => void {
+    holds += 1;
+    let released = false;
+    return () => {
+        if (released) return;
+        released = true;
+        holds -= 1;
+        if (holds === 0) for (const l of [...listeners]) l();
+    };
+}
+
+/** How many holds are outstanding. */
+export function revealHolds(): number {
+    return holds;
+}
+
+/** Run `l` each time the hold count drops to zero. */
+export function onRevealClear(l: Listener): () => void {
+    listeners.add(l);
+    return () => {
+        listeners.delete(l);
+    };
+}
+
+/** Test seam: forget every hold and listener. */
+export function resetRevealGate(): void {
+    holds = 0;
+    listeners.clear();
+}

--- a/tritium/react-gui/src/renderer/shell/reveal/useRevealWindow.test.ts
+++ b/tritium/react-gui/src/renderer/shell/reveal/useRevealWindow.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @file renderer/shell/reveal/useRevealWindow.test.ts
+ * @description When the renderer asks main to show its window.
+ *
+ * Main keeps the window hidden until this signal, so the signal must come
+ * only when there is something to show: the shell's boot conditions met, no
+ * pane still loading what it displays, and the frame with all of that in it
+ * already painted.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { IPC } from '@shared/ipcChannels';
+import { makeRenderHook, setupElectronAPI, teardownElectronAPI } from '@renderer/__test__/helpers/testHarness';
+import { useHoldReveal, useRevealWindow } from './useRevealWindow';
+import { holdReveal, resetRevealGate } from './revealGate';
+
+let frames: FrameRequestCallback[] = [];
+/** Run every animation-frame callback queued so far (one frame). */
+function paint(): void {
+    const due = frames;
+    frames = [];
+    for (const cb of due) cb(0);
+}
+
+describe('useRevealWindow', () => {
+    let api: ReturnType<typeof setupElectronAPI>;
+    beforeEach(() => {
+        resetRevealGate();
+        frames = [];
+        vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+            frames.push(cb);
+            return frames.length;
+        });
+        vi.stubGlobal('cancelAnimationFrame', vi.fn());
+        api = setupElectronAPI();
+    });
+    afterEach(() => {
+        teardownElectronAPI();
+        vi.unstubAllGlobals();
+    });
+
+    const reveals = (): number =>
+        (api.invoke.mock.calls as unknown[][]).filter((c) => c[0] === IPC.WINDOW_REVEAL).length;
+
+    it('signals after the second frame once ready, and not before ready', () => {
+        let ready = false;
+        const h = makeRenderHook(() => useRevealWindow(ready));
+        act(() => paint());
+        expect(reveals()).toBe(0);
+
+        ready = true;
+        h.rerender();
+        act(() => paint());
+        expect(reveals()).toBe(0);
+        act(() => paint());
+        expect(reveals()).toBe(1);
+        h.unmount();
+    });
+
+    it('waits for a hold taken before it was ready', () => {
+        const release = holdReveal();
+        const h = makeRenderHook(() => useRevealWindow(true));
+        act(() => { paint(); paint(); });
+        expect(reveals()).toBe(0);
+
+        act(() => release());
+        act(() => { paint(); paint(); });
+        expect(reveals()).toBe(1);
+        h.unmount();
+    });
+
+    it('starts over when a hold arrives while it was waiting for the frames', () => {
+        const h = makeRenderHook(() => useRevealWindow(true));
+        act(() => paint());
+        // A pane mounted in the same commit starts its load in an effect that
+        // runs after ours, so its hold lands between the two frames.
+        const release = holdReveal();
+        act(() => paint());
+        expect(reveals()).toBe(0);
+
+        act(() => release());
+        act(() => { paint(); paint(); });
+        expect(reveals()).toBe(1);
+        h.unmount();
+    });
+
+    it('useHoldReveal holds for exactly as long as the flag is on', () => {
+        let on = true;
+        const hold = makeRenderHook(() => useHoldReveal(on));
+        const h = makeRenderHook(() => useRevealWindow(true));
+        act(() => { paint(); paint(); });
+        expect(reveals()).toBe(0);
+
+        on = false;
+        hold.rerender();
+        act(() => { paint(); paint(); });
+        expect(reveals()).toBe(1);
+        hold.unmount();
+        h.unmount();
+    });
+});

--- a/tritium/react-gui/src/renderer/shell/reveal/useRevealWindow.ts
+++ b/tritium/react-gui/src/renderer/shell/reveal/useRevealWindow.ts
@@ -1,0 +1,64 @@
+/**
+ * @file renderer/shell/reveal/useRevealWindow.ts
+ * @description Tell main this window has something worth showing.
+ */
+
+import { useEffect } from 'react';
+import { IPC } from '@shared/ipcChannels';
+import { holdReveal, onRevealClear, revealHolds } from './revealGate';
+
+/**
+ * Once `ready` is true and no hold is outstanding (revealGate.ts), wait for
+ * the frame that has this render in it to be painted, then ask main to show
+ * the window.
+ *
+ * Two animation frames: the first callback runs before the next paint, the
+ * second after it. A hold taken while those frames were pending -- a pane
+ * that mounted in the same commit and started a load in its effect -- is
+ * respected: the attempt starts over when it clears.
+ *
+ * @param ready - the shell's own boot conditions, all met
+ */
+export function useRevealWindow(ready: boolean): void {
+    useEffect(() => {
+        if (!ready) return;
+        let raf1 = 0;
+        let raf2 = 0;
+        let off: (() => void) | null = null;
+
+        const attempt = (): void => {
+            const afterPaint = (): void => {
+                raf1 = requestAnimationFrame(() => {
+                    raf2 = requestAnimationFrame(() => {
+                        if (revealHolds() > 0) attempt();
+                        else window.electronAPI?.invoke(IPC.WINDOW_REVEAL).catch(() => {});
+                    });
+                });
+            };
+            if (revealHolds() === 0) {
+                afterPaint();
+            } else {
+                off = onRevealClear(() => {
+                    off?.();
+                    off = null;
+                    afterPaint();
+                });
+            }
+        };
+        attempt();
+
+        return () => {
+            off?.();
+            cancelAnimationFrame(raf1);
+            cancelAnimationFrame(raf2);
+        };
+    }, [ready]);
+}
+
+/** Keep the window off screen while `active` (a load in progress). */
+export function useHoldReveal(active: boolean): void {
+    useEffect(() => {
+        if (!active) return;
+        return holdReveal();
+    }, [active]);
+}

--- a/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
+++ b/tritium/react-gui/src/renderer/worker/client/AsyncCueMol.ts
@@ -228,7 +228,9 @@ export class AsyncCueMol {
      *   may be called only once. Use {@link addView} for additional view
      *   tabs on the already-bound canvas.
      */
-    bindCanvas(canvas: any, view_id: number, dpr: number): Promise<any[]> { return viewApi.bindCanvas(this._transport, canvas, view_id, dpr); }
+    bindCanvas(canvas: any, view_id: number, dpr: number, width: number, height: number): Promise<any[]> {
+        return viewApi.bindCanvas(this._transport, canvas, view_id, dpr, width, height);
+    }
 
     /** Attach a new view to the already-bound OffscreenCanvas. */
     addView(view_id: number, dpr: number): Promise<boolean> { return viewApi.addView(this._transport, view_id, dpr); }

--- a/tritium/react-gui/src/renderer/worker/client/apis/viewApi.ts
+++ b/tritium/react-gui/src/renderer/worker/client/apis/viewApi.ts
@@ -29,10 +29,11 @@ const log = console;
  */
 export async function bindCanvas(
     transport: WorkerTransport, canvas: any, view_id: number, dpr: number,
+    width: number, height: number,
 ): Promise<any[]> {
     const offscreen = canvas.transferControlToOffscreen();
     return await transport.invokeWorkerWithTransfer(
-        'bindCanvas', offscreen, offscreen, view_id, dpr,
+        'bindCanvas', offscreen, offscreen, view_id, dpr, width, height,
     );
 }
 

--- a/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
+++ b/tritium/react-gui/src/renderer/worker/server/WorkerService.ts
@@ -342,10 +342,21 @@ export class WorkerService {
      * GfxManager and activate the given view. Calling twice throws (the
      * canvas can only be transferred once); use `addView` for extra views.
      */
-    bindCanvas(canvas: any, view_id: number, dpr: number): boolean {
+    bindCanvas(canvas: any, view_id: number, dpr: number, width: number, height: number): boolean {
         if (this._gfx_mgr) {
-            console.log('bindCanvas:', view_id, dpr);
+            console.log('bindCanvas:', view_id, dpr, width, height);
             this._gfx_mgr.bindCanvas(canvas, view_id, dpr);
+            // Size the backing store before the first frame. The transferred
+            // canvas arrives at its attribute size (300x150 unless set), and a
+            // frame drawn at that size is stretched over the whole pane until
+            // the first `resized` lands -- a huge, blocky centre mark for a
+            // moment at launch. With the size known, activateView syncs the
+            // view and draws the first frame right.
+            if (width > 0 && height > 0) {
+                canvas.width = width * dpr;
+                canvas.height = height * dpr;
+                this._gfx_mgr.setLogicalSize(width, height);
+            }
             this._gfx_mgr.activateView(view_id);
             return true;
         } else {

--- a/tritium/react-gui/src/renderer/worker/shared/calls/methods.ts
+++ b/tritium/react-gui/src/renderer/worker/shared/calls/methods.ts
@@ -49,7 +49,7 @@ export interface MethodMap {
   terminateWorker:         { args: [];                                                                      result: void }
   addEventListener:        { args: [aCatStr: string, aSrcType: number, aEvtType: number, aSrcID: number]; result: number }
   removeEventListener:     { args: [nID: number];                                                           result: unknown }
-  bindCanvas:              { args: [canvas: OffscreenCanvas, view_id: number, dpr: number];               result: boolean }
+  bindCanvas:              { args: [canvas: OffscreenCanvas, view_id: number, dpr: number, width: number, height: number]; result: boolean }
   addView:                 { args: [view_id: number, dpr: number];                                          result: boolean }
   activateView:            { args: [view_id: number];                                                       result: void }
   removeView:              { args: [view_id: number];                                                       result: boolean }

--- a/tritium/react-gui/src/shared/ipcChannels.ts
+++ b/tritium/react-gui/src/shared/ipcChannels.ts
@@ -122,6 +122,9 @@ export const IPC = {
   // Main-window title: the renderer owns the active scene/view, so it pushes
   // the subtitle and main composes '<product> - <subtitle>'.
   WINDOW_SET_TITLE: 'window:set-title',        // invoke: renderer -> main
+  // The renderer's first real frame is up; the window that sent it was
+  // created hidden and is waiting on exactly this (main/windows/reveal.ts).
+  WINDOW_REVEAL: 'window:reveal',              // invoke: renderer -> main
 
   // Renderer/Worker crash reporting + fallback UI's Quit button
   CRASH_REPORT: 'app:crash-report',

--- a/tritium/react-gui/src/shared/ipcContract.ts
+++ b/tritium/react-gui/src/shared/ipcContract.ts
@@ -90,6 +90,7 @@ export interface InvokeChannels {
   [IPC.WINDOW_CLOSE_PROCEED]: { req: { proceed: boolean }; res: void }
   [IPC.WINDOW_FOCUS_MAIN]: { req: void;                  res: void }
   [IPC.WINDOW_SET_TITLE]:  { req: { subtitle: string }; res: void }
+  [IPC.WINDOW_REVEAL]:     { req: void;                  res: void }
   // Rendering window relay (see ipcChannels.ts for direction of each leg)
   [IPC.RENDER_WINDOW_OPEN]:    { req: RenderWindowOpenOptions; res: void }
   [IPC.RENDER_WINDOW_COMMAND]: { req: RenderWindowCommand;     res: void }


### PR DESCRIPTION
Both windows appeared the moment they were constructed and were then
furnished in front of the user: the splitters arriving, the theme flipping
from the default dark to the stored choice, the welcome pane giving way to
the molview; in the Rendering window, the target list, the camera fields and
the hatch layer editor each filling in as their answers came back from the
main window over the relay.

## Why `show: false` is not the whole fix

Each window already had the `ready-to-show` handler that is the second half
of the Electron recipe for this, with `show` left at its default of true --
so the handler had nothing to do. Adding `show: false` alone does not fix
it, which is worth stating because it looks like it should:

- `ready-to-show` fires on the document's **first paint**, which for both of
  these pages is an empty root element. Measured on the Rendering window:
  first paint at +47 ms after construction, the main window's context push
  at +176 ms, first-contentful-paint at +176 ms.
- On the main window there is a second reveal: `maximize()` shows a window
  that is being held back, so restoring the maximized state at construction
  put the unpainted window on screen anyway. (Confirmed by instrumenting
  `ready-to-show` -- `isVisible()` was already true there.)

## The reveal is the renderer's call

`windows/reveal.ts` holds a window until `IPC.WINDOW_REVEAL` arrives from
it. `useRevealWindow` sends that once the shell's own conditions are met
*and* the frame containing them has been painted (two animation frames: the
first callback runs before the next paint, the second after it).

The conditions are per window -- layout, theme and the first scene's tab for
the main window; the main window's context for the Rendering one -- because
only the shell knows them. What only a pane knows is its own load, so a pane
that fetches what it displays takes a hold for the duration (`useHoldReveal`:
the history image, the hatch template, the target view's camera) and the
reveal waits for the count to reach zero. A hold taken while the two frames
were already pending restarts the attempt.

`ready-to-show` still arms a 3 s fallback, so a renderer that never signals
-- crashed during boot, or running without Electron's bridge -- gets its
window shown late rather than never.

## The giant centre mark at launch

Separately reported and separately caused: `bindCanvas` transferred the
canvas without saying how big it was, so the first frame was drawn at the
transferred canvas's attribute size (300x150) and stretched over the whole
pane until the first `resized` message landed. The size now travels with the
bind. The explicit resize that followed the bind is kept only for the case
it was really for -- a canvas that had no size yet when it was bound --
since sending it when the size is already right would clear the frame that
was just drawn.

## Verification

Confirmed on screen by the user: the Rendering window is completely fixed,
and the centre mark flash at launch is gone.

typecheck (web + node) / vitest 372 files 3492 tests / eslint 0 errors, 68
warnings (unchanged) / stylelint baseline unchanged / `task build_tritium` /
`task run_tritium` to `shader program created OK`.

New tests: `reveal.test.ts` (signal / late signal / no signal / closed while
waiting), `windowVisibility.test.ts` (both windows defer to the signal, and
maximize happens at reveal time, before `show()`), `useRevealWindow.test.ts`
(the frame timing and the holds), plus the `bindCanvas` sizing contract in
`workerServiceDispatch.test.ts`.
