### PR TITLE
fix(molvis,molstr): ring pivot atom, table leaks, selection state, residue ranges

### DIFF
--- a/src/modules/molstr/AtomPosMap.cpp
+++ b/src/modules/molstr/AtomPosMap.cpp
@@ -48,6 +48,9 @@ void AtomPosMap::generate(SelectionPtr pSel)
 {
   MB_ASSERT(!m_pMol.isnull());
   if (m_pMap!=NULL) {
+    const int nsize = m_pMap->size();
+    for (int i=0; i<nsize; ++i)
+      delete (*m_pMap)[i];
     delete m_pMap;
     m_pMap = NULL;
   }

--- a/src/modules/molstr/MolCoord.cpp
+++ b/src/modules/molstr/MolCoord.cpp
@@ -439,6 +439,19 @@ MolBond *MolCoord::makeBond(int aaid1, int aaid2, bool bPersist /*=false*/)
   return pB;
 }
 
+namespace {
+  /// Drop pBond from the bond lists of its atoms (either atom may be gone)
+  void detachBond(MolCoord *pMol, MolBond *pBond)
+  {
+    MolAtomPtr pA1 = pMol->getAtom(pBond->getAtom1());
+    if (!pA1.isnull())
+      pA1->removeBond(pBond);
+    MolAtomPtr pA2 = pMol->getAtom(pBond->getAtom2());
+    if (!pA2.isnull())
+      pA2->removeBond(pBond);
+  }
+}
+
 bool MolCoord::removeBond(int aaid1, int aaid2)
 {
   BondPool::iterator iter = m_bondPool.begin();
@@ -455,7 +468,11 @@ bool MolCoord::removeBond(int aaid1, int aaid2)
   if (iter==iend)
     return false;
 
-  delete iter->second;
+  // the atoms must not keep a pointer to the deleted bond
+  // (makeBond() looks bonds up through MolAtom::getBond())
+  MolBond *pBond = iter->second;
+  detachBond(this, pBond);
+  delete pBond;
   m_bondPool.erase(iter);
   return true;
 }
@@ -472,20 +489,19 @@ void MolCoord::removeNonpersBonds()
     MolAtomPtr pA1 = getAtom(aid1);
     MolAtomPtr pA2 = getAtom(aid2);
 
-    if (pBond->isPersist()){
-      if (!pA1.isnull() && !pA2.isnull())
-        pers.push_back(pBond); // reserve presistent & valid bond
-      else
-        delete pBond; // remove persistent but orphan bond
+    // keep persistent bonds whose atoms both still exist
+    if (pBond->isPersist() && !pA1.isnull() && !pA2.isnull()) {
+      pers.push_back(pBond);
+      continue;
     }
-    else {
-      // remove non-persistent bond
-      if (!pA1.isnull())
-        pA1->removeBond(pBond);
-      if (!pA2.isnull())
-        pA2->removeBond(pBond);
-      delete pBond;
-    }
+
+    // non-persistent, or persistent but orphaned by removeAtom():
+    // the surviving atoms must not keep a pointer to the deleted bond
+    if (!pA1.isnull())
+      pA1->removeBond(pBond);
+    if (!pA2.isnull())
+      pA2->removeBond(pBond);
+    delete pBond;
   }
 
   m_bondPool.clear();

--- a/src/modules/molstr/ResidRangeSet.cpp
+++ b/src/modules/molstr/ResidRangeSet.cpp
@@ -49,6 +49,18 @@ void ResidRangeSet::append(MolCoordPtr pMol, SelectionPtr pSel)
   MB_DPRINTLN("ResidRngSet.append> result=%s", toString().c_str());
 }
 
+namespace {
+
+// Exclusive end of the one-residue range [resid, next).
+inline ResidIndex nextResidIndex(const ResidIndex &resid)
+{
+  if (resid.second=='\0')
+    return ResidIndex(resid.first+1);
+  return ResidIndex(resid.first, resid.second+1);
+}
+
+}  // namespace
+
 void ResidRangeSet::append(MolResiduePtr pRes)
 {
   LString chname = pRes->getChainName();
@@ -59,10 +71,7 @@ void ResidRangeSet::append(MolResiduePtr pRes)
     m_data.set(chname, pRng);
   }
 
