### PR TITLE
fix(molstr): detach deleted bonds from their atoms

### DIFF
--- a/src/modules/molstr/MolCoord.cpp
+++ b/src/modules/molstr/MolCoord.cpp
@@ -439,6 +439,19 @@ MolBond *MolCoord::makeBond(int aaid1, int aaid2, bool bPersist /*=false*/)
   return pB;
 }
 
+namespace {
+  /// Drop pBond from the bond lists of its atoms (either atom may be gone)
+  void detachBond(MolCoord *pMol, MolBond *pBond)
+  {
+    MolAtomPtr pA1 = pMol->getAtom(pBond->getAtom1());
+    if (!pA1.isnull())
+      pA1->removeBond(pBond);
+    MolAtomPtr pA2 = pMol->getAtom(pBond->getAtom2());
+    if (!pA2.isnull())
+      pA2->removeBond(pBond);
+  }
+}
+
 bool MolCoord::removeBond(int aaid1, int aaid2)
 {
   BondPool::iterator iter = m_bondPool.begin();
@@ -455,7 +468,11 @@ bool MolCoord::removeBond(int aaid1, int aaid2)
   if (iter==iend)
     return false;
 
-  delete iter->second;
+  // the atoms must not keep a pointer to the deleted bond
+  // (makeBond() looks bonds up through MolAtom::getBond())
+  MolBond *pBond = iter->second;
+  detachBond(this, pBond);
+  delete pBond;
   m_bondPool.erase(iter);
   return true;
 }
@@ -472,20 +489,19 @@ void MolCoord::removeNonpersBonds()
     MolAtomPtr pA1 = getAtom(aid1);
     MolAtomPtr pA2 = getAtom(aid2);
 
