### PR TITLE
fix(molstr): never evict a selection cache entry that is still being built

### DIFF
--- a/src/modules/molstr/SelCacheMgr.cpp
+++ b/src/modules/molstr/SelCacheMgr.cpp
@@ -46,11 +46,17 @@ SelCacheData *SelCacheMgr::createCacheEntry()
 
   MB_DPRINTLN("SelCacheMgr> molsel cache entry is created (%d); curr cache size=%d",id, (int)m_data.size());
 
-  while (m_data.size()>m_nCacheMax) {
-    CacheEntTab::iterator i = m_data.begin();
-    //MB_DPRINTLN("discard cache data ID=%d", i->first);
+  // Trim the cache to its limit, oldest first. Skip the entries that
+  // makeCache() is still filling (a nested around/byres selection creates
+  // entries from inside that loop) and the entry just created.
+  CacheEntTab::iterator i = m_data.begin();
+  while (m_data.size()>m_nCacheMax && i!=m_data.end()) {
+    if (i->second->m_bBuilding || i->second==pNewData) {
+      ++i;
+      continue;
+    }
     delete i->second;
-    m_data.erase(i);
+    i = m_data.erase(i);
   }
 
   return pNewData;
@@ -115,17 +121,29 @@ const SelCacheData *SelCacheMgr::makeCache(MolCoordPtr pMol, SelectionPtr pSel)
   MolCoord::AtomIter eiter = pMol->endAtom();
   Vector4D pos, cen(0,0,0);
   int nsel = 0;
-  for (; iter!=eiter; ++iter) {
-    MolAtomPtr pAtom = iter->second;
-    MB_ASSERT(!pAtom.isnull());
-    if (!pSel->isSelected(pAtom))
-      continue;
-    pos = pAtom->getPos();
-    pEnt->m_atomIdSet.insert(iter->first);
-    pEnt->m_bbox.merge(pos);
-    cen += pos;
-    nsel ++;
+
+  // Evaluating pSel may create further cache entries (nested around/byres);
+  // keep this entry from being evicted until it is complete.
+  pEnt->m_bBuilding = true;
+  try {
+    for (; iter!=eiter; ++iter) {
+      MolAtomPtr pAtom = iter->second;
+      MB_ASSERT(!pAtom.isnull());
+      if (!pSel->isSelected(pAtom))
+        continue;
+      pos = pAtom->getPos();
+      pEnt->m_atomIdSet.insert(iter->first);
+      pEnt->m_bbox.merge(pos);
+      cen += pos;
+      nsel ++;
+    }
   }
+  catch (...) {
+    // do not leave a half-built entry behind
+    invalidateCache(ncid);
+    throw;
+  }
+  pEnt->m_bBuilding = false;
   pEnt->m_nSel = nsel;
   if (nsel>0)
     pEnt->m_vCenter = cen.divide(nsel);

--- a/src/modules/molstr/SelCacheMgr.hpp
+++ b/src/modules/molstr/SelCacheMgr.hpp
@@ -50,10 +50,13 @@ private:
   /// Kd-tree data (for around op impl ver2)
   void *m_pExtData;
 
+  /// set while makeCache() is still filling this entry
+  bool m_bBuilding;
+
 public:
   SelCacheData()
        : m_nCacheID(-1), m_nMolID(qlib::invalid_uid), m_bAsetValid(false),
-         m_nSel(0), m_bBboxValid(false), m_pExtData(NULL)
+         m_nSel(0), m_bBboxValid(false), m_pExtData(NULL), m_bBuilding(false)
     {
     }
   

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(test_molstr
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
   modules/molstr/test_molcoord_bond.cpp
+  modules/molstr/test_selcachemgr.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp

--- a/src/tests/modules/molstr/test_selcachemgr.cpp
+++ b/src/tests/modules/molstr/test_selcachemgr.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/SelCommand.hpp"
+#include "molstr/SelCacheMgr.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using molstr::SelCacheData;
+using molstr::SelCacheMgr;
+using molstr::SelCommand;
+using molstr::SelectionPtr;
+using qlib::LString;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, int resid, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(resid));
+    pAtom->setName("CA");
+    pAtom->setElementName("C");
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+// Selects every atom, and while doing so builds a fresh cache entry for
+// another selection per atom. This is what a nested around/byres
+// selection does through findOrMakeCacheData(), and it used to evict the
+// entry that was still being filled once the cache limit was reached.
+class NestingSel : public SelCommand
+{
+public:
+    MolCoordPtr m_pMol;
+    int m_nCalls;
+
+    NestingSel() : SelCommand(LString("*")), m_nCalls(0) {}
+
+    bool isSelected(MolAtomPtr) override
+    {
+        ++m_nCalls;
+        SelectionPtr pSub(new SelCommand(LString::format("resi %d", m_nCalls)));
+        SelCacheMgr::getInstance()->findOrMakeCacheData(m_pMol, pSub);
+        return true;
+    }
+};
+
+}  // namespace
+
+TEST(SelCacheMgr, EntryUnderConstructionSurvivesNestedCacheBuilds)
+{
+    const int natoms = 16;  // more than the cache limit (10)
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    for (int i = 0; i < natoms; ++i) addAtom(pMol, i + 1, double(i));
+
+    NestingSel *pNest = new NestingSel();
+    pNest->m_pMol = pMol;
+    SelectionPtr pSel(pNest);
+
+    SelCacheMgr *pMgr = SelCacheMgr::getInstance();
+    const SelCacheData *pEnt = pMgr->makeCache(pMol, pSel);
+    ASSERT_NE(pEnt, nullptr);
+    EXPECT_EQ(pNest->m_nCalls, natoms);
+
+    // The outer entry must still be registered and complete.
+    EXPECT_EQ(pMgr->getCacheEntry(pEnt->getCacheID()), pEnt);
+    EXPECT_EQ(int(pEnt->getAtomIdSet().size()), natoms);
+    EXPECT_EQ(pMgr->findCacheData(pMol, pSel), pEnt);
+}
+
+TEST(SelCacheMgr, CacheLimitStillEvictsFinishedEntries)
+{
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    addAtom(pMol, 1, 0.0);
+
+    SelCacheMgr *pMgr = SelCacheMgr::getInstance();
+    SelectionPtr pFirst(new SelCommand(LString("resi 1")));
+    const SelCacheData *pEnt = pMgr->makeCache(pMol, pFirst);
+    const int firstId = pEnt->getCacheID();
+
+    // Fill the cache well past its limit with finished entries.
+    for (int i = 2; i < 30; ++i) {
+        SelectionPtr pSel(new SelCommand(LString::format("resi %d", i)));
+        pMgr->makeCache(pMol, pSel);
+    }
+    EXPECT_EQ(pMgr->getCacheEntry(firstId), nullptr);
+}


### PR DESCRIPTION
## Summary

Part 6 of the libcuemol2 bug-audit fixes (Phase 1: memory-safety). **Based on #553** (it needs the molstr test environment change from that PR to construct `MolCoord` in tests); retarget to `develop` once #553 is merged.

`SelCacheMgr::createCacheEntry()` trims the cache to `m_nCacheMax` (10) by deleting the oldest entries as soon as a new one is created. `makeCache()` fills its entry while evaluating `pSel->isSelected()` for every atom, and a nested `around`/`byres`/`bymainch` node creates further entries through `findOrMakeCacheData()` during that evaluation. With ten or more distinct nested sub-selections the entry being filled is the oldest one, gets deleted underneath `makeCache()`, and the remaining `m_atomIdSet.insert()` calls write into freed memory.

Entries now carry an in-construction flag for the duration of `makeCache()`, and the trim skips them (and the entry that was just created).

## Tests

`tests/modules/molstr/test_selcachemgr.cpp`: a selection whose `isSelected()` builds a fresh cache entry per atom (16 atoms, limit 10) must leave the outer entry registered and complete; a second case checks that finished entries are still evicted past the limit.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
