### PR TITLE
fix(qlib): make LVariant list/dict values own their contents

### DIFF
--- a/src/modules/importers/PSEFileReader.cpp
+++ b/src/modules/importers/PSEFileReader.cpp
@@ -27,6 +27,9 @@
 
 #include <boost/foreach.hpp>
 
+#include <iterator>
+#include <memory>
+
 #include "PickleInStream.hpp"
 #include "AtomPropColoring.hpp"
 #include "PSEConsts.hpp"
@@ -46,12 +49,13 @@ using molstr::MolAtomPtr;
 using molstr::ResidIndex;
 
 PSEFileReader::PSEFileReader()
+  : m_pSet(NULL), m_bColorWarned(false)
 {
-  m_pSet = NULL;
 }
 
 PSEFileReader::~PSEFileReader()
 {
+  delete m_pSet;
 }
 
 int PSEFileReader::getCatID() const
@@ -100,7 +104,7 @@ void PSEFileReader::setupSettingList(qlib::LVarList *pSet)
   if (m_pSet==NULL)
     m_pSet = new LVarList;
   else
-    m_pSet->clear();
+    m_pSet->clearAndDelete();
   
   LVarList::iterator iter = pSet->begin();
   LVarList::iterator eiter = pSet->end();
@@ -120,10 +124,31 @@ void PSEFileReader::setupSettingList(qlib::LVarList *pSet)
   for (; iter!=eiter; ++iter) {
     qlib::LVarList *pTuple = (*iter)->getListPtr();
     int id = pTuple->getInt(0);
-    m_pSet->at(id) = pTuple->at(2);
+    // m_pSet owns its entries, so keep a copy of the setting value
+    const LVariant *pval = pTuple->at(2);
+    delete m_pSet->at(id);
+    m_pSet->at(id) = (pval!=NULL) ? MB_NEW LVariant(*pval) : NULL;
   }
-  
+
   m_pSet->dump();
+}
+
+/// Convert a PyMOL color index to the 0xAARRGGBB value of the "col" atom prop
+unsigned int PSEFileReader::convColor(int ncol)
+{
+  // PyMOL encodes a direct RGB color as 0x40000000 | 0xRRGGBB. Negative
+  // indices are PyMOL-internal (ramps, defaults) and have no table entry.
+  if (ncol>=0 && (ncol & 0x40000000))
+    return 0xFF000000u | (static_cast<unsigned int>(ncol) & 0x00FFFFFFu);
+
+  if (ncol>=0 && ncol<int(std::size(PSE_colors)))
+    return PSE_colors[ncol];
+
+  if (!m_bColorWarned) {
+    LOG_DPRINTLN("PSEFileReader> unknown color index %d, using white", ncol);
+    m_bColorWarned = true;
+  }
+  return PSE_colors[0];
 }
 
 void PSEFileReader::read()
@@ -145,12 +170,11 @@ void PSEFileReader::read()
   fis.open(localfile);
   PickleInStream ois(fis);
 
-  LVariant *pTop = ois.getMap();
+  m_bColorWarned = false;
+  std::unique_ptr<LVariant> pTop(ois.getMap());
 
-  if (!pTop->isDict()) {
-    delete pTop;
+  if (!pTop->isDict())
     return;
-  }
 
   LVarDict *pDict = pTop->getDictPtr();
 
@@ -166,9 +190,7 @@ void PSEFileReader::read()
 
   LVarList *pNames = pDict->getList("names");
   procNames(pNames);
