### PR TITLE
fix(molvis,molstr): reject bad indices and unknown atoms at script entry points

### DIFF
--- a/src/modules/molstr/NameLabelRenderer.cpp
+++ b/src/modules/molstr/NameLabelRenderer.cpp
@@ -197,8 +197,10 @@ void NameLabelRenderer::render(DisplayContext *pdc)
     for (; iter!=eiter; iter++) {
       NameLabel &nlab = *iter;
       if (nlab.m_nCacheID<0) {
-        makeLabelStr(nlab, strlab, pos);
-        nlab.m_nCacheID = m_pixCache.addString(pos, strlab);
+        // a label whose atom is gone keeps m_nCacheID<0 instead of
+        // reusing the string/position of the previous label
+        if (makeLabelStr(nlab, strlab, pos))
+          nlab.m_nCacheID = m_pixCache.addString(pos, strlab);
       }
     }
   }
@@ -270,6 +272,10 @@ bool NameLabelRenderer::addLabelByID(int aid, const LString &label /*= LString()
   MB_ASSERT(!pobj.isnull());
   
   MolAtomPtr pAtom = pobj->getAtom(aid);
+  if (pAtom.isnull()) {
+    LOG_DPRINTLN("NameLabelRenderer> atom %d not found", aid);
+    return false;
+  }
   return addLabel(pAtom, label);
 }
 

--- a/src/modules/molvis/AtomIntrRenderer.cpp
+++ b/src/modules/molvis/AtomIntrRenderer.cpp
@@ -470,7 +470,7 @@ void AtomIntrRenderer::setAt(int index, const AtomIntrData &dat)
 
 bool AtomIntrRenderer::remove(int nid)
 {
-  if (m_data.size()<=nid)
+  if (nid<0 || int(m_data.size())<=nid)
     return false;
 
   AtomIntrData dat = m_data[nid];

--- a/src/modules/molvis/DistPickDrawObj.cpp
+++ b/src/modules/molvis/DistPickDrawObj.cpp
@@ -80,5 +80,9 @@ void DistPickDrawObj::append(qlib::uid_t mol_id, int naid)
     MolCoordPtr pMol = qsys::SceneManager::getObjectS(mol_id);
     if (pMol.isnull()) return;
     molstr::MolAtomPtr pAtom = pMol->getAtom(naid);
+    if (pAtom.isnull()) {
+        LOG_DPRINTLN("DistPickDrawObj> atom %d not found in mol %d", naid, int(mol_id));
+        return;
+    }
     m_data.push_back(pAtom->getPos());
 }

--- a/src/modules/molvis/JctTable.cpp
+++ b/src/modules/molvis/JctTable.cpp
@@ -26,17 +26,17 @@ JctTable::JctTable()
 JctTable::~JctTable()
 {
   if (m_pParTab!=NULL)
-    delete m_pParTab;
+    delete [] m_pParTab;
   if (m_pEsclTab!=NULL)
-    delete m_pEsclTab;
+    delete [] m_pEsclTab;
 }
 
 void JctTable::invalidate()
 {
   if (m_pParTab!=NULL)
-    delete m_pParTab;
+    delete [] m_pParTab;
   if (m_pEsclTab!=NULL)
-    delete m_pEsclTab;
+    delete [] m_pEsclTab;
 
   m_nTabSz = 0;
   m_pParTab = NULL;
@@ -258,6 +258,10 @@ bool JctTable::setup(int ndetail, TubeSection *pts1, TubeSection *pts2, bool fre
     m_fPartition = true;
   else
     m_fPartition = false;
+
+  // setup() runs once per segment on every rebuild: release the previous
+  // tables (and leave an empty table when the setup below fails)
+  invalidate();
 
   switch (m_nType) {
   default:

--- a/src/modules/molvis/JctTable.hpp
+++ b/src/modules/molvis/JctTable.hpp
@@ -129,8 +129,7 @@ public:
 
   /** get axial param & scaling coeff */
   bool get(int index, double &par, double &e1scl, double &e2scl) const {
-    MB_ASSERT(index>=0 && index<m_nTabSz);
-    if (index<0 && index>=m_nTabSz) return false;
+    if (index<0 || index>=m_nTabSz) return false;
     par = m_pParTab[index];
     e1scl = m_pEsclTab[index].sclx;
     e2scl = m_pEsclTab[index].scly;
@@ -139,8 +138,7 @@ public:
 
   /// Get axial param & scaling coeff
   bool get(int index, double &par, Vector4D &vv) const {
-    MB_ASSERT(index>=0 && index<m_nTabSz);
-    if (index<0 && index>=m_nTabSz) return false;
+    if (index<0 || index>=m_nTabSz) return false;
     par = m_pParTab[index];
     vv.x() = m_pEsclTab[index].sclx;
     vv.y() = m_pEsclTab[index].scly;
@@ -151,8 +149,7 @@ public:
 
   /// Get axial param only
   bool get(int index, double &par) const {
-    MB_ASSERT(index>=0 && index<m_nTabSz);
-    if (index<0 && index>=m_nTabSz) return false;
+    if (index<0 || index>=m_nTabSz) return false;
     par = m_pParTab[index];
     return true;
   }

--- a/src/modules/molvis/PaintColoring.cpp
+++ b/src/modules/molvis/PaintColoring.cpp
@@ -247,7 +247,7 @@ void PaintColoring::insertBefore(int ind, const SelectionPtr &psel, const ColorP
 
 bool PaintColoring::removeAtImpl(int ind)
 {
-  if (ind>=m_coltab.size())
+  if (ind<0 || ind>=int(m_coltab.size()))
     return false;
 
   ColorTab::iterator iter = m_coltab.begin()+ind;
@@ -284,7 +284,7 @@ bool PaintColoring::removeAt(int ind)
 
 bool PaintColoring::changeAt(int ind, const SelectionPtr &psel, const ColorPtr &pcol)
 {
-  if (ind>=m_coltab.size()) return false;
+  if (ind<0 || ind>=int(m_coltab.size())) return false;
   ColorTab::iterator iter = m_coltab.begin()+ind;
 
   SelectionPtr poldsel = iter->first;

--- a/src/modules/molvis/TubeSection.hpp
+++ b/src/modules/molvis/TubeSection.hpp
@@ -120,7 +120,9 @@ public:
   int getType() const { return m_nSectType; }
 
   void setDetail(int d) {
-    m_nSectDetail = d;
+    // detail is a script property; an empty section table would divide
+    // by zero in getVec()
+    m_nSectDetail = (d < 1) ? 1 : d;
     invalidate();
     //setupSectionTable();
   }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -143,6 +143,7 @@ gtest_discover_tests(test_molstr PROPERTIES LABELS "test_molstr")
 add_executable(test_molvis
   modules/molvis/test_main.cpp
   modules/molvis/test_cpk2renderer.cpp
+  modules/molvis/test_script_index_checks.cpp
 )
 target_include_directories(test_molvis PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/molvis/test_script_index_checks.cpp
+++ b/src/tests/modules/molvis/test_script_index_checks.cpp
@@ -1,0 +1,85 @@
+// -*-Mode: C++;-*-
+//
+// Script-visible entry points of molvis/molstr must reject bad indices and
+// unknown atoms instead of dereferencing past their tables.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "molvis/JctTable.hpp"
+#include "molvis/TubeSection.hpp"
+#include "molvis/PaintColoring.hpp"
+#include "molvis/AtomIntrRenderer.hpp"
+#include "molvis/DistPickDrawObj.hpp"
+#include "molstr/MolCoord.hpp"
+#include "molstr/NameLabelRenderer.hpp"
+
+#include <qlib/Vector4D.hpp>
+
+using qlib::Vector4D;
+
+// axialdetail=0 makes setup() fail and leaves no table; get() used to check
+// index<0 && index>=size and dereference NULL
+TEST(JctTableChecks, GetOnEmptyTableReturnsFalse)
+{
+    molvis::JctTable jt;
+    double par = 0.0, e1 = 0.0, e2 = 0.0;
+    EXPECT_FALSE(jt.get(0, par));
+    EXPECT_FALSE(jt.get(-1, par));
+    EXPECT_FALSE(jt.get(0, par, e1, e2));
+    Vector4D vv;
+    EXPECT_FALSE(jt.get(5, par, vv));
+}
+
+// detail is a script property; 0 produced an empty section table and
+// getVec() divided by it
+TEST(TubeSectionChecks, DetailBelowOneIsClamped)
+{
+    molvis::TubeSection ts;
+    ts.setDetail(0);
+    EXPECT_EQ(ts.getDetail(), 1);
+    ts.setupSectionTable();
+    ASSERT_GE(ts.getSize(), 1);
+    Vector4D e1(1, 0, 0), e2(0, 1, 0);
+    EXPECT_NO_FATAL_FAILURE(ts.getVec(7, e1, e2));
+
+    ts.setDetail(-4);
+    EXPECT_EQ(ts.getDetail(), 1);
+    ts.setDetail(12);
+    EXPECT_EQ(ts.getDetail(), 12);
+}
+
+TEST(PaintColoringChecks, NegativeIndexIsRejected)
+{
+    molvis::PaintColoring pc;
+    EXPECT_FALSE(pc.removeAt(-1));
+    EXPECT_FALSE(pc.removeAt(0));
+    EXPECT_FALSE(pc.changeAt(-1, molstr::SelectionPtr(), gfx::ColorPtr()));
+    EXPECT_FALSE(pc.changeAt(0, molstr::SelectionPtr(), gfx::ColorPtr()));
+}
+
+TEST(AtomIntrRendererChecks, NegativeIndexIsRejected)
+{
+    molvis::AtomIntrRenderer r;
+    EXPECT_FALSE(r.remove(-1));
+    EXPECT_FALSE(r.remove(0));
+}
+
+// DistPickDrawObj::append() is fed atom ids from the measure/bond-edit
+// services; an id the molecule does not have used to dereference NULL
+TEST(DistPickDrawObjChecks, UnknownAtomIsIgnored)
+{
+    molstr::MolCoordPtr pMol(new molstr::MolCoord());
+    molvis::DistPickDrawObj d;
+    EXPECT_NO_FATAL_FAILURE(d.append(pMol->getUID(), 12345));
+    EXPECT_NO_FATAL_FAILURE(d.append(qlib::invalid_uid, 0));
+}
+
+TEST(NameLabelRendererChecks, UnknownAtomIdReturnsFalse)
+{
+    molstr::MolCoordPtr pMol(new molstr::MolCoord());
+    molstr::NameLabelRenderer r;
+    r.attachObj(pMol->getUID());
+    EXPECT_FALSE(r.addLabelByID(12345));
+}


### PR DESCRIPTION
## Summary

Part 16 of the libcuemol2 bug-audit fixes (Phase 3: input validation, molvis / molstr script entry points). Independent of the other PRs.

### `JctTable` (molvis 3, 5, 6)

- `get()` checked `index<0 && index>=m_nTabSz`, which is never true. With `axialdetail=0` `setup()` fails and leaves no table, so every frame dereferenced NULL (the `MB_ASSERT` in front of it aborted debug builds instead). The check is `||` now and the assert is removed: an out-of-range index is a runtime condition that returns `false`.
- `setup()` never released the previous tables: two arrays leaked per segment on every cartoon rebuild (property / selection / molecule change). It calls `invalidate()` first.
- The tables were allocated with `new[]` and freed with `delete`.

### `TubeSection::setDetail()` (molvis 10)

`detail=0` produced an empty section table and `j % 0` in `getVec()` (SIGFPE). The setter clamps to 1.

### Script indices (molvis 11)

`PaintColoring::removeAt/changeAt` and `AtomIntrRenderer::remove` compared a signed index with `size()`; negatives were only rejected through the implicit unsigned conversion. The checks are explicit (`ind<0 ||`).

### Unknown atom ids (molvis 12, molstr 16)

`DistPickDrawObj::append()` (fed by the measure / bond-edit services) and `NameLabelRenderer::addLabelByID()` (script) dereferenced the NULL that `getAtom()` returns for an unknown id. `NameLabelRenderer::render()` also reused the previous label's string and position when `makeLabelStr()` failed for a label whose atom is gone; such a label is skipped now.

## Tests

`tests/modules/molvis/test_script_index_checks.cpp` (6 cases): `get()` on an empty `JctTable`, `setDetail(0/-4)` followed by `getVec()`, negative indices on `PaintColoring` / `AtomIntrRenderer`, `DistPickDrawObj::append()` with an unknown atom, `addLabelByID()` with an unknown atom.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