-  // XXX:
-  ResidIndex resid_plus1;
-  resid_plus1.first = resid.first+1;
-  resid_plus1.second = resid.second;
+  const ResidIndex resid_plus1 = nextResidIndex(resid);
   
   pRng->append(resid, resid_plus1);
 }
@@ -85,10 +94,10 @@ void ResidRangeSet::remove(MolCoordPtr pMol, SelectionPtr pSel)
       m_data.set(chname, pRng);
     }
 
-    // XXX:
-    ResidIndex resid_plus1;
-    resid_plus1.first = resid.first+1;
-    resid_plus1.second = resid.second;
+    // The range end is the next index. A residue without insertion code
+    // keeps (n+1, 0) so that consecutive residues merge into "n-m";
+    // (10,'A') used (11,'A') and thereby also covered 10B, 10C and 11.
+    const ResidIndex resid_plus1 = nextResidIndex(resid);
 
     pRng->remove(resid, resid_plus1);
   }

--- a/src/modules/molstr/SelCommand.cpp
+++ b/src/modules/molstr/SelCommand.cpp
@@ -175,18 +175,21 @@ int SelCommand::isSelectedMol(MolCoordPtr pmol)
   //return SEL_NONE;
   //MolCoord *pmol = (MolCoord *)pobj;
   
-  int nsel=0, nchs=0;
+  int nsel=0, npart=0, nchs=0;
   MolCoord::ChainIter iter = pmol->begin();
   for (; iter!=pmol->end(); ++iter) {
     MolChainPtr pCh = iter->second;
-    if (isSelectedChain(pCh))
+    const int nst = isSelectedChain(pCh);
+    if (nst==SEL_ALL)
       nsel++;
+    else if (nst==SEL_PART)
+      npart++;
     nchs ++;
   }
 
   if (nsel==nchs)
     return SEL_ALL;
-  else if (nsel==0)
+  else if (nsel==0 && npart==0)
     return SEL_NONE;
   else
     return SEL_PART;
@@ -198,20 +201,24 @@ int SelCommand::isSelectedChain(MolChainPtr pCh)
     return true;
 
   MolChain::ResidCursor riter = pCh->begin();
-  int nsel=0, nresid=0;
+  int nsel=0, npart=0, nresid=0;
   for ( ; riter!=pCh->end(); riter++) {
     MolResiduePtr pRes = *riter;
     if (pRes.isnull())
       continue;
       
-    if (isSelectedResid(pRes))
+    // SEL_PART is non-zero: it used to count as fully selected
+    const int nst = isSelectedResid(pRes);
+    if (nst==SEL_ALL)
       nsel++;
+    else if (nst==SEL_PART)
+      npart++;
     nresid++;
   }
 
   if (nsel==nresid)
     return SEL_ALL;
-  else if (nsel==0)
+  else if (nsel==0 && npart==0)
     return SEL_NONE;
   else
     return SEL_PART;

--- a/src/modules/molvis/AnIsoURenderer.cpp
+++ b/src/modules/molvis/AnIsoURenderer.cpp
@@ -65,6 +65,7 @@ void AnIsoURenderer::buildSphrTab()
 
   double thdel = M_PI/2.0/double(ndet);
 
