### PR TITLE
fix(qsys): clear camera vis settings safely before the scene finishes loading

### DIFF
--- a/src/qsys/Camera.cpp
+++ b/src/qsys/Camera.cpp
@@ -33,6 +33,11 @@ Camera::Camera()
   resetAllProps();
 }
 
+Camera::~Camera()
+{
+  delete m_pVisSetNodes;
+}
+
 void Camera::copyFrom(const Camera&r)
 {
   if (!r.m_visset.empty()) {
@@ -150,6 +155,7 @@ void Camera::readFrom2(qlib::LDom2Node *pNode)
   qlib::LDom2Node *pVisSet = pNode->findChild("visibilities");
   if (pVisSet!=NULL) {
     MB_DPRINTLN("Camera.readFrom> copy vis nodes");
+    delete m_pVisSetNodes;
     m_pVisSetNodes = MB_NEW qlib::LDom2Node(*pVisSet);
     return;
   }
@@ -395,15 +401,22 @@ bool Camera::visChange(qlib::uid_t tgtid, bool bVis)
 
 void Camera::clearVisSettings()
 {
-  while (getVisSize()>0) {
+  // getVisSize() also counts a pending <visibilities> node, so walk the
+  // map itself and never take begin() of an empty map
+  while (!m_visset.empty()) {
     VisSetting::iterator i = m_visset.begin();
-    visRemove(i->first);
+    const qlib::uid_t tgtid = i->first;
+    const bool bAlive = i->second.bObj
+      ? !SceneManager::getObjectS(tgtid).isnull()
+      : !SceneManager::getRendererS(tgtid).isnull();
+    if (!bAlive || !visRemove(tgtid)) {
+      // target already gone (nothing to notify) or removal failed: drop the entry
+      m_visset.erase(tgtid);
+    }
   }
-  // m_visset.clear();
-  if (m_pVisSetNodes!=NULL) {
-    delete m_pVisSetNodes;
-    m_pVisSetNodes = NULL;
-  }
+
+  delete m_pVisSetNodes;
+  m_pVisSetNodes = NULL;
 }
 
 void Camera::saveVisSettings(ScenePtr pScene)

--- a/src/qsys/Camera.cpp
+++ b/src/qsys/Camera.cpp
@@ -40,10 +40,6 @@ Camera::~Camera()
 
 void Camera::copyFrom(const Camera&r)
 {
-  if (!r.m_visset.empty()) {
-    LOG_DPRINTLN("Warning: copy of non-empty visflags camera <%s>", r.m_name.c_str());
-  }
-  
   m_name = r.m_name;
   m_source = r.m_source;
 
@@ -72,6 +68,14 @@ void Camera::copyFrom(const Camera&r)
   m_nCenterMark = r.m_nCenterMark;
   setDefaultPropFlag("centerMark", false);
 
+  // The visibility settings are part of the camera value: the copies made
+  // by Scene::getCamera(), the undo/redo edit info and the lightweight
+  // viewer must keep them. The pending <visibilities> node is deep-copied
+  // so that two cameras never share (and double-delete) the same tree.
+  m_visset = r.m_visset;
+  delete m_pVisSetNodes;
+  m_pVisSetNodes = (r.m_pVisSetNodes != NULL)
+    ? MB_NEW qlib::LDom2Node(*r.m_pVisSetNodes) : NULL;
 }
 
 bool Camera::equals(const Camera &r)
@@ -415,6 +419,12 @@ void Camera::clearVisSettings()
     }
   }
 
+  resetVisSettings();
+}
+
+void Camera::resetVisSettings()
+{
+  m_visset.clear();
   delete m_pVisSetNodes;
   m_pVisSetNodes = NULL;
 }

--- a/src/qsys/Camera.hpp
+++ b/src/qsys/Camera.hpp
@@ -246,6 +246,8 @@ namespace qsys {
       return *this;
     }
 
+    ~Camera() override;
+
     //////////
     
   private:

