### PR TITLE
fix(mdtools): bound the XTC decompressor and keep nevery >= 1

### DIFF
--- a/src/modules/mdtools/AmberNetCDFReader.hpp
+++ b/src/modules/mdtools/AmberNetCDFReader.hpp
@@ -66,7 +66,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     /// File atom count (0 until the header is read).

--- a/src/modules/mdtools/DCDTrajReader.hpp
+++ b/src/modules/mdtools/DCDTrajReader.hpp
@@ -72,7 +72,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     int m_natom;

--- a/src/modules/mdtools/TrrTrajReader.hpp
+++ b/src/modules/mdtools/TrrTrajReader.hpp
@@ -68,7 +68,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     /// File atom count (0 until the first frame header is read).

--- a/src/modules/mdtools/XdrInStream.cpp
+++ b/src/modules/mdtools/XdrInStream.cpp
@@ -84,6 +84,17 @@ struct DecodeState
     quint8 lastbyte;
 };
 
+/// Next byte of the compressed block; the block length comes from the file,
+/// so a truncated block must not be read past its end.
+inline quint8 nextByte(const std::vector<char> &buf, DecodeState &state)
+{
+    if (state.count >= buf.size()) {
+        MB_THROW(qlib::FileFormatException, "XTC: compressed block is truncated");
+        return 0;
+    }
+    return static_cast<quint8>(buf[state.count++]);
+}
+
 /// decodebits: extract num_of_bits from the buffer and build an integer.
 template <typename T>
 T decodebits(const std::vector<char> &buf, DecodeState &state, quint32 num_of_bits)
