### PR TITLE
fix(molanl,surface): stop reading past arrays in ContactMap and HoleSurfBuilder

### DIFF
--- a/src/modules/molanl/ContactMap.cpp
+++ b/src/modules/molanl/ContactMap.cpp
@@ -257,9 +257,9 @@ public:
     }
 
     {
-      // For mol2
+      // For mol2: its atoms follow mol1's entries
       AtomIterator aiter(pMol2, pSel2);
-      for (i=0,aiter.first(); aiter.hasMore()&&i<natoms; aiter.next(),++i) {
+      for (i=natoms1,aiter.first(); aiter.hasMore()&&i<natoms; aiter.next(),++i) {
 	MolAtomPtr pAtom = aiter.get();
 	m_data[i].pos = pAtom->getPos();
 	m_data[i].patm = pAtom;
@@ -334,7 +334,7 @@ public:
       LOG_DPRINTLN("Mol[%s] Atom contacts in %.2f -- %.2f Angstroms:", pMol->getName().c_str(), m_rmin, m_rmax);
       BOOST_FOREACH (const IntrSet::value_type &elem, intrset) {
         MolAtomPtr pA1 = pMol->getAtom(elem.first);
-        MolAtomPtr pA2 = pMol->getAtom(elem.second);
+        MolAtomPtr pA2 = pMol2->getAtom(elem.second);
         double dist = (pA1->getPos() - pA2->getPos()).length();
 
         if (!pSel1.isnull() && !pSel1->isSelected(pA2))

--- a/src/modules/surface/HoleSurfBuilder.cpp
+++ b/src/modules/surface/HoleSurfBuilder.cpp
@@ -15,6 +15,8 @@
 #include <modules/molstr/TopparManager.hpp>
 #include <modules/molstr/AtomPosMap.hpp>
 
+#include <iterator>
+
 using namespace surface;
 using molstr::MolCoordPtr;
 using molstr::MolAtomPtr;
@@ -84,7 +86,7 @@ void HoleSurfBuilder::doit()
   int nslice;
   double score = 0.0, prev_score = -1.0;
   std::vector<Vector4D> cen_ary;
-  for (int i=0; i<sizeof(trytemp); ++i) {
+  for (size_t i=0; i<std::size(trytemp); ++i) {
     std::vector<Vector4D> new_ary;
     findPath(trytemp[i], new_ary, score, nslice);
     if (score < prev_score) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -265,6 +265,7 @@ gtest_discover_tests(test_importers PROPERTIES LABELS "test_importers")
 add_executable(test_molanl
   modules/molanl/test_main.cpp
   modules/molanl/test_ssm_superpose.cpp
+  modules/molanl/test_contactmap.cpp
 )
 target_include_directories(test_molanl PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/molanl/test_contactmap.cpp
+++ b/src/tests/modules/molanl/test_contactmap.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molanl/MolAnlManager.hpp"
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/SelCommand.hpp"
+#include "qsys/SceneManager.hpp"
+#include "qsys/Scene.hpp"
+
+using molanl::MolAnlManager;
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using molstr::SelCommand;
+using molstr::SelectionPtr;
+using qlib::LString;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, const char *name, const char *elem, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(1));
+    pAtom->setName(name);
+    pAtom->setElementName(elem);
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+SelectionPtr allSel()
+{
+    return SelectionPtr(new SelCommand(LString("*")));
+}
+
+class ContactMapTest : public ::testing::Test
+{
+protected:
+    qsys::ScenePtr m_scene;
+
+    void SetUp() override
+    {
+        m_scene = qsys::SceneManager::getInstance()->createScene();
+        m_scene->setName("contactMapTestScene");
+    }
+
+    void TearDown() override
+    {
+        if (!m_scene.isnull()) {
+            qlib::uid_t uid = m_scene->getUID();
+            m_scene = qsys::ScenePtr();
+            qsys::SceneManager::getInstance()->destroyScene(uid);
+        }
+    }
+
+    MolCoordPtr newMol(const char *name)
+    {
+        MolCoordPtr pMol(MB_NEW MolCoord());
+        pMol->setName(name);
+        m_scene->addObject(pMol);
+        return pMol;
+    }
+
+    // calcAtomContact3JSON over two molecules, contacts within [0, 4] A
+    static LString contacts(MolCoordPtr pMol1, MolCoordPtr pMol2)
+    {
+        return MolAnlManager::getInstance()->calcAtomContact3JSON(
+            pMol1, allSel(), pMol2, allSel(), 0.0, 4.0, false, 100);
+    }
+};
+
+}  // namespace
+
+TEST_F(ContactMapTest, TwoMoleculesSameAtomCount)
+{
+    // mol1: N(0)  O(10)     mol2: O(3)  N(30)
+    // The only pair within 4 A is mol1:N -- mol2:O.
+    MolCoordPtr pMol1 = newMol("mol1");
+    const int n1 = addAtom(pMol1, "N", "N", 0.0);
+    addAtom(pMol1, "O", "O", 10.0);
+
+    MolCoordPtr pMol2 = newMol("mol2");
+    const int o2 = addAtom(pMol2, "O", "O", 3.0);
+    addAtom(pMol2, "N", "N", 30.0);
+
+    const LString expected = LString::format("[[%d,%d]]", n1, o2);
+    EXPECT_STREQ(contacts(pMol1, pMol2).c_str(), expected.c_str());
+}
+
+TEST_F(ContactMapTest, FirstMoleculeLargerThanSecond)
+{
+    // mol1: N(0) O(1.5) N(20)     mol2: O(2.5)
+    // Pairs within 4 A: mol1:N(0)--mol2:O and mol1:O(1.5)--mol2:O.
+    MolCoordPtr pMol1 = newMol("mol1");
+    const int a = addAtom(pMol1, "N1", "N", 0.0);
+    const int b = addAtom(pMol1, "O1", "O", 1.5);
+    addAtom(pMol1, "N2", "N", 20.0);
+
+    MolCoordPtr pMol2 = newMol("mol2");
+    const int c = addAtom(pMol2, "O", "O", 2.5);
+
+    const LString expected = LString::format("[[%d,%d],[%d,%d]]", a, c, b, c);
+    EXPECT_STREQ(contacts(pMol1, pMol2).c_str(), expected.c_str());
+}
+
+TEST_F(ContactMapTest, NoContactsGivesEmptyString)
+{
+    MolCoordPtr pMol1 = newMol("mol1");
+    addAtom(pMol1, "N", "N", 0.0);
+    MolCoordPtr pMol2 = newMol("mol2");
+    addAtom(pMol2, "O", "O", 50.0);
+    EXPECT_STREQ(contacts(pMol1, pMol2).c_str(), "");
+}


### PR DESCRIPTION
## Summary

Part 4 of the libcuemol2 bug-audit fixes (Phase 1: memory-safety). Independent of the other Phase 1 PRs.

### molanl: `ContactMap::doit2()` (two-molecule atom contacts)

The second molecule's atoms were copied starting at index 0 again, overwriting the first molecule's entries; the slots from `natoms1` upward were never filled (null `patm`, uninitialized position) before `m_tree.build()`. `calcAtomContact3JSON` therefore returned nothing when mol2 had at least as many selected atoms as mol1, and dereferenced a null atom pointer when it had fewer. The copy now starts at `natoms1`, and the contact log resolves the second atom in the second molecule (it used mol1's atom table with mol2's IDs).

### surface: `HoleSurfBuilder::doit()`

`for (i=0; i<sizeof(trytemp); ++i)` used the byte size (24) of a 3-element `double` array as its length, reading past the array whenever the score kept improving. Now uses `std::size`.

## Tests

`tests/modules/molanl/test_contactmap.cpp` (3 cases): two hand-built molecules with equal / unequal atom counts and the expected `[[aid1,aid2],...]` output, plus the no-contact case. The equal-count case returns `""` on the old code and the unequal case reads an unfilled slot.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
