### PR TITLE
fix(surface,symm,qsys): validate surface and potential map input

### DIFF
--- a/src/modules/surface/MSMSFileReader.cpp
+++ b/src/modules/surface/MSMSFileReader.cpp
@@ -285,6 +285,16 @@ bool MSMSFileReader::readFace(qlib::LineStream &ins)
       MB_THROW(qlib::FileFormatException, msg);
       return false;
     }
+    // MSMS vertex IDs are 1-based; the renderer and the cutting code index
+    // the vertex array with them unchecked, so reject out-of-range IDs here
+    const int nverts = m_pSurf->getVertSize();
+    if (id1<1 || id1>nverts || id2<1 || id2>nverts || id3<1 || id3>nverts) {
+      LOG_DPRINTLN("MSMSRead> %s", m_recbuf.c_str());
+      LString msg = LString::format("MSMSRead> FATAL Error: face vertex index out of range at %d.", m_lineno);
+      LOG_DPRINTLN(msg);
+      MB_THROW(qlib::FileFormatException, msg);
+      return false;
+    }
     m_pSurf->setFace(i, id1-1, id2-1, id3-1);
   }
 

--- a/src/modules/surface/OpenDXPotReader.cpp
+++ b/src/modules/surface/OpenDXPotReader.cpp
@@ -12,6 +12,8 @@
 #include "OpenDXPotReader.hpp"
 #include "ElePotMap.hpp"
 
+#include <vector>
+
 using namespace surface;
 
 // default constructor
@@ -232,14 +234,18 @@ bool OpenDXPotReader::read(qlib::InStream &arg)
   //
   //  allocate memory
   //