-  
-  delete pTop;
-  
+
   //////////
   // fire the scene-loaded event
   {
@@ -476,8 +498,7 @@ void PSEFileReader::parseObjectMolecule(LVarList *pData, MolCoordPtr pMol)
     pAtom->setPos(Vector4D(x,y,z));
 
     int ncol = pAtmDat->getInt(AT_COLOR);
-    // MB_DPRINTLN("color for %d = %d", i, ncol);
-    pAtom->setAtomPropInt("col", PSE_colors[ncol]);
+    pAtom->setAtomPropInt("col", convColor(ncol));
 
     int res = pMol->appendAtom(pAtom);
     if (res<0) {

--- a/src/modules/importers/PSEFileReader.hpp
+++ b/src/modules/importers/PSEFileReader.hpp
@@ -64,7 +64,13 @@ namespace importers {
 
   private:
 
+    /// Settings table indexed by PyMOL setting ID (owns its entries)
     qlib::LVarList *m_pSet;
+
+    /// Set once an unknown color index has been reported for this read
+    bool m_bColorWarned;
+
+    unsigned int convColor(int ncol);
 
     void procViewSettings(qlib::LVarList *pView);
 

--- a/src/modules/importers/PickleInStream.cpp
+++ b/src/modules/importers/PickleInStream.cpp
@@ -7,6 +7,10 @@
 
 #include "PickleInStream.hpp"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 using namespace importers;
 
 PickleInStream::~PickleInStream()
@@ -179,26 +183,18 @@ LVariant *PickleInStream::getMap()
       break;
     }
       
-    case BINSTRING: {
-      int i = readIntLE();
-      char *a = new char[i+1];
-      read(a, 0, i);
-      a[i]='\0';
-      LString s = a;
-      push(createString(s));
-      delete [] a;
-      //MB_DPRINTLN("BINSTRING len=%d %s", i, s.c_str());
-      break;
-    }
-      
+    case BINSTRING:
     case BINUNICODE: {
+      // BINUNICODE carries UTF-8; both are stored as-is
       int i = readIntLE();
-      char *a = new char[i];
-      read(a, 0, i);
-      LString s = a;
-      push(createString(s));
-      delete [] a;
-      // MB_DPRINTLN("BINUNICODE len=%d, %s", i, s.c_str());
+      if (i<0) {
+        MB_THROW(qlib::FileFormatException, "Invalid pickle format (negative string length)");
+        return NULL;
+      }
+      std::string s(size_t(i), '\0');
+      if (i>0)
+        readFully(&s[0], 0, i);
+      push(createString(LString(s)));
       break;
     }
       
@@ -246,49 +242,53 @@ LVariant *PickleInStream::getMap()
     }
 
     case SETITEM: {
-      LVariant *o = pop();
-      LVariant *pkey = pop();
+      std::unique_ptr<LVariant> o(pop());
+      std::unique_ptr<LVariant> pkey(pop());
       if (!pkey->isString()) {
         MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEM op mismatch)");
         return NULL;
       }
-      LString key = pkey->getStringValue();
-      delete pkey;
-      peek()->getDictPtr()->set(key, o);
-      // MB_DPRINTLN("SETITEM %s", key.c_str());
+      LVariant *phead = peek();
+      if (!phead->isDict()) {
+        MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEM on non-dict)");
+        return NULL;
+      }
+      // the dict owns the value from here on
+      phead->getDictPtr()->set(pkey->getStringValue(), std::move(*o));
       break;
     }
-      
+
     case SETITEMS: {
       int mark = getMark();
-      LVariant *pobjs = getObjects(mark);
+      std::unique_ptr<LVariant> pobjs(getObjects(mark));
+      LVarList *pItems = pobjs->getListPtr();
       LVariant *phead = peek();
-      int nput = 0;
       if (phead->isList()) {
-        while (!pobjs->getListPtr()->empty()) {
-          LVariant *o3 = pobjs->getListPtr()->front_pop_front();
+        while (!pItems->empty()) {
+          LVariant *o3 = pItems->front_pop_front();
           phead->getListPtr()->push_back(o3);
-          ++nput;
         }
       }
       else if (phead->isDict()) {
-        while (!pobjs->getListPtr()->empty()) {
-          LVariant *pvalue = pobjs->getListPtr()->back_pop_back();
-          LVariant *pkey = pobjs->getListPtr()->back_pop_back();
-          LString key = pkey->getStringValue();
-          delete pkey;
-          phead->getDictPtr()->set(key, pvalue);
-          // MB_DPRINTLN("SETITEMS %d %s", i, key->m_strValue.c_str());
-          ++nput;
+        // the items are key/value pairs
+        if (pItems->size()%2!=0) {
+          MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEMS odd item count)");
+          return NULL;
+        }
+        while (!pItems->empty()) {
+          std::unique_ptr<LVariant> pvalue(pItems->back_pop_back());
+          std::unique_ptr<LVariant> pkey(pItems->back_pop_back());
+          if (!pkey->isString()) {
+            MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEMS key is not a string)");
+            return NULL;
+          }
+          phead->getDictPtr()->set(pkey->getStringValue(), std::move(*pvalue));
         }
       }
       else {
-        delete pobjs;
         MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEMS op mismatch)");
         return NULL;
       }
