### PR TITLE
fix(qlib,qsys): range removal, Jacobi helper, string helpers, command UID, stream leaks

### DIFF
--- a/src/qlib/LDOM2Stream.cpp
+++ b/src/qlib/LDOM2Stream.cpp
@@ -440,7 +440,7 @@ void LDom2InStream::closeChunkStream(qlib::InStream *pin)
   FilterInStream<ChunkFilterImpl> *pcf =
     dynamic_cast<FilterInStream<ChunkFilterImpl> *>(pin);
 
-  if (pin==NULL) {
+  if (pcf==NULL) {
     MB_THROW(InvalidCastException, "LDom2InStream::closeChunkStream");
     return;
   }

--- a/src/qlib/LString.cpp
+++ b/src/qlib/LString.cpp
@@ -42,10 +42,14 @@ int LString::replace(char c, char to)
 
 int LString::replace(const LString &c, const LString &to)
 {
-    int i = 0, cnt = 0;
-    int nlen = c.length();
+    size_t i = 0;
+    int cnt = 0;
+    const size_t nlen = c.length();
+    if (nlen == 0) return 0;  // an empty pattern would match forever
     while ((i = m_data.find(c, i)) != std::string::npos) {
         m_data.replace(i, nlen, to);
+        // continue after the replacement, or "a" -> "aa" never terminates
+        i += to.length();
         ++cnt;
     }
     return cnt;
@@ -288,6 +292,7 @@ QLIB_API LString LString::fromReal(LReal value, int nMaxDigit /*=6*/)
     LString rval = LString::format(sbuf, value);
 
     // Remove trailing 0 after the decimal point
+    if (rval.indexOf('.') < 0) return rval;  // "100" with nMaxDigit==0
     char c;
     int nlen = rval.length();
     int i = nlen - 1;

--- a/src/qlib/LUnicode.cpp
+++ b/src/qlib/LUnicode.cpp
@@ -140,9 +140,9 @@ void qlib::UCS16toUTF8(const U16Char *ucs16, int nwclen, LString &utf8)
     unsigned int c = (unsigned int) ucs16[i];
     if (c==0)
       break;
-    else if (c<0x7F)
+    else if (c<=0x7F)
       utf8 += (char)c;
-    else if (c<0x7FF) {
+    else if (c<=0x7FF) {
       unsigned int c1 = c >> 6;
       unsigned int c2 = c & 0x3F;
       utf8 += char(c1 + 0xC0);

--- a/src/qlib/MatrixHelper.cpp
+++ b/src/qlib/MatrixHelper.cpp
@@ -17,7 +17,8 @@ namespace {
                           double &t, double &s, double &c)
   {
     if (isNear8(a_pq, 0.0)) {
-      t = a_pq/(a_qq - a_pp);
+      // nothing to rotate; a_pq/(a_qq-a_pp) was 0/0 for equal diagonals
+      t = 0.0;
     }
     else {
       double th = (a_qq - a_pp)/(2.0*a_pq);

--- a/src/qlib/PosixProcImpl.hpp
+++ b/src/qlib/PosixProcImpl.hpp
@@ -10,6 +10,8 @@
 
 #include "LRegExpr.hpp"
 
+#include <vector>
+
 #define HAVE_POSIX_SPAWN 1
 
 #ifdef HAVE_SPAWN_H
@@ -199,7 +201,8 @@ public:
         const char *prog_path = path.c_str();
         // char *const prog_argv[] = {(char *)prog_path, (char*)"-la", NULL};
         int nargs = vargs.size();
-        const char **prog_argv = new const char *[nargs + 2];
+        std::vector<const char *> argv_buf(nargs + 2);
+        const char **prog_argv = argv_buf.data();
         prog_argv[0] = prog_path;
         for (int i = 0; i < nargs; ++i) {
             prog_argv[i + 1] = vargs[i].c_str();

--- a/src/qlib/RangeSet.hpp
+++ b/src/qlib/RangeSet.hpp
@@ -247,8 +247,9 @@ public:
             }
             if (res == 0) {
                 // nr overwraps with tg
-                if (nr.includes(tg) || nr.equals(tg)) {
-                    // nr includes or equals tg --> remove tg
+                // includes() is strict: [5,10) was not removed by remove(0,10)
+                if (nr.contains(tg)) {
+                    // nr covers tg --> remove tg
                     iter2 = iter;
                     ++iter;
                     m_data.erase(iter2);

--- a/src/qsys/ObjReader.cpp
+++ b/src/qsys/ObjReader.cpp
@@ -5,6 +5,7 @@
 // $Id: ObjReader.cpp,v 1.6 2011/01/03 16:47:05 rishitani Exp $
 
 #include <common.h>
+#include <memory>
 
 #include "ObjReader.hpp"
 #include <qlib/FileStream.hpp>
@@ -65,27 +66,27 @@ void ObjReader::read2(qlib::InStream &ins)
 {
   qlib::InStream *pIn = &ins;
   qlib::InStream *pTIn = pIn;
-  qlib::InStream *pB64In = NULL;
-  qlib::InStream *pZIn = NULL;
+  std::unique_ptr<qlib::InStream> pB64In;  // freed on the exception paths of read() too
+  std::unique_ptr<qlib::InStream> pZIn;
 
   bool bb64 = getBase64Flag();
   int ncomp = getCompressMode();
 
   if (bb64) {
-    pB64In = new qlib::Base64InStream(*pTIn);
-    pTIn = pB64In;
+    pB64In.reset(new qlib::Base64InStream(*pTIn));
+    pTIn = pB64In.get();
   }
   
   if (ncomp==COMP_NONE) {
   }
   else if (ncomp==COMP_GZIP) {
-    pZIn = new qlib::GzipInStream(*pTIn);
-    pTIn = pZIn;
+    pZIn.reset(new qlib::GzipInStream(*pTIn));
+    pTIn = pZIn.get();
   }
 #ifdef HAVE_LZMA_H
   else if (ncomp==COMP_XZIP) {
-    pZIn = new qlib::XzInStream(*pTIn);
-    pTIn = pZIn;
+    pZIn.reset(new qlib::XzInStream(*pTIn));
+    pTIn = pZIn.get();
   }
 #endif
   else {
@@ -100,12 +101,10 @@ void ObjReader::read2(qlib::InStream &ins)
 
   if (pZIn) {
     pZIn->close();
-    delete pZIn;
   }
 
   if (pB64In) {
     pB64In->close();
-    delete pB64In;
   }
   
 }

--- a/src/qsys/ObjWriter.cpp
+++ b/src/qsys/ObjWriter.cpp
@@ -5,6 +5,7 @@
 // $Id: ObjWriter.cpp,v 1.4 2011/01/03 16:47:05 rishitani Exp $
 
 #include <common.h>
+#include <memory>
 
 #include "ObjWriter.hpp"
 #include <qlib/ClassRegistry.hpp>
@@ -51,27 +52,27 @@ ObjectPtr ObjWriter::detach()
 void ObjWriter::write2(qlib::OutStream &outs)
 {
   qlib::OutStream *pOut = &outs;
-  qlib::OutStream *pB64O = NULL;
-  qlib::OutStream *pZOut = NULL;
+  std::unique_ptr<qlib::OutStream> pB64O;  // freed on the exception paths of write() too
+  std::unique_ptr<qlib::OutStream> pZOut;
 
   qlib::OutStream *pTOut = pOut;
   
   if (getBase64Flag()) {
-    pB64O = new qlib::Base64OutStream(*pOut);
-    pTOut = pB64O;
+    pB64O.reset(new qlib::Base64OutStream(*pOut));
+    pTOut = pB64O.get();
   }
   
   int ncomp = getCompressMode();
   if (ncomp==COMP_NONE) {
   }
   else if (ncomp==COMP_GZIP) {
-    pZOut = new qlib::GzipOutStream(*pTOut);
-    pTOut = pZOut;
+    pZOut.reset(new qlib::GzipOutStream(*pTOut));
+    pTOut = pZOut.get();
   }
 #ifdef HAVE_LZMA_H
   else if (ncomp==COMP_XZIP) {
-    pZOut = new qlib::XzOutStream(*pTOut);
-    pTOut = pZOut;
+    pZOut.reset(new qlib::XzOutStream(*pTOut));
+    pTOut = pZOut.get();
   }
 #endif
   else {
@@ -86,12 +87,10 @@ void ObjWriter::write2(qlib::OutStream &outs)
   
   if (pZOut) {
     pZOut->close();
-    delete pZOut;
   }
 
   if (pB64O) {
     pB64O->close();
-    delete pB64O;
   }
   
   return;

--- a/src/qsys/command/Command.cpp
+++ b/src/qsys/command/Command.cpp
@@ -11,6 +11,20 @@ Command::Command()
     m_uid = qlib::ObjectManager::sRegObj(this);
 }
 
+Command::Command(const Command &r) : qlib::LSimpleCopyScrObject(r), qlib::LUIDObject(r)
+{
+    // CmdMgr::getCmd() hands out copies of the registered template; the
+    // implicit copy shared the UID and the copy's destructor unregistered
+    // the template
+    m_uid = qlib::ObjectManager::sRegObj(this);
+}
+
+Command &Command::operator=(const Command &r)
+{
+    if (&r != this) qlib::LSimpleCopyScrObject::operator=(r);
+    return *this;  // keeps its own UID
+}
+
 Command::~Command()
 {
     qlib::ObjectManager::sUnregObj(m_uid);

--- a/src/qsys/command/Command.hpp
+++ b/src/qsys/command/Command.hpp
@@ -20,6 +20,8 @@ private:
 
 public:
     Command();
+    Command(const Command &r);
+    Command &operator=(const Command &r);
     ~Command() override;
 
     /// Execute the command

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(test_qlib
   qlib/test_parallel.cpp
   qlib/test_chunked_array3d.cpp
   qlib/test_seekable_stream.cpp
+  qlib/test_small_logic.cpp
 )
 target_include_directories(test_qlib PRIVATE
   ${CMAKE_SOURCE_DIR}/src
@@ -74,6 +75,7 @@ add_executable(test_qsys
   qsys/test_editinfo.cpp
   qsys/test_sysconfig.cpp
   qsys/test_undomanager.cpp
+  qsys/test_command_copy.cpp
   qsys/test_multigradient.cpp
   qsys/test_propeditinfo.cpp
   qsys/test_viewinputconfig.cpp

--- a/src/tests/qlib/test_small_logic.cpp
+++ b/src/tests/qlib/test_small_logic.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qlib/LString.hpp"
+#include "qlib/LScrRangeSet.hpp"
+#include "qlib/Matrix3D.hpp"
+#include "qlib/Vector4D.hpp"
+#include "qlib/LUnicode.hpp"
+
+#include <cmath>
+
+using qlib::LString;
+using qlib::LScrRangeSet;
+using qlib::Matrix3D;
+using qlib::Vector4D;
+
+// remove() only dropped an element that the removed range strictly
+// included or equalled; a range sharing one end left it in place.
+TEST(RangeSetRemove, RangeSharingAnEndRemovesTheElement)
+{
+    LScrRangeSet rs = LScrRangeSet().scr_appendInt(5, 10);
+    EXPECT_TRUE(rs.scr_removeInt(0, 10).isEmpty());
+    EXPECT_TRUE(rs.scr_removeInt(5, 12).isEmpty());
+    EXPECT_TRUE(rs.scr_removeInt(5, 10).isEmpty());
+    EXPECT_TRUE(rs.scr_removeInt(0, 12).isEmpty());
+    // partial overlaps still trim
+    EXPECT_TRUE(rs.scr_removeInt(0, 7).toString().equals("7:9"));
+    EXPECT_TRUE(rs.scr_removeInt(8, 12).toString().equals("5:7"));
+}
+
+// replace() did not advance past the replacement, so a replacement that
+// contains the pattern looped forever.
+TEST(LStringReplace, ReplacementContainingThePatternTerminates)
+{
+    LString s("banana");
+    EXPECT_EQ(s.replace("a", "aa"), 3);
+    EXPECT_TRUE(s.equals("baanaanaa"));
+
+    LString t("abc");
+    EXPECT_EQ(t.replace("", "x"), 0);
+    EXPECT_TRUE(t.equals("abc"));
+
+    LString u("a.b.c");
+    EXPECT_EQ(u.replace(".", ""), 2);
+    EXPECT_TRUE(u.equals("abc"));
+}
+
+// fromReal(v, 0) has no decimal point, yet the trailing-zero trimming
+// turned "100" into "1".
+TEST(LStringFromReal, ZeroDigitsKeepsIntegerZeros)
+{
+    EXPECT_TRUE(LString::fromReal(100.0, 0).equals("100"));
+    EXPECT_TRUE(LString::fromReal(1.5, 3).equals("1.5"));
+    EXPECT_TRUE(LString::fromReal(2.0, 3).equals("2"));
+}
+
+// diag_helper() computed 0/0 for a zero off-diagonal element with equal
+// diagonals, so diagonalizing (even) the identity gave NaN.
+TEST(Matrix3DDiag, IdentityDiagonalizesToFiniteEigenvalues)
+{
+    Matrix3D ident;  // identity by default
+    // a tiny off-diagonal element with equal diagonals takes the isNear8()
+    // branch: t = a_pq / (a_qq - a_pp) = 1e-10 / 0
+    ident.aij(1, 2) = 1e-10;
+    ident.aij(2, 1) = 1e-10;
+    Matrix3D evecs;
+    Vector4D evals;
+    ASSERT_TRUE(ident.diag(evecs, evals));
+    EXPECT_TRUE(std::isfinite(evals.x()));
+    EXPECT_TRUE(std::isfinite(evals.y()));
+    EXPECT_TRUE(std::isfinite(evals.z()));
+    EXPECT_NEAR(evals.x(), 1.0, 1e-9);
+    EXPECT_NEAR(evals.y(), 1.0, 1e-9);
+    EXPECT_NEAR(evals.z(), 1.0, 1e-9);
+}
+
+// 0x7F still fits one byte and 0x7FF two; the boundaries produced overlong
+// encodings.
+TEST(LUnicode, UCS16toUTF8BoundariesAreNotOverlong)
+{
+    const U16Char in[3] = {0x7F, 0x7FF, 0x800};
+    LString out;
+    qlib::UCS16toUTF8(in, 3, out);
+    ASSERT_EQ(out.length(), 1 + 2 + 3);
+    EXPECT_EQ((unsigned char)out.getAt(0), 0x7Fu);
+    EXPECT_EQ((unsigned char)out.getAt(1), 0xDFu);
+    EXPECT_EQ((unsigned char)out.getAt(2), 0xBFu);
+    EXPECT_EQ((unsigned char)out.getAt(3), 0xE0u);
+}

--- a/src/tests/qsys/test_command_copy.cpp
+++ b/src/tests/qsys/test_command_copy.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qsys/command/Command.hpp"
+#include <qlib/ObjectManager.hpp>
+
+namespace {
+
+class NopCommand : public qsys::Command
+{
+public:
+    void run() override {}
+    void runGUI(void *) override {}
+    const char *getName() const override { return "nop"; }
+    qlib::LCloneableObject *clone() const override { return new NopCommand(*this); }
+};
+
+}  // namespace
+
+// CmdMgr::getCmd() hands out copies of the registered template. The implicit
+// copy shared the UID, and destroying the copy unregistered the template.
+TEST(CommandCopy, CopyOwnsItsOwnUID)
+{
+    NopCommand tmpl;
+    const qlib::uid_t uid = tmpl.getUID();
+    ASSERT_NE(uid, qlib::invalid_uid);
+    ASSERT_EQ(qlib::ObjectManager::sGetObj<qsys::Command>(uid), &tmpl);
+
+    {
+        NopCommand copy(tmpl);
+        EXPECT_NE(copy.getUID(), uid);
+        EXPECT_EQ(qlib::ObjectManager::sGetObj<qsys::Command>(copy.getUID()), &copy);
+    }
+
+    // the template is still registered after the copy is gone
+    EXPECT_EQ(qlib::ObjectManager::sGetObj<qsys::Command>(uid), &tmpl);
+}


### PR DESCRIPTION
## Summary

Part 20 of the libcuemol2 bug-audit fixes (Phase 4: qlib / qsys small logic and leaks). Independent of the other PRs.

### Logic (qlib 3, 7, 11, 15, 17)

- `RangeSet::remove()` only dropped an element that the removed range strictly included or equalled (`includes()` is strict), so `remove(0,10)` or `remove(5,12)` left `[5,10)` in place. It uses the non-strict `contains()` now (the Phase 5 item "RangeSet::remove の包含判定" resolved as recommended).
- `MatrixHelper::diag_helper()` computed `a_pq/(a_qq-a_pp)` for a (near) zero off-diagonal element, i.e. 0/0 for equal diagonals, and the Jacobi diagonalization of e.g. the identity returned NaN (`LScrMatrix4D::diag3` ignores the return value). No rotation is needed in that case.
- `LString::replace()` did not advance past the replacement (`"a" -> "aa"` looped forever; an empty pattern matched forever). `LString::fromReal(v, 0)` trimmed the trailing zeros of an integer without decimal point (`"100" -> "1"`).
- `UCS16toUTF8()` encoded 0x7F in two bytes and 0x7FF in three (overlong UTF-8).

### Leaks / null checks (qlib 13, 14, qsys 14, 16)

- `PosixProcImpl` leaked the argv array on every path (`std::vector` now).
- `LDom2InStream::closeChunkStream()` null-checked the argument instead of the `dynamic_cast` result.
- `Command` had no copy constructor: the copies `CmdMgr::getCmd()` hands out shared the template's UID and their destructor unregistered the template. A copy registers its own UID; assignment keeps it.
- `ObjReader::read2()` / `ObjWriter::write2()` leaked the gzip / xz / base64 filter streams when `read()` / `write()` threw; `unique_ptr` owns them.

## Tests

- `tests/qlib/test_small_logic.cpp` (5 cases): range removal sharing an end, `replace("a","aa")` / empty pattern, `fromReal(100, 0)`, Jacobi on the identity, UTF-8 boundaries.
- `tests/qsys/test_command_copy.cpp`: a copied command owns a new UID and the template stays registered after the copy is destroyed.

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
