### PR TITLE
fix(xtal): correct BRIX/DSN6 map statistics and clamp an off-map box region

### DIFF
--- a/src/modules/xtal/BrixMapReader.cpp
+++ b/src/modules/xtal/BrixMapReader.cpp
@@ -117,6 +117,16 @@ bool BrixMapReader::read(qlib::InStream &ins)
 
   LOG_DPRINTLN("BRIX> brix   %d %d %d", xbri, ybri, zbri);
 
+  if (!(m_prod>0.0)) {
+    LOG_DPRINTLN("BRIX> invalid prod value %f", m_prod);
+    return false;
+  }
+  if (m_ncol<=0 || m_nrow<=0 || m_nsect<=0) {
+    LOG_DPRINTLN("BRIX> invalid extent %d %d %d", m_ncol, m_nrow, m_nsect);
+    return false;
+  }
+
+  // byte value b maps to density as rho = (b - plus) / prod
   double rmax = (255.0-m_plus)/m_prod;
   double rmin = -m_plus/m_prod;
 
@@ -165,9 +175,11 @@ bool BrixMapReader::read(qlib::InStream &ins)
             }
       }
 
-  double mean = (sum/double(nadd)) * m_prod + m_plus;
-  double sqmean = (sqsum/double(nadd)) * m_prod + m_plus;
-  double sigma = sqrt(sqmean-mean*mean);
+  // statistics of the byte values, converted with rho = (b - plus) / prod
+  const double bmean = sum/double(nadd);
+  const double bvar = sqsum/double(nadd) - bmean*bmean;
+  double mean = (bmean - m_plus)/m_prod;
+  double sigma = sqrt(qlib::max(0.0, bvar))/m_prod;
   LOG_DPRINTLN("mean density=%f", mean);
   LOG_DPRINTLN("rms density=%f", sigma);
 
@@ -197,13 +209,19 @@ bool BrixMapReader::readHeader(qlib::InStream &in)
 
   const char *delimitor = " ,\t\r\n";
 
-  // check the "smiley" mark
+  // check the "smiley" mark. A DSN6 header is binary and usually starts
+  // with NUL bytes (origin 0), so it must be detected before strtok().
+  {
+    const char *p = sbuf;
+    while (*p!='\0' && strchr(delimitor, *p)!=NULL)
+      ++p;
+    if (strncmp(p, ":-)", 3)!=0)
+      return readDns6Header(sbuf);
+  }
+
   char *tok = strtok(sbuf, delimitor);
   if (tok==NULL)
     return false;
-  if (!LChar::equals(tok, ":-)")) {
-    return readDns6Header(sbuf);
-  }
   
   //
   // read origin
@@ -497,16 +515,24 @@ bool BrixMapReader::readDns6Header(const char *sbuf)
   
   MB_DPRINTLN("DNS6 dmin,dmax = %f+/-%f,%f+/-%f", dmin, dminError, dmax, dmaxError);
 
+  if (!(scalingFactor>0.0) || !(drange>0.0) || !(header16>0.0)) {
+    LOG_DPRINTLN("DSN6> invalid header (scale %f, range %f)", scalingFactor, drange);
+    return false;
+  }
+
   m_cella = a / scalingFactor;
   m_cellb = b / scalingFactor;
   m_cellc = c / scalingFactor;
   m_alpha = alpha / scalingFactor;
   m_beta = beta / scalingFactor;
   m_gamma = gamma / scalingFactor;
-  
-  m_prod = byteFactor;
-  m_plus = dmin;
-  
+
+  // DSN6 stores rho = dmin + b * byteFactor. Express it in the BRIX
+  // convention used by read(), b = prod * rho + plus, so both formats share
+  // the same quantization and statistics code.
+  m_prod = 1.0 / byteFactor;
+  m_plus = -dmin / byteFactor;
+
   return true;
 }
 