-      delete pobjs;
-      // MB_DPRINTLN("SETITEMS (%d)", nput);
       break;
     }
 
@@ -333,17 +333,13 @@ LVariant *PickleInStream::getMap()
   //memo = null;
 
   MB_DPRINTLN("====================");
-  LVariant *pMap = m_stack.front_pop_front();
-
-  if (pMap->getDictPtr()->size()==0) {
-  //   for (i = stack.size(); --i >= 0;) {
-  //     o = stack.get(i--);
-  //     s = (String) stack.get(i);
-  //     map.put(s, o);
+  if (m_stack.empty()) {
+    MB_THROW(qlib::FileFormatException, "Invalid pickle format (no object on the stack at STOP)");
+    return NULL;
   }
-    
-  return pMap;
-  
+
+  // the caller checks the type of the top-level object
+  return m_stack.front_pop_front();
 }
 
 

--- a/src/modules/importers/PickleInStream.hpp
+++ b/src/modules/importers/PickleInStream.hpp
@@ -66,7 +66,7 @@ namespace importers {
     static const int BININT2 = 77; /* M */
     static const int BINPUT = 113; /* q */
     static const int BINSTRING = 84; /* T */
-    static const int BINUNICODE = 87; /* X */
+    static const int BINUNICODE = 88; /* X */
     static const int BUILD = 98; /* b */
     static const int EMPTY_DICT = 125; /* } */
     static const int EMPTY_LIST = 93; /* ] */
@@ -218,26 +218,28 @@ namespace importers {
     //////////////////////////////////////
     // MEMO
 
-    typedef std::map<int, LVariant*> ValTable;
-    ValTable m_memo; // = new Hashtable<Integer, Object>();
+    /// Memoized values. The memo keeps its own copies, so every stack entry
+    /// stays uniquely owned and BINGET hands out fresh copies.
+    typedef std::map<int, LVariant> ValTable;
+    ValTable m_memo;
     int m_retrieveCount;
-    
+
     void putMemo(int i, bool doCheck)
     {
       LVariant *o = peek();
-      
+
       if (o->isString()) {
         // XXX: handle the inMovie case
         // if (doCheck && markCount >= 6 || markCount == 3 && inMovie)
         //  return;
         if (doCheck && m_markCount >= 6)
           return;
-        m_memo.insert(ValTable::value_type(i, o));
-        //MB_DPRINTLN("caching string");
-        //System.out.println("caching string " + o + " at " + binaryDoc.getPosition());
+        m_memo[i] = *o;
       }
     }
-  
+
+    /// Returns a new copy of the memoized value (owned by the caller),
+    /// or NULL when the memo index is unknown
     LVariant *getMemo(int i)
     {
       ValTable::const_iterator iter = m_memo.find(i);
@@ -245,16 +247,8 @@ namespace importers {
         MB_DPRINTLN("  ERROR!! memo %d not found!!", i);
         return NULL;
       }
-      LVariant *o = iter->second;
-      //Object o = memo.get(Integer.valueOf(i));
-      //if (o == null)
-      //return o;
-      //System.out.println("retrieving string " + o + " at " + binaryDoc.getPosition());
-
-      //MB_DPRINTLN("retrieving string");
       m_retrieveCount++;
-      
-      return o;
+      return MB_NEW LVariant(iter->second);
     }
     
     LVariant *getObjects(int mark)

--- a/src/qlib/LVarDict.hpp
+++ b/src/qlib/LVarDict.hpp
@@ -6,23 +6,22 @@
 #ifndef L_VARIANT_DICT_HPP_INCLUDED_
 #define L_VARIANT_DICT_HPP_INCLUDED_
 
+#include <utility>
+
 #include "LVariant.hpp"
 #include "MapTable.hpp"
 #include "qlib.hpp"
-
-//#include "LScrObjects.hpp"
-//#include "LScrSmartPtr.hpp"
-//#include "mcutils.hpp"
 
 namespace qlib {
 
 ///
 /// Scriptable dict of variants
 ///
-// class QLIB_API LVarDict : public MapPtrTable<LVariant>
+/// Values are stored by value: copying the dict deep-copies list/dict
+/// contents, and the getters hand out pointers into the stored entries.
+///
 class QLIB_API LVarDict : public MapTable<LVariant>
 {
-    // typedef MapPtrTable<LVariant> super_t;
     using super_t = MapTable<LVariant>;
 
 public:
@@ -34,68 +33,62 @@ public:
 
     //////
 
+    using super_t::set;
+
+    /// Move val into the dict without copying list/dict contents.
+    /// Returns false (and leaves the dict unchanged) when the key already exists.
+    bool set(const LString &key, LVariant &&val)
+    {
+        return super_t::try_emplace(key, std::move(val)).second;
+    }
+
+    /// Pointer to the stored value, or nullptr when the key is absent.
+    /// The pointer stays valid as long as the entry is in this dict.
+    const LVariant *lookup(const LString &key) const
+    {
+        super_t::const_iterator iter = super_t::find(key);
+        if (iter == super_t::end()) return nullptr;
+        return &iter->second;
+    }
+
     LString getString(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isString()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getString key not found");
-        //     return LString();
-        // }
-        // return pval->getStringValue();
-        LVariant val = super_t::get(key);
-        if (!val.isString()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isString()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getString key not found");
             return LString();
         }
-        return val.getStringValue();
+        return pval->getStringValue();
     }
 
     int getInt(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isInt()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getInt key not found");
-        //     return 0;
-        // }
-        // return pval->getIntValue();
-        LVariant val = super_t::get(key);
-        if (!val.isInt()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isInt()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getInt key not found");
             return 0;
         }
-        return val.getIntValue();
+        return pval->getIntValue();
     }
 
     double getReal(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isReal()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getReal key not found");
-        //     return 0.0;
-        // }
-        // return pval->getRealValue();
-        LVariant val = super_t::get(key);
-        if (!val.isReal()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isReal()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getReal key not found");
             return 0.0;
         }
-        return val.getRealValue();
+        return pval->getRealValue();
     }
 
     LVarList *getList(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isList()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getList key not found");
-        //     return NULL;
-        // }
-        // return pval->getListPtr();
-        LVariant val = super_t::get(key);
-        if (!val.isList()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isList()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getList key not found");
-            return NULL;
+            return nullptr;
         }
-        return val.getListPtr();
+        return pval->getListPtr();
     }
 
     void dump() const;
@@ -106,4 +99,4 @@ using LDict = LVarDict;
 
 }  // namespace qlib
 
-#endif  // L_VARIANT_ARRAY_HPP_INCLUDED_
+#endif  // L_VARIANT_DICT_HPP_INCLUDED_

--- a/src/qlib/LVarList.hpp
+++ b/src/qlib/LVarList.hpp
@@ -33,21 +33,44 @@ namespace qlib {
     {
     }
 
+    /// Deep copy: the elements are owned, so each one is cloned
     LVarList(const LVarList &a)
-         : super_t(a)
+         : super_t()
     {
+      copyElems(a);
+    }
+
+    LVarList &operator=(const LVarList &a)
+    {
+      if (this!=&a) {
+        clearAndDelete();
+        copyElems(a);
+      }
+      return *this;
     }
 
     ~LVarList()
     {
-      super_t::iterator i = super_t::begin();
-      super_t::iterator e = super_t::end();
-      for (; i!=e; ++i) {
-        if (*i!=NULL)
-          delete *i;
-      }
+      clearAndDelete();
     }
 
+    /// Delete all owned elements and empty the list
+    /// (clear() alone drops the pointers without deleting them)
+    void clearAndDelete()
+    {
+      for (LVariant *p : *this)
+        delete p;
+      super_t::clear();
+    }
+
+  private:
+    void copyElems(const LVarList &a)
+    {
+      for (const LVariant *p : a)
+        super_t::push_back(p!=nullptr ? MB_NEW LVariant(*p) : nullptr);
+    }
+
+  public:
     //////
 
     LVariant *front_pop_front()

--- a/src/qlib/LVariant.hpp
+++ b/src/qlib/LVariant.hpp
@@ -61,11 +61,23 @@ public:
     /// Default ctor (initialize null value)
     LVariant() : type(LT_NULL), m_bOwned(true) {}
 
-    /// Copy ctor
+    /// Copy ctor (deep copy of the value)
     LVariant(const LVariant &src)
     {
         LVariant::copyFrom(src);
     }
+
+    /// Move ctor: takes over the value, src becomes null
+    LVariant(LVariant &&src) noexcept
+        : type(src.type), value(src.value), m_bOwned(src.m_bOwned)
+    {
+        src.type = LT_NULL;
+        src.m_bOwned = true;
+    }
+
+    /// A pointer to a variant is never a value. Without this overload a
+    /// LVariant* argument silently converts to LVariant(bool).
+    LVariant(const LVariant *) = delete;
 
     /// Destructor
     ~LVariant()
@@ -81,7 +93,9 @@ public:
     {
         value.realValue = v;
     }
-    LVariant(bool v) : type(LT_BOOLEAN), m_bOwned(true)
+    // explicit: an implicit pointer-to-bool conversion would otherwise turn
+    // any stray pointer argument into a boolean true
+    explicit LVariant(bool v) : type(LT_BOOLEAN), m_bOwned(true)
     {
         value.boolValue = v;
     }
@@ -137,6 +151,20 @@ public:
         if (&arg != this) {
             cleanup();
             copyFrom(arg);
+        }
+        return *this;
+    }
+
+    /// Move assignment: takes over the value, src becomes null
+    LVariant &operator=(LVariant &&src) noexcept
+    {
+        if (&src != this) {
+            cleanup();
+            type = src.type;
+            value = src.value;
+            m_bOwned = src.m_bOwned;
+            src.type = LT_NULL;
+            src.m_bOwned = true;
         }
         return *this;
     }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(test_qlib
   qlib/test_parallel.cpp
   qlib/test_chunked_array3d.cpp
   qlib/test_seekable_stream.cpp
+  qlib/test_lvardict.cpp
 )
 target_include_directories(test_qlib PRIVATE
   ${CMAKE_SOURCE_DIR}/src
@@ -246,6 +247,7 @@ add_executable(test_importers
   modules/importers/test_amber_reader.cpp
   modules/importers/test_load_object_command_guess.cpp
   modules/importers/test_trajio.cpp
+  modules/importers/test_pickle_instream.cpp
 )
 target_include_directories(test_importers PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/importers/test_pickle_instream.cpp
+++ b/src/tests/modules/importers/test_pickle_instream.cpp
@@ -1,0 +1,216 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <qlib/LExceptions.hpp>
+#include <qlib/StringStream.hpp>
+#include "importers/PickleInStream.hpp"
+
+using importers::PickleInStream;
+using qlib::LVarDict;
+using qlib::LVariant;
+using qlib::LVarList;
+using qlib::StrInStream;
+
+namespace {
+
+// Emits the subset of pickle protocol 2 opcodes that PickleInStream reads.
+class PickleBuilder
+{
+public:
+    void emptyDict()
+    {
+        m_buf += '}';
+    }
+    void emptyList()
+    {
+        m_buf += ']';
+    }
+    void mark()
+    {
+        m_buf += '(';
+    }
+    void stop()
+    {
+        m_buf += '.';
+    }
+    void setItem()
+    {
+        m_buf += 's';
+    }
+    void setItems()
+    {
+        m_buf += 'u';
+    }
+    void appends()
+    {
+        m_buf += 'e';
+    }
+    void binput(int i)
+    {
+        m_buf += 'q';
+        m_buf += char(i);
+    }
+    void binget(int i)
+    {
+        m_buf += 'h';
+        m_buf += char(i);
+    }
+    void binint(int v)
+    {
+        m_buf += 'J';
+        le32(v);
+    }
+    void binstring(const std::string &s)
+    {
+        m_buf += 'T';
+        le32(int(s.size()));
+        m_buf += s;
+    }
+    void binunicode(const std::string &s)
+    {
+        m_buf += 'X';
+        le32(int(s.size()));
+        m_buf += s;
+    }
+
+    void binfloat(double d)
+    {
+        m_buf += 'G';
+        unsigned char raw[sizeof(double)];
+        std::memcpy(raw, &d, sizeof(double));
+        // BINFLOAT payload is big-endian
+        if (hostIsLittleEndian()) {
+            for (int i = int(sizeof(double)) - 1; i >= 0; --i) m_buf += char(raw[i]);
+        } else {
+            for (int i = 0; i < int(sizeof(double)); ++i) m_buf += char(raw[i]);
+        }
+    }
+
+    /// Length header that claims more bytes than follow (simulates a truncated file)
+    void truncatedUnicode(int claimed, const std::string &partial)
+    {
+        m_buf += 'X';
+        le32(claimed);
+        m_buf += partial;
+    }
+
+    const std::string &bytes() const
+    {
+        return m_buf;
+    }
+
+private:
+    static bool hostIsLittleEndian()
+    {
+        const unsigned short one = 1;
+        return *reinterpret_cast<const unsigned char *>(&one) == 1;
+    }
+
+    void le32(int v)
+    {
+        const unsigned int u = static_cast<unsigned int>(v);
+        for (int i = 0; i < 4; ++i) m_buf += char((u >> (8 * i)) & 0xffu);
+    }
+
+    std::string m_buf;
+};
+
+// Parses the pickle and destroys the stream before returning, so the result
+// must not alias anything the stream owned (its stack or memo).
+std::unique_ptr<LVariant> parse(const PickleBuilder &pb)
+{
+    StrInStream ins(pb.bytes().data(), static_cast<int>(pb.bytes().size()));
+    PickleInStream pis(ins);
+    return std::unique_ptr<LVariant>(pis.getMap());
+}
+
+}  // namespace
+
+TEST(PickleInStream, SetItemsBuildsDictWithNestedListAndMemoRefs)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.binput(0);
+    pb.mark();
+    pb.binunicode("version");
+    pb.binput(1);
+    pb.binint(1810);
+    pb.binunicode("names");
+    pb.binput(2);
+    pb.emptyList();
+    pb.mark();
+    pb.binget(1);  // "version" again, through the memo
+    pb.binfloat(1.5);
+    pb.binstring("abc");
+    pb.appends();
+    pb.binunicode("flag");
+    pb.binget(2);  // "names" reused as a value
+    pb.setItems();
+    pb.stop();
+
+    std::unique_ptr<LVariant> pTop = parse(pb);
+    ASSERT_TRUE(pTop->isDict());
+    LVarDict *pDict = pTop->getDictPtr();
+
+    EXPECT_EQ(pDict->getInt("version"), 1810);
+    EXPECT_STREQ(pDict->getString("flag").c_str(), "names");
+
+    LVarList *pNames = pDict->getList("names");
+    ASSERT_NE(pNames, nullptr);
+    ASSERT_EQ(pNames->size(), 3u);
+    EXPECT_STREQ(pNames->getString(0).c_str(), "version");
+    EXPECT_DOUBLE_EQ(pNames->getReal(1), 1.5);
+    EXPECT_STREQ(pNames->getString(2).c_str(), "abc");
+
+    // getList() hands out the stored list, not a copy
+    EXPECT_EQ(pDict->getList("names"), pNames);
+}
+
+TEST(PickleInStream, SetItemStoresSingleEntry)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.binunicode("k");
+    pb.binint(5);
+    pb.setItem();
+    pb.stop();
+
+    std::unique_ptr<LVariant> pTop = parse(pb);
+    ASSERT_TRUE(pTop->isDict());
+    EXPECT_EQ(pTop->getDictPtr()->getInt("k"), 5);
+}
+
+TEST(PickleInStream, UnicodeStringIsBoundedByItsLength)
+{
+    // The bytes after "ab" are opcodes; they must not leak into the string.
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.binunicode("k");
+    pb.binunicode("ab");
+    pb.setItem();
+    pb.stop();
+
+    std::unique_ptr<LVariant> pTop = parse(pb);
+    EXPECT_STREQ(pTop->getDictPtr()->getString("k").c_str(), "ab");
+}
+
+TEST(PickleInStream, SetItemsWithOddItemCountThrows)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.mark();
+    pb.binunicode("k");  // key without a value
+    pb.setItems();
+    pb.stop();
+    EXPECT_THROW(parse(pb), qlib::LException);
+}
+
+TEST(PickleInStream, TruncatedStringThrows)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.truncatedUnicode(100, "abc");
+    EXPECT_THROW(parse(pb), qlib::LException);
+}

--- a/src/tests/qlib/test_lvardict.cpp
+++ b/src/tests/qlib/test_lvardict.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include "qlib/LExceptions.hpp"
+#include "qlib/LVariant.hpp"
+#include "qlib/LVarList.hpp"
+#include "qlib/LVarDict.hpp"
+
+using qlib::LString;
+using qlib::LVarDict;
+using qlib::LVariant;
+using qlib::LVarList;
+
+namespace {
+
+// Builds ["a", 1, [2.5]] as a heap-allocated, element-owning list.
+LVarList *makeNestedList()
+{
+    LVarList *pList = new LVarList();
+    pList->push_back(new LVariant(LString("a")));
+    pList->push_back(new LVariant(1));
+    LVarList *pInner = new LVarList();
+    pInner->push_back(new LVariant(2.5));
+    pList->push_back(new LVariant(pInner));
+    return pList;
+}
+
+}  // namespace
+
+// A LVariant* is never a value. It used to convert to LVariant(bool) and
+// store true, which silently broke LVarDict::set(key, LVariant*).
+static_assert(!std::is_constructible<LVariant, LVariant *>::value,
+              "LVariant must not be constructible from LVariant*");
+
+// ---- LVarList ------------------------------------------------------------
+
+TEST(LVarList, CopyIsDeep)
+{
+    LVarList *pOrig = makeNestedList();
+    LVarList copy(*pOrig);
+
+    ASSERT_EQ(copy.size(), 3u);
+    EXPECT_NE(copy.at(0), pOrig->at(0));
+    EXPECT_NE(copy.getList(2), pOrig->getList(2));
+
+    // Destroying the original must leave the copy intact.
+    delete pOrig;
+    EXPECT_STREQ(copy.getString(0).c_str(), "a");
+    EXPECT_EQ(copy.getInt(1), 1);
+    EXPECT_DOUBLE_EQ(copy.getList(2)->getReal(0), 2.5);
+}
+
+TEST(LVarList, AssignmentIsDeepAndReplacesOldElements)
+{
+    LVarList dest;
+    dest.push_back(new LVariant(LString("old")));
+
+    LVarList *pSrc = makeNestedList();
+    dest = *pSrc;
+    delete pSrc;
+
+    ASSERT_EQ(dest.size(), 3u);
+    EXPECT_STREQ(dest.getString(0).c_str(), "a");
+    EXPECT_DOUBLE_EQ(dest.getList(2)->getReal(0), 2.5);
+}
+
+TEST(LVarList, ClearAndDeleteEmptiesTheList)
+{
+    std::unique_ptr<LVarList> pSrc(makeNestedList());
+    LVarList list(*pSrc);
+    list.clearAndDelete();
+    EXPECT_TRUE(list.empty());
+}
+
+// ---- LVariant ------------------------------------------------------------
+
+TEST(LVariant, ListValueCopyIsIndependent)
+{
+    LVariant v(makeNestedList());
+    LVariant w(v);
+    EXPECT_NE(v.getListPtr(), w.getListPtr());
+
+    v.setNull();
+    ASSERT_TRUE(w.isList());
+    EXPECT_STREQ(w.getListPtr()->getString(0).c_str(), "a");
+}
+
+TEST(LVariant, MoveTransfersOwnership)
+{
+    LVariant v(makeNestedList());
+    LVarList *pList = v.getListPtr();
+
+    LVariant w(std::move(v));
+    EXPECT_TRUE(v.isNull());
+    EXPECT_EQ(w.getListPtr(), pList);
+
+    LVariant x(LString("replaced"));
+    x = std::move(w);
+    EXPECT_TRUE(w.isNull());
+    ASSERT_TRUE(x.isList());
+    EXPECT_EQ(x.getListPtr(), pList);
+}
+
+// ---- LVarDict ------------------------------------------------------------
+
+TEST(LVarDict, SetByMoveAndGetListReturnsStoredPointer)
+{
+    LVarDict dict;
+    LVariant val(makeNestedList());
+    LVarList *pList = val.getListPtr();
+
+    EXPECT_TRUE(dict.set("names", std::move(val)));
+    EXPECT_TRUE(val.isNull());
+
+    // No copy on lookup, and the pointer stays stable across calls.
+    EXPECT_EQ(dict.getList("names"), pList);
+    EXPECT_EQ(dict.getList("names"), pList);
+    EXPECT_STREQ(dict.getList("names")->getString(0).c_str(), "a");
+
+    // set() keeps the first value for a duplicate key and leaves the
+    // rejected value untouched.
+    LVariant dup(2);
+    EXPECT_FALSE(dict.set("names", std::move(dup)));
+    EXPECT_EQ(dict.getList("names"), pList);
+    ASSERT_TRUE(dup.isInt());
+    EXPECT_EQ(dup.getIntValue(), 2);
+}
+
+TEST(LVarDict, ScalarGettersAndMissingKeys)
+{
+    LVarDict dict;
+    dict.set("i", LVariant(7));
+    dict.set("r", LVariant(1.5));
+    dict.set("s", LVariant(LString("str")));
+
+    EXPECT_EQ(dict.getInt("i"), 7);
+    EXPECT_DOUBLE_EQ(dict.getReal("r"), 1.5);
+    EXPECT_DOUBLE_EQ(dict.getReal("i"), 7.0);
+    EXPECT_STREQ(dict.getString("s").c_str(), "str");
+
+    EXPECT_EQ(dict.lookup("missing"), nullptr);
+    EXPECT_THROW(dict.getInt("missing"), qlib::RuntimeException);
+    EXPECT_THROW(dict.getInt("s"), qlib::RuntimeException);
+    EXPECT_THROW(dict.getList("s"), qlib::RuntimeException);
+}
+
+TEST(LVarDict, CopyIsDeep)
+{
+    LVarDict *pDict = new LVarDict();
+    pDict->set("names", LVariant(makeNestedList()));
+
+    LVarDict copy(*pDict);
+    EXPECT_NE(copy.getList("names"), pDict->getList("names"));
+
+    delete pDict;
+    EXPECT_STREQ(copy.getList("names")->getString(0).c_str(), "a");
+}


### PR DESCRIPTION
## Summary

Part 1 of the libcuemol2 bug-audit fixes (Phase 1: memory-safety). This PR makes `LVariant` list/dict values own their contents and repairs the PSE (PyMOL session) importer that depended on the broken behaviour.

### qlib

- `LVarList` copied its element pointers, so every copy of a list-typed `LVariant` (`LVariant::copyFrom`, `LVarDict::get`, `setListValue`) ended in a double delete. The copy ctor/assignment now deep-copy; `clearAndDelete()` is the owning clear (same name as `GenericPtrTable`).
- `LVarDict::getList()` returned a pointer into a temporary that was destroyed on return. `lookup()` now returns a pointer to the stored entry and the getters use it; `set(key, LVariant&&)` moves values in via `try_emplace`.
- `LVariant(bool)` is now `explicit` and `LVariant(const LVariant*)` is deleted: `LVarDict::set(key, LVariant*)` used to compile and store `true`.
- `LVariant` gained move ctor/assignment.

### importers (PSE / pickle)

- `PickleInStream` used the pointer-to-bool conversion above, so every dict value became `true` and `PSEFileReader::read()` failed at `getInt("version")`.
- The `BINUNICODE` opcode was defined as 87 (`'W'`); the real value is 88 (`'X'`). Pickles written by Python 3 PyMOL never reached the unicode case and were rejected as "unknown opcode".
- `BINSTRING`/`BINUNICODE` payloads are read with `readFully()` into a bounded buffer (the unicode path had no NUL terminator and over-read the heap).
- The memo keeps its own copies and `BINGET` pushes fresh ones, so no `LVariant` is owned by two containers (previously a double free / use-after-free on shared keys).
- `SETITEMS` with an odd item count and an empty stack at `STOP` are format errors instead of being silently dropped.
- `PSEFileReader` owns its settings table, keeps the parsed tree in a `unique_ptr`, and bounds-checks the PyMOL color index (`PSE_colors[ncol]` was unchecked). Direct `0x40000000|RGB` colors are decoded; negative/unknown indices fall back to white with one warning per read.

## Tests

- `tests/qlib/test_lvardict.cpp` (8 cases): deep copy of `LVarList`/`LVariant`/`LVarDict`, move semantics, `lookup`/`getList` pointer stability, duplicate-key handling, and a `static_assert` that `LVariant` is not constructible from `LVariant*`.
- `tests/modules/importers/test_pickle_instream.cpp` (5 cases): hand-built pickle streams covering `SETITEM`/`SETITEMS`/`APPENDS`, memo references, bounded unicode strings, odd `SETITEMS`, and truncated input.
- `task run_gtest`: 1418/1418 pass.

## Notes for review

- `BINGET` on a memo index that was never stored still pushes a placeholder string (behaviour inherited from Jmol's reader, which deliberately skips memoizing deeply nested strings). Left as is; it is now at least reachable for Python 3 session files.
- The direct-RGB color decoding follows PyMOL's `0x40000000 | 0xRRGGBB` convention and has not been checked against a real `.pse` with custom colors yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
