### PR TITLE
fix(qlib,qsys): range-check script arguments and qdf record indices

### DIFF
--- a/src/qlib/ExpatInStream.cpp
+++ b/src/qlib/ExpatInStream.cpp
@@ -94,7 +94,8 @@ void ExpatInStream::parse()
   bool done=false;
   do {
     int len = super_t::read(buf, 0, sizeof(buf));
-    done = len < sizeof(buf);
+    if (len < 0) len = 0;  // EOF: feed an empty final chunk
+    done = len < int(sizeof(buf));
     if (XML_Parse(getParser(), buf, len, done) == XML_STATUS_ERROR) {
       LString msg =
         LString::format("%s at line %d\n",
@@ -127,7 +128,8 @@ void ExpatInStream::procExtEntity(const char *fname, const char *szctxt)
     bool done=false;
     do {
       int len = fis.read(buf, 0, sizeof(buf));
-      done = len < sizeof(buf);
+      if (len < 0) len = 0;  // EOF: feed an empty final chunk
+      done = len < int(sizeof(buf));
       if (XML_Parse(expar, buf, len, done) == XML_STATUS_ERROR) {
 	LString msg =
 	  LString::format("%s at line %d\n",

--- a/src/qlib/LByteArray.cpp
+++ b/src/qlib/LByteArray.cpp
@@ -138,10 +138,10 @@ int LByteArray::getAt(int ind) const
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray getAt() out of index %d", ind));
 
@@ -183,10 +183,10 @@ void LByteArray::setAt(int ind, int value)
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray setAt() out of index %d", ind));
 
@@ -228,10 +228,10 @@ double LByteArray::getAtF(int ind) const
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray getAtF() out of index %d", ind));
 
@@ -256,10 +256,10 @@ void LByteArray::setAtF(int ind, double value)
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray setAtF() out of index %d", ind));
 

--- a/src/qlib/LRegExpr.cpp
+++ b/src/qlib/LRegExpr.cpp
@@ -115,6 +115,10 @@ LString LRegExpr::getSubstr(int index)
     int nstart = m_ovector[2 * index];
     int nsize = m_ovector[2 * index + 1] - m_ovector[2 * index];
 
+    // pcre marks a group that did not take part in the match with -1
+    if (nstart < 0 || nsize < 0)
+        return LString();
+
     return m_subj.substr(nstart, nsize);
 }
 

--- a/src/qlib/LScrMatrix4D.hpp
+++ b/src/qlib/LScrMatrix4D.hpp
@@ -56,13 +56,17 @@ public:
     typedef std::true_type has_fromString;
     static LScrMatrix4D *fromStringS(const LString &src);
 
+    // row/column indices are 1-based and run to 4 (aij(i,j) maps them to
+    // the 16-element array, so checking against _N_ELEM let 16 write past it)
+    static constexpr int _N_DIM = 4;
+
     static inline void indexCheck(int i, int j) {
-        if (i<=0 || Matrix4D::_N_ELEM <i) {
+        if (i<=0 || _N_DIM <i) {
             auto msg = LString::format("index i=%d out of range", i);
             MB_THROW(IndexOutOfBoundsException, msg);
             return;
         }
-        if (j<=0 || Matrix4D::_N_ELEM <j) {
+        if (j<=0 || _N_DIM <j) {
             auto msg = LString::format("index j=%d out of range", j);
             MB_THROW(IndexOutOfBoundsException, msg);
             return;

--- a/src/qsys/Object.cpp
+++ b/src/qsys/Object.cpp
@@ -177,6 +177,9 @@ RendererPtr Object::getRendererByType(const LString &type_name)
 
 RendererPtr Object::getRendererByIndex(int ind)
 {
+  // script argument: advancing past end() is undefined
+  if (ind<0 || ind>=int(m_rendtab.size()))
+    return RendererPtr();
   rendtab_t::const_iterator i = m_rendtab.begin();
   while (ind>0) {
     ++i;

--- a/src/qsys/QdfStream.cpp
+++ b/src/qsys/QdfStream.cpp
@@ -17,6 +17,23 @@
 #endif
 
 using namespace qsys;
+
+namespace {
+
+// The record definition comes from the file, so reading (or writing) more
+// fields than it defines must fail as a format error, not as a vector
+// overrun.
+inline const qsys::QdfDataType::RecElem &recElemAt(
+    const qsys::QdfDataType::RecElemList &defs, int ind)
+{
+  if (ind < 0 || size_t(ind) >= defs.size()) {
+    MB_THROW(qlib::FileFormatException, "Qdf record index out of range");
+  }
+  return defs[ind];
+}
+
+}  // namespace
+
 using qlib::Vector4D;
 
 //static
@@ -353,7 +370,7 @@ void QdfInStream::endRecord()
 
 void QdfInStream::skipRecord()
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   const LString nm = elem.first;
   const int type = elem.second;
 
@@ -427,7 +444,7 @@ void QdfInStream::skipAllRecordsImpl()
 
 qfloat32 QdfInStream::readFloat32(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_FLOAT32) {
     MB_THROW(qlib::FileFormatException, "setRecValFloat32 inconsistent record order");
     return -0.0f;
@@ -439,7 +456,7 @@ qfloat32 QdfInStream::readFloat32(const LString &name)
 
 qint32 QdfInStream::readInt32(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT32) {
     MB_THROW(qlib::FileFormatException, "setRecValInt32 inconsistent record order");
     return 0;
@@ -452,7 +469,7 @@ qint32 QdfInStream::readInt32(const LString &name)
 
 quint32 QdfInStream::readUInt32(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT32) {
     MB_THROW(qlib::FileFormatException, "readUInt32 inconsistent record order");
     return 0;
@@ -465,7 +482,7 @@ quint32 QdfInStream::readUInt32(const LString &name)
 
 qint8 QdfInStream::readInt8(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT8) {
     MB_THROW(qlib::FileFormatException, "readInt8 inconsistent record order");
     return 0;
@@ -478,7 +495,7 @@ qint8 QdfInStream::readInt8(const LString &name)
 
 quint8 QdfInStream::readUInt8(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT8) {
     MB_THROW(qlib::FileFormatException, "readUInt8 inconsistent record order");
     return 0;
@@ -491,7 +508,7 @@ quint8 QdfInStream::readUInt8(const LString &name)
 
 bool QdfInStream::readBool(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_BOOL) {
     MB_THROW(qlib::FileFormatException, "readBool inconsistent record order");
     return 0;
@@ -506,7 +523,7 @@ bool QdfInStream::readBool(const LString &name)
 
 LString QdfInStream::readStr(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name)) {
     MB_THROW(qlib::FileFormatException, "readStr inconsistent record order");
     return LString();
@@ -540,7 +557,7 @@ LString QdfInStream::readStr(const LString &name)
 
 void QdfInStream::readVec3D(const LString &name, qfloat32 *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "readVec3f inconsistent record order");
     return;
@@ -555,7 +572,7 @@ void QdfInStream::readVec3D(const LString &name, qfloat32 *pvec)
 
 Vector4D QdfInStream::readVec3D(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "readVec3f inconsistent record order");
     return Vector4D();
@@ -572,7 +589,7 @@ Vector4D QdfInStream::readVec3D(const LString &name)
 
 quint32 QdfInStream::readColorRGBA(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "readColorRGBA inconsistent record order");
     return 0;
@@ -590,7 +607,7 @@ quint32 QdfInStream::readColorRGBA(const LString &name)
 
 void QdfInStream::readColorRGBA(const LString &name, qbyte *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "readColorRGBA inconsistent record order");
     return;
@@ -840,7 +857,7 @@ void QdfOutStream::endRecord()
 
 void QdfOutStream::writeStr(const LString &name, const LString &value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UTF8STR) {
     MB_THROW(qlib::FileFormatException, "writeStr inconsistent record order");
     return;
@@ -852,7 +869,7 @@ void QdfOutStream::writeStr(const LString &name, const LString &value)
 
 void QdfOutStream::writeFixedStr(const LString &name, const LString &value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name)) {
     LString msg = LString::format("writeFixStr(%s,%s) inconsistent record order", name.c_str(), value.c_str());
     MB_THROW(qlib::FileFormatException, msg);
@@ -874,7 +891,7 @@ void QdfOutStream::writeFixedStr(const LString &name, const LString &value)
 
 void QdfOutStream::writeInt32(const LString &name, int value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT32) {
     MB_THROW(qlib::FileFormatException, "writeInt inconsistent record order");
     return;
@@ -886,7 +903,7 @@ void QdfOutStream::writeInt32(const LString &name, int value)
 
 void QdfOutStream::writeUInt32(const LString &name, quint32 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT32) {
     MB_THROW(qlib::FileFormatException, "writeInt inconsistent record order");
     return;
@@ -898,7 +915,7 @@ void QdfOutStream::writeUInt32(const LString &name, quint32 value)
 
 void QdfOutStream::writeInt16(const LString &name, qint16 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT16) {
     MB_THROW(qlib::FileFormatException, "writeInt8 inconsistent record order");
     return;
@@ -910,7 +927,7 @@ void QdfOutStream::writeInt16(const LString &name, qint16 value)
 
 void QdfOutStream::writeInt8(const LString &name, qint8 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT8) {
     MB_THROW(qlib::FileFormatException, "writeInt8 inconsistent record order");
     return;
@@ -922,7 +939,7 @@ void QdfOutStream::writeInt8(const LString &name, qint8 value)
 
 void QdfOutStream::writeUInt8(const LString &name, quint8 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT8) {
     MB_THROW(qlib::FileFormatException, "writeInt8 inconsistent record order");
     return;
@@ -934,7 +951,7 @@ void QdfOutStream::writeUInt8(const LString &name, quint8 value)
 
 void QdfOutStream::writeBool(const LString &name, bool value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_BOOL) {
     MB_THROW(qlib::FileFormatException, "writeBool inconsistent record order");
     return;
@@ -947,7 +964,7 @@ void QdfOutStream::writeBool(const LString &name, bool value)
 
 void QdfOutStream::writeFloat32(const LString &name, qfloat32 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_FLOAT32) {
     MB_THROW(qlib::FileFormatException, "writeFloat32 inconsistent record order");
     return;
@@ -959,7 +976,7 @@ void QdfOutStream::writeFloat32(const LString &name, qfloat32 value)
 
 void QdfOutStream::writeVec3D(const LString &name, const qlib::Vector4D &vec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "writeVec3D inconsistent record order");
     return;
@@ -974,7 +991,7 @@ void QdfOutStream::writeVec3D(const LString &name, const qlib::Vector4D &vec)
 
 void QdfOutStream::writeVec3D(const LString &name, const qfloat32 *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "writeVec3D inconsistent record order");
     return;
@@ -989,7 +1006,7 @@ void QdfOutStream::writeVec3D(const LString &name, const qfloat32 *pvec)
 
 void QdfOutStream::writeColorRGBA(const LString &name, quint32 ccode)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "writeColorRGBA inconsistent record order");
     return;
@@ -1004,7 +1021,7 @@ void QdfOutStream::writeColorRGBA(const LString &name, quint32 ccode)
 
 void QdfOutStream::writeColorRGBA(const LString &name, const qbyte *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "writeColorRGBA inconsistent record order");
     return;

--- a/src/qsys/UndoManager.cpp
+++ b/src/qsys/UndoManager.cpp
@@ -101,6 +101,8 @@ bool UndoManager::getUndoDesc(int n, LString &str) const
 {
   if (!isUndoable())
     return false;
+  if (n<0 || n>=int(m_udata.size()))
+    return false;
   // UndoInfo *pui = m_udata.front();
   UndoInfoList::const_iterator iter = m_udata.begin();
   for (int i=0; i<n; ++i)
@@ -115,6 +117,8 @@ bool UndoManager::getUndoDesc(int n, LString &str) const
 bool UndoManager::getRedoDesc(int n, LString &str) const
 {
   if (!isRedoable())
+    return false;
+  if (n<0 || n>=int(m_rdata.size()))
     return false;
   //UndoInfo *pui = m_rdata.front();
   UndoInfoList::const_iterator iter = m_rdata.begin();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(test_qlib
   qlib/test_parallel.cpp
   qlib/test_chunked_array3d.cpp
   qlib/test_seekable_stream.cpp
+  qlib/test_lbytearray.cpp
+  qlib/test_expat_instream.cpp
 )
 target_include_directories(test_qlib PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/qlib/test_expat_instream.cpp
+++ b/src/tests/qlib/test_expat_instream.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qlib/ExpatInStream.hpp"
+#include "qlib/StringStream.hpp"
+
+#include <string>
+
+using qlib::LString;
+
+namespace {
+
+class CountingExpat : public qlib::ExpatInStream
+{
+public:
+    int nstart = 0;
+    int nend = 0;
+
+    explicit CountingExpat(qlib::InStream &ins) : qlib::ExpatInStream(ins) {}
+
+    void startElement(const LString &, const Attributes &) override { ++nstart; }
+    void endElement(const LString &) override { ++nend; }
+};
+
+}  // namespace
+
+// ExpatInStream reads the input in 2048-byte chunks. A document that is
+// exactly one chunk long fills the first read; the second read reports EOF
+// (-1), which used to be handed to XML_Parse() as the chunk length.
+TEST(ExpatInStream, DocumentOfExactlyOneChunkParses)
+{
+    // 6 + 500*4 + 35 + 7 = 2048 bytes
+    std::string xml = "<root>";
+    for (int i = 0; i < 500; ++i) xml += "<a/>";
+    xml += "<!--" + std::string(28, 'x') + "-->";
+    xml += "</root>";
+    ASSERT_EQ(xml.size(), 2048u);
+
+    qlib::StrInStream ins(xml.data(), static_cast<int>(xml.size()));
+    CountingExpat parser(ins);
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_EQ(parser.nstart, 501);
+    EXPECT_EQ(parser.nend, 501);
+}

--- a/src/tests/qlib/test_lbytearray.cpp
+++ b/src/tests/qlib/test_lbytearray.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qlib/LByteArray.hpp"
+#include "qlib/LExceptions.hpp"
+#include "qlib/LTypes.hpp"
+
+using qlib::LByteArray;
+
+// getAt/setAt are script-visible: an index whose byte offset wraps around in
+// int used to pass the bounds check and read far outside the array.
+TEST(LByteArray, HugeIndexIsRejectedNotWrapped)
+{
+    LByteArray arr(16);
+    arr.setElemType(qlib::type_consts::QTC_INT32);
+
+    arr.setAt(3, 7);
+    EXPECT_EQ(arr.getAt(3), 7);
+
+    // 0x40000000 * 4 == 0 in 32-bit int
+    EXPECT_THROW(arr.getAt(0x40000000), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.setAt(0x40000000, 1), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.getAt(4), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.getAt(-1), qlib::IndexOutOfBoundsException);
+}
+
+TEST(LByteArray, HugeFloatIndexIsRejected)
+{
+    LByteArray arr(16);
+    arr.setElemType(qlib::type_consts::QTC_FLOAT32);
+
+    arr.setAtF(1, 2.5);
+    EXPECT_DOUBLE_EQ(arr.getAtF(1), 2.5);
+
+    EXPECT_THROW(arr.getAtF(0x40000000), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.setAtF(0x40000000, 1.0), qlib::IndexOutOfBoundsException);
+}

--- a/src/tests/qlib/test_lregexpr.cpp
+++ b/src/tests/qlib/test_lregexpr.cpp
@@ -101,3 +101,19 @@ TEST(LRegExpr, NamedCapture)
     EXPECT_TRUE(re.getNamedSubstr("month").equals("03"));
     EXPECT_TRUE(re.getNamedSubstr("day").equals("15"));
 }
+
+// pcre reports a group that did not take part in the match with offset -1;
+// substr(size_t(-1)) used to throw std::out_of_range past the LException
+// handlers.
+TEST(LRegExpr, UnmatchedOptionalGroupGivesEmptyString)
+{
+    LRegExpr re;
+    re.setPattern("(a)?(b)");
+    ASSERT_TRUE(re.match("b"));
+    EXPECT_TRUE(re.getSubstr(0).equals("b"));
+    EXPECT_TRUE(re.getSubstr(1).isEmpty());
+    EXPECT_TRUE(re.getSubstr(2).equals("b"));
+
+    ASSERT_TRUE(re.match("ab"));
+    EXPECT_TRUE(re.getSubstr(1).equals("a"));
+}

--- a/src/tests/qlib/test_lscrmatrix4d.cpp
+++ b/src/tests/qlib/test_lscrmatrix4d.cpp
@@ -95,3 +95,17 @@ TEST(LScrMatrix4D, FromStringMissingParentheses)
     LString s("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
     EXPECT_THROW(LScrMatrix4D::fromStringS(s), qlib::RuntimeException);
 }
+
+// setAt/getAt/addAt are script-visible with 1-based row/column indices;
+// the check used to accept anything up to 16 and wrote past the array.
+TEST(LScrMatrix4D, IndicesAboveFourAreRejected)
+{
+    LScrMatrix4D m;
+    m.setAt(4, 4, 2.5);
+    EXPECT_DOUBLE_EQ(m.getAt(4, 4), 2.5);
+
+    EXPECT_THROW(m.setAt(5, 1, 1.0), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(m.setAt(16, 16, 1.0), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(m.getAt(1, 5), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(m.addAt(0, 1, 1.0), qlib::IndexOutOfBoundsException);
+}

--- a/src/tests/qsys/test_object.cpp
+++ b/src/tests/qsys/test_object.cpp
@@ -133,3 +133,13 @@ TEST(ObjectTest, ForceEmbedSetsDataChunkSource)
     EXPECT_TRUE(obj.getSource().startsWith("datachunk:"));
     EXPECT_TRUE(obj.getAltSource().isEmpty());
 }
+
+// getRendererByIndex is script-visible; an index past the table used to
+// advance the iterator beyond end().
+TEST(ObjectTest, GetRendererByIndexOutOfRangeReturnsNull)
+{
+    ConcreteObject obj;
+    EXPECT_TRUE(obj.getRendererByIndex(0).isnull());
+    EXPECT_TRUE(obj.getRendererByIndex(3).isnull());
+    EXPECT_TRUE(obj.getRendererByIndex(-1).isnull());
+}

--- a/src/tests/qsys/test_qdfstream.cpp
+++ b/src/tests/qsys/test_qdfstream.cpp
@@ -197,3 +197,35 @@ TEST(QdfStreamTest, RoundTripFloat32)
         EXPECT_NEAR(fval, 3.14f, 1e-5f);
     }
 }
+
+// The record definition comes from the file: reading one more field than it
+// defines used to index past m_recdefs.
+TEST(QdfStreamTest, ReadingPastRecordDefinitionThrows)
+{
+    qlib::StrOutStream sos;
+    {
+        QdfOutStream qos(sos);
+        qos.setVersion(0);
+        qos.start();
+        qos.writeFileType("TEST");
+        qos.defData("data", 1);
+        qos.defInt32("ival");
+        qos.startData();
+        qos.startRecord();
+        qos.writeInt32("ival", 42);
+        qos.endRecord();
+        qos.endData();
+        qos.end();
+    }
+
+    int nsize;
+    char *buf = sos.getData(nsize);
+    qlib::StrInStream sis(buf, nsize);
+    QdfInStream qis(sis);
+    qis.start();
+    EXPECT_EQ(qis.readDataDef("data"), 1);
+    qis.readRecordDef();
+    qis.startRecord();
+    EXPECT_EQ(qis.readInt32("ival"), 42);
+    EXPECT_THROW(qis.readInt32("other"), qlib::FileFormatException);
+}

--- a/src/tests/qsys/test_undomanager.cpp
+++ b/src/tests/qsys/test_undomanager.cpp
@@ -168,3 +168,24 @@ TEST(UndoManagerTest, IsOKOnlyInsideTxn)
     um.commitTxn();
     EXPECT_FALSE(um.isOK());
 }
+
+// getUndoDesc/getRedoDesc are script-visible; an index past the list used to
+// advance the iterator beyond end().
+TEST(UndoManagerTest, DescIndexOutOfRangeReturnsFalse)
+{
+    UndoManager um;
+    um.startTxn("only");
+    um.addEditInfo(new CountEditInfo());
+    um.commitTxn();
+
+    LString desc;
+    EXPECT_TRUE(um.getUndoDesc(0, desc));
+    EXPECT_EQ(desc, LString("only"));
+    EXPECT_FALSE(um.getUndoDesc(1, desc));
+    EXPECT_FALSE(um.getUndoDesc(5, desc));
+    EXPECT_FALSE(um.getUndoDesc(-1, desc));
+
+    ASSERT_TRUE(um.undo());
+    EXPECT_TRUE(um.getRedoDesc(0, desc));
+    EXPECT_FALSE(um.getRedoDesc(3, desc));
+}


### PR DESCRIPTION
## Summary

Part 15 of the libcuemol2 bug-audit fixes (Phase 3: input validation, qlib / qsys script arguments and qdf records). Independent of the other PRs.

### Script-visible arguments

- `LScrMatrix4D::indexCheck()` (qlib 4) compared the 1-based row/column indices with `_N_ELEM` (16) instead of 4; `setAt(16,16)` wrote 60 elements past the matrix.
- `LByteArray::getAt/setAt/getAtF/setAtF` (qlib 12) computed the byte offset in `int`; `getAt(0x40000000)` on a 4-byte element type wrapped to 0, passed the bounds check and read far outside the array.
- `LRegExpr::getSubstr()` (qlib 9) called `substr(size_t(-1))` for a group that did not take part in the match (pcre reports offset -1), throwing `std::out_of_range` past the `LException` handlers. It returns an empty string.
- `UndoManager::getUndoDesc/getRedoDesc` and `Object::getRendererByIndex` (qsys 13) advanced a list/map iterator past `end()` for an index beyond the size.

### `ExpatInStream` (qlib 5)

`read()` returns -1 at EOF; when the document length was a multiple of the 2048-byte buffer the next read's -1 was passed to `XML_Parse()` as the chunk length (the `len < sizeof(buf)` comparison is unsigned). EOF now feeds an empty final chunk.

### `QdfInStream` / `QdfOutStream` (qsys 8)

Every `read*` / `write*` method indexed `m_recdefs[m_nRecInd]` without a check, so a file whose record definition is shorter than the reader expects read past the vector and called `equals()` on garbage. A file-local `recElemAt()` raises `FileFormatException` instead.

## Tests

- new `tests/qlib/test_lbytearray.cpp` (2), `tests/qlib/test_expat_instream.cpp` (1: a document of exactly 2048 bytes)
- `test_lscrmatrix4d` (+1), `test_lregexpr` (+1: `(a)?(b)` on `b`), `test_qdfstream` (+1: reading one more field than defined), `test_undomanager` (+1), `test_object` (+1)

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
