### PR TITLE
fix: libcuemol2 audit Phase 1 - memory safety

### DIFF
--- a/pymod/CMakeLists.txt
+++ b/pymod/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.15...3.26)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C CXX)
-set(CMAKE_CXX_STANDARD 14)
+# libcuemol2 is built as C++17 and its public headers may use C++17 library
+# features; the module compiles those headers, so it must use the same standard.
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE 1)  # ref. https://texus.me/2015/09/06/cmake-and-gcov/
 
 ##########

--- a/src/modules/importers/PSEFileReader.cpp
+++ b/src/modules/importers/PSEFileReader.cpp
@@ -27,6 +27,9 @@
 
 #include <boost/foreach.hpp>
 
+#include <iterator>
+#include <memory>
+
 #include "PickleInStream.hpp"
 #include "AtomPropColoring.hpp"
 #include "PSEConsts.hpp"
@@ -46,12 +49,13 @@ using molstr::MolAtomPtr;
 using molstr::ResidIndex;
 
 PSEFileReader::PSEFileReader()
+  : m_pSet(NULL), m_bColorWarned(false)
 {
-  m_pSet = NULL;
 }
 
 PSEFileReader::~PSEFileReader()
 {
+  delete m_pSet;
 }
 
 int PSEFileReader::getCatID() const
@@ -100,7 +104,7 @@ void PSEFileReader::setupSettingList(qlib::LVarList *pSet)
   if (m_pSet==NULL)
     m_pSet = new LVarList;
   else
-    m_pSet->clear();
+    m_pSet->clearAndDelete();
   
   LVarList::iterator iter = pSet->begin();
   LVarList::iterator eiter = pSet->end();
@@ -120,10 +124,31 @@ void PSEFileReader::setupSettingList(qlib::LVarList *pSet)
   for (; iter!=eiter; ++iter) {
     qlib::LVarList *pTuple = (*iter)->getListPtr();
     int id = pTuple->getInt(0);
-    m_pSet->at(id) = pTuple->at(2);
+    // m_pSet owns its entries, so keep a copy of the setting value
+    const LVariant *pval = pTuple->at(2);
+    delete m_pSet->at(id);
+    m_pSet->at(id) = (pval!=NULL) ? MB_NEW LVariant(*pval) : NULL;
   }
-  
+
   m_pSet->dump();
+}
+
+/// Convert a PyMOL color index to the 0xAARRGGBB value of the "col" atom prop
+unsigned int PSEFileReader::convColor(int ncol)
+{
+  // PyMOL encodes a direct RGB color as 0x40000000 | 0xRRGGBB. Negative
+  // indices are PyMOL-internal (ramps, defaults) and have no table entry.
+  if (ncol>=0 && (ncol & 0x40000000))
+    return 0xFF000000u | (static_cast<unsigned int>(ncol) & 0x00FFFFFFu);
+
+  if (ncol>=0 && ncol<int(std::size(PSE_colors)))
+    return PSE_colors[ncol];
+
+  if (!m_bColorWarned) {
+    LOG_DPRINTLN("PSEFileReader> unknown color index %d, using white", ncol);
+    m_bColorWarned = true;
+  }
+  return PSE_colors[0];
 }
 
 void PSEFileReader::read()
@@ -145,12 +170,11 @@ void PSEFileReader::read()
   fis.open(localfile);
   PickleInStream ois(fis);
 
-  LVariant *pTop = ois.getMap();
+  m_bColorWarned = false;
+  std::unique_ptr<LVariant> pTop(ois.getMap());
 
-  if (!pTop->isDict()) {
-    delete pTop;
+  if (!pTop->isDict())
     return;
-  }
 
   LVarDict *pDict = pTop->getDictPtr();
 
@@ -166,9 +190,7 @@ void PSEFileReader::read()
 
   LVarList *pNames = pDict->getList("names");
   procNames(pNames);
-  
-  delete pTop;
-  
+
   //////////
   // fire the scene-loaded event
   {
@@ -476,8 +498,7 @@ void PSEFileReader::parseObjectMolecule(LVarList *pData, MolCoordPtr pMol)
     pAtom->setPos(Vector4D(x,y,z));
 
     int ncol = pAtmDat->getInt(AT_COLOR);
-    // MB_DPRINTLN("color for %d = %d", i, ncol);
-    pAtom->setAtomPropInt("col", PSE_colors[ncol]);
+    pAtom->setAtomPropInt("col", convColor(ncol));
 
     int res = pMol->appendAtom(pAtom);
     if (res<0) {

--- a/src/modules/importers/PSEFileReader.hpp
+++ b/src/modules/importers/PSEFileReader.hpp
@@ -64,7 +64,13 @@ namespace importers {
 
   private:
 
+    /// Settings table indexed by PyMOL setting ID (owns its entries)
     qlib::LVarList *m_pSet;
+
+    /// Set once an unknown color index has been reported for this read
+    bool m_bColorWarned;
+
+    unsigned int convColor(int ncol);
 
     void procViewSettings(qlib::LVarList *pView);
 

--- a/src/modules/importers/PickleInStream.cpp
+++ b/src/modules/importers/PickleInStream.cpp
@@ -7,6 +7,10 @@
 
 #include "PickleInStream.hpp"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 using namespace importers;
 
 PickleInStream::~PickleInStream()
@@ -179,26 +183,18 @@ LVariant *PickleInStream::getMap()
       break;
     }
       
-    case BINSTRING: {
-      int i = readIntLE();
-      char *a = new char[i+1];
-      read(a, 0, i);
-      a[i]='\0';
-      LString s = a;
-      push(createString(s));
-      delete [] a;
-      //MB_DPRINTLN("BINSTRING len=%d %s", i, s.c_str());
-      break;
-    }
-      
+    case BINSTRING:
     case BINUNICODE: {
+      // BINUNICODE carries UTF-8; both are stored as-is
       int i = readIntLE();
-      char *a = new char[i];
-      read(a, 0, i);
-      LString s = a;
-      push(createString(s));
-      delete [] a;
-      // MB_DPRINTLN("BINUNICODE len=%d, %s", i, s.c_str());
+      if (i<0) {
+        MB_THROW(qlib::FileFormatException, "Invalid pickle format (negative string length)");
+        return NULL;
+      }
+      std::string s(size_t(i), '\0');
+      if (i>0)
+        readFully(&s[0], 0, i);
+      push(createString(LString(s)));
       break;
     }
       
@@ -246,49 +242,53 @@ LVariant *PickleInStream::getMap()
     }
 
     case SETITEM: {
-      LVariant *o = pop();
-      LVariant *pkey = pop();
+      std::unique_ptr<LVariant> o(pop());
+      std::unique_ptr<LVariant> pkey(pop());
       if (!pkey->isString()) {
         MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEM op mismatch)");
         return NULL;
       }
-      LString key = pkey->getStringValue();
-      delete pkey;
-      peek()->getDictPtr()->set(key, o);
-      // MB_DPRINTLN("SETITEM %s", key.c_str());
+      LVariant *phead = peek();
+      if (!phead->isDict()) {
+        MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEM on non-dict)");
+        return NULL;
+      }
+      // the dict owns the value from here on
+      phead->getDictPtr()->set(pkey->getStringValue(), std::move(*o));
       break;
     }
-      
+
     case SETITEMS: {
       int mark = getMark();
-      LVariant *pobjs = getObjects(mark);
+      std::unique_ptr<LVariant> pobjs(getObjects(mark));
+      LVarList *pItems = pobjs->getListPtr();
       LVariant *phead = peek();
-      int nput = 0;
       if (phead->isList()) {
-        while (!pobjs->getListPtr()->empty()) {
-          LVariant *o3 = pobjs->getListPtr()->front_pop_front();
+        while (!pItems->empty()) {
+          LVariant *o3 = pItems->front_pop_front();
           phead->getListPtr()->push_back(o3);
-          ++nput;
         }
       }
       else if (phead->isDict()) {
-        while (!pobjs->getListPtr()->empty()) {
-          LVariant *pvalue = pobjs->getListPtr()->back_pop_back();
-          LVariant *pkey = pobjs->getListPtr()->back_pop_back();
-          LString key = pkey->getStringValue();
-          delete pkey;
-          phead->getDictPtr()->set(key, pvalue);
-          // MB_DPRINTLN("SETITEMS %d %s", i, key->m_strValue.c_str());
-          ++nput;
+        // the items are key/value pairs
+        if (pItems->size()%2!=0) {
+          MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEMS odd item count)");
+          return NULL;
+        }
+        while (!pItems->empty()) {
+          std::unique_ptr<LVariant> pvalue(pItems->back_pop_back());
+          std::unique_ptr<LVariant> pkey(pItems->back_pop_back());
+          if (!pkey->isString()) {
+            MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEMS key is not a string)");
+            return NULL;
+          }
+          phead->getDictPtr()->set(pkey->getStringValue(), std::move(*pvalue));
         }
       }
       else {
-        delete pobjs;
         MB_THROW(qlib::FileFormatException, "Invalid pickle format (SETITEMS op mismatch)");
         return NULL;
       }
-      delete pobjs;
-      // MB_DPRINTLN("SETITEMS (%d)", nput);
       break;
     }
 
