### PR TITLE
fix(xtal): validate CCP4 header words and the MTZ body length

### DIFF
--- a/src/modules/xtal/CCP4MapReader.cpp
+++ b/src/modules/xtal/CCP4MapReader.cpp
@@ -538,6 +538,36 @@ bool CCP4MapReader::read(qlib::InStream &arg)
     hdrin.fetch_float(origin[2]);
   }
 
+  // The axis order words select the storage axes (rotate() writes r[ax])
+  // and the counts size the chunk arrays, so a corrupt header must be
+  // rejected before either is used. MAPC=MAPR=MAPS=0 exists in the wild.
+  {
+    const int ax[3] = {axcol, axrow, axsect};
+    bool bSeen[3] = {false, false, false};
+    bool bAxesOK = true;
+    for (int i=0; i<3; ++i) {
+      if (ax[i]<1 || ax[i]>3 || bSeen[ax[i]-1]) {
+        bAxesOK = false;
+        break;
+      }
+      bSeen[ax[i]-1] = true;
+    }
+    if (!bAxesOK) {
+      LString msg = LString::format("CCP4MapReader read: invalid axis order (%d,%d,%d)",
+                                    axcol, axrow, axsect);
+      LOG_DPRINTLN(msg);
+      MB_THROW(qlib::FileFormatException, msg);
+      return false;
+    }
+    if (ncol<=0 || nrow<=0 || nsect<=0) {
+      LString msg = LString::format("CCP4MapReader read: invalid map size (%d,%d,%d)",
+                                    ncol, nrow, nsect);
+      LOG_DPRINTLN(msg);
+      MB_THROW(qlib::FileFormatException, msg);
+      return false;
+    }
+  }
+
   LOG_DPRINT("CCP4Map> Header Info:\n");
   LOG_DPRINT("  map size  : (%d,%d,%d)\n", ncol, nrow, nsect);
   LOG_DPRINT("  map start : (%d,%d,%d)\n", stacol, starow, stasect);

--- a/src/modules/xtal/MTZ2MapReader.cpp
+++ b/src/modules/xtal/MTZ2MapReader.cpp
@@ -131,6 +131,9 @@ bool MTZ2MapReader::read(qlib::InStream &arg)
                  m_nfp, m_nphi, m_nwgt);
   mapfft.doFFT();
 
+  // the reflection buffer is only needed for the FFT
+  cleanup();
+
   return true;
 }
 
@@ -146,8 +149,16 @@ void MTZ2MapReader::readData(qlib::InStream &arg)
 
   readFooter(ins);
   
-  if (m_ncol<=3 || m_nrefl==0 || m_ncol!=m_columns.size())
+  if (m_ncol<=3 || m_nrefl<=0 || m_ncol!=m_columns.size())
     MB_THROW(qlib::FileFormatException, "No refls in mtzfile");
+
+  // NCOL/NREFL come from the footer: the FFT reads nrefl*ncol floats from
+  // the body, which must actually hold them
+  if (size_t(m_nrefl)*size_t(m_ncol)*sizeof(float) > size_t(m_nrawdat)) {
+    MB_THROW(qlib::FileFormatException,
+             "MTZ body is shorter than NCOL*NREFL reflections");
+    return;
+  }
 
   LOG_DPRINT("MTZ> Unit cell a=%.2fA, b=%.2fA, c=%.2fA,\n", m_cella, m_cellb, m_cellc);
   LOG_DPRINT("MTZ> alpha=%.2f, beta=%.2f, gamma=%.2f,\n", m_alpha, m_beta, m_gamma);