--- a/src/modules/xtal/GLSLMapMeshRenderer2.cpp
+++ b/src/modules/xtal/GLSLMapMeshRenderer2.cpp
@@ -233,9 +233,19 @@ void GLSLMapMeshRenderer2::make3DTexMap(DisplayContext *pdc, ScalarObject *pMap,
     int strow = m_nStRow - pMap->getStartRow();
     int stsec = m_nStSec - pMap->getStartSec();
 
-    int ncol = int(vmax.x() - vmin.x());
-    int nrow = int(vmax.y() - vmin.y());
-    int nsec = int(vmax.z() - vmin.z());
+    // the box can lie entirely outside the map (non-PBC): an empty region
+    // means there is nothing to upload
+    int ncol = qlib::max(0, int(vmax.x() - vmin.x()));
+    int nrow = qlib::max(0, int(vmax.y() - vmin.y()));
+    int nsec = qlib::max(0, int(vmax.z() - vmin.z()));
+
+    m_nActCol = ncol;
+    m_nActRow = nrow;
+    m_nActSec = nsec;
+    if (ncol <= 0 || nrow <= 0 || nsec <= 0) {
+        m_bMapTexOK = false;
+        return;
+    }
 
     MapBufTex::DataArray &maptmp = m_mapBufTex.m_data;
     if (int(maptmp.cols()) != ncol || int(maptmp.rows()) != nrow ||

--- a/src/modules/xtal/MapSurfRenderer.cpp
+++ b/src/modules/xtal/MapSurfRenderer.cpp
@@ -439,9 +439,11 @@ void MapSurfRenderer::makerange()
     vmax.z() = floor(qlib::min<double>(vmax.z(), pMap->getStartSec()+pMap->getSecNo()));
   }
 
-  m_nActCol = int(vmax.x() - vmin.x());
-  m_nActRow = int(vmax.y() - vmin.y());
-  m_nActSec = int(vmax.z() - vmin.z());
+  // the box can lie entirely outside the map (non-PBC): clamp to an empty
+  // range instead of a negative size
+  m_nActCol = qlib::max(0, int(vmax.x() - vmin.x()));
+  m_nActRow = qlib::max(0, int(vmax.y() - vmin.y()));
+  m_nActSec = qlib::max(0, int(vmax.z() - vmin.z()));
 
   m_nStCol = int(vmin.x());
   m_nStRow = int(vmin.y());
@@ -622,13 +624,16 @@ void MapSurfRenderer::runMarchingCubes(bool bGenSurf,
   const int nrow = m_nActRow;
   const int nsec = m_nActSec;
 
+  slabs.clear();
+  if (ncol<=0 || nrow<=0 || nsec<=0)
+    return; // empty region (box outside the map): nothing to march
+
   // Phase 1: run the per-cell marching-cubes kernel over the grid, slab by
   // slab along the col axis, recording the emissions into per-slab buffers.
   // The kernel only reads shared state, so the slabs run concurrently on
   // oneTBB; consuming the buffers in slab order reproduces the serial
   // emission order exactly, independent of the thread count.
   const int nslabs = (ncol + m_nStep - 1) / m_nStep;
-  slabs.clear();
   slabs.resize(nslabs);
 
   qlib::parallel_for(0, (size_t) nslabs, [&](size_t si) {
@@ -1319,12 +1324,16 @@ qsys::ObjectPtr MapSurfRenderer::generateSurfObj()
   renderImpl(NULL);
   int nverts = m_msverts.size();
   int nfaces = nverts/3;
-  pSurfObj->setVertSize(nverts);
-  for (int i=0; i<nverts; ++i)
-    pSurfObj->setVertex(i, m_msverts[i]);
-  pSurfObj->setFaceSize(nfaces);
-  for (int i=0; i<nfaces; ++i)
-    pSurfObj->setFace(i, i*3, i*3+1, i*3+2);
+  // an empty region (box outside the map, no crossing) gives an empty
+  // surface object; MolSurfObj rejects a zero-sized allocation
+  if (nverts>0) {
+    pSurfObj->setVertSize(nverts);
+    for (int i=0; i<nverts; ++i)
+      pSurfObj->setVertex(i, m_msverts[i]);
+    pSurfObj->setFaceSize(nfaces);
+    for (int i=0; i<nfaces; ++i)
+      pSurfObj->setFace(i, i*3, i*3+1, i*3+2);
+  }
   m_msverts.clear();
 
   m_bGenSurfMode = false;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -184,6 +184,7 @@ gtest_discover_tests(test_surface PROPERTIES LABELS "test_surface")
 add_executable(test_xtal
   modules/xtal/test_main.cpp
   modules/xtal/test_atomposmap2.cpp
+  modules/xtal/test_brix_reader.cpp
   modules/xtal/test_ccp4_origin.cpp
   modules/xtal/test_ccp4map_stream.cpp
   modules/xtal/test_map_block_extract.cpp
@@ -192,6 +193,7 @@ add_executable(test_xtal
   modules/xtal/test_maplod.cpp
   modules/xtal/test_mapmesh_full.cpp
   modules/xtal/test_mapmesh_viewregion.cpp
+  modules/xtal/test_mapsurf_box_outside.cpp
   modules/xtal/test_maprenderer_color.cpp
   modules/xtal/test_maprenderer_region.cpp
   modules/xtal/test_mapsurf_molfanc.cpp

--- a/src/tests/modules/xtal/test_brix_reader.cpp
+++ b/src/tests/modules/xtal/test_brix_reader.cpp
@@ -1,0 +1,119 @@
+// -*-Mode: C++;-*-
+//
+// BrixMapReader: the density statistics and the value range must follow
+// the byte-to-density mapping of the format (BRIX: rho = (b - plus) / prod,
+// DSN6: rho = dmin + b * byteFactor).
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/StringStream.hpp>
+#include <qsys/Object.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include "xtal/BrixMapReader.hpp"
+#include "xtal/DensityMap.hpp"
+
+using qlib::StrInStream;
+using xtal::BrixMapReader;
+using xtal::DensityMap;
+
+namespace {
+
+// One 8x8x8 brick: the first half of the voxels hold lo, the rest hi.
+std::string makeBrick(unsigned char lo, unsigned char hi)
+{
+    std::string brick(512, '\0');
+    for (int i = 0; i < 512; ++i) brick[i] = char(i < 256 ? lo : hi);
+    return brick;
+}
+
+std::string makeBrixImage(double prod, double plus, unsigned char lo, unsigned char hi)
+{
+    char hdr[600];
+    std::snprintf(hdr, sizeof(hdr),
+                  ":-) Origin 0 0 0 Extent 8 8 8 Grid 8 8 8 "
+                  "Cell 10.0 10.0 10.0 90.0 90.0 90.0 Prod %.4f Plus %.4f Sigma 1.0 ",
+                  prod, plus);
+    std::string image(hdr);
+    image.resize(512, ' ');
+    return image + makeBrick(lo, hi);
+}
+
+void putInt16(std::string &buf, int index, int value)
+{
+    const uint16_t u = uint16_t(int16_t(value));
+    buf[index * 2] = char(u & 0xff);
+    buf[index * 2 + 1] = char((u >> 8) & 0xff);
+}
+
+// DSN6 header words (little-endian int16): origin, extent, grid, cell*scale,
+// 100*255/(dmax-dmin), -255*dmin/(dmax-dmin), scale, 100.
+std::string makeDsn6Image(double dmin, double dmax, unsigned char lo, unsigned char hi)
+{
+    std::string hdr(512, '\0');
+    const int scale = 100;
+    const double range = dmax - dmin;
+    int w = 0;
+    putInt16(hdr, w++, 0); putInt16(hdr, w++, 0); putInt16(hdr, w++, 0);
+    putInt16(hdr, w++, 8); putInt16(hdr, w++, 8); putInt16(hdr, w++, 8);
+    putInt16(hdr, w++, 8); putInt16(hdr, w++, 8); putInt16(hdr, w++, 8);
+    for (int i = 0; i < 3; ++i) putInt16(hdr, w++, 10 * scale);
+    for (int i = 0; i < 3; ++i) putInt16(hdr, w++, 90 * scale);
+    putInt16(hdr, w++, int(100.0 * 255.0 / range + 0.5));
+    putInt16(hdr, w++, int(-255.0 * dmin / range + 0.5));
+    putInt16(hdr, w++, scale);
+    putInt16(hdr, w++, 100);
+    return hdr + makeBrick(lo, hi);
+}
+
+DensityMap *readImage(const std::string &image, qsys::ObjectPtr &rpObj)
+{
+    DensityMap *pMap = MB_NEW DensityMap();
+    rpObj = qsys::ObjectPtr(pMap);
+    BrixMapReader reader;
+    reader.attach(rpObj);
+    StrInStream ins(image.data(), static_cast<int>(image.size()));
+    const bool bOK = reader.read(ins);
+    reader.detach();
+    return bOK ? pMap : NULL;
+}
+
+}  // namespace
+
+TEST(BrixMapReader, BrixStatisticsFollowByteMapping)
+{
+    // prod 10, plus 100: bytes 90 / 110 are densities -1 / +1
+    qsys::ObjectPtr pObj;
+    DensityMap *pMap = readImage(makeBrixImage(10.0, 100.0, 90, 110), pObj);
+    ASSERT_NE(pMap, nullptr);
+
+    EXPECT_NEAR(pMap->getMinDensity(), -10.0, 1e-6);   // byte 0
+    EXPECT_NEAR(pMap->getMaxDensity(), 15.5, 1e-6);    // byte 255
+    EXPECT_NEAR(pMap->getMeanDensity(), 0.0, 1e-6);
+    EXPECT_NEAR(pMap->getRmsdDensity(), 1.0, 1e-6);
+    EXPECT_EQ(pMap->getColNo(), 8);
+    EXPECT_EQ(pMap->getRowNo(), 8);
+    EXPECT_EQ(pMap->getSecNo(), 8);
+}
+
+TEST(BrixMapReader, Dsn6RangeAndStatisticsFollowHeader)
+{
+    // dmin -1, dmax 1.55: byte 0 is -1, byte 200 is +1
+    qsys::ObjectPtr pObj;
+    DensityMap *pMap = readImage(makeDsn6Image(-1.0, 1.55, 0, 200), pObj);
+    ASSERT_NE(pMap, nullptr);
+
+    EXPECT_NEAR(pMap->getMinDensity(), -1.0, 1e-3);
+    EXPECT_NEAR(pMap->getMaxDensity(), 1.55, 1e-3);
+    EXPECT_NEAR(pMap->getMeanDensity(), 0.0, 1e-3);
+    EXPECT_NEAR(pMap->getRmsdDensity(), 1.0, 1e-3);
+}
+
+TEST(BrixMapReader, ZeroProdIsRejected)
+{
+    qsys::ObjectPtr pObj;
+    EXPECT_EQ(readImage(makeBrixImage(0.0, 100.0, 90, 110), pObj), nullptr);
+}

--- a/src/tests/modules/xtal/test_mapsurf_box_outside.cpp
+++ b/src/tests/modules/xtal/test_mapsurf_box_outside.cpp
@@ -1,0 +1,88 @@
+// -*-Mode: C++;-*-
+//
+// MapSurfRenderer in box region mode: a display box that lies entirely
+// outside a non-periodic map must give an empty region, not a negative
+// size (which used to throw from vector::resize on every frame).
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/Vector4D.hpp>
+#include <qsys/Scene.hpp>
+#include <qsys/SceneManager.hpp>
+#include <vector>
+#include "xtal/DensityMap.hpp"
+#include "xtal/MapRenderer.hpp"
+#include "xtal/MapSurfRenderer.hpp"
+#include "surface/MolSurfObj.hpp"
+
+using qlib::Vector4D;
+using xtal::DensityMap;
+using xtal::MapRenderer;
+using xtal::MapSurfRenderer;
+
+namespace {
+
+class MapBoxOutsideTest : public ::testing::Test {
+protected:
+    qsys::ScenePtr m_pScene;
+    qsys::ObjectPtr m_pObj;
+    qsys::RendererPtr m_pRend;
+    MapSurfRenderer *m_pMSR;
+
+    static const int N = 16;
+
+    void SetUp() override
+    {
+        m_pScene = qsys::SceneManager::getInstance()->createScene();
+
+        DensityMap *pMap = MB_NEW DensityMap();
+        std::vector<float> data((size_t)N * N * N);
+        for (size_t i = 0; i < data.size(); ++i) data[i] = float(i % 7) - 3.0f;
+        pMap->setMapFloatArray(data.data(), N, N, N, 0, 1, 2);
+        pMap->setMapParams(0, 0, 0, N, N, N);
+        pMap->setXtalParams(double(N), double(N), double(N), 90.0, 90.0, 90.0);
+        pMap->setDetectedMapType(DensityMap::MAPTYPE_EM);
+
+        m_pObj = qsys::ObjectPtr(pMap);
+        m_pObj->setName("boxmap");
+        m_pScene->addObject(m_pObj);
+
+        m_pRend = m_pObj->createRenderer("isosurf");
+        m_pMSR = dynamic_cast<MapSurfRenderer *>(m_pRend.get());
+        ASSERT_NE(m_pMSR, nullptr);
+        m_pMSR->setRegionMode(MapRenderer::REGION_BOX);
+        m_pMSR->setExtent(5.0);
+    }
+
+    void TearDown() override
+    {
+        qsys::SceneManager::getInstance()->destroyScene(m_pScene->getUID());
+    }
+};
+
+}  // namespace
+
+TEST_F(MapBoxOutsideTest, BoxInsideMapProducesSurface)
+{
+    m_pMSR->setCenter(Vector4D(8.0, 8.0, 8.0));
+    qsys::ObjectPtr pSurf;
+    ASSERT_NO_THROW(pSurf = m_pMSR->generateSurfObj());
+    ASSERT_FALSE(pSurf.isnull());
+    surface::MolSurfObj *pMS = dynamic_cast<surface::MolSurfObj *>(pSurf.get());
+    ASSERT_NE(pMS, nullptr);
+    EXPECT_GT(pMS->getVertSize(), 0);
+}
+
+TEST_F(MapBoxOutsideTest, BoxOutsideMapGivesEmptySurface)
+{
+    // far beyond the 16 A block along every axis
+    m_pMSR->setCenter(Vector4D(200.0, 200.0, 200.0));
+    qsys::ObjectPtr pSurf;
+    ASSERT_NO_THROW(pSurf = m_pMSR->generateSurfObj());
+    ASSERT_FALSE(pSurf.isnull());
+    surface::MolSurfObj *pMS = dynamic_cast<surface::MolSurfObj *>(pSurf.get());
+    ASSERT_NE(pMS, nullptr);
+    EXPECT_EQ(pMS->getVertSize(), 0);
+    EXPECT_EQ(pMS->getFaceSize(), 0);
+}


### PR DESCRIPTION
## Summary

Part 7 of the libcuemol2 bug-audit fixes (Phase 2: broken behaviour). Independent of the Phase 1 PRs.

### BRIX / DSN6 statistics (`BrixMapReader`)

The bricks are quantized with `rho = (b - plus) / prod`, but the statistics were computed as `mean = E[b] * prod + plus` and `sqmean = E[b^2] * prod + plus`, then `sigma = sqrt(sqmean - mean^2)`. For typical headers that is the square root of a negative number, so `getRmsdDensity()` was NaN and the contour level (`rmsd * siglevel`) could not be set for any BRIX/DSN6 map. The DSN6 header path also stored `prod`/`plus` in the opposite convention (`rho = dmin + b * byteFactor`), so the value range of DSN6 maps was wrong too.

- both formats now use the BRIX convention (`b = prod * rho + plus`); the DSN6 header is converted (`prod = 1/byteFactor`, `plus = -dmin/byteFactor`)
- mean/sigma are derived from the byte moments: `mean = (E[b] - plus)/prod`, `sigma = sqrt(Var[b])/prod`
- `prod <= 0`, an empty extent and a degenerate DSN6 header (zero scale or range) are rejected
- found while testing: `readHeader()` ran `strtok()` over the 512-byte header before deciding between BRIX and DSN6. A DSN6 header is binary and starts with a NUL byte whenever the origin is 0, so `strtok()` returned NULL and the reader failed before trying the DSN6 path at all. The smiley is now checked on the raw buffer first.

### Box region outside the map (`MapSurfRenderer`, `GLSLMapMeshRenderer2`)

`makerange()` clamps `vmin`/`vmax` to the map block independently, so a box entirely outside a non-periodic map gave a negative `m_nActCol/Row/Sec`. Since the marching-cubes parallelization that became `slabs.resize(nslabs)` with a negative count -> `std::length_error` on every frame (`Scene::display()` has no try/catch); the GPU mesh path hit `new[]` with a negative size. The sizes are now clamped to zero and an empty region marches nothing / uploads nothing; `generateSurfObj()` returns an empty `MolSurfObj` instead of hitting the `n>=1` assertion in `setVertSize(0)`.

## Tests

- `tests/modules/xtal/test_brix_reader.cpp` (3 cases): synthetic BRIX and DSN6 images with known byte values pin min/max/mean/sigma; a zero `prod` is rejected. The BRIX case yields NaN sigma on the old code.
- `tests/modules/xtal/test_mapsurf_box_outside.cpp` (2 cases): box mode inside / entirely outside a 16^3 EM map; the outside case threw `std::length_error` before.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