@@ -333,17 +333,13 @@ LVariant *PickleInStream::getMap()
   //memo = null;
 
   MB_DPRINTLN("====================");
-  LVariant *pMap = m_stack.front_pop_front();
-
-  if (pMap->getDictPtr()->size()==0) {
-  //   for (i = stack.size(); --i >= 0;) {
-  //     o = stack.get(i--);
-  //     s = (String) stack.get(i);
-  //     map.put(s, o);
+  if (m_stack.empty()) {
+    MB_THROW(qlib::FileFormatException, "Invalid pickle format (no object on the stack at STOP)");
+    return NULL;
   }
-    
-  return pMap;
-  
+
+  // the caller checks the type of the top-level object
+  return m_stack.front_pop_front();
 }
 
 

--- a/src/modules/importers/PickleInStream.hpp
+++ b/src/modules/importers/PickleInStream.hpp
@@ -66,7 +66,7 @@ namespace importers {
     static const int BININT2 = 77; /* M */
     static const int BINPUT = 113; /* q */
     static const int BINSTRING = 84; /* T */
-    static const int BINUNICODE = 87; /* X */
+    static const int BINUNICODE = 88; /* X */
     static const int BUILD = 98; /* b */
     static const int EMPTY_DICT = 125; /* } */
     static const int EMPTY_LIST = 93; /* ] */
@@ -218,26 +218,28 @@ namespace importers {
     //////////////////////////////////////
     // MEMO
 
-    typedef std::map<int, LVariant*> ValTable;
-    ValTable m_memo; // = new Hashtable<Integer, Object>();
+    /// Memoized values. The memo keeps its own copies, so every stack entry
+    /// stays uniquely owned and BINGET hands out fresh copies.
+    typedef std::map<int, LVariant> ValTable;
+    ValTable m_memo;
     int m_retrieveCount;
-    
+
     void putMemo(int i, bool doCheck)
     {
       LVariant *o = peek();
-      
+
       if (o->isString()) {
         // XXX: handle the inMovie case
         // if (doCheck && markCount >= 6 || markCount == 3 && inMovie)
         //  return;
         if (doCheck && m_markCount >= 6)
           return;
-        m_memo.insert(ValTable::value_type(i, o));
-        //MB_DPRINTLN("caching string");
-        //System.out.println("caching string " + o + " at " + binaryDoc.getPosition());
+        m_memo[i] = *o;
       }
     }
-  
+
+    /// Returns a new copy of the memoized value (owned by the caller),
+    /// or NULL when the memo index is unknown
     LVariant *getMemo(int i)
     {
       ValTable::const_iterator iter = m_memo.find(i);
@@ -245,16 +247,8 @@ namespace importers {
         MB_DPRINTLN("  ERROR!! memo %d not found!!", i);
         return NULL;
       }
-      LVariant *o = iter->second;
-      //Object o = memo.get(Integer.valueOf(i));
-      //if (o == null)
-      //return o;
-      //System.out.println("retrieving string " + o + " at " + binaryDoc.getPosition());
-
-      //MB_DPRINTLN("retrieving string");
       m_retrieveCount++;
-      
-      return o;
+      return MB_NEW LVariant(iter->second);
     }
     
     LVariant *getObjects(int mark)

--- a/src/modules/molanl/ContactMap.cpp
+++ b/src/modules/molanl/ContactMap.cpp
@@ -257,9 +257,9 @@ public:
     }
 
     {
-      // For mol2
+      // For mol2: its atoms follow mol1's entries
       AtomIterator aiter(pMol2, pSel2);
-      for (i=0,aiter.first(); aiter.hasMore()&&i<natoms; aiter.next(),++i) {
+      for (i=natoms1,aiter.first(); aiter.hasMore()&&i<natoms; aiter.next(),++i) {
 	MolAtomPtr pAtom = aiter.get();
 	m_data[i].pos = pAtom->getPos();
 	m_data[i].patm = pAtom;
@@ -334,7 +334,7 @@ public:
       LOG_DPRINTLN("Mol[%s] Atom contacts in %.2f -- %.2f Angstroms:", pMol->getName().c_str(), m_rmin, m_rmax);
       BOOST_FOREACH (const IntrSet::value_type &elem, intrset) {
         MolAtomPtr pA1 = pMol->getAtom(elem.first);
-        MolAtomPtr pA2 = pMol->getAtom(elem.second);
+        MolAtomPtr pA2 = pMol2->getAtom(elem.second);
         double dist = (pA1->getPos() - pA2->getPos()).length();
 
         if (!pSel1.isnull() && !pSel1->isSelected(pA2))

--- a/src/modules/molstr/MolCoord.cpp
+++ b/src/modules/molstr/MolCoord.cpp
@@ -439,6 +439,19 @@ MolBond *MolCoord::makeBond(int aaid1, int aaid2, bool bPersist /*=false*/)
   return pB;
 }
 
+namespace {
+  /// Drop pBond from the bond lists of its atoms (either atom may be gone)
+  void detachBond(MolCoord *pMol, MolBond *pBond)
+  {
+    MolAtomPtr pA1 = pMol->getAtom(pBond->getAtom1());
+    if (!pA1.isnull())
+      pA1->removeBond(pBond);
+    MolAtomPtr pA2 = pMol->getAtom(pBond->getAtom2());
+    if (!pA2.isnull())
+      pA2->removeBond(pBond);
+  }
+}
+
 bool MolCoord::removeBond(int aaid1, int aaid2)
 {
   BondPool::iterator iter = m_bondPool.begin();
@@ -455,7 +468,11 @@ bool MolCoord::removeBond(int aaid1, int aaid2)
   if (iter==iend)
     return false;
 
-  delete iter->second;
+  // the atoms must not keep a pointer to the deleted bond
+  // (makeBond() looks bonds up through MolAtom::getBond())
+  MolBond *pBond = iter->second;
+  detachBond(this, pBond);
+  delete pBond;
   m_bondPool.erase(iter);
   return true;
 }
@@ -472,20 +489,19 @@ void MolCoord::removeNonpersBonds()
     MolAtomPtr pA1 = getAtom(aid1);
     MolAtomPtr pA2 = getAtom(aid2);
 
-    if (pBond->isPersist()){
-      if (!pA1.isnull() && !pA2.isnull())
-        pers.push_back(pBond); // reserve presistent & valid bond
-      else
-        delete pBond; // remove persistent but orphan bond
+    // keep persistent bonds whose atoms both still exist
+    if (pBond->isPersist() && !pA1.isnull() && !pA2.isnull()) {
+      pers.push_back(pBond);
+      continue;
     }
-    else {
-      // remove non-persistent bond
-      if (!pA1.isnull())
-        pA1->removeBond(pBond);
-      if (!pA2.isnull())
-        pA2->removeBond(pBond);
-      delete pBond;
-    }
+
+    // non-persistent, or persistent but orphaned by removeAtom():
+    // the surviving atoms must not keep a pointer to the deleted bond
+    if (!pA1.isnull())
+      pA1->removeBond(pBond);
+    if (!pA2.isnull())
+      pA2->removeBond(pBond);
+    delete pBond;
   }
 
   m_bondPool.clear();

--- a/src/modules/molstr/SelCacheMgr.cpp
+++ b/src/modules/molstr/SelCacheMgr.cpp
@@ -46,11 +46,17 @@ SelCacheData *SelCacheMgr::createCacheEntry()
 
   MB_DPRINTLN("SelCacheMgr> molsel cache entry is created (%d); curr cache size=%d",id, (int)m_data.size());
 
-  while (m_data.size()>m_nCacheMax) {
-    CacheEntTab::iterator i = m_data.begin();
-    //MB_DPRINTLN("discard cache data ID=%d", i->first);
+  // Trim the cache to its limit, oldest first. Skip the entries that
+  // makeCache() is still filling (a nested around/byres selection creates
+  // entries from inside that loop) and the entry just created.
+  CacheEntTab::iterator i = m_data.begin();
+  while (m_data.size()>m_nCacheMax && i!=m_data.end()) {
+    if (i->second->m_bBuilding || i->second==pNewData) {
+      ++i;
+      continue;
+    }
     delete i->second;
-    m_data.erase(i);
+    i = m_data.erase(i);
   }
 
   return pNewData;
@@ -115,17 +121,29 @@ const SelCacheData *SelCacheMgr::makeCache(MolCoordPtr pMol, SelectionPtr pSel)
   MolCoord::AtomIter eiter = pMol->endAtom();
   Vector4D pos, cen(0,0,0);
   int nsel = 0;
-  for (; iter!=eiter; ++iter) {
-    MolAtomPtr pAtom = iter->second;
-    MB_ASSERT(!pAtom.isnull());
-    if (!pSel->isSelected(pAtom))
-      continue;
-    pos = pAtom->getPos();
-    pEnt->m_atomIdSet.insert(iter->first);
-    pEnt->m_bbox.merge(pos);
-    cen += pos;
-    nsel ++;
+
+  // Evaluating pSel may create further cache entries (nested around/byres);
+  // keep this entry from being evicted until it is complete.
+  pEnt->m_bBuilding = true;
+  try {
+    for (; iter!=eiter; ++iter) {
+      MolAtomPtr pAtom = iter->second;
+      MB_ASSERT(!pAtom.isnull());
+      if (!pSel->isSelected(pAtom))
+        continue;
+      pos = pAtom->getPos();
+      pEnt->m_atomIdSet.insert(iter->first);
+      pEnt->m_bbox.merge(pos);
+      cen += pos;
+      nsel ++;
+    }
   }
+  catch (...) {
+    // do not leave a half-built entry behind
+    invalidateCache(ncid);
+    throw;
+  }
+  pEnt->m_bBuilding = false;
   pEnt->m_nSel = nsel;
   if (nsel>0)
     pEnt->m_vCenter = cen.divide(nsel);

--- a/src/modules/molstr/SelCacheMgr.hpp
+++ b/src/modules/molstr/SelCacheMgr.hpp
@@ -50,10 +50,13 @@ private:
   /// Kd-tree data (for around op impl ver2)
   void *m_pExtData;
 
+  /// set while makeCache() is still filling this entry
+  bool m_bBuilding;
+
 public:
   SelCacheData()
        : m_nCacheID(-1), m_nMolID(qlib::invalid_uid), m_bAsetValid(false),
-         m_nSel(0), m_bBboxValid(false), m_pExtData(NULL)
+         m_nSel(0), m_bBboxValid(false), m_pExtData(NULL), m_bBuilding(false)
     {
     }
   

--- a/src/modules/molvis/Ribbon2Renderer.cpp
+++ b/src/modules/molvis/Ribbon2Renderer.cpp
@@ -34,6 +34,8 @@ SecSplDat::SecSplDat(Ribbon2Renderer *pP)
   m_bFixStart = false;
   m_bFixEnd = false;
   m_nStartId = 0;
+  m_bWsplValid = false;
+  m_dWidthAver = 1.0;
 }
 
 bool SecSplDat::generate()
@@ -78,9 +80,10 @@ bool SecSplDat::generateHelix(double wrho)
   else
     m_dWidthAver = 1.0; // XXX
 
-  if (!m_wspl.generate())
-    return false;
-  
+  // The width spline needs at least three points; a shorter helix falls
+  // back to the average width in renderHelix().
+  m_bWsplValid = m_wspl.generate();
+
   return true;
 }
 
@@ -729,11 +732,11 @@ void Ribbon2Renderer::renderHelix(DisplayContext *pdl)
       double t = tstart + double(j)*fdelta; ///double(naxdet);
       pCol = calcColor(t, pC);
       pC->m_spl.interpolate(t, &f1, &vpt);
-      // if (!m_bWidthAver) {
-      if (m_nHelixWidthMode==HWIDTH_WAVY) {
+      if (m_nHelixWidthMode==HWIDTH_WAVY && pC->m_bWsplValid) {
         pC->m_wspl.interpolate(t, &width, &dwidth);
       }
-      else if (m_nHelixWidthMode==HWIDTH_AVER) {
+      else if (m_nHelixWidthMode==HWIDTH_AVER || m_nHelixWidthMode==HWIDTH_WAVY) {
+        // average width (also the fallback for a wavy helix too short for its spline)
         width = pC->m_dWidthAver;
         dwidth = 0.0;
       }

--- a/src/modules/molvis/Ribbon2Renderer.hpp
+++ b/src/modules/molvis/Ribbon2Renderer.hpp
@@ -41,6 +41,8 @@ using namespace molstr;
 
       // cylinder data
       SmoothSpline1D m_wspl;
+      /// m_wspl could be generated (needs at least three points)
+      bool m_bWsplValid;
       double m_dWidthAver;
 
       // sheet data

--- a/src/modules/molvis/smospl/SmoothSpline.cpp
+++ b/src/modules/molvis/smospl/SmoothSpline.cpp
@@ -12,6 +12,7 @@
 using namespace molvis;
 
 SmoothSpline1D::SmoothSpline1D()
+  : m_nPoints(0)
 {
   m_rho = 3.0;
 }
@@ -37,6 +38,9 @@ void SmoothSpline1D::cleanup()
 bool SmoothSpline1D::generate()
 {
   int i;
+  // drop the coefficients of a previous generate() so that a failure
+  // below leaves interpolate() with nothing to read
+  cleanup();
   m_nPoints = m_veclist.size();
 
   if (m_nPoints==0)
@@ -105,6 +109,10 @@ bool SmoothSpline1D::interpolate(double par, double *vec,
                               double *dvec /*= NULL*/,
                               double *ddvec /*= NULL*/)
 {
+  // no coefficients: generate() has not run or rejected the points
+  if (m_vecx.size()<2 || m_coeff0.empty())
+    return false;
+
   int l = 0;
   int r = m_vecx.size()-2+1;
   int m;

--- a/src/modules/surface/HoleSurfBuilder.cpp
+++ b/src/modules/surface/HoleSurfBuilder.cpp
@@ -15,6 +15,8 @@
 #include <modules/molstr/TopparManager.hpp>
 #include <modules/molstr/AtomPosMap.hpp>
 
+#include <iterator>
+
 using namespace surface;
 using molstr::MolCoordPtr;
 using molstr::MolAtomPtr;
@@ -84,7 +86,7 @@ void HoleSurfBuilder::doit()
   int nslice;
   double score = 0.0, prev_score = -1.0;
   std::vector<Vector4D> cen_ary;
-  for (int i=0; i<sizeof(trytemp); ++i) {
+  for (size_t i=0; i<std::size(trytemp); ++i) {
     std::vector<Vector4D> new_ary;
     findPath(trytemp[i], new_ary, score, nslice);
     if (score < prev_score) {

--- a/src/qlib/LVarDict.hpp
+++ b/src/qlib/LVarDict.hpp
@@ -6,23 +6,22 @@
 #ifndef L_VARIANT_DICT_HPP_INCLUDED_
 #define L_VARIANT_DICT_HPP_INCLUDED_
 
+#include <utility>
+
 #include "LVariant.hpp"
 #include "MapTable.hpp"
 #include "qlib.hpp"
-
-//#include "LScrObjects.hpp"
-//#include "LScrSmartPtr.hpp"
-//#include "mcutils.hpp"
 
 namespace qlib {
 
 ///
 /// Scriptable dict of variants
 ///
-// class QLIB_API LVarDict : public MapPtrTable<LVariant>
+/// Values are stored by value: copying the dict deep-copies list/dict
+/// contents, and the getters hand out pointers into the stored entries.
+///
 class QLIB_API LVarDict : public MapTable<LVariant>
 {
-    // typedef MapPtrTable<LVariant> super_t;
     using super_t = MapTable<LVariant>;
 
 public:
@@ -34,68 +33,62 @@ public:
 
     //////
 
+    using super_t::set;
+
+    /// Move val into the dict without copying list/dict contents.
+    /// Returns false (and leaves the dict unchanged) when the key already exists.
+    bool set(const LString &key, LVariant &&val)
+    {
+        return super_t::try_emplace(key, std::move(val)).second;
+    }
+
+    /// Pointer to the stored value, or nullptr when the key is absent.
+    /// The pointer stays valid as long as the entry is in this dict.
+    const LVariant *lookup(const LString &key) const
+    {
+        super_t::const_iterator iter = super_t::find(key);
+        if (iter == super_t::end()) return nullptr;
+        return &iter->second;
+    }
+
     LString getString(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isString()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getString key not found");
-        //     return LString();
-        // }
-        // return pval->getStringValue();
-        LVariant val = super_t::get(key);
-        if (!val.isString()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isString()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getString key not found");
             return LString();
         }
-        return val.getStringValue();
+        return pval->getStringValue();
     }
 
     int getInt(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isInt()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getInt key not found");
-        //     return 0;
-        // }
-        // return pval->getIntValue();
-        LVariant val = super_t::get(key);
-        if (!val.isInt()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isInt()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getInt key not found");
             return 0;
         }
-        return val.getIntValue();
+        return pval->getIntValue();
     }
 
     double getReal(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isReal()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getReal key not found");
-        //     return 0.0;
-        // }
-        // return pval->getRealValue();
-        LVariant val = super_t::get(key);
-        if (!val.isReal()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isReal()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getReal key not found");
             return 0.0;
         }
-        return val.getRealValue();
+        return pval->getRealValue();
     }
 
     LVarList *getList(const LString &key) const
     {
-        // LVariant *pval = super_t::get(key);
-        // if (pval == NULL || !pval->isList()) {
-        //     MB_THROW(qlib::RuntimeException, "LVarDict, getList key not found");
-        //     return NULL;
-        // }
-        // return pval->getListPtr();
-        LVariant val = super_t::get(key);
-        if (!val.isList()) {
+        const LVariant *pval = lookup(key);
+        if (pval == nullptr || !pval->isList()) {
             MB_THROW(qlib::RuntimeException, "LVarDict, getList key not found");
-            return NULL;
+            return nullptr;
         }
-        return val.getListPtr();
+        return pval->getListPtr();
     }
 
     void dump() const;
@@ -106,4 +99,4 @@ using LDict = LVarDict;
 
 }  // namespace qlib
 
-#endif  // L_VARIANT_ARRAY_HPP_INCLUDED_
+#endif  // L_VARIANT_DICT_HPP_INCLUDED_

--- a/src/qlib/LVarDict.hpp
+++ b/src/qlib/LVarDict.hpp
@@ -39,7 +39,11 @@ public:
     /// Returns false (and leaves the dict unchanged) when the key already exists.
     bool set(const LString &key, LVariant &&val)
     {
-        return super_t::try_emplace(key, std::move(val)).second;
+        // find + insert(value_type&&) instead of try_emplace: the header is also
+        // compiled by consumers whose build may predate C++17
+        if (super_t::find(key) != super_t::end()) return false;
+        super_t::insert(typename super_t::value_type(key, std::move(val)));
+        return true;
     }
 
     /// Pointer to the stored value, or nullptr when the key is absent.

--- a/src/qlib/LVarList.hpp
+++ b/src/qlib/LVarList.hpp
@@ -33,21 +33,44 @@ namespace qlib {
     {
     }
 
+    /// Deep copy: the elements are owned, so each one is cloned
     LVarList(const LVarList &a)
-         : super_t(a)
+         : super_t()
     {
+      copyElems(a);
+    }
+
+    LVarList &operator=(const LVarList &a)
+    {
+      if (this!=&a) {
+        clearAndDelete();
+        copyElems(a);
+      }
+      return *this;
     }
 
     ~LVarList()
     {
-      super_t::iterator i = super_t::begin();
-      super_t::iterator e = super_t::end();
-      for (; i!=e; ++i) {
-        if (*i!=NULL)
-          delete *i;
-      }
+      clearAndDelete();
     }
 
+    /// Delete all owned elements and empty the list
+    /// (clear() alone drops the pointers without deleting them)
+    void clearAndDelete()
+    {
+      for (LVariant *p : *this)
+        delete p;
+      super_t::clear();
+    }
+
+  private:
+    void copyElems(const LVarList &a)
+    {
+      for (const LVariant *p : a)
+        super_t::push_back(p!=nullptr ? MB_NEW LVariant(*p) : nullptr);
+    }
+
+  public:
     //////
 
     LVariant *front_pop_front()

--- a/src/qlib/LVariant.hpp
+++ b/src/qlib/LVariant.hpp
@@ -61,11 +61,23 @@ public:
     /// Default ctor (initialize null value)
     LVariant() : type(LT_NULL), m_bOwned(true) {}
 
-    /// Copy ctor
+    /// Copy ctor (deep copy of the value)
     LVariant(const LVariant &src)
     {
         LVariant::copyFrom(src);
     }
+
+    /// Move ctor: takes over the value, src becomes null
+    LVariant(LVariant &&src) noexcept
+        : type(src.type), value(src.value), m_bOwned(src.m_bOwned)
+    {
+        src.type = LT_NULL;
+        src.m_bOwned = true;
+    }
+
+    /// A pointer to a variant is never a value. Without this overload a
+    /// LVariant* argument silently converts to LVariant(bool).
+    LVariant(const LVariant *) = delete;
 
     /// Destructor
     ~LVariant()
@@ -81,7 +93,9 @@ public:
     {
         value.realValue = v;
     }
-    LVariant(bool v) : type(LT_BOOLEAN), m_bOwned(true)
+    // explicit: an implicit pointer-to-bool conversion would otherwise turn
+    // any stray pointer argument into a boolean true
+    explicit LVariant(bool v) : type(LT_BOOLEAN), m_bOwned(true)
     {
         value.boolValue = v;
     }
@@ -137,6 +151,20 @@ public:
         if (&arg != this) {
             cleanup();
             copyFrom(arg);
+        }
+        return *this;
+    }
+
+    /// Move assignment: takes over the value, src becomes null
+    LVariant &operator=(LVariant &&src) noexcept
+    {
+        if (&src != this) {
+            cleanup();
+            type = src.type;
+            value = src.value;
+            m_bOwned = src.m_bOwned;
+            src.type = LT_NULL;
+            src.m_bOwned = true;
         }
         return *this;
     }

--- a/src/qsys/Camera.cpp
+++ b/src/qsys/Camera.cpp
@@ -33,6 +33,11 @@ Camera::Camera()
   resetAllProps();
 }
 
+Camera::~Camera()
+{
+  delete m_pVisSetNodes;
+}
+
 void Camera::copyFrom(const Camera&r)
 {
   if (!r.m_visset.empty()) {
@@ -150,6 +155,7 @@ void Camera::readFrom2(qlib::LDom2Node *pNode)
   qlib::LDom2Node *pVisSet = pNode->findChild("visibilities");
   if (pVisSet!=NULL) {
     MB_DPRINTLN("Camera.readFrom> copy vis nodes");
+    delete m_pVisSetNodes;
     m_pVisSetNodes = MB_NEW qlib::LDom2Node(*pVisSet);
     return;
   }
@@ -395,15 +401,22 @@ bool Camera::visChange(qlib::uid_t tgtid, bool bVis)
 
 void Camera::clearVisSettings()
 {
-  while (getVisSize()>0) {
+  // getVisSize() also counts a pending <visibilities> node, so walk the
+  // map itself and never take begin() of an empty map
+  while (!m_visset.empty()) {
     VisSetting::iterator i = m_visset.begin();
-    visRemove(i->first);
+    const qlib::uid_t tgtid = i->first;
+    const bool bAlive = i->second.bObj
+      ? !SceneManager::getObjectS(tgtid).isnull()
+      : !SceneManager::getRendererS(tgtid).isnull();
+    if (!bAlive || !visRemove(tgtid)) {
+      // target already gone (nothing to notify) or removal failed: drop the entry
+      m_visset.erase(tgtid);
+    }
   }
-  // m_visset.clear();
-  if (m_pVisSetNodes!=NULL) {
-    delete m_pVisSetNodes;
-    m_pVisSetNodes = NULL;
-  }
+
+  delete m_pVisSetNodes;
+  m_pVisSetNodes = NULL;
 }
 
 void Camera::saveVisSettings(ScenePtr pScene)

--- a/src/qsys/Camera.hpp
+++ b/src/qsys/Camera.hpp
@@ -246,6 +246,8 @@ namespace qsys {
       return *this;
     }
 
+    ~Camera() override;
+
     //////////
     
   private:

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -148,6 +148,7 @@ gtest_discover_tests(test_molstr PROPERTIES LABELS "test_molstr")
 add_executable(test_molvis
   modules/molvis/test_main.cpp
   modules/molvis/test_cpk2renderer.cpp
+  modules/molvis/test_smoothspline.cpp
 )
 target_include_directories(test_molvis PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(test_molstr
   modules/molstr/test_molresidue.cpp
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
+  modules/molstr/test_molcoord_bond.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp
@@ -134,6 +135,9 @@ target_include_directories(test_molstr PRIVATE
   ${CMAKE_SOURCE_DIR}/src/modules
   ${CMAKE_BINARY_DIR}/src
   ${Boost_INCLUDE_DIRS}
+)
+target_compile_definitions(test_molstr PRIVATE
+  CUEMOL2_SYSCONFIG_PATH="${CMAKE_SOURCE_DIR}/data/sysconfig.xml"
 )
 target_link_libraries(test_molstr PRIVATE molstr qsys gfx qlib Boost::filesystem GTest::gtest)
 if (BUILD_OPENGL_SYSDEP)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(test_qlib
   qlib/test_parallel.cpp
   qlib/test_chunked_array3d.cpp
   qlib/test_seekable_stream.cpp
+  qlib/test_lvardict.cpp
 )
 target_include_directories(test_qlib PRIVATE
   ${CMAKE_SOURCE_DIR}/src
@@ -246,6 +247,7 @@ add_executable(test_importers
   modules/importers/test_amber_reader.cpp
   modules/importers/test_load_object_command_guess.cpp
   modules/importers/test_trajio.cpp
+  modules/importers/test_pickle_instream.cpp
 )
 target_include_directories(test_importers PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -271,6 +271,7 @@ gtest_discover_tests(test_importers PROPERTIES LABELS "test_importers")
 add_executable(test_molanl
   modules/molanl/test_main.cpp
   modules/molanl/test_ssm_superpose.cpp
+  modules/molanl/test_contactmap.cpp
 )
 target_include_directories(test_molanl PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -126,6 +126,7 @@ add_executable(test_molstr
   modules/molstr/test_molchain.cpp
   modules/molstr/test_molbond.cpp
   modules/molstr/test_molcoord_bond.cpp
+  modules/molstr/test_selcachemgr.cpp
   modules/molstr/test_selcommand.cpp
   modules/molstr/test_simplerenderer.cpp
   modules/molstr/test_tracerenderer.cpp

--- a/src/tests/modules/importers/test_pickle_instream.cpp
+++ b/src/tests/modules/importers/test_pickle_instream.cpp
@@ -1,0 +1,216 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <qlib/LExceptions.hpp>
+#include <qlib/StringStream.hpp>
+#include "importers/PickleInStream.hpp"
+
+using importers::PickleInStream;
+using qlib::LVarDict;
+using qlib::LVariant;
+using qlib::LVarList;
+using qlib::StrInStream;
+
+namespace {
+
+// Emits the subset of pickle protocol 2 opcodes that PickleInStream reads.
+class PickleBuilder
+{
+public:
+    void emptyDict()
+    {
+        m_buf += '}';
+    }
+    void emptyList()
+    {
+        m_buf += ']';
+    }
+    void mark()
+    {
+        m_buf += '(';
+    }
+    void stop()
+    {
+        m_buf += '.';
+    }
+    void setItem()
+    {
+        m_buf += 's';
+    }
+    void setItems()
+    {
+        m_buf += 'u';
+    }
+    void appends()
+    {
+        m_buf += 'e';
+    }
+    void binput(int i)
+    {
+        m_buf += 'q';
+        m_buf += char(i);
+    }
+    void binget(int i)
+    {
+        m_buf += 'h';
+        m_buf += char(i);
+    }
+    void binint(int v)
+    {
+        m_buf += 'J';
+        le32(v);
+    }
+    void binstring(const std::string &s)
+    {
+        m_buf += 'T';
+        le32(int(s.size()));
+        m_buf += s;
+    }
+    void binunicode(const std::string &s)
+    {
+        m_buf += 'X';
+        le32(int(s.size()));
+        m_buf += s;
+    }
+
+    void binfloat(double d)
+    {
+        m_buf += 'G';
+        unsigned char raw[sizeof(double)];
+        std::memcpy(raw, &d, sizeof(double));
+        // BINFLOAT payload is big-endian
+        if (hostIsLittleEndian()) {
+            for (int i = int(sizeof(double)) - 1; i >= 0; --i) m_buf += char(raw[i]);
+        } else {
+            for (int i = 0; i < int(sizeof(double)); ++i) m_buf += char(raw[i]);
+        }
+    }
+
+    /// Length header that claims more bytes than follow (simulates a truncated file)
+    void truncatedUnicode(int claimed, const std::string &partial)
+    {
+        m_buf += 'X';
+        le32(claimed);
+        m_buf += partial;
+    }
+
+    const std::string &bytes() const
+    {
+        return m_buf;
+    }
+
+private:
+    static bool hostIsLittleEndian()
+    {
+        const unsigned short one = 1;
+        return *reinterpret_cast<const unsigned char *>(&one) == 1;
+    }
+
+    void le32(int v)
+    {
+        const unsigned int u = static_cast<unsigned int>(v);
+        for (int i = 0; i < 4; ++i) m_buf += char((u >> (8 * i)) & 0xffu);
+    }
+
+    std::string m_buf;
+};
+
+// Parses the pickle and destroys the stream before returning, so the result
+// must not alias anything the stream owned (its stack or memo).
+std::unique_ptr<LVariant> parse(const PickleBuilder &pb)
+{
+    StrInStream ins(pb.bytes().data(), static_cast<int>(pb.bytes().size()));
+    PickleInStream pis(ins);
+    return std::unique_ptr<LVariant>(pis.getMap());
+}
+
+}  // namespace
+
+TEST(PickleInStream, SetItemsBuildsDictWithNestedListAndMemoRefs)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.binput(0);
+    pb.mark();
+    pb.binunicode("version");
+    pb.binput(1);
+    pb.binint(1810);
+    pb.binunicode("names");
+    pb.binput(2);
+    pb.emptyList();
+    pb.mark();
+    pb.binget(1);  // "version" again, through the memo
+    pb.binfloat(1.5);
+    pb.binstring("abc");
+    pb.appends();
+    pb.binunicode("flag");
+    pb.binget(2);  // "names" reused as a value
+    pb.setItems();
+    pb.stop();
+
+    std::unique_ptr<LVariant> pTop = parse(pb);
+    ASSERT_TRUE(pTop->isDict());
+    LVarDict *pDict = pTop->getDictPtr();
+
+    EXPECT_EQ(pDict->getInt("version"), 1810);
+    EXPECT_STREQ(pDict->getString("flag").c_str(), "names");
+
+    LVarList *pNames = pDict->getList("names");
+    ASSERT_NE(pNames, nullptr);
+    ASSERT_EQ(pNames->size(), 3u);
+    EXPECT_STREQ(pNames->getString(0).c_str(), "version");
+    EXPECT_DOUBLE_EQ(pNames->getReal(1), 1.5);
+    EXPECT_STREQ(pNames->getString(2).c_str(), "abc");
+
+    // getList() hands out the stored list, not a copy
+    EXPECT_EQ(pDict->getList("names"), pNames);
+}
+
+TEST(PickleInStream, SetItemStoresSingleEntry)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.binunicode("k");
+    pb.binint(5);
+    pb.setItem();
+    pb.stop();
+
+    std::unique_ptr<LVariant> pTop = parse(pb);
+    ASSERT_TRUE(pTop->isDict());
+    EXPECT_EQ(pTop->getDictPtr()->getInt("k"), 5);
+}
+
+TEST(PickleInStream, UnicodeStringIsBoundedByItsLength)
+{
+    // The bytes after "ab" are opcodes; they must not leak into the string.
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.binunicode("k");
+    pb.binunicode("ab");
+    pb.setItem();
+    pb.stop();
+
+    std::unique_ptr<LVariant> pTop = parse(pb);
+    EXPECT_STREQ(pTop->getDictPtr()->getString("k").c_str(), "ab");
+}
+
+TEST(PickleInStream, SetItemsWithOddItemCountThrows)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.mark();
+    pb.binunicode("k");  // key without a value
+    pb.setItems();
+    pb.stop();
+    EXPECT_THROW(parse(pb), qlib::LException);
+}
+
+TEST(PickleInStream, TruncatedStringThrows)
+{
+    PickleBuilder pb;
+    pb.emptyDict();
+    pb.truncatedUnicode(100, "abc");
+    EXPECT_THROW(parse(pb), qlib::LException);
+}

--- a/src/tests/modules/molanl/test_contactmap.cpp
+++ b/src/tests/modules/molanl/test_contactmap.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molanl/MolAnlManager.hpp"
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/SelCommand.hpp"
+#include "qsys/SceneManager.hpp"
+#include "qsys/Scene.hpp"
+
+using molanl::MolAnlManager;
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using molstr::SelCommand;
+using molstr::SelectionPtr;
+using qlib::LString;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, const char *name, const char *elem, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(1));
+    pAtom->setName(name);
+    pAtom->setElementName(elem);
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+SelectionPtr allSel()
+{
+    return SelectionPtr(new SelCommand(LString("*")));
+}
+
+class ContactMapTest : public ::testing::Test
+{
+protected:
+    qsys::ScenePtr m_scene;
+
+    void SetUp() override
+    {
+        m_scene = qsys::SceneManager::getInstance()->createScene();
+        m_scene->setName("contactMapTestScene");
+    }
+
+    void TearDown() override
+    {
+        if (!m_scene.isnull()) {
+            qlib::uid_t uid = m_scene->getUID();
+            m_scene = qsys::ScenePtr();
+            qsys::SceneManager::getInstance()->destroyScene(uid);
+        }
+    }
+
+    MolCoordPtr newMol(const char *name)
+    {
+        MolCoordPtr pMol(MB_NEW MolCoord());
+        pMol->setName(name);
+        m_scene->addObject(pMol);
+        return pMol;
+    }
+
+    // calcAtomContact3JSON over two molecules, contacts within [0, 4] A
+    static LString contacts(MolCoordPtr pMol1, MolCoordPtr pMol2)
+    {
+        return MolAnlManager::getInstance()->calcAtomContact3JSON(
+            pMol1, allSel(), pMol2, allSel(), 0.0, 4.0, false, 100);
+    }
+};
+
+}  // namespace
+
+TEST_F(ContactMapTest, TwoMoleculesSameAtomCount)
+{
+    // mol1: N(0)  O(10)     mol2: O(3)  N(30)
+    // The only pair within 4 A is mol1:N -- mol2:O.
+    MolCoordPtr pMol1 = newMol("mol1");
+    const int n1 = addAtom(pMol1, "N", "N", 0.0);
+    addAtom(pMol1, "O", "O", 10.0);
+
+    MolCoordPtr pMol2 = newMol("mol2");
+    const int o2 = addAtom(pMol2, "O", "O", 3.0);
+    addAtom(pMol2, "N", "N", 30.0);
+
+    const LString expected = LString::format("[[%d,%d]]", n1, o2);
+    EXPECT_STREQ(contacts(pMol1, pMol2).c_str(), expected.c_str());
+}
+
+TEST_F(ContactMapTest, FirstMoleculeLargerThanSecond)
+{
+    // mol1: N(0) O(1.5) N(20)     mol2: O(2.5)
+    // Pairs within 4 A: mol1:N(0)--mol2:O and mol1:O(1.5)--mol2:O.
+    MolCoordPtr pMol1 = newMol("mol1");
+    const int a = addAtom(pMol1, "N1", "N", 0.0);
+    const int b = addAtom(pMol1, "O1", "O", 1.5);
+    addAtom(pMol1, "N2", "N", 20.0);
+
+    MolCoordPtr pMol2 = newMol("mol2");
+    const int c = addAtom(pMol2, "O", "O", 2.5);
+
+    const LString expected = LString::format("[[%d,%d],[%d,%d]]", a, c, b, c);
+    EXPECT_STREQ(contacts(pMol1, pMol2).c_str(), expected.c_str());
+}
+
+TEST_F(ContactMapTest, NoContactsGivesEmptyString)
+{
+    MolCoordPtr pMol1 = newMol("mol1");
+    addAtom(pMol1, "N", "N", 0.0);
+    MolCoordPtr pMol2 = newMol("mol2");
+    addAtom(pMol2, "O", "O", 50.0);
+    EXPECT_STREQ(contacts(pMol1, pMol2).c_str(), "");
+}

--- a/src/tests/modules/molstr/test_main.cpp
+++ b/src/tests/modules/molstr/test_main.cpp
@@ -2,25 +2,23 @@
 #include <common.h>
 #include "qlib/qlib.hpp"
 #include "qsys/qsys.hpp"
-#include "qsys/style/StyleMgr.hpp"
-#include "qsys/RendererFactory.hpp"
-#include "qsys/StreamManager.hpp"
-#include "molstr/ElemSym.hpp"
-#include "molstr/SelCompiler.hpp"
 
+namespace molstr {
+extern bool init();
+extern void fini();
+}
+
+// Same setup as the molvis/molanl suites: molstr::init() registers the
+// scriptable classes (MolCoord etc.), so objects can be constructed in tests.
 class MolstrEnvironment : public ::testing::Environment {
 public:
     void SetUp() override {
         qlib::init();
-        qsys::init("");
-        qsys::StyleMgr::init();
-        qsys::RendererFactory::init();
-        molstr::ElemSym::init();
-        molstr::SelCompiler::init();
+        qsys::init(CUEMOL2_SYSCONFIG_PATH);
+        molstr::init();
     }
     void TearDown() override {
-        molstr::SelCompiler::fini();
-        molstr::ElemSym::fini();
+        molstr::fini();
         qsys::fini();
         qlib::fini();
     }

--- a/src/tests/modules/molstr/test_molcoord_bond.cpp
+++ b/src/tests/modules/molstr/test_molcoord_bond.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/MolBond.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolBond;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, const char *name, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(1));
+    pAtom->setName(name);
+    pAtom->setElementName("C");
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+// One residue with three carbon atoms and no bonds.
+struct ThreeAtoms
+{
+    MolCoordPtr pMol;
+    int a, b, c;
+
+    ThreeAtoms() : pMol(MB_NEW MolCoord())
+    {
+        a = addAtom(pMol, "C1", 0.0);
+        b = addAtom(pMol, "C2", 1.5);
+        c = addAtom(pMol, "C3", 3.0);
+    }
+};
+
+}  // namespace
+
+TEST(MolCoordBond, RemoveBondDetachesBothAtoms)
+{
+    ThreeAtoms m;
+    ASSERT_NE(m.pMol->makeBond(m.a, m.b, true), nullptr);
+    ASSERT_TRUE(m.pMol->getAtom(m.a)->isBonded(m.b));
+
+    ASSERT_TRUE(m.pMol->removeBond(m.a, m.b));
+
+    // Neither atom may keep a pointer to the deleted bond.
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), nullptr);
+    EXPECT_FALSE(m.pMol->getAtom(m.b)->isBonded(m.a));
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+}
+
+TEST(MolCoordBond, MakeBondAfterRemoveCreatesFreshBond)
+{
+    // Undo of MolAnlManager::removeBond: makeBond() first looks the pair up
+    // through MolAtom::getBond(), which must not find the deleted bond.
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b, true);
+    ASSERT_TRUE(m.pMol->removeBond(m.a, m.b));
+
+    MolBond *pBond = m.pMol->makeBond(m.a, m.b, true);
+    ASSERT_NE(pBond, nullptr);
+    EXPECT_TRUE(pBond->isPersist());
+    EXPECT_EQ(m.pMol->getBondSize(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), pBond);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBond(m.a), pBond);
+}
+
+TEST(MolCoordBond, RemoveBondAcceptsReversedIdsAndRejectsUnknownPair)
+{
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b);
+    EXPECT_FALSE(m.pMol->removeBond(m.a, m.c));
+    EXPECT_TRUE(m.pMol->removeBond(m.b, m.a));
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+}
+
+TEST(MolCoordBond, RemoveNonpersBondsDropsOrphanPersistentBondFromSurvivor)
+{
+    ThreeAtoms m;
+    m.pMol->makeBond(m.a, m.b, true);   // persistent (SSBOND/LINK style)
+    m.pMol->makeBond(m.b, m.c, false);  // non-persistent (topology)
+
+    // removeAtom() leaves the bonds in place; applyTopology() cleans them up
+    // through removeNonpersBonds().
+    ASSERT_TRUE(m.pMol->removeAtom(m.b));
+    m.pMol->removeNonpersBonds();
+
+    EXPECT_EQ(m.pMol->getBondSize(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 0);
+    EXPECT_EQ(m.pMol->getAtom(m.c)->getBondCount(), 0);
+
+    // The survivors can be bonded again without tripping over stale pointers.
+    ASSERT_NE(m.pMol->makeBond(m.a, m.c, true), nullptr);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBondCount(), 1);
+}
+
+TEST(MolCoordBond, RemoveNonpersBondsKeepsValidPersistentBond)
+{
+    ThreeAtoms m;
+    MolBond *pPers = m.pMol->makeBond(m.a, m.b, true);
+    m.pMol->makeBond(m.b, m.c, false);
+
+    m.pMol->removeNonpersBonds();
+
+    EXPECT_EQ(m.pMol->getBondSize(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.a)->getBond(m.b), pPers);
+    EXPECT_EQ(m.pMol->getAtom(m.b)->getBondCount(), 1);
+    EXPECT_EQ(m.pMol->getAtom(m.c)->getBondCount(), 0);
+}

--- a/src/tests/modules/molstr/test_selcachemgr.cpp
+++ b/src/tests/modules/molstr/test_selcachemgr.cpp
@@ -1,0 +1,94 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molstr/MolCoord.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/SelCommand.hpp"
+#include "molstr/SelCacheMgr.hpp"
+
+using molstr::MolAtom;
+using molstr::MolAtomPtr;
+using molstr::MolCoord;
+using molstr::MolCoordPtr;
+using molstr::ResidIndex;
+using molstr::SelCacheData;
+using molstr::SelCacheMgr;
+using molstr::SelCommand;
+using molstr::SelectionPtr;
+using qlib::LString;
+using qlib::Vector4D;
+
+namespace {
+
+int addAtom(MolCoordPtr pMol, int resid, double x)
+{
+    MolAtomPtr pAtom(MB_NEW MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("XXX");
+    pAtom->setResIndex(ResidIndex(resid));
+    pAtom->setName("CA");
+    pAtom->setElementName("C");
+    pAtom->setPos(Vector4D(x, 0.0, 0.0));
+    return pMol->appendAtom(pAtom);
+}
+
+// Selects every atom, and while doing so builds a fresh cache entry for
+// another selection per atom. This is what a nested around/byres
+// selection does through findOrMakeCacheData(), and it used to evict the
+// entry that was still being filled once the cache limit was reached.
+class NestingSel : public SelCommand
+{
+public:
+    MolCoordPtr m_pMol;
+    int m_nCalls;
+
+    NestingSel() : SelCommand(LString("*")), m_nCalls(0) {}
+
+    bool isSelected(MolAtomPtr) override
+    {
+        ++m_nCalls;
+        SelectionPtr pSub(new SelCommand(LString::format("resi %d", m_nCalls)));
+        SelCacheMgr::getInstance()->findOrMakeCacheData(m_pMol, pSub);
+        return true;
+    }
+};
+
+}  // namespace
+
+TEST(SelCacheMgr, EntryUnderConstructionSurvivesNestedCacheBuilds)
+{
+    const int natoms = 16;  // more than the cache limit (10)
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    for (int i = 0; i < natoms; ++i) addAtom(pMol, i + 1, double(i));
+
+    NestingSel *pNest = new NestingSel();
+    pNest->m_pMol = pMol;
+    SelectionPtr pSel(pNest);
+
+    SelCacheMgr *pMgr = SelCacheMgr::getInstance();
+    const SelCacheData *pEnt = pMgr->makeCache(pMol, pSel);
+    ASSERT_NE(pEnt, nullptr);
+    EXPECT_EQ(pNest->m_nCalls, natoms);
+
+    // The outer entry must still be registered and complete.
+    EXPECT_EQ(pMgr->getCacheEntry(pEnt->getCacheID()), pEnt);
+    EXPECT_EQ(int(pEnt->getAtomIdSet().size()), natoms);
+    EXPECT_EQ(pMgr->findCacheData(pMol, pSel), pEnt);
+}
+
+TEST(SelCacheMgr, CacheLimitStillEvictsFinishedEntries)
+{
+    MolCoordPtr pMol(MB_NEW MolCoord());
+    addAtom(pMol, 1, 0.0);
+
+    SelCacheMgr *pMgr = SelCacheMgr::getInstance();
+    SelectionPtr pFirst(new SelCommand(LString("resi 1")));
+    const SelCacheData *pEnt = pMgr->makeCache(pMol, pFirst);
+    const int firstId = pEnt->getCacheID();
+
+    // Fill the cache well past its limit with finished entries.
+    for (int i = 2; i < 30; ++i) {
+        SelectionPtr pSel(new SelCommand(LString::format("resi %d", i)));
+        pMgr->makeCache(pMol, pSel);
+    }
+    EXPECT_EQ(pMgr->getCacheEntry(firstId), nullptr);
+}

--- a/src/tests/modules/molvis/test_smoothspline.cpp
+++ b/src/tests/modules/molvis/test_smoothspline.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "molvis/smospl/SmoothSpline.hpp"
+
+using molvis::SmoothSpline1D;
+
+TEST(SmoothSpline1D, TwoPointsCannotBeInterpolated)
+{
+    // A helix truncated to two residues gives a two-point width spline.
+    // generate() rejects it, and interpolate() must then fail instead of
+    // reading the empty coefficient tables.
+    SmoothSpline1D spl;
+    spl.setSize(2);
+    spl.setValue(0, 1.0);
+    spl.setValue(1, 2.0);
+    EXPECT_FALSE(spl.generate());
+    EXPECT_EQ(spl.getPoints(), 2);
+
+    double v = -1.0, dv = -1.0;
+    EXPECT_FALSE(spl.interpolate(0.5, &v, &dv));
+    EXPECT_DOUBLE_EQ(v, -1.0);
+    EXPECT_DOUBLE_EQ(dv, -1.0);
+}
+
+TEST(SmoothSpline1D, InterpolateBeforeGenerateFails)
+{
+    SmoothSpline1D spl;
+    EXPECT_EQ(spl.getPoints(), 0);
+    double v = 0.0;
+    EXPECT_FALSE(spl.interpolate(0.0, &v));
+}
+
+TEST(SmoothSpline1D, ThreePointsInterpolateThroughKnots)
+{
+    SmoothSpline1D spl;
+    spl.setRho(3.0);
+    spl.setSize(3);
+    spl.setValue(0, 1.0);
+    spl.setValue(1, 2.0);
+    spl.setValue(2, 3.0);
+    ASSERT_TRUE(spl.generate());
+
+    double v = 0.0;
+    ASSERT_TRUE(spl.interpolate(0.0, &v));
+    EXPECT_NEAR(v, 1.0, 1e-6);
+    ASSERT_TRUE(spl.interpolate(1.0, &v));
+    EXPECT_NEAR(v, 2.0, 1e-6);
+}
+
+TEST(SmoothSpline1D, RegenerateWithTooFewPointsDropsOldCoefficients)
+{
+    SmoothSpline1D spl;
+    spl.setSize(3);
+    spl.setValue(0, 1.0);
+    spl.setValue(1, 2.0);
+    spl.setValue(2, 3.0);
+    ASSERT_TRUE(spl.generate());
+
+    spl.setSize(2);
+    EXPECT_FALSE(spl.generate());
+    double v = -1.0;
+    EXPECT_FALSE(spl.interpolate(0.5, &v));
+}

--- a/src/tests/qlib/test_lvardict.cpp
+++ b/src/tests/qlib/test_lvardict.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include "qlib/LExceptions.hpp"
+#include "qlib/LVariant.hpp"
+#include "qlib/LVarList.hpp"
+#include "qlib/LVarDict.hpp"
+
+using qlib::LString;
+using qlib::LVarDict;
+using qlib::LVariant;
+using qlib::LVarList;
+
+namespace {
+
+// Builds ["a", 1, [2.5]] as a heap-allocated, element-owning list.
+LVarList *makeNestedList()
+{
+    LVarList *pList = new LVarList();
+    pList->push_back(new LVariant(LString("a")));
+    pList->push_back(new LVariant(1));
+    LVarList *pInner = new LVarList();
+    pInner->push_back(new LVariant(2.5));
+    pList->push_back(new LVariant(pInner));
+    return pList;
+}
+
+}  // namespace
+
+// A LVariant* is never a value. It used to convert to LVariant(bool) and
+// store true, which silently broke LVarDict::set(key, LVariant*).
+static_assert(!std::is_constructible<LVariant, LVariant *>::value,
+              "LVariant must not be constructible from LVariant*");
+
+// ---- LVarList ------------------------------------------------------------
+
+TEST(LVarList, CopyIsDeep)
+{
+    LVarList *pOrig = makeNestedList();
+    LVarList copy(*pOrig);
+
+    ASSERT_EQ(copy.size(), 3u);
+    EXPECT_NE(copy.at(0), pOrig->at(0));
+    EXPECT_NE(copy.getList(2), pOrig->getList(2));
+
+    // Destroying the original must leave the copy intact.
+    delete pOrig;
+    EXPECT_STREQ(copy.getString(0).c_str(), "a");
+    EXPECT_EQ(copy.getInt(1), 1);
+    EXPECT_DOUBLE_EQ(copy.getList(2)->getReal(0), 2.5);
+}
+
+TEST(LVarList, AssignmentIsDeepAndReplacesOldElements)
+{
+    LVarList dest;
+    dest.push_back(new LVariant(LString("old")));
+
+    LVarList *pSrc = makeNestedList();
+    dest = *pSrc;
+    delete pSrc;
+
+    ASSERT_EQ(dest.size(), 3u);
+    EXPECT_STREQ(dest.getString(0).c_str(), "a");
+    EXPECT_DOUBLE_EQ(dest.getList(2)->getReal(0), 2.5);
+}
+
+TEST(LVarList, ClearAndDeleteEmptiesTheList)
+{
+    std::unique_ptr<LVarList> pSrc(makeNestedList());
+    LVarList list(*pSrc);
+    list.clearAndDelete();
+    EXPECT_TRUE(list.empty());
+}
+
+// ---- LVariant ------------------------------------------------------------
+
+TEST(LVariant, ListValueCopyIsIndependent)
+{
+    LVariant v(makeNestedList());
+    LVariant w(v);
+    EXPECT_NE(v.getListPtr(), w.getListPtr());
+
+    v.setNull();
+    ASSERT_TRUE(w.isList());
+    EXPECT_STREQ(w.getListPtr()->getString(0).c_str(), "a");
+}
+
+TEST(LVariant, MoveTransfersOwnership)
+{
+    LVariant v(makeNestedList());
+    LVarList *pList = v.getListPtr();
+
+    LVariant w(std::move(v));
+    EXPECT_TRUE(v.isNull());
+    EXPECT_EQ(w.getListPtr(), pList);
+
+    LVariant x(LString("replaced"));
+    x = std::move(w);
+    EXPECT_TRUE(w.isNull());
+    ASSERT_TRUE(x.isList());
+    EXPECT_EQ(x.getListPtr(), pList);
+}
+
+// ---- LVarDict ------------------------------------------------------------
+
+TEST(LVarDict, SetByMoveAndGetListReturnsStoredPointer)
+{
+    LVarDict dict;
+    LVariant val(makeNestedList());
+    LVarList *pList = val.getListPtr();
+
+    EXPECT_TRUE(dict.set("names", std::move(val)));
+    EXPECT_TRUE(val.isNull());
+
+    // No copy on lookup, and the pointer stays stable across calls.
+    EXPECT_EQ(dict.getList("names"), pList);
+    EXPECT_EQ(dict.getList("names"), pList);
+    EXPECT_STREQ(dict.getList("names")->getString(0).c_str(), "a");
+
+    // set() keeps the first value for a duplicate key and leaves the
+    // rejected value untouched.
+    LVariant dup(2);
+    EXPECT_FALSE(dict.set("names", std::move(dup)));
+    EXPECT_EQ(dict.getList("names"), pList);
+    ASSERT_TRUE(dup.isInt());
+    EXPECT_EQ(dup.getIntValue(), 2);
+}
+
+TEST(LVarDict, ScalarGettersAndMissingKeys)
+{
+    LVarDict dict;
+    dict.set("i", LVariant(7));
+    dict.set("r", LVariant(1.5));
+    dict.set("s", LVariant(LString("str")));
+
+    EXPECT_EQ(dict.getInt("i"), 7);
+    EXPECT_DOUBLE_EQ(dict.getReal("r"), 1.5);
+    EXPECT_DOUBLE_EQ(dict.getReal("i"), 7.0);
+    EXPECT_STREQ(dict.getString("s").c_str(), "str");
+
+    EXPECT_EQ(dict.lookup("missing"), nullptr);
+    EXPECT_THROW(dict.getInt("missing"), qlib::RuntimeException);
+    EXPECT_THROW(dict.getInt("s"), qlib::RuntimeException);
+    EXPECT_THROW(dict.getList("s"), qlib::RuntimeException);
+}
+
+TEST(LVarDict, CopyIsDeep)
+{
+    LVarDict *pDict = new LVarDict();
+    pDict->set("names", LVariant(makeNestedList()));
+
+    LVarDict copy(*pDict);
+    EXPECT_NE(copy.getList("names"), pDict->getList("names"));
+
+    delete pDict;
+    EXPECT_STREQ(copy.getList("names")->getString(0).c_str(), "a");
+}

--- a/src/tests/qsys/test_camera.cpp
+++ b/src/tests/qsys/test_camera.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <common.h>
+#include <memory>
+#include "qlib/LDOM2Tree.hpp"
 #include "qsys/Camera.hpp"
 
 using qsys::Camera;
@@ -146,5 +148,58 @@ TEST(CameraTest, ClearVisSettingsNoCrash)
 {
     Camera cam;
     cam.clearVisSettings();  // no-op when empty
+    EXPECT_EQ(cam.getVisSize(), 0);
+}
+
+namespace {
+
+// Builds a <camera> node with a <visibilities> child, the shape a camera
+// serialized with vis flags has before the scene finishes loading.
+qlib::LDom2Node *makeCameraNodeWithVisibilities()
+{
+    qlib::LDom2Node *pCam = new qlib::LDom2Node();
+    pCam->setTagName("camera");
+
+    qlib::LDom2Node *pVis = new qlib::LDom2Node();
+    pVis->setTagName("visibilities");
+
+    qlib::LDom2Node *pObj = new qlib::LDom2Node();
+    pObj->setTagName("object");
+    pObj->setStrAttr("target", "mol1");
+    pObj->setValue("false");
+    pVis->appendChild(pObj);
+
+    pCam->appendChild(pVis);
+    return pCam;
+}
+
+}  // namespace
+
+TEST(CameraTest, ClearVisSettingsDropsUnconvertedNodes)
+{
+    // A camera read from a file keeps the <visibilities> node until the
+    // scene finishes loading (notifyLoaded). Clearing before that used to
+    // walk an empty map because getVisSize() reports the pending node as 1.
+    std::unique_ptr<qlib::LDom2Node> pNode(makeCameraNodeWithVisibilities());
+    Camera cam;
+    cam.readFrom2(pNode.get());
+    ASSERT_EQ(cam.getVisSize(), 1);
+
+    cam.clearVisSettings();
+    EXPECT_EQ(cam.getVisSize(), 0);
+
+    // clearing twice stays a no-op
+    cam.clearVisSettings();
+    EXPECT_EQ(cam.getVisSize(), 0);
+}
+
+TEST(CameraTest, ReadFrom2ReplacesPendingVisibilities)
+{
+    std::unique_ptr<qlib::LDom2Node> pNode(makeCameraNodeWithVisibilities());
+    Camera cam;
+    cam.readFrom2(pNode.get());
+    cam.readFrom2(pNode.get());  // second read must not leak the first node
+    EXPECT_EQ(cam.getVisSize(), 1);
+    cam.clearVisSettings();
     EXPECT_EQ(cam.getVisSize(), 0);
 }


### PR DESCRIPTION
## Summary

libcuemol2 bug-audit fixes, **Phase 1: memory safety** (use-after-free, double free, out-of-bounds). One commit per fix; the audit report with the full finding list is linked in the session.

| Commit | Findings | Fix | Tests |
|---|---|---|---|
| qlib LVariant/LVarList/LVarDict | qlib 1, 2 / importers 1, 2, 4, 20 | `LVarList` deep-copies its elements (the shallow copy double-freed them), `LVariant` gets move ctor/assign and `LVariant(const LVariant*) = delete`, `LVariant(bool)` is explicit, `LVarDict::lookup()`; `PickleInStream` keeps its memo in a `std::map<int, LVariant>` instead of sharing raw pointers, reads BINUNICODE fully (and uses the right opcode 88), rejects odd SETITEMS; `PSEFileReader` frees `m_pSet`, validates the color index | `test_lvardict` (8), `test_pickle_instream` (5) |
| molstr bond lifetime | molstr 1, 2 | `MolCoord::removeBond()` / `removeNonpersBonds()` detach the bond from both atoms before deleting it; the molstr test environment initializes `molstr` | `test_molcoord_bond` (5) |
| qsys Camera | qsys 1, 15 | `Camera::clearVisSettings()` walks the map instead of dereferencing `begin()` of an empty one (the pending `<visibilities>` node counted as 1), drops entries whose target is gone; the node is freed in the destructor and on re-read | `test_camera` (+2) |
| molanl/surface OOB | surface 1, 2 | `HoleSurfBuilder` used `sizeof` as an element count; `ContactMap::doit2()` restarted the mol2 index at 0 and overwrote mol1 | `test_contactmap` (3) |
| molvis Ribbon2 wavy width | molvis 1 | a helix with two points interpolated an empty spline; `SmoothSpline1D` guards `interpolate()` and resets state in `generate()` | `test_smoothspline` (4) |
| molstr SelCacheMgr | molstr 3 | never evict the cache entry that is still being built (nested `around`/`byres`) | `test_selcachemgr` (2) |

## CI fix (2026-08-31)

The first CI run failed in "Build and test python module" on macOS / Linux (`LVarDict.hpp:42: no member named 'try_emplace'`). `pymod/CMakeLists.txt` compiled the installed libcuemol2 headers with `CMAKE_CXX_STANDARD 14` while the library is C++17, and the new `LVarDict::set(key, LVariant&&)` used `std::map::try_emplace` (C++17). Fixed in the last commit: the python module now builds as C++17 (like the library and `tritium/core`), and `LVarDict::set` uses `find` + `insert` so the header does not need C++17 either. Reproduced locally (the module sources against the installed headers with `-std=gnu++14` fail before / pass after; `pip install pymod` builds and installs), and `task run_gtest` still passes.

Every new test was run against the old code first: SIGSEGV, infinite loop or wrong result in each case. `task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
