### PR TITLE
fix(qsys,xtal): NaN gradient lookup, renderCPU Z-X plane table

### DIFF
--- a/src/modules/xtal/GLSLMapMeshRenderer.cpp
+++ b/src/modules/xtal/GLSLMapMeshRenderer.cpp
@@ -597,10 +597,10 @@ void GLSLMapMeshRenderer::renderCPU(DisplayContext *pdc)
         m_ivdel[7] = IntVec3D(0, 0, 1);
 
         // Z-X plane
-        m_ivdel[4] = IntVec3D(0, 0, 0);
-        m_ivdel[5] = IntVec3D(0, 0, 1);
-        m_ivdel[6] = IntVec3D(1, 0, 1);
-        m_ivdel[7] = IntVec3D(1, 0, 0);
+        m_ivdel[8] = IntVec3D(0, 0, 0);
+        m_ivdel[9] = IntVec3D(0, 0, 1);
+        m_ivdel[10] = IntVec3D(1, 0, 1);
+        m_ivdel[11] = IntVec3D(1, 0, 0);
     }
 
     quint8 isolev;

--- a/src/modules/xtal/GLSLMapMeshRenderer2.cpp
+++ b/src/modules/xtal/GLSLMapMeshRenderer2.cpp
@@ -450,10 +450,10 @@ void GLSLMapMeshRenderer2::renderCPU(DisplayContext *pdc)
         m_ivdel[6] = IntVec3D(0, 1, 1);
         m_ivdel[7] = IntVec3D(0, 0, 1);
 
-        m_ivdel[4] = IntVec3D(0, 0, 0);
-        m_ivdel[5] = IntVec3D(0, 0, 1);
-        m_ivdel[6] = IntVec3D(1, 0, 1);
-        m_ivdel[7] = IntVec3D(1, 0, 0);
+        m_ivdel[8] = IntVec3D(0, 0, 0);
+        m_ivdel[9] = IntVec3D(0, 0, 1);
+        m_ivdel[10] = IntVec3D(1, 0, 1);
+        m_ivdel[11] = IntVec3D(1, 0, 0);
     }
 
     quint8 isolev;

--- a/src/qsys/MultiGradient.cpp
+++ b/src/qsys/MultiGradient.cpp
@@ -49,6 +49,10 @@ gfx::ColorPtr MultiGradient::getColor(double rho) const
   if (m_data.size()==1)
     return iter->pColor;
 
+  // NaN matches no interval below and walked the loop off the end
+  if (rho!=rho)
+    return iter->pColor;
+
   // check lower bound
   if (iter->value>rho) {
     return iter->pColor;
@@ -66,6 +70,8 @@ gfx::ColorPtr MultiGradient::getColor(double rho) const
   for (; iter!=eiter; ++iter) {
     iter2 = iter;
     iter2++;
+    if (iter2==eiter)
+      break;
 
     double v1 = iter->value;
     double v2 = iter2->value;

--- a/src/tests/qsys/test_multigradient.cpp
+++ b/src/tests/qsys/test_multigradient.cpp
@@ -2,6 +2,7 @@
 #include <common.h>
 #include "qsys/MultiGradient.hpp"
 #include <gfx/SolidColor.hpp>
+#include <limits>
 
 using qsys::MultiGradient;
 using qsys::MultiGradientPtr;
@@ -241,4 +242,15 @@ TEST(MultiGradientJSONTest, NamedColorRoundTrip)
     mg2.setNodesJSON(json);
     ASSERT_EQ(mg2.getSize(), 1);
     EXPECT_DOUBLE_EQ(mg2.getValueAt(0), 0.5);
+}
+
+// A NaN density matched no interval and the lookup walked past end() before
+// hitting the "should not be reached" assert.
+TEST(MultiGradientTest, GetColorWithNaNReturnsAColor)
+{
+    MultiGradient mg;
+    mg.insert(0.0, makeColor(1, 0, 0));
+    mg.insert(1.0, makeColor(0, 1, 0));
+    gfx::ColorPtr col = mg.getColor(std::numeric_limits<double>::quiet_NaN());
+    EXPECT_FALSE(col.isnull());
 }


### PR DESCRIPTION
## Summary

Part 21 of the libcuemol2 bug-audit fixes (leftovers: qsys 12, xtal 13). Independent of the other PRs.

- `MultiGradient::getColor(NaN)` (qsys 12): every comparison with NaN is false, so the lookup matched no interval and the middle-point loop dereferenced `end()` before reaching the "should not be reached" assert. NaN returns the first color, and the loop stops at the last node.
- `GLSLMapMeshRenderer` / `GLSLMapMeshRenderer2::renderCPU()` (xtal 13): `m_ivdel[4..7]` was filled twice (Y-Z and Z-X planes) and `[8..11]` left unset. The CPU path is currently unused; the table is corrected so that it works when it is.

## Tests

`tests/qsys/test_multigradient.cpp` (+1): `getColor(NaN)` on a two-stop gradient returns a color (aborted in the assert before).

`task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