+  delete m_pSphrTab;
   m_pSphrTab = MB_NEW std::valarray<double>((ndet+1)*2);
   
   for (j=0; j<=ndet; ++j) {

--- a/src/modules/molvis/BallStickRenderer.cpp
+++ b/src/modules/molvis/BallStickRenderer.cpp
@@ -9,6 +9,8 @@
 
 #include "BallStickRenderer.hpp"
 
+#include <vector>
+
 #include <modules/molstr/MolCoord.hpp>
 #include <modules/molstr/MolChain.hpp>
 #include <modules/molstr/MolResidue.hpp>
@@ -366,7 +368,7 @@ void BallStickRenderer::drawRings(DisplayContext *pdl)
       for (j=0; j<pmembs->size(); j++) {
         LString nm = pmembs->at(j);
         int maid = pres->getAtomID(nm);
-        if (maid<=0) {
+        if (maid<0) {
           fcompl = false;
           break;
         }
@@ -396,7 +398,7 @@ void BallStickRenderer::drawRings(DisplayContext *pdl)
       for (j=0; j<pmembs->size(); j++) {
         LString nm = pmembs->at(j);
         int maid = pres->getAtomID(nm);
-        if (maid<=0)
+        if (maid<0)
           continue;
 
         std::set<int>::iterator miter = m_atoms.find(maid);
@@ -416,13 +418,14 @@ void BallStickRenderer::drawRingImpl(const std::list<int> atoms, DisplayContext 
 
   double len;
   int i, nsize = atoms.size();
-  Vector4D *pvecs = MB_NEW Vector4D[nsize];
+  if (nsize<3) return;
+  std::vector<Vector4D> pvecs(nsize);
   Vector4D cen;
   std::list<int>::const_iterator iter = atoms.begin();
   std::list<int>::const_iterator eiter = atoms.end();
   MolAtomPtr pPivAtom, pAtom;
   for (i=0; iter!=eiter; ++iter, i++) {
-    MolAtomPtr pAtom = pMol->getAtom(*iter);
+    pAtom = pMol->getAtom(*iter);
     if (pAtom.isnull()) return;
     MolResiduePtr pres = pAtom->getParentResidue();
     MolChainPtr pch = pAtom->getParentChain();
@@ -480,9 +483,6 @@ void BallStickRenderer::drawRingImpl(const std::list<int> atoms, DisplayContext 
   }
   pdl->end();
   pdl->setPolygonMode(gfx::DisplayContext::POLY_FILL);
-
-  delete [] pvecs;
-
 }
 
 void BallStickRenderer::propChanged(qlib::LPropEvent &ev)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(test_molstr
   modules/molstr/test_molresidue.cpp
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
+  modules/molstr/test_molcoord_bond.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp
@@ -133,6 +134,9 @@ target_include_directories(test_molstr PRIVATE
   ${CMAKE_SOURCE_DIR}/src/modules
   ${CMAKE_BINARY_DIR}/src
   ${Boost_INCLUDE_DIRS}
+)
+target_compile_definitions(test_molstr PRIVATE
+  CUEMOL2_SYSCONFIG_PATH="${CMAKE_SOURCE_DIR}/data/sysconfig.xml"
 )
 target_link_libraries(test_molstr PRIVATE molstr qsys gfx qlib Boost::filesystem GTest::gtest)
 if (BUILD_OPENGL_SYSDEP)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(test_molstr
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
   modules/molstr/test_molcoord_bond.cpp
+  modules/molstr/test_selstate_ranges.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp

--- a/src/tests/modules/molstr/test_main.cpp
+++ b/src/tests/modules/molstr/test_main.cpp
@@ -2,25 +2,23 @@
 #include <common.h>
 #include "qlib/qlib.hpp"
 #include "qsys/qsys.hpp"
-#include "qsys/style/StyleMgr.hpp"
-#include "qsys/RendererFactory.hpp"
-#include "qsys/StreamManager.hpp"
-#include "molstr/ElemSym.hpp"
-#include "molstr/SelCompiler.hpp"
 
+namespace molstr {
+extern bool init();
+extern void fini();
+}
+
+// Same setup as the molvis/molanl suites: molstr::init() registers the
+// scriptable classes (MolCoord etc.), so objects can be constructed in tests.
 class MolstrEnvironment : public ::testing::Environment {
 public:
     void SetUp() override {
         qlib::init();
-        qsys::init("");
-        qsys::StyleMgr::init();
-        qsys::RendererFactory::init();
-        molstr::ElemSym::init();
-        molstr::SelCompiler::init();
+        qsys::init(CUEMOL2_SYSCONFIG_PATH);
+        molstr::init();
     }
     void TearDown() override {
-        molstr::SelCompiler::fini();
-        molstr::ElemSym::fini();
+        molstr::fini();
         qsys::fini();
         qlib::fini();
     }

--- a/src/tests/modules/molstr/test_molcoord_bond.cpp
+++ b/src/tests/modules/molstr/test_molcoord_bond.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/MolBond.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolBond;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, const char *name, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(1));
+    pAtom->setName(name);
+    pAtom->setElementName("C");
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+// One residue with three carbon atoms and no bonds.
+struct ThreeAtoms
+{
+    MolCoordPtr pMol;
+    int a, b, c;
+
+    ThreeAtoms() : pMol(MB_NEW MolCoord())
+    {
+        a = addAtom(pMol, "C1", 0.0);
+        b = addAtom(pMol, "C2", 1.5);
+        c = addAtom(pMol, "C3", 3.0);
+    }
+};
+
+}  // namespace
+
+TEST(MolCoordBond, RemoveBondDetachesBothAtoms)
+{
+    ThreeAtoms m;
+    ASSERT_NE(m.pMol->makeBond(m.a, m.b, true), nullptr);
+    ASSERT_TRUE(m.pMol->getAtom(m.a)->isBonded(m.b));
+
+    ASSERT_TRUE(m.pMol->removeBond(m.a, m.b));
+
+    // Neither atom may keep a pointer to the deleted bond.
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), nullptr);
+    EXPECT_FALSE(m.pMol->getAtom(m.b)->isBonded(m.a));
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+}
+
+TEST(MolCoordBond, MakeBondAfterRemoveCreatesFreshBond)
+{
+    // Undo of MolAnlManager::removeBond: makeBond() first looks the pair up
+    // through MolAtom::getBond(), which must not find the deleted bond.
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b, true);
+    ASSERT_TRUE(m.pMol->removeBond(m.a, m.b));
+
+    MolBond *pBond = m.pMol->makeBond(m.a, m.b, true);
+    ASSERT_NE(pBond, nullptr);
+    EXPECT_TRUE(pBond->isPersist());
+    EXPECT_EQ(m.pMol->getBondSize(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), pBond);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBond(m.a), pBond);
+}
+
+TEST(MolCoordBond, RemoveBondAcceptsReversedIdsAndRejectsUnknownPair)
+{
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b);
+    EXPECT_FALSE(m.pMol->removeBond(m.a, m.c));
+    EXPECT_TRUE(m.pMol->removeBond(m.b, m.a));
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+}
+
+TEST(MolCoordBond, RemoveNonpersBondsDropsOrphanPersistentBondFromSurvivor)
+{
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b, true);   // persistent (SSBOND/LINK style)
+    m.pMol->makeBond(m.b, m.c, false);  // non-persistent (topology)
+
+    // removeAtom() leaves the bonds in place; applyTopology() cleans them up
+    // through removeNonpersBonds().
+    ASSERT_TRUE(m.pMol->removeAtom(m.b));
+    m.pMol->removeNonpersBonds();
+
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.c)->getBondCount(), 0);
+
+    // The survivors can be bonded again without tripping over stale pointers.
+    ASSERT_NE(m.pMol->makeBond(m.a, m.c, true), nullptr);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 1);
+}
+
+TEST(MolCoordBond, RemoveNonpersBondsKeepsValidPersistentBond)
+{
+    ThreeAtoms m;
+    MolBond *pPers = m.pMol->makeBond(m.a, m.b, true);
+    m.pMol->makeBond(m.b, m.c, false);
+
+    m.pMol->removeNonpersBonds();
+
+    EXPECT_EQ(m.pMol->getBondSize(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), pPers);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBondCount(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.c)->getBondCount(), 0);
+}