@@ -95,14 +106,14 @@ T decodebits(const std::vector<char> &buf, DecodeState &state, quint32 num_of_bi
 
     quint32 num = 0;
     while (num_of_bits >= CHAR_BIT) {
-        lastbyte = (lastbyte << CHAR_BIT) | static_cast<quint8>(buf[state.count++]);
+        lastbyte = (lastbyte << CHAR_BIT) | nextByte(buf, state);
         num |= (lastbyte >> lastbits) << (num_of_bits - CHAR_BIT);
         num_of_bits -= CHAR_BIT;
     }
     if (num_of_bits > 0) {
         if (lastbits < num_of_bits) {
             lastbits += CHAR_BIT;
-            lastbyte = (lastbyte << CHAR_BIT) | static_cast<quint8>(buf[state.count++]);
+            lastbyte = (lastbyte << CHAR_BIT) | nextByte(buf, state);
         }
         lastbits -= num_of_bits;
         num |= (lastbyte >> lastbits) & (static_cast<quint32>(1 << num_of_bits) - 1);
@@ -334,8 +345,12 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
     const float precision = readF32();
     const int minint[3] = {readI32(), readI32(), readI32()};
     const int maxint[3] = {readI32(), readI32(), readI32()};
-    quint32 smallidx = readU32();
-    if (!(smallidx < LASTIDX)) {
+    // smallidx indexes MAGICINTS and moves up/down while decoding; the
+    // encoder never writes one below FIRSTIDX (MAGICINTS[FIRSTIDX-1] == 0)
+    const int kFirstIdx = static_cast<int>(FIRSTIDX);
+    const int kLastIdx = static_cast<int>(LASTIDX);
+    int smallidx = readI32();
+    if (smallidx < kFirstIdx || smallidx >= kLastIdx) {
         MB_THROW(qlib::FileFormatException, "XTC: internal overflow (smallidx)");
         return precision;
     }
@@ -344,7 +359,7 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
     quint32 bitsizeint[3];
     const quint32 bitsize = calc_sizeint(minint, maxint, sizeint, bitsizeint);
 
-    int smaller = MAGICINTS[std::max(FIRSTIDX, smallidx - 1)] / 2;
+    int smaller = MAGICINTS[std::max(kFirstIdx, smallidx - 1)] / 2;
     int smallnum = MAGICINTS[smallidx] / 2;
     quint32 sizesmall[3];
     sizesmall[0] = sizesmall[1] = sizesmall[2] = static_cast<quint32>(MAGICINTS[smallidx]);
@@ -386,14 +401,15 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
             run -= is_smaller;
             is_smaller--;
         }
-        if (run > 0 && write_idx * 3 + static_cast<size_t>(run) > data.size()) {
+        if (run > 0 && (write_idx + 1) * 3 + static_cast<size_t>(run) > data.size()) {
             MB_THROW(qlib::FileFormatException, "XTC: buffer overrun during decompression");
             return precision;
         }
         if (run > 0) {
             thiscoord = m_intbuf.data() + (read_idx + 1) * 3;
             for (int k = 0; k < run; k += 3) {
-                decodeints(m_compressed, state, smallidx, sizesmall, thiscoord);
+                decodeints(m_compressed, state, static_cast<quint32>(smallidx), sizesmall,
+                           thiscoord);
                 ++read_idx;
                 thiscoord[0] += prevcoord[0] - smallnum;
                 thiscoord[1] += prevcoord[1] - smallnum;
@@ -430,16 +446,21 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
         if (is_smaller < 0) {
             --smallidx;
             smallnum = smaller;
-            if (smallidx > FIRSTIDX) {
+            if (smallidx > kFirstIdx) {
                 smaller = MAGICINTS[smallidx - 1] / 2;
             } else {
                 smaller = 0;
             }
         } else if (is_smaller > 0) {
             ++smallidx;
+            if (smallidx >= kLastIdx) {
+                MB_THROW(qlib::FileFormatException, "XTC: internal overflow (smallidx)");
+                return precision;
+            }
             smaller = smallnum;
             smallnum = MAGICINTS[smallidx] / 2;
         }
+        // MAGICINTS[smallidx] == 0 below FIRSTIDX: caught by the size check
         sizesmall[0] = sizesmall[1] = sizesmall[2] = static_cast<quint32>(MAGICINTS[smallidx]);
         if (sizesmall[0] == 0) {
             MB_THROW(qlib::FileFormatException, "XTC: invalid size during decompression");

--- a/src/modules/mdtools/XtcTrajReader.hpp
+++ b/src/modules/mdtools/XtcTrajReader.hpp
@@ -66,7 +66,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     /// File atom count (0 until the first frame header is read).

--- a/src/tests/modules/importers/test_trajio.cpp
+++ b/src/tests/modules/importers/test_trajio.cpp
@@ -1506,3 +1506,64 @@ TEST(TrajectoryTest, AmberNetCDFInitialFrameIsTrajFrameZero)
         EXPECT_NEAR(pos.z(), ncCoord(0, i, 2), 1e-4);
     }
 }
+
+// ---- corrupt XTC input ----
+//
+// Offsets inside one compressed frame: 56-byte frame header, then precision,
+// minint[3] and maxint[3] (28 bytes), so smallidx sits at 84, the opaque byte
+// count at 88 and the compressed bytes start at 92.
+
+TEST(TrajectoryTest, XtcTruncatedCompressedBlockThrows)
+{
+    const int natom = 12;
+    TrajectoryPtr pTraj = makeTrajectoryNAtoms(natom);
+    std::string xtc = buildXTCCompressed(natom, 1, 1000.0f);
+    ASSERT_GT(xtc.size(), 96u);
+
+    // keep only 4 bytes of the compressed block; the decoder used to read on
+    // past the end of the vector
+    std::string cut = xtc.substr(0, 96);
+    patchBE32(cut, 88, 4u);
+    EXPECT_THROW(appendXTC(pTraj, cut), qlib::FileFormatException);
+}
+
+TEST(TrajectoryTest, XtcSmallidxOutsideTableThrows)
+{
+    const int natom = 12;
+    TrajectoryPtr pTraj = makeTrajectoryNAtoms(natom);
+    const std::string xtc = buildXTCCompressed(natom, 1, 1000.0f);
+
+    // smallidx 0: MAGICINTS[smallidx - 1] wrapped around as unsigned
+    std::string bad = xtc;
+    patchBE32(bad, 84, 0u);
+    EXPECT_THROW(appendXTC(pTraj, bad), qlib::FileFormatException);
+
+    // smallidx past the end of the table
+    bad = xtc;
+    patchBE32(bad, 84, 1000u);
+    EXPECT_THROW(appendXTC(pTraj, bad), qlib::FileFormatException);
+}
+
+// nevery is a script property; 0 used to divide the frame counter by zero.
+TEST(TrajReaderNevery, BelowOneIsClampedToOne)
+{
+    XtcTrajReader xr;
+    xr.setSkipNo(0);
+    EXPECT_EQ(xr.getSkipNo(), 1);
+    xr.setSkipNo(-3);
+    EXPECT_EQ(xr.getSkipNo(), 1);
+    xr.setSkipNo(4);
+    EXPECT_EQ(xr.getSkipNo(), 4);
+
+    mdtools::DCDTrajReader dr;
+    dr.setSkipNo(0);
+    EXPECT_EQ(dr.getSkipNo(), 1);
+
+    mdtools::TrrTrajReader tr;
+    tr.setSkipNo(0);
+    EXPECT_EQ(tr.getSkipNo(), 1);
+
+    mdtools::AmberNetCDFReader ar;
+    ar.setSkipNo(0);
+    EXPECT_EQ(ar.getSkipNo(), 1);
+}


### PR DESCRIPTION
## Summary

Part 14 of the libcuemol2 bug-audit fixes (Phase 3: input validation, mdtools trajectory readers). Independent of the other PRs.

### XTC decompression (mdtools, `XdrInStream.cpp`)

`readCompressedCoords()` trusted the compressed block it had just read:

- `decodebits()` read `buf[state.count++]` without comparing it to the block length, so a truncated frame read past the vector.
- `smallidx` was `quint32`: a header value of 0 turned `smallidx - 1` into a huge index into `MAGICINTS`, and the per-atom `++smallidx` could walk off the end of the table.
- The overrun guard of the run branch (`write_idx*3 + run > data.size()`) was one atom short: the branch writes the current atom plus `run/3` neighbours.

The block length, the table bounds and the output size are checked now, each raising `FileFormatException`.

### `nevery` (xtal 9)

The `nevery` property (`m_nSkip`) of the DCD / XTC / TRR / AMBER NetCDF readers is a divisor in the frame loop; a script could set it to 0 and crash with SIGFPE. The setter clamps it to 1.

## Tests

`tests/modules/importers/test_trajio.cpp` (+3): a compressed XTC frame cut to 4 bytes of compressed data, `smallidx` 0 and 1000 in the frame header (both built with the test's XTC compressor), and `setSkipNo(0)` / `(-3)` on the four readers.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
