### PR TITLE
fix(molstr): match prime/asterisk atom names, Pro donors, and 0-based PDB models

### DIFF
--- a/src/modules/molstr/PDBFileReader.cpp
+++ b/src/modules/molstr/PDBFileReader.cpp
@@ -376,9 +376,13 @@ int PDBFileReader::convFromAname(const LString &atomname)
 
 bool PDBFileReader::readAtom()
 {
+  // Records outside a MODEL block (m_nCurrModel==-1, e.g. HETATM after the
+  // last ENDMDL) belong to the default model.
+  const bool bDefaultModel = (m_nCurrModel==-1 || m_nCurrModel==m_nDefaultModel);
+
   // If LoadMultiModel==false,
   // we ignore ATOM line in the non-default models.
-  if (!m_bLoadMultiModel && m_nDefaultModel!=m_nCurrModel)
+  if (!m_bLoadMultiModel && !bDefaultModel)
     return true;
 
   LString atomname;
@@ -480,10 +484,13 @@ bool PDBFileReader::readAtom()
   if (!checkAtomRecord(chain, resname, atomname))
     return false;
 
-  // process model ID (encode model ID in the chain name)
+  // process model ID (encode model ID in the chain name). The models are
+  // numbered relative to the first one of the file: encodeModelInChain()
+  // leaves model 1 unprefixed, so a file whose models start at 0 would
+  // otherwise merge MODEL 1 into the default model.
   LString schain(chain);
-  if (m_nDefaultModel!=m_nCurrModel)
-    schain = MolCoord::encodeModelInChain(chain, m_nCurrModel);
+  if (!bDefaultModel)
+    schain = MolCoord::encodeModelInChain(chain, m_nCurrModel - m_nDefaultModel + 1);
 
   MolAtomPtr pAtom = MolAtomPtr(MB_NEW MolAtom());
   pAtom->setParentUID(m_pMol->getUID());

--- a/src/modules/molstr/Prot2ndry.cpp
+++ b/src/modules/molstr/Prot2ndry.cpp
@@ -606,7 +606,7 @@ namespace {
       
       hbe = 0;
       Backbone &WITH = *m_chains[i];
-      if (WITH.resn.equals("pro"))
+      if (WITH.resn.equalsIgnoreCase("PRO"))
 	return hbe;
 
       dho = (WITH.h - m_chains[j]->o).length();

--- a/src/modules/molstr/SelNodes.cpp
+++ b/src/modules/molstr/SelNodes.cpp
@@ -421,11 +421,11 @@ bool SelNamesNode::isAtomSelected(const LString &aName, char altconf) const
   if (matches(aName))
     return true;
 
-  // check prime<->aster conversion
+  // check prime<->aster conversion (old nucleic-acid naming uses '*')
   LString pmnam = aName;
   int nrepl = pmnam.replace('*', '\'');
   if (nrepl!=0) {
-    if (matches(aName))
+    if (matches(pmnam))
       return true;
   }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -125,6 +125,8 @@ add_executable(test_molstr
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
   modules/molstr/test_molcoord_bond.cpp
+  modules/molstr/test_pdb_multimodel.cpp
+  modules/molstr/test_selnames_prime.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp

--- a/src/tests/modules/molstr/test_pdb_multimodel.cpp
+++ b/src/tests/modules/molstr/test_pdb_multimodel.cpp
@@ -1,0 +1,103 @@
+// -*-Mode: C++;-*-
+//
+// PDBFileReader multi-model handling: the first model of the file is the
+// unprefixed default model whatever its number, later models get a
+// distinct chain prefix, and atoms outside any MODEL block belong to the
+// default model.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/StringStream.hpp>
+#include <qsys/Object.hpp>
+#include <cstdio>
+#include <string>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolChain.hpp"
+#include "molstr/PDBFileReader.hpp"
+
+using molstr::MolCoordPtr;
+using molstr::PDBFileReader;
+using qlib::StrInStream;
+
+namespace {
+
+std::string atomLine(int serial, const char *name, const char *resn, char chain,
+                     int resi, double x, double y, double z)
+{
+    char buf[128];
+    std::snprintf(
+        buf, sizeof(buf),
+        "ATOM  %5d %-4s %-3s %c%4d    %8.3f%8.3f%8.3f%6.2f%6.2f          %2s\n", serial,
+        name, resn, chain, resi, x, y, z, 1.0, 20.0, "C");
+    return buf;
+}
+
+std::string modelLine(int n)
+{
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "MODEL     %4d\n", n);
+    return buf;
+}
+
+MolCoordPtr readPdb(const std::string &text, bool bMultiModel)
+{
+    PDBFileReader reader;
+    reader.m_bLoadMultiModel = bMultiModel;
+    reader.m_bBuild2ndry = false;
+    StrInStream ins(text.data(), static_cast<int>(text.size()));
+    return MolCoordPtr(reader.load(ins));
+}
+
+}  // namespace
+
+TEST(PDBFileReaderModels, ModelsNumberedFromZeroStayDistinct)
+{
+    const std::string text =
+        modelLine(0) + atomLine(1, " CA ", "ALA", 'A', 1, 0.0, 0.0, 0.0) + "ENDMDL\n" +
+        modelLine(1) + atomLine(2, " CA ", "ALA", 'A', 1, 1.0, 0.0, 0.0) +
+        "ENDMDL\n"
+        "END\n";
+
+    MolCoordPtr pMol = readPdb(text, true);
+    ASSERT_FALSE(pMol.isnull());
+    EXPECT_EQ(pMol->getAtomSize(), 2);
+    EXPECT_EQ(pMol->getChainSize(), 2);
+    // the first model keeps the plain chain name, the second is prefixed
+    EXPECT_FALSE(pMol->getChain("A").isnull());
+    EXPECT_FALSE(pMol->getChain("02_A").isnull());
+}
+
+TEST(PDBFileReaderModels, AtomsAfterLastEndmdlBelongToDefaultModel)
+{
+    const std::string text =
+        modelLine(1) + atomLine(1, " CA ", "ALA", 'A', 1, 0.0, 0.0, 0.0) + "ENDMDL\n" +
+        atomLine(2, " O  ", "HOH", 'A', 2, 5.0, 0.0, 0.0).replace(0, 6, "HETATM") +
+        "END\n";
+
+    MolCoordPtr pMol;
+    ASSERT_NO_THROW(pMol = readPdb(text, true));
+    ASSERT_FALSE(pMol.isnull());
+    EXPECT_EQ(pMol->getAtomSize(), 2);
+    EXPECT_EQ(pMol->getChainSize(), 1);
+    EXPECT_FALSE(pMol->getChain("A").isnull());
+
+    // the same holds when only the default model is loaded
+    pMol = readPdb(text, false);
+    ASSERT_FALSE(pMol.isnull());
+    EXPECT_EQ(pMol->getAtomSize(), 2);
+}
+
+TEST(PDBFileReaderModels, SingleModelLoadKeepsFirstModelOnly)
+{
+    const std::string text =
+        modelLine(0) + atomLine(1, " CA ", "ALA", 'A', 1, 0.0, 0.0, 0.0) + "ENDMDL\n" +
+        modelLine(1) + atomLine(2, " CA ", "ALA", 'A', 1, 1.0, 0.0, 0.0) +
+        "ENDMDL\n"
+        "END\n";
+
+    MolCoordPtr pMol = readPdb(text, false);
+    ASSERT_FALSE(pMol.isnull());
+    EXPECT_EQ(pMol->getAtomSize(), 1);
+    EXPECT_EQ(pMol->getChainSize(), 1);
+}

--- a/src/tests/modules/molstr/test_selnames_prime.cpp
+++ b/src/tests/modules/molstr/test_selnames_prime.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolAtom.hpp"
+#include "molstr/MolCoord.hpp"
+#include "molstr/SelCommand.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using molstr::SelCommand;
+using qlib::LString;
+
+namespace {
+
+MolAtomPtr addAtom(MolCoordPtr pMol, const char *name)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("G");
+    pAtom->setResIndex(ResidIndex(1));
+    pAtom->setName(name);
+    pAtom->setElementName("C");
+    pMol->appendAtom(pAtom);
+    return pAtom;
+}
+
+}  // namespace
+
+// Old nucleic-acid naming uses '*' where the current convention uses a
+// prime; a selection written with the prime must still match those atoms.
+TEST(SelNamesNode, PrimeMatchesAsteriskAtomName)
+{
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    MolAtomPtr pStar = addAtom(pMol, "C1*");
+    MolAtomPtr pPrime = addAtom(pMol, "C2'");
+    MolAtomPtr pOther = addAtom(pMol, "N1");
+
+    SelCommand sel(LString("name C1'"));
+    EXPECT_TRUE(sel.isSelected(pStar));
+    EXPECT_FALSE(sel.isSelected(pPrime));
+    EXPECT_FALSE(sel.isSelected(pOther));
+
+    SelCommand sel2(LString("name C2'"));
+    EXPECT_TRUE(sel2.isSelected(pPrime));
+    EXPECT_FALSE(sel2.isSelected(pStar));
+}


### PR DESCRIPTION
## Summary

Part 9 of the libcuemol2 bug-audit fixes (Phase 2: broken behaviour, molstr). **Based on #553** (it needs the molstr test environment change from that PR to construct `MolCoord` in tests); retarget to `develop` once #553 is merged.

- **`SelNamesNode::isAtomSelected()`**: converted `*` to `'` in the atom name (`pmnam`) and then called `matches(aName)` with the *original* name again, so the conversion never had an effect and `name C1'` did not select atoms named `C1*` (old nucleic-acid naming, which the PDB reader keeps as-is).
- **`Prot2ndry` (DSSP-style secondary structure)**: proline was excluded from the H-bond donors with `resn.equals("pro")`, but residue names are upper-case, so the comparison was always false: every Pro N received a synthetic H and was counted as a donor, which can extend helices across prolines and change turn assignments compared to DSSP.
- **`PDBFileReader` multi-model files**: chain names of non-default models are prefixed via `MolCoord::encodeModelInChain()`, which leaves model 1 unprefixed because the other readers (mmCIF, SDF, MOL2) number from 1. For a PDB whose models start at `MODEL 0`, `MODEL 1` therefore got the bare chain name and merged into the default model; `ATOM`/`HETATM` records after the last `ENDMDL` (`m_nCurrModel == -1`) threw `IllegalArgumentException` and aborted the load. Models are now numbered relative to the first one of the file, and records outside a MODEL block belong to the default model (also when `loadmodel=false`).

## Tests

- `tests/modules/molstr/test_selnames_prime.cpp`: `name C1'` matches `C1*` and not other atoms.
- `tests/modules/molstr/test_pdb_multimodel.cpp` (3 cases): 0-based models stay distinct, atoms after the last `ENDMDL` load into the default model, single-model load keeps the first model only.
- The Pro donor change has no unit test (it needs a protein with a DSSP reference); the fix is a one-token case-insensitive compare.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