--- a/src/tests/modules/molstr/test_selstate_ranges.cpp
+++ b/src/tests/modules/molstr/test_selstate_ranges.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolChain.hpp"
+#include "molstr/MolResidue.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/SelCommand.hpp"
+#include "molstr/Selection.hpp"
+#include "molstr/ResidRangeSet.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::MolResiduePtr;
+using molstr::ResidIndex;
+using molstr::ResidRangeSet;
+using molstr::SelCommand;
+using molstr::Selection;
+using qlib::LString;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, const char *name, const ResidIndex &resid, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(resid);
+    pAtom->setName(name);
+    pAtom->setElementName("C");
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+}  // namespace
+
+// isSelectedResid() returns SEL_PART (2) for a residue with some atoms
+// selected; isSelectedChain()/isSelectedMol() used it as a bool and reported
+// the chain / molecule as fully selected.
+TEST(SelCommandState, PartiallySelectedResidueMakesChainPartial)
+{
+    // copies: the in-class constants have no out-of-line definition to bind to
+    const int kNone = Selection::SEL_NONE;
+    const int kAll = Selection::SEL_ALL;
+    const int kPart = Selection::SEL_PART;
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    addAtom(pMol, "C1", ResidIndex(1), 0.0);
+    addAtom(pMol, "C2", ResidIndex(1), 1.5);
+    molstr::MolChainPtr pCh = pMol->getChain("A");
+    ASSERT_FALSE(pCh.isnull());
+
+    SelCommand selOne("name C1");
+    EXPECT_EQ(selOne.isSelectedChain(pCh), kPart);
+    EXPECT_EQ(selOne.isSelectedMol(pMol), kPart);
+
+    SelCommand selAll("all");
+    EXPECT_EQ(selAll.isSelectedChain(pCh), kAll);
+    EXPECT_EQ(selAll.isSelectedMol(pMol), kAll);
+
+    SelCommand selNone("name XX");
+    EXPECT_EQ(selNone.isSelectedChain(pCh), kNone);
+    EXPECT_EQ(selNone.isSelectedMol(pMol), kNone);
+}
+
+// The one-residue range of 10A ended at 11A and therefore also covered
+// 10B and 11; residues without an insertion code keep the (n+1) end so
+// that consecutive residues still merge.
+TEST(ResidRangeSetTest, InsertionCodeResidueCoversOnlyItself)
+{
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    addAtom(pMol, "C1", ResidIndex(10, 'A'), 0.0);
+    addAtom(pMol, "C1", ResidIndex(10, 'B'), 1.0);
+    addAtom(pMol, "C1", ResidIndex(11), 2.0);
+    addAtom(pMol, "C1", ResidIndex(12), 3.0);
+    MolResiduePtr p10A = pMol->getResidue("A", ResidIndex(10, 'A'));
+    MolResiduePtr p10B = pMol->getResidue("A", ResidIndex(10, 'B'));
+    MolResiduePtr p11 = pMol->getResidue("A", ResidIndex(11));
+    MolResiduePtr p12 = pMol->getResidue("A", ResidIndex(12));
+    ASSERT_FALSE(p10A.isnull());
+    ASSERT_FALSE(p10B.isnull());
+    ASSERT_FALSE(p11.isnull());
+    ASSERT_FALSE(p12.isnull());
+
+    ResidRangeSet rs;
+    rs.append(p10A);
+    EXPECT_TRUE(rs.contains(p10A));
+    EXPECT_FALSE(rs.contains(p10B));
+    EXPECT_FALSE(rs.contains(p11));
+
+    ResidRangeSet rs2;
+    rs2.append(p11);
+    rs2.append(p12);
+    EXPECT_TRUE(rs2.contains(p11));
+    EXPECT_TRUE(rs2.contains(p12));
+    EXPECT_FALSE(rs2.contains(p10B));
+    // consecutive plain residues still merge into one range
+    EXPECT_TRUE(rs2.toString().indexOf("11-12") >= 0 || rs2.toString().indexOf("11:12") >= 0)
+        << rs2.toString().c_str();
+}