-  float *fbuf;
-  int ntotal = m_nx*m_ny*m_nz;
-  fbuf = MB_NEW float[ntotal];
-  LOG_DPRINT("memory allocation %d bytes\n", ntotal*4);
-  if (fbuf==NULL) {
-    MB_THROW(qlib::OutOfMemoryException, "OpenDX PotFile read: cannot allocate memory");
+  if (m_nx<=0 || m_ny<=0 || m_nz<=0) {
+    MB_THROW(qlib::FileFormatException, "OpenDX PotFile read: invalid map size");
     return false;
   }
+  // the map is indexed with int arithmetic, so the element count must fit
+  const size_t ntotal = size_t(m_nx)*size_t(m_ny)*size_t(m_nz);
+  if (ntotal > size_t(0x7fffffff)) {
+    MB_THROW(qlib::FileFormatException, "OpenDX PotFile read: map size too large");
+    return false;
+  }
+  std::vector<float> fbuf(ntotal);
+  LOG_DPRINT("memory allocation %zu bytes\n", ntotal*sizeof(float));
 
   //int ii=0;
   for (int ix=0; ix<m_nx; ix++) {
@@ -265,7 +271,8 @@ bool OpenDXPotReader::read(qlib::InStream &arg)
   LOG_DPRINTLN("OpenDXPotReader> Map origin: (%f, %f, %f)", orig.x(), orig.y(), orig.z());
   const double scale = 1.0/m_hx;
 
-  m_pMap->setMapFloatArray(fbuf, m_nx, m_ny, m_nz,
+  // setMapFloatArray() copies the array
+  m_pMap->setMapFloatArray(fbuf.data(), m_nx, m_ny, m_nz,
                            m_hx, m_hy, m_hz, orig);
 
   if (m_dSmooth>0.0) {

--- a/src/modules/surface/QdfPotReader.cpp
+++ b/src/modules/surface/QdfPotReader.cpp
@@ -13,6 +13,8 @@
 
 #include "ElePotMap.hpp"
 
+#include <vector>
+
 using namespace surface;
 
 MC_DYNCLASS_IMPL(QdfPotReader, QdfPotReader, qlib::LSpecificClass<QdfPotReader>);
@@ -91,8 +93,17 @@ void QdfPotReader::readData()
   m_nx = getRecValInt32("nx");
   m_ny = getRecValInt32("ny");
   m_nz = getRecValInt32("nz");
-  const int ntotal = m_nx*m_ny*m_nz;
-  LOG_DPRINTLN("QdfPot> map size (%d,%d,%d)=%d", m_nx, m_ny, m_nz, ntotal);
+  if (m_nx<=0 || m_ny<=0 || m_nz<=0) {
+    MB_THROW(qlib::FileFormatException, "invalid map size");
+    return;
+  }
+  // the map is indexed with int arithmetic, so the element count must fit
+  const size_t ntotal = size_t(m_nx)*size_t(m_ny)*size_t(m_nz);
+  if (ntotal > size_t(0x7fffffff)) {
+    MB_THROW(qlib::FileFormatException, "map size too large");
+    return;
+  }
+  LOG_DPRINTLN("QdfPot> map size (%d,%d,%d)=%zu", m_nx, m_ny, m_nz, ntotal);
 
   const double gx = getRecValFloat32("gx");
   const double gy = getRecValFloat32("gy");
@@ -116,7 +127,7 @@ void QdfPotReader::readData()
   ///////////////////
 
   int ndata = readDataDef("data");
-  if (ndata!=ntotal) {
+  if (ndata<0 || size_t(ndata)!=ntotal) {
     MB_THROW(qlib::FileFormatException, "inconsistent data (ndata!=nx*ny*nz)");
     return;
   }
@@ -124,18 +135,15 @@ void QdfPotReader::readData()
   //
   //  allocate memory
   //
-  float *fbuf = MB_NEW float[ntotal];
-  LOG_DPRINTLN("QdfPot> memory allocation %f Mbytes", double(ntotal*4.0)/(1024.0*1024.0));
-  if (fbuf==NULL) {
-    MB_THROW(qlib::OutOfMemoryException, "cannot allocate memory");
-    return;
-  }
+  std::vector<float> fbuf(ntotal);
+  LOG_DPRINTLN("QdfPot> memory allocation %f Mbytes", double(ntotal)*4.0/(1024.0*1024.0));
 
   readRecordDef();
 
-  readDataArray(fbuf);
+  readDataArray(fbuf.data());
 
-  m_pObj->setMapFloatArray(fbuf, m_nx, m_ny, m_nz,
+  // setMapFloatArray() copies the array
+  m_pObj->setMapFloatArray(fbuf.data(), m_nx, m_ny, m_nz,
                            gx, gy, gz, orig);
 
 }

--- a/src/modules/surface/QdfSurfReader.cpp
+++ b/src/modules/surface/QdfSurfReader.cpp
@@ -78,6 +78,8 @@ bool QdfSurfReader::read(qlib::InStream &ins)
     readFaceData2();
   }
   
+  checkFaces();
+
   end();
 
   m_pObj = NULL;
@@ -133,6 +135,13 @@ void QdfSurfReader::readVertData2()
   
   readRecordDef();
 
+  // the records are copied straight into the MSVert array, so the file
+  // layout must be exactly the in-memory one
+  if (getStream().getFxRecordSize() != int(sizeof (MSVert))) {
+    MB_THROW(qlib::FileFormatException, "QdfSurf vert record size mismatch");
+    return;
+  }
+
   MSVert *pv = m_pObj->getVertPtr();
   getStream().readFxRecords(nverts, pv, sizeof (MSVert)*nverts);
 
@@ -164,6 +173,11 @@ void QdfSurfReader::readFaceData2()
   
   readRecordDef();
 
+  if (getStream().getFxRecordSize() != int(sizeof (MSFace))) {
+    MB_THROW(qlib::FileFormatException, "QdfSurf face record size mismatch");
+    return;
+  }
+
   MSFace *pf = m_pObj->getFacePtr();
   getStream().readFxRecords(nfaces, pf, sizeof (MSFace)*nfaces);
   /*
@@ -179,4 +193,21 @@ void QdfSurfReader::readFaceData2()
 */
 }
 
+void QdfSurfReader::checkFaces() const
+{
+  // the renderer and the cutting code index the vertex array with the face
+  // IDs unchecked, so a corrupt file must be rejected here
+  const int nverts = m_pObj->getVertSize();
+  const int nfaces = m_pObj->getFaceSize();
+  for (int i=0; i<nfaces; ++i) {
+    const MSFace &f = m_pObj->getFaceAt(i);
+    if (f.id1<0 || f.id1>=nverts ||
+        f.id2<0 || f.id2>=nverts ||
+        f.id3<0 || f.id3>=nverts) {
+      MB_THROW(qlib::FileFormatException,
+               LString::format("QdfSurf face %d: vertex index out of range", i));
+      return;
+    }
+  }
+}
 

--- a/src/modules/surface/QdfSurfReader.hpp
+++ b/src/modules/surface/QdfSurfReader.hpp
@@ -66,6 +66,9 @@ private:
 
   void readVertData2();
   void readFaceData2();
+
+  /// Reject faces whose vertex indices are outside the vertex array
+  void checkFaces() const;
 };
 
 }

--- a/src/modules/symm/PDBCryst1Handler.cpp
+++ b/src/modules/symm/PDBCryst1Handler.cpp
@@ -112,7 +112,13 @@ bool PDBCryst1Handler::write(LString &record, MolCoord *pMol)
 
   int nsg = pci->getSG();
   SymOpDB *pdb = SymOpDB::getInstance();
-  LString hmname = pdb->getCName(nsg);
+  const char *pcname = pdb->getCName(nsg);
+  if (pcname==NULL) {
+    // nsg is writable from scripts; an unknown number has no name to write
+    LOG_DPRINTLN("PDBCryst1Handler> unknown space group number %d, CRYST1 not written", nsg);
+    return false;
+  }
+  LString hmname(pcname);
 
   record = LString::format(
     "CRYST1"

--- a/src/qsys/QdfStream.cpp
+++ b/src/qsys/QdfStream.cpp
@@ -610,9 +610,17 @@ void QdfInStream::readFxRecords(int nrec, void *pbuf, int nbufsz)
 {
   const int nrecsz = getFxRecordSize();
 
+  if (nrec<0) {
+    MB_THROW(qlib::FileFormatException, "QdfInStream: negative record count");
+    return;
+  }
   const size_t ntotal = size_t(nrecsz) * size_t(nrec);
-  MB_ASSERT(size_t(nbufsz)>=ntotal);
-  MB_ASSERT(ntotal <= size_t(0x7fffffff));
+  // the record definition comes from the file: a layout the caller did not
+  // expect must not overrun its buffer
+  if (ntotal > size_t(nbufsz) || ntotal > size_t(0x7fffffff)) {
+    MB_THROW(qlib::FileFormatException, "QdfInStream: fixed record size mismatch");
+    return;
+  }
 
   m_pBinIn->readFully((char *)pbuf, 0, int(ntotal));
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -165,6 +165,7 @@ add_executable(test_surface
   modules/surface/test_ply_reader.cpp
   modules/surface/test_molsurf_serialize.cpp
   modules/surface/test_ses_from_array.cpp
+  modules/surface/test_reader_validation.cpp
 )
 target_include_directories(test_surface PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/surface/test_main.cpp
+++ b/src/tests/modules/surface/test_main.cpp
@@ -6,6 +6,7 @@
 #include "qsys/RendererFactory.hpp"
 #include "molstr/molstr.hpp"
 #include "surface/surface.hpp"
+#include "symm/symm.hpp"
 
 #ifndef CUEMOL2_SYSCONFIG_PATH
 #define CUEMOL2_SYSCONFIG_PATH ""
@@ -20,8 +21,10 @@ public:
         qsys::RendererFactory::init();
         molstr::init();
         surface::init();
+        symm::init();
     }
     void TearDown() override {
+        symm::fini();
         surface::fini();
         molstr::fini();
         qsys::fini();

--- a/src/tests/modules/surface/test_reader_validation.cpp
+++ b/src/tests/modules/surface/test_reader_validation.cpp
@@ -1,0 +1,307 @@
+//
+// Input validation of the surface readers: corrupt files must be rejected
+// with a FileFormatException instead of being stored and indexed later.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "surface/MSMSFileReader.hpp"
+#include "surface/QdfSurfReader.hpp"
+#include "surface/QdfSurfWriter.hpp"
+#include "surface/OpenDXPotReader.hpp"
+#include "surface/MolSurfObj.hpp"
+#include "surface/ElePotMap.hpp"
+#include "symm/PDBCryst1Handler.hpp"
+#include "symm/symm.hpp"
+#include "symm/CrystalInfo.hpp"
+#include "symm/SymOpDB.hpp"
+#include "molstr/MolCoord.hpp"
+
+#include <qsys/QdfAbsWriter.hpp>
+#include <qlib/LExceptions.hpp>
+#include <qlib/PipeStream.hpp>
+#include <qlib/StringStream.hpp>
+#include <qlib/Vector4D.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using qlib::LString;
+using qlib::Vector4D;
+using qlib::StrInStream;
+using qsys::ObjectPtr;
+using surface::MolSurfObj;
+
+namespace {
+
+std::string drainPipe(qlib::PipeStreamImpl &impl)
+{
+    std::string result;
+    char buf[256];
+    while (impl.ready()) {
+        int n = impl.read(buf, 0, sizeof buf);
+        if (n <= 0) break;
+        result.append(buf, static_cast<size_t>(n));
+    }
+    return result;
+}
+
+// Serialize pObj with the given qdf writer and return the bytes.
+std::string writeQdf(qsys::ObjWriter &writer, const ObjectPtr &pObj)
+{
+    auto impl = qlib::sp<qlib::PipeStreamImpl>(new qlib::PipeStreamImpl());
+    qlib::PipeOutStream out;
+    out.setImpl(impl);
+    writer.attach(pObj);
+    writer.write(out);
+    writer.detach();
+    impl->o_close();
+    return drainPipe(*impl);
+}
+
+// A surface with three vertices and one face (id1, id2, id3).
+ObjectPtr makeSurf(int id1, int id2, int id3)
+{
+    MolSurfObj *pSurf = new MolSurfObj();
+    ObjectPtr pObj(pSurf);
+    pSurf->setVertSize(3);
+    pSurf->setVertex(0, Vector4D(0, 0, 0), Vector4D(0, 0, 1));
+    pSurf->setVertex(1, Vector4D(1, 0, 0), Vector4D(0, 0, 1));
+    pSurf->setVertex(2, Vector4D(0, 1, 0), Vector4D(0, 0, 1));
+    pSurf->setFaceSize(1);
+    pSurf->setFace(0, id1, id2, id3);
+    return pObj;
+}
+
+// Writes "SRF1" whose vert records carry one float more than MSVert holds.
+class OversizedVertQdfWriter : public qsys::QdfAbsWriter
+{
+public:
+    bool write(qlib::OutStream &outs) override
+    {
+        start(outs);
+        getStream().writeFileType("SRF1");
+
+        defineData("vert", 1);
+        for (const char *nm : {"x", "y", "z", "nx", "ny", "nz", "extra"})
+            defineRecord(nm, QDF_TYPE_FLOAT32);
+        defineRecord("id", QDF_TYPE_UTF8STR);
+        startData();
+        startRecord();
+        for (const char *nm : {"x", "y", "z", "nx", "ny", "nz", "extra"})
+            setRecValFloat32(nm, 1.0f);
+        setRecValStr("id", LString());
+        endRecord();
+        endData();
+
+        defineData("face", 1);
+        defineRecord("id1", QDF_TYPE_INT32);
+        defineRecord("id2", QDF_TYPE_INT32);
+        defineRecord("id3", QDF_TYPE_INT32);
+        startData();
+        startRecord();
+        setRecValInt32("id1", 0);
+        setRecValInt32("id2", 0);
+        setRecValInt32("id3", 0);
+        endRecord();
+        endData();
+
+        end();
+        return true;
+    }
+    const char *getName() const override { return "oversized_vert_qdf"; }
+    const char *getTypeDescr() const override { return "test"; }
+    const char *getFileExt() const override { return "*.qdf"; }
+    bool canHandle(ObjectPtr) const override { return true; }
+};
+
+ObjectPtr readQdfSurf(const std::string &bytes)
+{
+    StrInStream ins(bytes.data(), static_cast<int>(bytes.size()));
+    surface::QdfSurfReader reader;
+    return reader.load(ins);
+}
+
+// MSMS reads the vertices from a side file named through the "vert" path.
+struct TempVertFile
+{
+    std::filesystem::path path;
+    explicit TempVertFile(const std::string &body)
+        : path(std::filesystem::temp_directory_path() / "cuemol_reader_validation_test.vert")
+    {
+        std::ofstream ofs(path);
+        ofs << body;
+    }
+    ~TempVertFile()
+    {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
+
+const char *const MSMS_VERT =
+    "# MSMS solvent excluded surface vertices\n"
+    "#vertex #sphere density probe_r\n"
+    "      3    3  1.00  1.50\n"
+    "    0.000     0.000     0.000     0.000     0.000     1.000\n"
+    "    1.000     0.000     0.000     0.000     0.000     1.000\n"
+    "    0.000     1.000     0.000     0.000     0.000     1.000\n";
+
+ObjectPtr readMSMS(const std::string &faceBody)
+{
+    TempVertFile vert(MSMS_VERT);
+    surface::MSMSFileReader reader;
+    reader.setPath("vert", LString(vert.path.string().c_str()));
+    StrInStream ins(faceBody.data(), static_cast<int>(faceBody.size()));
+    return reader.load(ins);
+}
+
+}  // namespace
+
+// ----------------------------------------------------------------------
+// MSMS face file
+// ----------------------------------------------------------------------
+
+TEST(MSMSFileReaderValidation, ValidFaceIsStoredZeroBased)
+{
+    ObjectPtr pObj = readMSMS(
+        "# MSMS solvent excluded surface faces\n"
+        "#faces  #sphere density probe_r\n"
+        "      1    3  1.00  1.50\n"
+        "     1      2      3\n");
+    MolSurfObj *pSurf = dynamic_cast<MolSurfObj *>(pObj.get());
+    ASSERT_NE(pSurf, nullptr);
+    ASSERT_EQ(pSurf->getFaceSize(), 1);
+    EXPECT_EQ(pSurf->getFaceAt(0).id1, 0u);
+    EXPECT_EQ(pSurf->getFaceAt(0).id3, 2u);
+}
+
+TEST(MSMSFileReaderValidation, FaceIndexOutOfRangeIsRejected)
+{
+    // 9 > 3 vertices; the renderer would index the vertex array with it
+    EXPECT_THROW(readMSMS(
+        "# MSMS solvent excluded surface faces\n"
+        "#faces  #sphere density probe_r\n"
+        "      1    3  1.00  1.50\n"
+        "     1      2      9\n"), qlib::FileFormatException);
+    // 0 would become 0xFFFFFFFF after the 1-based conversion
+    EXPECT_THROW(readMSMS(
+        "# MSMS solvent excluded surface faces\n"
+        "#faces  #sphere density probe_r\n"
+        "      1    3  1.00  1.50\n"
+        "     0      2      3\n"), qlib::FileFormatException);
+}
+
+// ----------------------------------------------------------------------
+// QDF surface file
+// ----------------------------------------------------------------------
+
+TEST(QdfSurfReaderValidation, RoundTripKeepsFaces)
+{
+    surface::QdfSurfWriter writer;
+    std::string bytes = writeQdf(writer, makeSurf(0, 1, 2));
+    ObjectPtr pObj = readQdfSurf(bytes);
+    MolSurfObj *pSurf = dynamic_cast<MolSurfObj *>(pObj.get());
+    ASSERT_NE(pSurf, nullptr);
+    ASSERT_EQ(pSurf->getVertSize(), 3);
+    ASSERT_EQ(pSurf->getFaceSize(), 1);
+    EXPECT_EQ(pSurf->getFaceAt(0).id2, 1u);
+    EXPECT_FLOAT_EQ(pSurf->getVertAt(1).x, 1.0f);
+}
+
+TEST(QdfSurfReaderValidation, FaceIndexOutOfRangeIsRejected)
+{
+    surface::QdfSurfWriter writer;
+    std::string bytes = writeQdf(writer, makeSurf(0, 1, 99));
+    EXPECT_THROW(readQdfSurf(bytes), qlib::FileFormatException);
+}
+
+TEST(QdfSurfReaderValidation, VertRecordSizeMismatchIsRejected)
+{
+    // the fixed-record path copies the records straight into the MSVert
+    // array; a different layout used to overrun it (only an assert in debug)
+    OversizedVertQdfWriter writer;
+    std::string bytes = writeQdf(writer, makeSurf(0, 1, 2));
+    EXPECT_THROW(readQdfSurf(bytes), qlib::FileFormatException);
+}
+
+// ----------------------------------------------------------------------
+// OpenDX potential map
+// ----------------------------------------------------------------------
+
+namespace {
+
+std::string dxHeader(const char *counts)
+{
+    std::string s;
+    s += "object 1 class gridpositions counts ";
+    s += counts;
+    s += "\norigin 0 0 0\ndelta 1 0 0\ndelta 0 1 0\ndelta 0 0 1\n";
+    s += "object 2 class gridconnections counts ";
+    s += counts;
+    s += "\nobject 3 class array type double rank 0 items 1 data follows\n";
+    return s;
+}
+
+ObjectPtr readDX(const std::string &body)
+{
+    StrInStream ins(body.data(), static_cast<int>(body.size()));
+    surface::OpenDXPotReader reader;
+    return reader.load(ins);
+}
+
+}  // namespace
+
+TEST(OpenDXPotReaderValidation, ValidTinyMapLoads)
+{
+    ObjectPtr pObj = readDX(dxHeader("1 1 2") + "0.5 1.5\n");
+    surface::ElePotMap *pMap = dynamic_cast<surface::ElePotMap *>(pObj.get());
+    ASSERT_NE(pMap, nullptr);
+    EXPECT_EQ(pMap->getColNo(), 1);
+    EXPECT_EQ(pMap->getSecNo(), 2);
+}
+
+TEST(OpenDXPotReaderValidation, ZeroSizedMapIsRejected)
+{
+    EXPECT_THROW(readDX(dxHeader("0 0 0") + "\n"), qlib::FileFormatException);
+}
+
+TEST(OpenDXPotReaderValidation, OverflowingMapSizeIsRejected)
+{
+    // 1626^3 wraps to about 4M in int: the old code allocated that and then
+    // wrote 4.3G values into it
+    EXPECT_THROW(readDX(dxHeader("1626 1626 1626") + "0 0 0 0\n"),
+                 qlib::FileFormatException);
+}
+
+// ----------------------------------------------------------------------
+// CRYST1 writer with an unknown space group number
+// ----------------------------------------------------------------------
+
+TEST(PDBCryst1HandlerValidation, UnknownSpaceGroupSkipsTheRecord)
+{
+    // the pre-install sysconfig points the symop table at an install-only
+    // path; use the source-tree copy next to sysconfig.xml
+    std::filesystem::path symop =
+        std::filesystem::path(CUEMOL2_SYSCONFIG_PATH).parent_path() / "symop.dat";
+    symm::SymOpDB::getInstance()->setSymLibFile(LString(symop.string().c_str()));
+
+    molstr::MolCoordPtr pMol(new molstr::MolCoord());
+    symm::CrystalInfoPtr pci = pMol->getCreateExtData("CrystalInfo");
+    ASSERT_FALSE(pci.isnull());
+    pci->setCellDimension(10.0, 10.0, 10.0, 90.0, 90.0, 90.0);
+
+    symm::PDBCryst1Handler handler;
+    LString record;
+
+    pci->setSG(1);  // P 1: the table is loaded and the record is written
+    ASSERT_TRUE(handler.write(record, pMol.get()));
+    EXPECT_TRUE(record.startsWith("CRYST1"));
+
+    record = LString();
+    pci->setSG(99999);  // writable from scripts; no such group
+    EXPECT_FALSE(handler.write(record, pMol.get()));
+    EXPECT_TRUE(record.isEmpty());
+}


### PR DESCRIPTION
## Summary

Part 12 of the libcuemol2 bug-audit fixes (Phase 3: input validation, surface / symm readers). Independent of the other PRs.

### Face indices (surface 3, high)

`MSMSFileReader` and `QdfSurfReader` stored face vertex indices without comparing them to the vertex count. `MolSurfRenderer` (`idmap[face.id1]`) and `CutByPlane*` (`m_vinflg[id[0]]`) index the vertex array with them unchecked, so a corrupt file crashed later, far from the reader; an MSMS id of 0 even wrapped to 0xFFFFFFFF. Both readers now throw `FileFormatException` (the PLY reader already did this).

### Fixed-size qdf records (surface 10)

`QdfSurfReader` copies the fixed-size records straight into the `MSVert` / `MSFace` arrays. A file whose record definition differs from the struct layout (other version / other tool) overran them, guarded only by `MB_ASSERT`. The reader now checks `getFxRecordSize()` against the struct size, and `QdfInStream::readFxRecords()` refuses to read past the caller's buffer in release builds too.

### Potential maps (surface 5, 6)

`OpenDXPotReader` / `QdfPotReader` computed `nx*ny*nz` in `int`: hostile counts (e.g. `1626 1626 1626`) overflowed to a ~4M-element allocation followed by a 4.3G-element write, and zero dimensions produced an empty map. Each dimension must be > 0 and the product must fit in `int` (the map is indexed with `int` arithmetic). The read buffer is a `std::vector` now; it was leaked on every load because `setMapFloatArray()` copies it.

### CRYST1 with an unknown space group (surface 7)

`PDBCryst1Handler::write()` built an `LString` from the NULL that `SymOpDB::getCName()` returns for an unregistered space group number (`CrystalInfo.nsg` is writable from scripts). The record is skipped with a log line instead.

## Tests

`tests/modules/surface/test_reader_validation.cpp` (9 cases): MSMS face out of range / zero id, qdfsurf round trip, out-of-range face, oversized vert record layout (custom writer), OpenDX tiny map / zero size / overflowing size, CRYST1 with P 1 and with an unknown number. The surface test environment now initializes `symm` and the CRYST1 test points `SymOpDB` at the source-tree `data/symop.dat` (the pre-install sysconfig entry resolves to an install-only path).

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
