### PR TITLE
fix(gfx): make color parsing and the color table robust against bad input

### DIFF
--- a/src/gfx/ColCompiler.cpp
+++ b/src/gfx/ColCompiler.cpp
@@ -48,6 +48,8 @@ AbstractColor *ColCompiler::compile(const LString &cmd)
   resetParserState();
   m_alpha = 1.0;
   m_material = LString();
+  // modifiers left over from a failed compilation must not apply here
+  m_defs.clear();
 
   char *porig = m_sbuf = LChar::dup(cmd.c_str());
   m_nsize = LChar::length(porig);

--- a/src/gfx/ColorTable.hpp
+++ b/src/gfx/ColorTable.hpp
@@ -25,11 +25,12 @@ public:
   /// Internal color data structure (supporting gradient color between two clut entries)
   class IntColor {
   public:
-    /// Index for the internal CLUT
-    short cid1;
+    /// Index for the internal CLUT (int: an export can need more than
+    /// 32768 entries)
+    int cid1;
 
     /// Index for the internal CLUT. Valid only for gradient color.
-    short cid2;
+    int cid2;
     
     /// gradient param.
     unsigned char rho;

--- a/src/gfx/GradientColor.cpp
+++ b/src/gfx/GradientColor.cpp
@@ -123,6 +123,10 @@ quint32 GradientColor::getCode() const
 
 LString GradientColor::getMaterial() const
 {
+  // a gradient without component colors (freshly created from a script)
+  // has no material; this is a readonly property, so do not throw
+  if (m_pColor1.isnull())
+    return LString();
   return m_pColor1->getMaterial();
 }
     

--- a/src/gfx/StrColorFormat.cpp
+++ b/src/gfx/StrColorFormat.cpp
@@ -27,6 +27,12 @@ AbstractColor *AbstractColor::fromNode(qlib::LDom2Node *pNode)
   LString value = pNode->getValue();
   AbstractColor *pCol = AbstractColor::fromStringS(value);
 
+  // the color string did not compile: nothing to apply the modifiers to
+  if (pCol==NULL) {
+    LOG_DPRINTLN("AbstractColor.fromNode> invalid color \"%s\"", value.c_str());
+    return NULL;
+  }
+
   if (pNode->getChildCount()==0) {
     // pChNode has no child nodes ==> no modifications
     return pCol;

--- a/src/modules/molvis/PaintColoring.cpp
+++ b/src/modules/molvis/PaintColoring.cpp
@@ -407,6 +407,10 @@ void PaintColoring::readFrom2(qlib::LDom2Node *pNode)
       continue;
     }
     ColorPtr pCol(gfx::AbstractColor::fromNode(pColNode));
+    if (pCol.isnull()) {
+      LOG_DPRINTLN("PaintColoring.readFrom> invalid color in paint tag (ignored)");
+      continue;
+    }
 
     append(pSel, pCol);
     //m_coltab.push_back(PaintTuple(pSel, pCol));

--- a/src/qsys/MultiGradient.cpp
+++ b/src/qsys/MultiGradient.cpp
@@ -203,6 +203,10 @@ void MultiGradient::readFrom2(qlib::LDom2Node *pNode)
       continue;
     }
     gfx::ColorPtr pCol(gfx::AbstractColor::fromNode(pColNode));
