### PR TITLE
fix(surface,symm): delete mismatches, constant-map division and off-by-ones

### DIFF
--- a/src/modules/surface/CutByPlane.cpp
+++ b/src/modules/surface/CutByPlane.cpp
@@ -294,11 +294,11 @@ void CutByPlane::update()
   for (i=0; i<nnfaces; ++i)
     pNFaces[i] = m_faces[i];
 
-  delete m_pTgt->m_pVerts;
+  delete [] m_pTgt->m_pVerts;
   m_pTgt->m_pVerts = pNVerts;
   m_pTgt->m_nVerts = nnverts;
 
-  delete m_pTgt->m_pFaces;
+  delete [] m_pTgt->m_pFaces;
   m_pTgt->m_pFaces = pNFaces;
   m_pTgt->m_nFaces = nnfaces;
   
@@ -640,7 +640,9 @@ void CutByPlane::makeSection(Bndry &outer)
     for (j=0; j<ny; ++j)
       m_segrid.at(i, j) = -1;
 
-    if (yset.size()/2==0)
+    // crossings come in pairs; a boundary vertex exactly on xx produces
+    // an odd count, and walking it in pairs would dereference end()
+    if (yset.size()<2 || yset.size()%2!=0)
       continue;
 
     std::set<double>::const_iterator iys = yset.begin();

--- a/src/modules/surface/CutByPlane2.cpp
+++ b/src/modules/surface/CutByPlane2.cpp
@@ -211,11 +211,11 @@ void CutByPlane2::update()
   for (i=0; i<nnfaces; ++i)
     pNFaces[i] = m_faces[i];
 
-  delete m_pTgt->m_pVerts;
+  delete [] m_pTgt->m_pVerts;
   m_pTgt->m_pVerts = pNVerts;
   m_pTgt->m_nVerts = nnverts;
 
-  delete m_pTgt->m_pFaces;
+  delete [] m_pTgt->m_pFaces;
   m_pTgt->m_pFaces = pNFaces;
   m_pTgt->m_nFaces = nnfaces;
   