@@ -193,12 +204,14 @@ void MTZ2MapReader::readHeader(qlib::InStream &ins)
 
 void MTZ2MapReader::readBody(qlib::InStream &ins)
 {
-  m_nrawdat = (m_nhdrst-1)*4 - 20*4;
-  m_pbuf = new char[m_nrawdat];
-  if (m_pbuf==NULL) {
-    MB_THROW(qlib::OutOfMemoryException, "MTZ2MapReader> cannot allocate memory");
+  // the header location word must leave room for the 80-byte header
+  if (m_nhdrst < 21) {
+    MB_THROW(qlib::FileFormatException, "MTZ header location is inside the header");
     return;
   }
+  m_nrawdat = (m_nhdrst-1)*4 - 20*4;
+  cleanup();
+  m_pbuf = new char[m_nrawdat];
   MB_DPRINTLN("MTZ2MapReader> alloc %d bytes\n", m_nrawdat);
 
   ins.readFully(m_pbuf, 0, m_nrawdat*sizeof(char));
@@ -206,6 +219,10 @@ void MTZ2MapReader::readBody(qlib::InStream &ins)
 
 void MTZ2MapReader::skipBody(qlib::InStream &ins)
 {
+  if (m_nhdrst < 21) {
+    MB_THROW(qlib::FileFormatException, "MTZ header location is inside the header");
+    return;
+  }
   m_nrawdat = (m_nhdrst-1)*4 - 20*4;
   ins.skip(m_nrawdat*sizeof(char));
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -185,6 +185,7 @@ add_executable(test_xtal
   modules/xtal/test_main.cpp
   modules/xtal/test_atomposmap2.cpp
   modules/xtal/test_ccp4_origin.cpp
+  modules/xtal/test_map_reader_validation.cpp
   modules/xtal/test_ccp4map_stream.cpp
   modules/xtal/test_map_block_extract.cpp
   modules/xtal/test_map_histogram.cpp

--- a/src/tests/modules/xtal/test_map_reader_validation.cpp
+++ b/src/tests/modules/xtal/test_map_reader_validation.cpp
@@ -1,0 +1,154 @@
+// -*-Mode: C++;-*-
+//
+// Header validation of the CCP4/MRC and MTZ readers: corrupt size / axis /
+// length words must raise a FileFormatException instead of indexing
+// arrays with them.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/LExceptions.hpp>
+#include <qlib/StringStream.hpp>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include "xtal/CCP4MapReader.hpp"
+#include "xtal/MTZ2MapReader.hpp"
+#include "xtal/DensityMap.hpp"
+
+using qlib::StrInStream;
+using xtal::CCP4MapReader;
+using xtal::DensityMap;
+using xtal::MTZ2MapReader;
+
+namespace {
+
+/// Minimal MRC image (mode 2, 1024-byte header) with the given map size and
+/// axis order words, followed by nc*nr*ns floats.
+std::string makeMrc(int nc, int nr, int ns, int mapc, int mapr, int maps)
+{
+    std::string buf(1024, '\0');
+    auto putI = [&](int word, int v) { std::memcpy(&buf[(word - 1) * 4], &v, 4); };
+    auto putF = [&](int word, float v) { std::memcpy(&buf[(word - 1) * 4], &v, 4); };
+
+    putI(1, nc);
+    putI(2, nr);
+    putI(3, ns);
+    putI(4, 2);  // MODE: float32
+    putI(8, 4);
+    putI(9, 4);
+    putI(10, 4);
+    putF(11, 4.0f);
+    putF(12, 4.0f);
+    putF(13, 4.0f);
+    putF(14, 90.0f);
+    putF(15, 90.0f);
+    putF(16, 90.0f);
+    putI(17, mapc);
+    putI(18, mapr);
+    putI(19, maps);
+    putF(20, -1.0f);
+    putF(21, 1.0f);
+    putF(22, 0.0f);
+    putI(23, 1);  // ISPG
+    putI(24, 0);  // NSYMBT
+    std::memcpy(&buf[208], "MAP ", 4);
+    buf[212] = 0x44;  // MACHST: little endian
+    buf[213] = 0x44;
+    putF(55, 0.5f);  // RMS
+
+    const int ntotal = (nc > 0 && nr > 0 && ns > 0) ? nc * nr * ns : 0;
+    for (int i = 0; i < ntotal; ++i) {
+        const float v = float(i % 5) - 2.0f;
+        buf.append(reinterpret_cast<const char *>(&v), 4);
+    }
+    return buf;
+}
+
+bool readMrc(const std::string &image)
+{
+    qsys::ObjectPtr pObj(MB_NEW DensityMap());
+    CCP4MapReader reader;
+    reader.attach(pObj);
+    StrInStream ins(image.data(), static_cast<int>(image.size()));
+    const bool bOK = reader.read(ins);
+    reader.detach();
+    return bOK;
+}
+
+/// 80-character MTZ footer record.
+std::string mtzRecord(const std::string &s)
+{
+    std::string r = s;
+    r.resize(80, ' ');
+    return r;
+}
+
+/// Minimal MTZ image: 80-byte header whose header-location word is nhdrst,
+/// the reflection body that word implies, then the footer records.
+std::string makeMtz(uint32_t nhdrst, const std::string &footer)
+{
+    std::string buf = "MTZ ";
+    buf.append(reinterpret_cast<const char *>(&nhdrst), 4);
+    unsigned char mtstring[4] = {0x41, 0x41, 0, 0};  // native int/float
+    buf.append(reinterpret_cast<const char *>(mtstring), 4);
+    buf.resize(80, '\0');
+    if (nhdrst >= 21)
+        buf.resize((nhdrst - 1) * 4, '\0');
+    buf += footer;
+    return buf;
+}
+
+bool readMtz(const std::string &image)
+{
+    qsys::ObjectPtr pObj(MB_NEW DensityMap());
+    MTZ2MapReader reader;
+    reader.attach(pObj);
+    StrInStream ins(image.data(), static_cast<int>(image.size()));
+    const bool bOK = reader.read(ins);
+    reader.detach();
+    return bOK;
+}
+
+}  // namespace
+
+TEST(CCP4MapReaderValidation, ValidTinyMapLoads)
+{
+    EXPECT_TRUE(readMrc(makeMrc(4, 4, 4, 1, 2, 3)));
+    EXPECT_TRUE(readMrc(makeMrc(4, 4, 4, 3, 1, 2)));
+}
+
+TEST(CCP4MapReaderValidation, AxisOrderMustBeAPermutation)
+{
+    // MAPC=MAPR=MAPS=0 (seen in broken MRC files) made rotate() write r[-1]
+    EXPECT_THROW(readMrc(makeMrc(4, 4, 4, 0, 0, 0)), qlib::FileFormatException);
+    EXPECT_THROW(readMrc(makeMrc(4, 4, 4, 1, 1, 2)), qlib::FileFormatException);
+    EXPECT_THROW(readMrc(makeMrc(4, 4, 4, 1, 2, 4)), qlib::FileFormatException);
+}
+
+TEST(CCP4MapReaderValidation, ZeroMapSizeIsRejected)
+{
+    // NC=0 left the chunk arrays empty and sliceBytes() dereferenced them
+    EXPECT_THROW(readMrc(makeMrc(0, 4, 4, 1, 2, 3)), qlib::FileFormatException);
+    EXPECT_THROW(readMrc(makeMrc(4, 4, -1, 1, 2, 3)), qlib::FileFormatException);
+}
+
+TEST(MTZ2MapReaderValidation, HeaderLocationInsideHeaderIsRejected)
+{
+    // nhdrst < 21 made the body length negative
+    EXPECT_THROW(readMtz(makeMtz(5, mtzRecord("END"))), qlib::FileFormatException);
+}
+
+TEST(MTZ2MapReaderValidation, BodyShorterThanNcolNreflIsRejected)
+{
+    // 10 words of body (40 bytes) but NCOL*NREFL = 5*100 floats
+    std::string footer;
+    footer += mtzRecord("NCOL 5 100 0");
+    footer += mtzRecord("COLUMN H H 0 0");
+    footer += mtzRecord("COLUMN K H 0 0");
+    footer += mtzRecord("COLUMN L H 0 0");
+    footer += mtzRecord("COLUMN FWT F 0 0");
+    footer += mtzRecord("COLUMN PHWT P 0 0");
+    footer += mtzRecord("END");
+    EXPECT_THROW(readMtz(makeMtz(21 + 10, footer)), qlib::FileFormatException);
+}


### PR DESCRIPTION
## Summary

Part 13 of the libcuemol2 bug-audit fixes (Phase 3: input validation, xtal map readers). Independent of the other PRs.

### `CCP4MapReader` (xtal 3)

`MAPC/MAPR/MAPS` were used as array indices in `rotate()` and `NC/NR/NS` as chunk counts without any check. A header with `MAPC=MAPR=MAPS=0` (broken MRC files like this exist) wrote to `r[-1]` on the stack; `NC=0` left the chunk arrays empty and `sliceBytes()` dereferenced an empty vector. The axis words must be a permutation of 1..3 and the counts positive; otherwise `FileFormatException`.

### `MTZ2MapReader` (xtal 7)

- A header location word below 21 made `m_nrawdat = (nhdrst-1)*4 - 80` negative and `new char[negative]` followed.
- `NCOL`/`NREFL` from the footer were never compared with the body that was actually read (the check in `MapFFT` was commented out), so the FFT read past the buffer for a truncated or hostile file.
- The reflection buffer is released after the FFT and before a second `read()`; it used to live until the reader was destroyed and leaked when a reader was reused.

## Tests

`tests/modules/xtal/test_map_reader_validation.cpp` (5 cases): CCP4 with axis order (1,2,3) and (3,1,2) loads; (0,0,0), (1,1,2) and (1,2,4) are rejected; NC=0 / NS=-1 are rejected; MTZ with nhdrst=5, and an MTZ whose footer claims 5x100 reflections over a 40-byte body.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
