### PR TITLE
fix(molvis): keep wavy helix width from interpolating an empty spline

### DIFF
--- a/src/modules/molvis/Ribbon2Renderer.cpp
+++ b/src/modules/molvis/Ribbon2Renderer.cpp
@@ -34,6 +34,8 @@ SecSplDat::SecSplDat(Ribbon2Renderer *pP)
   m_bFixStart = false;
   m_bFixEnd = false;
   m_nStartId = 0;
+  m_bWsplValid = false;
+  m_dWidthAver = 1.0;
 }
 
 bool SecSplDat::generate()
@@ -78,9 +80,10 @@ bool SecSplDat::generateHelix(double wrho)
   else
     m_dWidthAver = 1.0; // XXX
 
-  if (!m_wspl.generate())
-    return false;
-  
+  // The width spline needs at least three points; a shorter helix falls
+  // back to the average width in renderHelix().
+  m_bWsplValid = m_wspl.generate();
+
   return true;
 }
 
@@ -729,11 +732,11 @@ void Ribbon2Renderer::renderHelix(DisplayContext *pdl)
       double t = tstart + double(j)*fdelta; ///double(naxdet);
       pCol = calcColor(t, pC);
       pC->m_spl.interpolate(t, &f1, &vpt);
-      // if (!m_bWidthAver) {
-      if (m_nHelixWidthMode==HWIDTH_WAVY) {
+      if (m_nHelixWidthMode==HWIDTH_WAVY && pC->m_bWsplValid) {
         pC->m_wspl.interpolate(t, &width, &dwidth);
       }
-      else if (m_nHelixWidthMode==HWIDTH_AVER) {
+      else if (m_nHelixWidthMode==HWIDTH_AVER || m_nHelixWidthMode==HWIDTH_WAVY) {
+        // average width (also the fallback for a wavy helix too short for its spline)
         width = pC->m_dWidthAver;
         dwidth = 0.0;
       }

--- a/src/modules/molvis/Ribbon2Renderer.hpp
+++ b/src/modules/molvis/Ribbon2Renderer.hpp
@@ -41,6 +41,8 @@ using namespace molstr;
 
       // cylinder data
       SmoothSpline1D m_wspl;
+      /// m_wspl could be generated (needs at least three points)
+      bool m_bWsplValid;
       double m_dWidthAver;
 
       // sheet data

--- a/src/modules/molvis/smospl/SmoothSpline.cpp
+++ b/src/modules/molvis/smospl/SmoothSpline.cpp
@@ -12,6 +12,7 @@
 using namespace molvis;
 
 SmoothSpline1D::SmoothSpline1D()
+  : m_nPoints(0)
 {
   m_rho = 3.0;
 }
@@ -37,6 +38,9 @@ void SmoothSpline1D::cleanup()
 bool SmoothSpline1D::generate()
 {
   int i;
+  // drop the coefficients of a previous generate() so that a failure
+  // below leaves interpolate() with nothing to read
+  cleanup();
   m_nPoints = m_veclist.size();
 
   if (m_nPoints==0)
@@ -105,6 +109,10 @@ bool SmoothSpline1D::interpolate(double par, double *vec,
                               double *dvec /*= NULL*/,
                               double *ddvec /*= NULL*/)
 {
+  // no coefficients: generate() has not run or rejected the points
+  if (m_vecx.size()<2 || m_coeff0.empty())
+    return false;
+
   int l = 0;
   int r = m_vecx.size()-2+1;
   int m;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -143,6 +143,7 @@ gtest_discover_tests(test_molstr PROPERTIES LABELS "test_molstr")
 add_executable(test_molvis
   modules/molvis/test_main.cpp
   modules/molvis/test_cpk2renderer.cpp
+  modules/molvis/test_smoothspline.cpp
 )
 target_include_directories(test_molvis PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/molvis/test_smoothspline.cpp
+++ b/src/tests/modules/molvis/test_smoothspline.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molvis/smospl/SmoothSpline.hpp"
+
+using molvis::SmoothSpline1D;
+
+TEST(SmoothSpline1D, TwoPointsCannotBeInterpolated)
+{
+    // A helix truncated to two residues gives a two-point width spline.
+    // generate() rejects it, and interpolate() must then fail instead of
+    // reading the empty coefficient tables.
+    SmoothSpline1D spl;
+    spl.setSize(2);
+    spl.setValue(0, 1.0);
+    spl.setValue(1, 2.0);
+    EXPECT_FALSE(spl.generate());
+    EXPECT_EQ(spl.getPoints(), 2);
+
+    double v = -1.0, dv = -1.0;
+    EXPECT_FALSE(spl.interpolate(0.5, &v, &dv));
+    EXPECT_DOUBLE_EQ(v, -1.0);
+    EXPECT_DOUBLE_EQ(dv, -1.0);
+}
+
+TEST(SmoothSpline1D, InterpolateBeforeGenerateFails)
+{
+    SmoothSpline1D spl;
+    EXPECT_EQ(spl.getPoints(), 0);
+    double v = 0.0;
+    EXPECT_FALSE(spl.interpolate(0.0, &v));
+}
+
+TEST(SmoothSpline1D, ThreePointsInterpolateThroughKnots)
+{
+    SmoothSpline1D spl;
+    spl.setRho(3.0);
+    spl.setSize(3);
+    spl.setValue(0, 1.0);
+    spl.setValue(1, 2.0);
+    spl.setValue(2, 3.0);
+    ASSERT_TRUE(spl.generate());
+
+    double v = 0.0;
+    ASSERT_TRUE(spl.interpolate(0.0, &v));
+    EXPECT_NEAR(v, 1.0, 1e-6);
+    ASSERT_TRUE(spl.interpolate(1.0, &v));
+    EXPECT_NEAR(v, 2.0, 1e-6);
+}
+
+TEST(SmoothSpline1D, RegenerateWithTooFewPointsDropsOldCoefficients)
+{
+    SmoothSpline1D spl;
+    spl.setSize(3);
+    spl.setValue(0, 1.0);
+    spl.setValue(1, 2.0);
+    spl.setValue(2, 3.0);
+    ASSERT_TRUE(spl.generate());
+
+    spl.setSize(2);
+    EXPECT_FALSE(spl.generate());
+    double v = -1.0;
+    EXPECT_FALSE(spl.interpolate(0.5, &v));
+}


### PR DESCRIPTION
## Summary

Part 5 of the libcuemol2 bug-audit fixes (Phase 1: memory-safety). Independent of the other Phase 1 PRs.

`SecSplDat::generateHelix()` builds the helix width spline with `SmoothSpline1D`, which refuses fewer than three points (`m_nPoints<=2`), but the caller in `Ribbon2Renderer::buildHelixData()` ignored the result and pushed the cylinder anyway. With `helix_width_mode=wavy`, a helix cut down to two residues (selection boundary, or a one-residue helix from DSSP) then called `SmoothSpline1D::interpolate()` on empty coefficient tables: `int r = m_vecx.size()-2+1` wraps and `m_vecx[m]` / `m_coeff0[l]` read out of bounds.

Changes:

- `SecSplDat` records whether the width spline is valid; `renderHelix()` falls back to the average width for `wavy` when it is not.
- `SmoothSpline1D::interpolate()` returns `false` without coefficients, `generate()` clears stale coefficients before bailing out, and `m_nPoints` starts at zero (it was uninitialized until the first `generate()`).

## Tests

`tests/modules/molvis/test_smoothspline.cpp` (4 cases): two-point / not-yet-generated splines fail cleanly, a three-point spline interpolates through its knots, and regenerating with too few points drops the old coefficients.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