+    if (pCol.isnull()) {
+      LOG_DPRINTLN("MultiGradient.readFrom> invalid color in gradnode tag (ignored)");
+      continue;
+    }
 
     insert(val, pCol);
   }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(test_gfx
   gfx/test_solid_color.cpp
   gfx/test_gpuprim.cpp
   gfx/test_aoconstants.cpp
+  gfx/test_color_robustness.cpp
 )
 target_include_directories(test_gfx PRIVATE
   ${CMAKE_SOURCE_DIR}/src
@@ -109,6 +110,7 @@ add_executable(test_qsys
   qsys/test_guiview.cpp
   qsys/test_shaderobjmgr.cpp
   qsys/test_animmgr.cpp
+  qsys/test_colcompiler.cpp
 )
 target_include_directories(test_qsys PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/gfx/test_color_robustness.cpp
+++ b/src/tests/gfx/test_color_robustness.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <memory>
+#include "qlib/LDOM2Tree.hpp"
+#include "gfx/AbstractColor.hpp"
+#include "gfx/ColCompiler.hpp"
+#include "gfx/ColorTable.hpp"
+#include "gfx/GradientColor.hpp"
+#include "gfx/SolidColor.hpp"
+
+using gfx::AbstractColor;
+using gfx::ColCompiler;
+using gfx::ColorPtr;
+using gfx::ColorTable;
+using gfx::GradientColor;
+using gfx::SolidColor;
+using qlib::LString;
+
+// A freshly created GradientColor (createObj("GradientColor") from a
+// script) has no component colors yet; reading its material property
+// must not dereference them.
+TEST(GradientColor, MaterialOfEmptyGradientIsEmpty)
+{
+    GradientColor col;
+    EXPECT_STREQ(col.getMaterial().c_str(), "");
+}
+
+// A color node whose value does not compile must not be dereferenced
+// while its modifier children are applied.
+TEST(AbstractColor, FromNodeWithInvalidValueReturnsNull)
+{
+    qlib::LDom2Node node;
+    node.setTagName("col");
+    node.setValue("this is not a color");
+    qlib::LDom2Node *pMod = new qlib::LDom2Node();
+    pMod->setTagName("material");
+    pMod->setValue("shiny");
+    node.appendChild(pMod);
+
+    AbstractColor *pCol = AbstractColor::fromNode(&node);
+    EXPECT_EQ(pCol, nullptr);
+    delete pCol;
+}
+
+
+// The CLUT index must not wrap when an export needs more than 32768
+// distinct colors (a large molecule with a continuous gradient).
+TEST(ColorTable, MoreThanShortMaxEntries)
+{
+    ColorTable ct;
+    const int n = 40000;
+    ColorTable::elem_t last;
+    for (int i = 0; i < n; ++i) {
+        const double r = double(i % 256) / 255.0;
+        const double g = double((i / 256) % 256) / 255.0;
+        const double b = double((i / 65536) % 256) / 255.0;
+        last = ct.newColor(ColorPtr(MB_NEW SolidColor(r, g, b, 1.0)), LString());
+    }
+    ASSERT_EQ(ct.size(), n);
+    EXPECT_GE(last.cid1, 32768);
+
+    ColorPtr pCol;
+    ASSERT_TRUE(ct.getColor(last, pCol));
+    ASSERT_FALSE(pCol.isnull());
+    EXPECT_NEAR(pCol->fr(), double((n - 1) % 256) / 255.0, 1e-6);
+}

--- a/src/tests/qsys/test_colcompiler.cpp
+++ b/src/tests/qsys/test_colcompiler.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <memory>
+#include "gfx/AbstractColor.hpp"
+#include "gfx/ColCompiler.hpp"
+
+using gfx::AbstractColor;
+using gfx::ColCompiler;
+
+// Modifiers collected while parsing a color that then fails to compile
+// must not leak into the next color compiled by the singleton. Named
+// colors are used because only they carry a writable material property;
+// the qsys environment provides the named-color resolver (StyleMgr).
+TEST(ColCompiler, FailedCompileDoesNotLeakModifiersIntoNextColor)
+{
+    std::unique_ptr<AbstractColor> pBad(ColCompiler::compileS("red{material:foo;alpha"));
+    EXPECT_EQ(pBad.get(), nullptr);
+
+    std::unique_ptr<AbstractColor> pBlue(ColCompiler::compileS("blue"));
+    ASSERT_NE(pBlue.get(), nullptr);
+    EXPECT_STREQ(pBlue->getMaterial().c_str(), "");
+
+    std::unique_ptr<AbstractColor> pMod(ColCompiler::compileS("blue{material:foo}"));
+    ASSERT_NE(pMod.get(), nullptr);
+    EXPECT_STREQ(pMod->getMaterial().c_str(), "foo");
+}


### PR DESCRIPTION
## Summary

Part 10 of the libcuemol2 bug-audit fixes (Phase 2: broken behaviour, gfx). Independent of the other PRs.

- **`GradientColor::getMaterial()`** dereferenced `m_pColor1` without the null check that `r()/g()/b()/a()` have. `material` is a readonly property in `GradientColor.qif`, so reading it on a freshly created `GradientColor` (or `getPropsJSON()` listing all properties) segfaulted.
- **`AbstractColor::fromNode()`** applied the modifier children of a `<col>`/`<color>` node to the result of `fromStringS()` even when the color string did not compile (NULL). It now returns NULL, and the two scene-file readers that build color tables (`qsys/MultiGradient::readFrom2`, `molvis/PaintColoring::readFrom2`) skip such entries with a log line instead of storing a null `ColorPtr` that crashed later during rendering.
- **`ColCompiler`** keeps color modifiers (`{material:...; alpha:...}`) in a singleton table that was only cleared on success; after a color that failed to compile, its modifiers were silently applied to the next color. The table is cleared at the start of every compilation.
- **`ColorTable::IntColor`** stored CLUT indices as `short` while `clutNewColorImpl()` returns `int`; past 32768 entries the index wrapped negative, `m_clut[cid1]` read out of bounds and `isGrad()` misclassified gradients as solid. This is reachable from the POV-Ray / MQO / Lux exporters on a large molecule with a continuous (B-factor style) gradient. The indices are `int` now.

## Tests

- `tests/gfx/test_color_robustness.cpp` (3 cases): empty `GradientColor` material, `fromNode` with a non-compiling value plus modifiers, and a 40000-entry color table.
- `tests/qsys/test_colcompiler.cpp` (1 case): modifier leakage across a failed compile. It lives in the qsys suite because only `NamedColor` has a writable `material` property and named colors need the resolver that `StyleMgr` installs.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