--- a/src/qsys/Camera.hpp
+++ b/src/qsys/Camera.hpp
@@ -297,6 +297,10 @@ namespace qsys {
     /// Clear visibility settings
     void clearVisSettings();
 
+    /// Drop the visibility settings without undo/redo bookkeeping
+    /// (used where the camera is a plain value, e.g. the view's current camera)
+    void resetVisSettings();
+
     LString getVisSetJSON() const;
 
     /// Called when the parent scene loading is completed

--- a/src/qsys/View.cpp
+++ b/src/qsys/View.cpp
@@ -973,6 +973,8 @@ void View::setCameraAnim(CameraPtr rcam, bool bAnim)
   else {
     m_curcam = Camera(*(rcam.get()));
     m_curcam.setSource("");
+    // the view only tracks the geometry; vis flags stay with the named camera
+    m_curcam.resetVisSettings();
 
     // camera changed, so we must update proj matrix
     setProjChange();

--- a/src/tests/qsys/test_camera.cpp
+++ b/src/tests/qsys/test_camera.cpp
@@ -203,3 +203,27 @@ TEST(CameraTest, ReadFrom2ReplacesPendingVisibilities)
     cam.clearVisSettings();
     EXPECT_EQ(cam.getVisSize(), 0);
 }
+
+TEST(CameraTest, CopyKeepsPendingVisibilityNodesWithoutSharingThem)
+{
+    // Scene::getCamera(), the undo/redo edit info and the lightweight viewer
+    // all work on copies; a copy that dropped the vis settings silently lost
+    // them for the user.
+    std::unique_ptr<qlib::LDom2Node> pNode(makeCameraNodeWithVisibilities());
+    Camera orig;
+    orig.readFrom2(pNode.get());
+    ASSERT_EQ(orig.getVisSize(), 1);
+
+    Camera copy(orig);
+    EXPECT_EQ(copy.getVisSize(), 1);
+
+    Camera assigned;
+    assigned = orig;
+    EXPECT_EQ(assigned.getVisSize(), 1);
+
+    // the node tree is deep-copied: clearing one camera leaves the others
+    copy.clearVisSettings();
+    EXPECT_EQ(copy.getVisSize(), 0);
+    EXPECT_EQ(orig.getVisSize(), 1);
+    EXPECT_EQ(assigned.getVisSize(), 1);
+}

--- a/src/tests/qsys/test_camera.cpp
+++ b/src/tests/qsys/test_camera.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <common.h>
+#include <memory>
+#include "qlib/LDOM2Tree.hpp"
 #include "qsys/Camera.hpp"
 
 using qsys::Camera;
@@ -146,5 +148,58 @@ TEST(CameraTest, ClearVisSettingsNoCrash)
 {
     Camera cam;
     cam.clearVisSettings();  // no-op when empty
+    EXPECT_EQ(cam.getVisSize(), 0);
+}
+
+namespace {
+
+// Builds a <camera> node with a <visibilities> child, the shape a camera
+// serialized with vis flags has before the scene finishes loading.
+qlib::LDom2Node *makeCameraNodeWithVisibilities()
+{
+    qlib::LDom2Node *pCam = new qlib::LDom2Node();
+    pCam->setTagName("camera");
+
+    qlib::LDom2Node *pVis = new qlib::LDom2Node();
+    pVis->setTagName("visibilities");
+
+    qlib::LDom2Node *pObj = new qlib::LDom2Node();
+    pObj->setTagName("object");
+    pObj->setStrAttr("target", "mol1");
+    pObj->setValue("false");
+    pVis->appendChild(pObj);
+
+    pCam->appendChild(pVis);
+    return pCam;
+}
+
+}  // namespace
+
+TEST(CameraTest, ClearVisSettingsDropsUnconvertedNodes)
+{
+    // A camera read from a file keeps the <visibilities> node until the
+    // scene finishes loading (notifyLoaded). Clearing before that used to
+    // walk an empty map because getVisSize() reports the pending node as 1.
+    std::unique_ptr<qlib::LDom2Node> pNode(makeCameraNodeWithVisibilities());
+    Camera cam;
+    cam.readFrom2(pNode.get());
+    ASSERT_EQ(cam.getVisSize(), 1);
+
+    cam.clearVisSettings();
+    EXPECT_EQ(cam.getVisSize(), 0);
+
+    // clearing twice stays a no-op
+    cam.clearVisSettings();
+    EXPECT_EQ(cam.getVisSize(), 0);
+}
+
+TEST(CameraTest, ReadFrom2ReplacesPendingVisibilities)
+{
+    std::unique_ptr<qlib::LDom2Node> pNode(makeCameraNodeWithVisibilities());
+    Camera cam;
+    cam.readFrom2(pNode.get());
+    cam.readFrom2(pNode.get());  // second read must not leak the first node
+    EXPECT_EQ(cam.getVisSize(), 1);
+    cam.clearVisSettings();
     EXPECT_EQ(cam.getVisSize(), 0);
 }

--- a/src/tests/qsys/test_scene.cpp
+++ b/src/tests/qsys/test_scene.cpp
@@ -449,3 +449,75 @@ TEST_F(SceneTest, SmaaThresholdDefaultAndSetGet)
     m_pScene->setAASmaaThreshold(0.12);
     EXPECT_DOUBLE_EQ(m_pScene->getAASmaaThreshold(), 0.12);
 }
