### PR TITLE
fix(qsys): guard undo transactions, keep redo order, skip failed chunks, fix velocity units

### DIFF
--- a/src/qsys/MouseEventHandler.cpp
+++ b/src/qsys/MouseEventHandler.cpp
@@ -4,6 +4,7 @@
 
 #include <common.h>
 #include "MouseEventHandler.hpp"
+#include <qlib/LTimeValue.hpp>
 
 using namespace qsys;
 
@@ -173,7 +174,7 @@ void MouseEventHandler::calcVelocity(InDevEvent &ev, qlib::time_value curr)
     iter++;
     const EventEnt &t2 = *iter;
 
-    if (t0.t-t1.t>50) {
+    if (t0.t-t1.t>qlib::timeval::fromMilliSec(VELO_GAP_TIME)) {
       // no velocity
       return;
     }
@@ -189,12 +190,14 @@ void MouseEventHandler::calcVelocity(InDevEvent &ev, qlib::time_value curr)
     return;
   }
 
+  const qlib::time_value aver_win = qlib::timeval::fromMilliSec(AVER_TIME);
+
   {
     EventBuf::const_iterator iter = m_cbuf.begin();
     EventBuf::const_iterator eiter = m_cbuf.end();
     for (; iter!=eiter; ++iter) {
       const EventEnt &elem = *iter;
-      if (elem.t>curr-qlib::time_value(AVER_TIME)) {
+      if (elem.t>curr-aver_win) {
         const qlib::time_value del_t = (elem.t-curr);
         //MB_DPRINT("%d: t=%ld", nave, del_t);
         //MB_DPRINTLN("[%d, %d]", elem.x, elem.y);
@@ -221,7 +224,7 @@ void MouseEventHandler::calcVelocity(InDevEvent &ev, qlib::time_value curr)
     EventBuf::const_iterator eiter = m_cbuf.end();
     for (; iter!=eiter; ++iter) {
       const EventEnt &elem = *iter;
-      if (elem.t>curr-qlib::time_value(AVER_TIME)) {
+      if (elem.t>curr-aver_win) {
         const double dt = (elem.t-curr)-avet;
         tvar += dt*dt;
         xtvar += (elem.x-avex)*dt;
@@ -239,8 +242,10 @@ void MouseEventHandler::calcVelocity(InDevEvent &ev, qlib::time_value curr)
     return;
   }
 
-  double bx = xtvar/tvar*1000.0;
-  double by = ytvar/tvar*1000.0;
+  // slope is pixels per event-clock tick (ns); report pixels per second
+  const double ns_per_sec = 1.0e9;
+  double bx = xtvar/tvar*ns_per_sec;
+  double by = ytvar/tvar*ns_per_sec;
 
   ev.setVeloX(bx);
   ev.setVeloY(by);

--- a/src/qsys/MouseEventHandler.hpp
+++ b/src/qsys/MouseEventHandler.hpp
@@ -40,7 +40,11 @@ namespace qsys {
     EventBuf  m_cbuf;
 
     static const int EVENTBUF_SIZE = 16;
+    /// velocity averaging window (milliseconds; the event clock is in ns)
     static const int AVER_TIME = 500;
+    /// longest move-to-release gap that still yields a velocity (milliseconds)
+    static const int VELO_GAP_TIME = 50;
+    /// double click interval (nanoseconds)
     static const int DBLCLICK_TIME = 500*1000*1000;
 
     InDevEvent m_lastEvent;

--- a/src/qsys/SceneXMLReader.cpp
+++ b/src/qsys/SceneXMLReader.cpp
@@ -164,6 +164,24 @@ void SceneXMLReader::read()
   }
 }
 
+namespace {
+  /// After a failed chunk read, skip to the end of the chunk so that the
+  /// next chunk starts at its marker; otherwise every following chunk
+  /// fails to parse and its object stays empty.
+  template <class _Stream>
+  void skipFailedChunk(_Stream &ois, qlib::InStream *pin)
+  {
+    if (pin==NULL)
+      return;
+    try {
+      ois.closeChunkStream(pin);
+    }
+    catch (...) {
+      // the stream is beyond repair; the caller reports the original error
+    }
+  }
+}
+
 #ifdef USE_OBJSTR3
 void SceneXMLReader::procDataChunks(qlib::LDom2InStream &ois, LDom2Node *pNode) {}
 void SceneXMLReader::procDataChunks(qlib::LObjInStream3 &ois, LDom2Node *pNode)
@@ -173,6 +191,7 @@ void SceneXMLReader::procDataChunks(qlib::LDom2InStream &ois, LDom2Node *pNode)
 #endif
 {
   for (;;) {
+    qlib::InStream *pin = NULL;
     try {
       LString chunkid = ois.getNextDataChunkID();
       if (chunkid.isEmpty())
@@ -185,18 +204,22 @@ void SceneXMLReader::procDataChunks(qlib::LDom2InStream &ois, LDom2Node *pNode)
         return;
       }
 
-      qlib::InStream *pin = ois.getNextChunkStream();
+      pin = ois.getNextChunkStream();
+      if (pin==NULL)
+        return;
       pCnt->readFromStream(*pin);
       ois.closeChunkStream(pin);
-      
+      pin = NULL;
     }
     catch (qlib::LException &e) {
       pNode->appendErrMsg("SceneXML> Load object error (ignored).");
       pNode->appendErrMsg("SceneXML> Reason: %s", e.getMsg().c_str());
+      skipFailedChunk(ois, pin);
     }
     catch (...) {
       pNode->appendErrMsg("SceneXML> Load object error (ignored).");
       pNode->appendErrMsg("SceneXML> Reason: unknown");
+      skipFailedChunk(ois, pin);
     }
   }
 }

--- a/src/qsys/UndoManager.cpp
+++ b/src/qsys/UndoManager.cpp
@@ -207,7 +207,12 @@ void UndoManager::rollbackTxn()
     return;
   }
   
-  MB_ASSERT(m_pPendInfo!=NULL);
+  if (m_pPendInfo==NULL) {
+    // script-visible: rollbackTxn() without a matching startTxn()
+    LOG_DPRINTLN("UndoManager> rollbackTxn() called outside a transaction (ignored)");
+    return;
+  }
+
   // undo pending operation
   m_pPendInfo->undo();
   delete m_pPendInfo;
@@ -225,7 +230,11 @@ void UndoManager::commitTxn()
     return;
   }
 
-  MB_ASSERT(m_pPendInfo!=NULL);
+  if (m_pPendInfo==NULL) {
+    // script-visible: commitTxn() without a matching startTxn()
+    LOG_DPRINTLN("UndoManager> commitTxn() called outside a transaction (ignored)");
+    return;
+  }
 
   if (m_pPendInfo->size()>0) {
     m_udata.push_front(m_pPendInfo);

--- a/src/qsys/style/StyleEditInfo.cpp
+++ b/src/qsys/style/StyleEditInfo.cpp
@@ -68,8 +68,8 @@ bool StyleCreateEditInfo::redo()
   StyleMgr *pSM = StyleMgr::getInstance();
 
   if (m_bCreate) {
-    // Redo of creation
-    if (!pSM->registerStyleSet(m_pTgt, 0, m_nSceneID))
+    // Redo of creation: put the set back where it was created
+    if (!pSM->registerStyleSet(m_pTgt, m_nInsBefore, m_nSceneID))
       return false;
   }
   else {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -109,6 +109,8 @@ add_executable(test_qsys
   qsys/test_guiview.cpp
   qsys/test_shaderobjmgr.cpp
   qsys/test_animmgr.cpp
+  qsys/test_mouseeventhandler.cpp
+  qsys/test_styleeditinfo.cpp
 )
 target_include_directories(test_qsys PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/qsys/test_mouseeventhandler.cpp
+++ b/src/tests/qsys/test_mouseeventhandler.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qsys/InDevEvent.hpp"
+#include "qsys/MouseEventHandler.hpp"
+
+using qsys::InDevEvent;
+using qsys::MouseEventHandler;
+
+namespace {
+
+InDevEvent at(int x, int y)
+{
+    InDevEvent ev;
+    ev.setX(x);
+    ev.setY(y);
+    return ev;
+}
+
+}  // namespace
+
+// A drag that ends right after a run of moves must report a velocity
+// (momentum scrolling). The move/release gap and the averaging window are
+// milliseconds; the event clock is nanoseconds, so comparing them without
+// conversion used to reject every drag.
+TEST(MouseEventHandler, ReleaseAfterQuickDragHasVelocity)
+{
+    MouseEventHandler h;
+    InDevEvent down = at(0, 0);
+    h.buttonDown(down);
+
+    for (int i = 1; i <= 8; ++i) {
+        InDevEvent mv = at(i * 10, 0);
+        h.move(mv);
+    }
+    EXPECT_EQ(h.getState(), MouseEventHandler::DRAG_DRAG);
+
+    InDevEvent up = at(80, 0);
+    h.buttonUp(up);
+    EXPECT_GT(up.getVeloX(), 0.0);
+    EXPECT_NEAR(up.getVeloY(), 0.0, 1e-9);
+}
+
+TEST(MouseEventHandler, ClickWithoutDragHasNoVelocity)
+{
+    MouseEventHandler h;
+    InDevEvent down = at(5, 5);
+    h.buttonDown(down);
+    InDevEvent up = at(5, 5);
+    h.buttonUp(up);
+    EXPECT_NEAR(up.getVeloX(), 0.0, 1e-9);
+    EXPECT_NEAR(up.getVeloY(), 0.0, 1e-9);
+}

--- a/src/tests/qsys/test_styleeditinfo.cpp
+++ b/src/tests/qsys/test_styleeditinfo.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <string>
+#include "qsys/style/StyleEditInfo.hpp"
+#include "qsys/style/StyleMgr.hpp"
+#include "qsys/style/StyleSet.hpp"
+
+using qlib::LString;
+using qsys::StyleCreateEditInfo;
+using qsys::StyleMgr;
+using qsys::StyleSetPtr;
+
+namespace {
+
+// Position of the style set named `name` in the list of the context
+// (from the JSON listing, which follows the list order).
+size_t posOf(qlib::uid_t ctxt, const char *name)
+{
+    const std::string js(StyleMgr::getInstance()->getStyleSetsJSON(ctxt).c_str());
+    return js.find(std::string("\"name\":\"") + name + "\"");
+}
+
+}  // namespace
+
+// Undo/redo of a style-set creation must put the set back where it was
+// (at the end, nbefore = -1), not at the front of the list.
+TEST(StyleCreateEditInfo, RedoRestoresListPosition)
+{
+    // a private context id: no scene is attached, so no events are fired
+    const qlib::uid_t ctxt = 987654;
+    StyleMgr *pSM = StyleMgr::getInstance();
+
+    StyleSetPtr pA = pSM->createStyleSet("styA", ctxt);
+    StyleSetPtr pB = pSM->createStyleSet("styB", ctxt);
+    ASSERT_FALSE(pA.isnull());
+    ASSERT_FALSE(pB.isnull());
+    ASSERT_LT(posOf(ctxt, "styA"), posOf(ctxt, "styB"));
+
+    StyleCreateEditInfo ei;
+    ei.setupCreate(ctxt, pB, -1);
+
+    ASSERT_TRUE(ei.undo());
+    EXPECT_EQ(posOf(ctxt, "styB"), std::string::npos);
+
+    ASSERT_TRUE(ei.redo());
+    EXPECT_NE(posOf(ctxt, "styB"), std::string::npos);
+    EXPECT_LT(posOf(ctxt, "styA"), posOf(ctxt, "styB"));
+
+    pSM->destroyStyleSet(ctxt, pB->getUID());
+    pSM->destroyStyleSet(ctxt, pA->getUID());
+}

--- a/src/tests/qsys/test_undomanager.cpp
+++ b/src/tests/qsys/test_undomanager.cpp
@@ -168,3 +168,35 @@ TEST(UndoManagerTest, IsOKOnlyInsideTxn)
     um.commitTxn();
     EXPECT_FALSE(um.isOK());
 }
+
+// ---- Transaction calls outside a transaction ----------------------------
+// commitTxn()/rollbackTxn() are script-visible; calling them without a
+// matching startTxn() must be a no-op, not a null dereference.
+
+TEST(UndoManagerTest, CommitWithoutTxnIsIgnored)
+{
+    UndoManager um;
+    um.commitTxn();
+    EXPECT_FALSE(um.isInTxn());
+    EXPECT_EQ(um.getUndoSize(), 0);
+}
+
+TEST(UndoManagerTest, RollbackWithoutTxnIsIgnored)
+{
+    UndoManager um;
+    um.rollbackTxn();
+    EXPECT_FALSE(um.isInTxn());
+    EXPECT_EQ(um.getUndoSize(), 0);
+}
+
+TEST(UndoManagerTest, DoubleCommitKeepsSingleEntry)
+{
+    UndoManager um;
+    um.startTxn("op");
+    um.addEditInfo(new CountEditInfo());
+    um.commitTxn();
+    um.commitTxn();
+    EXPECT_FALSE(um.isInTxn());
+    EXPECT_EQ(um.getUndoSize(), 1);
+    EXPECT_TRUE(um.isUndoable());
+}


### PR DESCRIPTION
## Summary

Part 8 of the libcuemol2 bug-audit fixes (Phase 2: broken behaviour, qsys). Independent of the other PRs (the Camera undo/vis-settings item is handled on #554 instead, to keep the Camera.cpp changes in one place).

- **`UndoManager::commitTxn()` / `rollbackTxn()`**: script-visible (`Scene.qif`), but the only protection against being called outside a transaction was an `MB_ASSERT`, which is compiled out in release builds; a catch block rolling back a transaction that was never started, or a double commit, dereferenced `m_pPendInfo == NULL`. Now logged and ignored.
- **`StyleCreateEditInfo::redo()`** re-registered the style set at index 0 instead of the recorded `m_nInsBefore` (undo used the right one), so undo -> redo of a style-set creation moved it to the front of the list and inverted the style resolution order.
- **`SceneXMLReader::procDataChunks()`** caught a failed chunk read but did not close/skip the chunk stream, so `getNextDataChunkID()` continued from the middle of the failed chunk, every remaining chunk failed too (all later objects in the `.qsc` came up empty), and the stream object leaked. A failed chunk is now skipped to its end marker.
- **`MouseEventHandler::calcVelocity()`** compared the event clock (nanoseconds, `EventManager::sGetCurrentTime()`) with millisecond constants: the move-to-release gap limit was effectively 50 ns and the averaging window 500 ns, so no drag ever produced a velocity and momentum scrolling (`setRotMMS` / `setTransMMS`) never engaged. The constants are converted with `timeval::fromMilliSec()` and the velocity is reported in pixels per second.

## Tests

- `tests/qsys/test_undomanager.cpp` (+3): commit / rollback outside a transaction and a double commit are no-ops (null dereference before).
- `tests/qsys/test_styleeditinfo.cpp` (new): undo -> redo of a created style set keeps its list position (moved to the front before).
- `tests/qsys/test_mouseeventhandler.cpp` (new): a quick drag reports a positive velocity on release, a plain click reports none (the drag reported no velocity before).
- The chunk-skip change has no unit test (it needs a scene file with a corrupt embedded object); verified by reading the `LDom2InStream` chunk protocol.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