-    if (pBond->isPersist()){
-      if (!pA1.isnull() && !pA2.isnull())
-        pers.push_back(pBond); // reserve presistent & valid bond
-      else
-        delete pBond; // remove persistent but orphan bond
+    // keep persistent bonds whose atoms both still exist
+    if (pBond->isPersist() && !pA1.isnull() && !pA2.isnull()) {
+      pers.push_back(pBond);
+      continue;
     }
-    else {
-      // remove non-persistent bond
-      if (!pA1.isnull())
-        pA1->removeBond(pBond);
-      if (!pA2.isnull())
-        pA2->removeBond(pBond);
-      delete pBond;
-    }
+
+    // non-persistent, or persistent but orphaned by removeAtom():
+    // the surviving atoms must not keep a pointer to the deleted bond
+    if (!pA1.isnull())
+      pA1->removeBond(pBond);
+    if (!pA2.isnull())
+      pA2->removeBond(pBond);
+    delete pBond;
   }
 
   m_bondPool.clear();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(test_molstr
   modules/molstr/test_molresidue.cpp
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
+  modules/molstr/test_molcoord_bond.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp
@@ -133,6 +134,9 @@ target_include_directories(test_molstr PRIVATE
   ${CMAKE_SOURCE_DIR}/src/modules
   ${CMAKE_BINARY_DIR}/src
   ${Boost_INCLUDE_DIRS}
+)
+target_compile_definitions(test_molstr PRIVATE
+  CUEMOL2_SYSCONFIG_PATH="${CMAKE_SOURCE_DIR}/data/sysconfig.xml"
 )
 target_link_libraries(test_molstr PRIVATE molstr qsys gfx qlib Boost::filesystem GTest::gtest)
 if (BUILD_OPENGL_SYSDEP)

--- a/src/tests/modules/molstr/test_main.cpp
+++ b/src/tests/modules/molstr/test_main.cpp
@@ -2,25 +2,23 @@
 #include <common.h>
 #include "qlib/qlib.hpp"
 #include "qsys/qsys.hpp"
-#include "qsys/style/StyleMgr.hpp"
-#include "qsys/RendererFactory.hpp"
-#include "qsys/StreamManager.hpp"
-#include "molstr/ElemSym.hpp"
-#include "molstr/SelCompiler.hpp"
 
+namespace molstr {
+extern bool init();
+extern void fini();
+}
+
+// Same setup as the molvis/molanl suites: molstr::init() registers the
+// scriptable classes (MolCoord etc.), so objects can be constructed in tests.
 class MolstrEnvironment : public ::testing::Environment {
 public:
     void SetUp() override {
         qlib::init();
-        qsys::init("");
-        qsys::StyleMgr::init();
-        qsys::RendererFactory::init();
-        molstr::ElemSym::init();
-        molstr::SelCompiler::init();
+        qsys::init(CUEMOL2_SYSCONFIG_PATH);
+        molstr::init();
     }
     void TearDown() override {
-        molstr::SelCompiler::fini();
-        molstr::ElemSym::fini();
+        molstr::fini();
         qsys::fini();
         qlib::fini();
     }

--- a/src/tests/modules/molstr/test_molcoord_bond.cpp
+++ b/src/tests/modules/molstr/test_molcoord_bond.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/MolBond.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolBond;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, const char *name, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(1));
+    pAtom->setName(name);
+    pAtom->setElementName("C");
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+// One residue with three carbon atoms and no bonds.
+struct ThreeAtoms
+{
+    MolCoordPtr pMol;
+    int a, b, c;
+
+    ThreeAtoms() : pMol(MB_NEW MolCoord())
+    {
+        a = addAtom(pMol, "C1", 0.0);
+        b = addAtom(pMol, "C2", 1.5);
+        c = addAtom(pMol, "C3", 3.0);
+    }
+};
+
+}  // namespace
+
+TEST(MolCoordBond, RemoveBondDetachesBothAtoms)
+{
+    ThreeAtoms m;
+    ASSERT_NE(m.pMol->makeBond(m.a, m.b, true), nullptr);
+    ASSERT_TRUE(m.pMol->getAtom(m.a)->isBonded(m.b));
+
+    ASSERT_TRUE(m.pMol->removeBond(m.a, m.b));
+
+    // Neither atom may keep a pointer to the deleted bond.
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), nullptr);
+    EXPECT_FALSE(m.pMol->getAtom(m.b)->isBonded(m.a));
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+}
+
+TEST(MolCoordBond, MakeBondAfterRemoveCreatesFreshBond)
+{
+    // Undo of MolAnlManager::removeBond: makeBond() first looks the pair up
+    // through MolAtom::getBond(), which must not find the deleted bond.
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b, true);
+    ASSERT_TRUE(m.pMol->removeBond(m.a, m.b));
+
+    MolBond *pBond = m.pMol->makeBond(m.a, m.b, true);
+    ASSERT_NE(pBond, nullptr);
+    EXPECT_TRUE(pBond->isPersist());
+    EXPECT_EQ(m.pMol->getBondSize(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), pBond);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBond(m.a), pBond);
+}
+
+TEST(MolCoordBond, RemoveBondAcceptsReversedIdsAndRejectsUnknownPair)
+{
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b);
+    EXPECT_FALSE(m.pMol->removeBond(m.a, m.c));
+    EXPECT_TRUE(m.pMol->removeBond(m.b, m.a));
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+}
+
+TEST(MolCoordBond, RemoveNonpersBondsDropsOrphanPersistentBondFromSurvivor)
+{
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b, true);   // persistent (SSBOND/LINK style)
+    m.pMol->makeBond(m.b, m.c, false);  // non-persistent (topology)
+
+    // removeAtom() leaves the bonds in place; applyTopology() cleans them up
+    // through removeNonpersBonds().
+    ASSERT_TRUE(m.pMol->removeAtom(m.b));
+    m.pMol->removeNonpersBonds();
+
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.c)->getBondCount(), 0);
+
+    // The survivors can be bonded again without tripping over stale pointers.
+    ASSERT_NE(m.pMol->makeBond(m.a, m.c, true), nullptr);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 1);
+}
+
+TEST(MolCoordBond, RemoveNonpersBondsKeepsValidPersistentBond)
+{
+    ThreeAtoms m;
+    MolBond *pPers = m.pMol->makeBond(m.a, m.b, true);
+    m.pMol->makeBond(m.b, m.c, false);
+
+    m.pMol->removeNonpersBonds();
+
+    EXPECT_EQ(m.pMol->getBondSize(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), pPers);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBondCount(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.c)->getBondCount(), 0);
+}


### PR DESCRIPTION
## Summary

Part 2 of the libcuemol2 bug-audit fixes (Phase 1: memory-safety). Independent of #552.

`MolCoord::removeBond()` deleted the `MolBond` but left the pointer in both atoms' `m_bonded` lists, and `removeNonpersBonds()` did the same for a persistent bond whose partner atom had been removed. Every later walk over `MolAtom::m_bonded` (`getBond`, `isBonded`, `bondBegin`) read freed memory, and `makeBond()` wrote to it through `setPersist()` when the same pair was bonded again.

Reachable from normal use:

- `MolAnlManager::removeBond` -> Undo (`MolBondEditInfo::bondImpl(true)` -> `makeBond` -> `MolAtom::getBond` on the freed bond)
- load a PDB with SSBOND/LINK (persistent bonds) -> `deleteAtoms` on one side -> `applyTopology()` -> `removeNonpersBonds()` deletes the orphan bond, then `makeBond` on the surviving atom dereferences it

Both paths now detach the bond from the surviving atoms before deleting it.

## Tests

`tests/modules/molstr/test_molcoord_bond.cpp` (5 cases): `removeBond` clears both atoms' bond lists and accepts reversed ids, re-bonding after removal creates a fresh bond, `removeNonpersBonds` drops an orphaned persistent bond from the survivor while keeping intact persistent bonds.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