+
+// --- camera visibility settings survive copies ---
+
+namespace {
+
+// A camera whose vis flags hide the (only) object of the scene.
+CameraPtr makeCameraHidingObject(qlib::uid_t objUID)
+{
+    CameraPtr pCam(new qsys::Camera());
+    pCam->setName("cam1");
+    pCam->visAppend(objUID, false, true);
+    return pCam;
+}
+
+}  // namespace
+
+TEST_F(SceneTest, GetCameraCopyKeepsVisSettings)
+{
+    ObjectPtr pObj(new ConcreteObject());
+    pObj->setName("mol1");
+    m_pScene->addObject(pObj);
+
+    m_pScene->setCamera("cam1", makeCameraHidingObject(pObj->getUID()));
+
+    // getCamera() hands out a copy (scripts, exporters, lightweight viewer)
+    CameraPtr pCopy = m_pScene->getCamera("cam1");
+    ASSERT_FALSE(pCopy.isnull());
+    EXPECT_EQ(pCopy->getVisSize(), 1);
+    EXPECT_NE(pCopy->getVisSetJSON().indexOf("\"visible\":false"), -1);
+}
+
+TEST_F(SceneTest, UndoOfSetCameraRestoresVisSettings)
+{
+    ObjectPtr pObj(new ConcreteObject());
+    pObj->setName("mol1");
+    m_pScene->addObject(pObj);
+    m_pScene->setCamera("cam1", makeCameraHidingObject(pObj->getUID()));
+    ASSERT_EQ(m_pScene->getCameraRef("cam1")->getVisSize(), 1);
+
+    // overwriting the camera (e.g. "save view to camera" without vis flags)
+    // drops the flags; the edit info holds copies of both cameras
+    m_pScene->startUndoTxn("Change camera cam1");
+    m_pScene->setCamera("cam1", CameraPtr(new qsys::Camera()));
+    m_pScene->commitUndoTxn();
+    EXPECT_EQ(m_pScene->getCameraRef("cam1")->getVisSize(), 0);
+
+    ASSERT_TRUE(m_pScene->getUndoMgr()->undo());
+    EXPECT_EQ(m_pScene->getCameraRef("cam1")->getVisSize(), 1);
+
+    ASSERT_TRUE(m_pScene->getUndoMgr()->redo());
+    EXPECT_EQ(m_pScene->getCameraRef("cam1")->getVisSize(), 0);
+}
+
+TEST_F(SceneTest, ViewCameraDoesNotCarryVisSettings)
+{
+    ObjectPtr pObj(new ConcreteObject());
+    pObj->setName("mol1");
+    m_pScene->addObject(pObj);
+    m_pScene->setCamera("cam1", makeCameraHidingObject(pObj->getUID()));
+
+    ViewPtr pView = m_pScene->createView();
+    ASSERT_FALSE(pView.isnull());
+
+    // loading a named camera into the view only takes its geometry, so saving
+    // the view to another camera must not spread the vis flags around
+    m_pScene->loadViewFromCam(pView->getUID(), "cam1");
+    EXPECT_EQ(pView->getCamera()->getVisSize(), 0);
+
+    m_pScene->saveViewToCam(pView->getUID(), "cam2");
+    EXPECT_EQ(m_pScene->getCameraRef("cam2")->getVisSize(), 0);
+    EXPECT_EQ(m_pScene->getCameraRef("cam1")->getVisSize(), 1);
+}


### PR DESCRIPTION
## Summary

Part 3 of the libcuemol2 bug-audit fixes (Phase 1: memory-safety, plus one Phase 2 item in the same file). Independent of #552 and the molstr bond PR.

### Commit 1: `clearVisSettings()` before the scene finishes loading

`Camera::getVisSize()` reports 1 while a camera still holds the raw `<visibilities>` node read from a file (it is converted to `m_visset` only in `notifyLoaded()`, i.e. on `SCE_SCENE_ONLOADED`). `clearVisSettings()` trusted that count and dereferenced `m_visset.begin()` on an empty map. Reachable from the UI: reload a camera file (`Scene::loadCamera`) or paste a camera from XML, then "Clear visibility flags" or "Save camera with vis flags" (which clears first).

- `clearVisSettings()` walks the map itself, drops an entry whose target object/renderer no longer exists instead of looping on it, and deletes the pending node.
- `Camera` frees the pending `<visibilities>` node in its destructor and when `readFrom2()` replaces it (both leaked before).

### Commit 2: camera copies keep the visibility settings

`Camera::copyFrom()` copied every property except `m_visset` / the pending `<visibilities>` node and only logged a warning, so every path that works on a copy lost the flags:

- `CameraPropEditInfo` stores copies of the before/after cameras: undo or redo of any camera change ("save view to camera", property edit) silently wiped the vis flags of the restored camera.
- `Scene::getCamera()` returns a copy: scripts, the scene exporters and the lightweight viewer (which rebuilds its camera table from copies) saw `vis_size == 0` for cameras that do have flags.

The copy now takes the map and deep-copies the pending node (no shared tree). The view's current camera is the one place where the old behaviour is wanted (loading a named camera into a view must not let "save view to camera" spread its flags to another camera), so `View::setCameraAnim()` drops them explicitly via the new `Camera::resetVisSettings()` (clear without undo bookkeeping).

## Tests

- `tests/qsys/test_camera.cpp`: clearing a camera that still holds an unconverted `<visibilities>` node, reading the same node twice, and copy / assignment keeping the pending node without sharing it.
- `tests/qsys/test_scene.cpp`: `getCamera()` copy keeps the flags, undo/redo of `setCamera()` restores them, and a camera loaded into a `TTYView` does not carry them into `saveViewToCam()`.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