--- a/src/modules/surface/ElePotMap.cpp
+++ b/src/modules/surface/ElePotMap.cpp
@@ -42,7 +42,7 @@ bool ElePotMap::setMapFloatArray(const float *array,
                                  const Vector4D &origpos)
 {
   if (m_pMap!=NULL)
-    delete [] m_pMap;
+    delete m_pMap;
 
   m_pMap = MB_NEW FloatMap(ncol, nrow, nsect, array);
   MB_DPRINTLN("OK.");
@@ -79,6 +79,8 @@ bool ElePotMap::setMapFloatArray(const float *array,
 
   // map truncation level
   m_dLevelStep = (double)(rhomax - rhomin)/256.0;
+  if (m_dLevelStep<=0.0)
+    m_dLevelStep = 1.0;  // constant map: every voxel maps to byte 0
   m_dLevelBase = rhomin;
   
   LOG_DPRINTLN("ElePot> Minimum: %f", rhomin);
@@ -200,7 +202,7 @@ void ElePotMap::smooth2(double rad)
     for (iy=0; iy<ny; iy++) {
       for (iz=0; iz<nz; iz++) {
         double sum = 0.0;
-        for (jj=-mx; jj<mx; ++jj) {
+        for (jj=-mx; jj<=mx; ++jj) {
           if (!isInBoundary(ix+jj, iy, iz))
             continue;
           sum += m_pMap->at(ix+jj, iy, iz);
@@ -214,7 +216,7 @@ void ElePotMap::smooth2(double rad)
     for (iy=0; iy<ny; iy++) {
       for (iz=0; iz<nz; iz++) {
         double sum = 0.0;
-        for (jj=-my; jj<my; ++jj) {
+        for (jj=-my; jj<=my; ++jj) {
           if (!isInBoundary(ix, iy+jj, iz))
             continue;
           sum += pMap->at(ix, iy+jj, iz);
@@ -228,7 +230,7 @@ void ElePotMap::smooth2(double rad)
     for (iy=0; iy<ny; iy++) {
       for (iz=0; iz<nz; iz++) {
         double sum = 0.0;
-        for (jj=-mz; jj<mz; ++jj) {
+        for (jj=-mz; jj<=mz; ++jj) {
           if (!isInBoundary(ix, iy, iz+jj))
             continue;
           sum += m_pMap->at(ix, iy, iz+jj);

--- a/src/modules/surface/MolSurfRenderer.cpp
+++ b/src/modules/surface/MolSurfRenderer.cpp
@@ -425,7 +425,7 @@ Vector4D MolSurfRenderer::getCenter() const
     v = pSurf->getXformVertAt(i);
     p = v.v3d();
     if (m_pAmap!=NULL) {
-      if (!isShowVert(pos)) {
+      if (!isShowVert(p)) {
         // skip hidden verteces by molsel
         continue;
       }

--- a/src/modules/symm/SymOpDB.cpp
+++ b/src/modules/symm/SymOpDB.cpp
@@ -378,7 +378,11 @@ void SymOpDB::loadSymLibFile()
         continue;
 
       if (m_psgtab->find(nsg)!=m_psgtab->end()) {
+        // keep the first definition; the duplicate's lines are skipped
+        // through pCurSg==NULL below (a second Group would never be
+        // inserted and leak)
         MB_DPRINTLN("SymOpLib Loader: sg %d already exists (ignored)", nsg);
+        continue;
       }
       // m_nMaxSgID = qlib::max<int>(m_nMaxSgID, nsg);
 
@@ -389,7 +393,7 @@ void SymOpDB::loadSymLibFile()
       pCurSg->cname = cname;
     }
     else if (!sline.isEmpty()){
-      if (pCurSg==NULL || ii>pCurSg->nasym) {
+      if (pCurSg==NULL || ii>=pCurSg->nasym) {
         MB_DPRINTLN("SymOpLib Loader: invalid input line: %s", sline.c_str());
         continue;
       }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -165,6 +165,7 @@ add_executable(test_surface
   modules/surface/test_ply_reader.cpp
   modules/surface/test_molsurf_serialize.cpp
   modules/surface/test_ses_from_array.cpp
+  modules/surface/test_elepot_symop_fixes.cpp
 )
 target_include_directories(test_surface PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/surface/test_elepot_symop_fixes.cpp
+++ b/src/tests/modules/surface/test_elepot_symop_fixes.cpp
@@ -1,0 +1,134 @@
+//
+// ElePotMap memory / arithmetic fixes and SymOpDB table parsing.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "surface/ElePotMap.hpp"
+#include "symm/SymOpDB.hpp"
+
+#include <qlib/LString.hpp>
+#include <qlib/Vector4D.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using qlib::LString;
+using qlib::Vector4D;
+using surface::ElePotMap;
+
+namespace {
+
+void setConstMap(ElePotMap &map, int n, float value)
+{
+    std::vector<float> buf(static_cast<size_t>(n) * n * n, value);
+    map.setMapFloatArray(buf.data(), n, n, n, 1.0, 1.0, 1.0, Vector4D());
+}
+
+}  // namespace
+
+// The map is allocated with scalar new but was freed with delete [] when a
+// second array was set on the same object (the dtor uses delete).
+TEST(ElePotMapFixes, SettingTheArrayTwiceKeepsTheHeapIntact)
+{
+    ElePotMap map;
+    setConstMap(map, 2, 1.0f);
+    setConstMap(map, 3, 2.0f);
+    EXPECT_EQ(map.getColNo(), 3);
+    EXPECT_FLOAT_EQ(map.atFloat(1, 1, 1), 2.0f);
+}
+
+// A constant map has no level range; atByte() divided by zero and cast the
+// NaN to unsigned char.
+TEST(ElePotMapFixes, ConstantMapMapsToByteZero)
+{
+    ElePotMap map;
+    setConstMap(map, 2, 5.0f);
+    EXPECT_DOUBLE_EQ(map.atFloat(0, 0, 0), 5.0);
+    EXPECT_EQ(map.atByte(0, 0, 0), 0);
+    EXPECT_EQ(map.atByte(1, 1, 1), 0);
+}
+
+// The box filter used the window [-m, m) but divided by 2m+1, so the result
+// leaned to the low-index side.
+TEST(ElePotMapFixes, SmoothingWindowIsSymmetric)
+{
+    ElePotMap map;
+    std::vector<float> buf(7, 0.0f);
+    buf[3] = 27.0f;  // impulse; three passes each divide by 3
+    map.setMapFloatArray(buf.data(), 7, 1, 1, 1.0, 1.0, 1.0, Vector4D());
+    map.smooth2(1.0);
+
+    EXPECT_NEAR(map.atFloat(3, 0, 0), 1.0, 1e-5);
+    EXPECT_NEAR(map.atFloat(2, 0, 0), 1.0, 1e-5);
+    EXPECT_NEAR(map.atFloat(4, 0, 0), 1.0, 1e-5);
+    EXPECT_NEAR(map.atFloat(1, 0, 0), 0.0, 1e-5);
+    EXPECT_NEAR(map.atFloat(5, 0, 0), 0.0, 1e-5);
+}
+
+namespace {
+
+struct TempSymopFile
+{
+    std::filesystem::path path;
+    explicit TempSymopFile(const std::string &body)
+        : path(std::filesystem::temp_directory_path() / "cuemol_symop_fixes_test.dat")
+    {
+        std::ofstream ofs(path);
+        ofs << body;
+    }
+    ~TempSymopFile()
+    {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
+
+const char *const IDENT_OP =
+    "X,Y,Z\n"
+    "1,0,0,0,1\n"
+    "0,1,0,0,1\n"
+    "0,0,1,0,1\n";
+
+const char *const INV_OP =
+    "-X,-Y,-Z\n"
+    "-1,0,0,0,1\n"
+    "0,-1,0,0,1\n"
+    "0,0,-1,0,1\n";
+
+}  // namespace
+
+// A group that lists more operators than its ASU count wrote pOps[nasym];
+// a second definition of the same number leaked a Group.
+TEST(SymOpDBFixes, ExtraOperatorAndDuplicateGroupAreIgnored)
+{
+    std::string body;
+    body += ">900,1,Q1,Q 1,TRICLINIC\n";
+    body += IDENT_OP;
+    body += "\n";
+    body += INV_OP;  // one more than nasym=1
+    body += "\n";
+    body += ">900,2,QDUP,Q DUP,TRICLINIC\n";  // duplicate number
+    body += IDENT_OP;
+    body += "\n";
+    body += INV_OP;
+    body += "\n";
+    body += ">901,1,Q2,Q 2,TRICLINIC\n";
+    body += IDENT_OP;
+    body += "\n";
+    TempSymopFile f(body);
+
+    symm::SymOpDB db;  // a private table: the singleton needs symm::init()
+    symm::SymOpDB *pdb = &db;
+    pdb->setSymLibFile(LString(f.path.string().c_str()));
+
+    ASSERT_NE(pdb->getCName(900), nullptr);
+    EXPECT_STREQ(pdb->getCName(900), "Q 1");
+    EXPECT_EQ(pdb->getAsymNum(900), 1);
+    ASSERT_NE(pdb->getCName(901), nullptr);
+    EXPECT_STREQ(pdb->getCName(901), "Q 2");
+    EXPECT_EQ(pdb->getCName(902), nullptr);
+}


### PR DESCRIPTION
## Summary

Part 17 of the libcuemol2 bug-audit fixes (Phase 4: memory / logic, surface + symm). Independent of the other PRs.

### `ElePotMap` (surface 4, 15)

- `setMapFloatArray()` freed the previous `FloatMap` with `delete []` although it is allocated with scalar `new` (the destructor and `smooth2()` use `delete`); the second array set on the same object corrupted the heap.
- `atByte()` divided by a level step of 0 for a constant map and cast the NaN to `unsigned char`. The step is 1 in that case, so every voxel maps to byte 0.
- `smooth2()` summed the window `[-m, m)` but divided by `2m+1`, shifting the smoothed map towards the low indices.

### `CutByPlane` / `CutByPlane2` (surface 9, 11)

- The `new[]` vertex / face arrays of the target surface were freed with `delete`.
- `CutByPlane::doit()` walked the crossing list in pairs after rejecting only sizes 0 and 1; a boundary vertex exactly on the sampling line gives an odd count and the walk dereferenced `end()`.

### `MolSurfRenderer::getCenter()` (surface 14)

Tested the running sum `pos` instead of the current vertex `p` against the selection.

### `SymOpDB::loadSymLibFile()` (surface 12)

Accepted one operator line more than the group's ASU count (`ii>nasym`) and wrote `pOps[nasym]`; a duplicate group number created a second `Group` that was never inserted and leaked. The bundled `symop.dat` triggers neither.

## Tests

`tests/modules/surface/test_elepot_symop_fixes.cpp` (4 cases): setting the array twice, a constant map, a 1-D impulse through `smooth2()` (symmetric result), and a private `SymOpDB` loaded from a table with an extra operator line and a duplicate group. Against the old code the first case aborts in `free()` and the smoothing case fails; the constant-map and symop cases pin the new behaviour but happen to pass on the old code on arm64 (the NaN cast yields 0 there, and the one-element overrun is not observable). The cut-by-plane and center changes are one-token fixes without a dedicated test (they need a rendered surface).

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