### PR DESCRIPTION
## Summary

Part 18 of the libcuemol2 bug-audit fixes (Phase 4: molvis / molstr). Stacked on #553 (`fix/molstr-bond-lifetime`) for the molstr test environment; otherwise independent.

### `BallStickRenderer` (molvis 2, 8, 9)

- `drawRingImpl()` declared a second `pAtom` inside the atom loop, shadowing the one the "no carbon in the ring: last atom becomes the pivot" fallback reads, so a ring without carbon passed a null pointer to `ColSchmHolder::getColor()`.
- The per-ring vertex array leaked on every early return; it is a `std::vector` now.
- The ring completeness check treated atom ID 0 as missing (`maid<=0`; `getAtomID()` reports a missing atom as -1), so a ring containing the first atom of the molecule was never drawn.

### Leaks (molvis 7, molstr 15)

`AnIsoURenderer::buildSphrTab()` allocated a new table on every detail change without freeing the old one. `AtomPosMap::generate()` freed the cell array but not the per-cell lists (the destructor does).

### `SelCommand::isSelectedChain/Mol` (molstr 9)

Used the tri-state result of `isSelectedResid()` as a bool, so a chain with one partially selected residue was reported as `SEL_ALL`. Partial residues / chains now yield `SEL_PART`.

### `ResidRangeSet` (molstr 14)

`append()`/`remove()` ended the one-residue range of `10A` at `11A`, which also covers `10B`, `10C` and `11`. A residue with an insertion code now ends at the next code; residues without one keep the `(n+1)` end so that consecutive residues still merge into `n-m`.

## Tests

`tests/modules/molstr/test_selstate_ranges.cpp` (2 cases): a two-atom residue with one atom selected reports `SEL_PART` for chain and molecule; a range built from `10A` does not contain `10B` / `11`, and `11` + `12` still merge. The renderer changes need a display context and have no dedicated test.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
