### PR TITLE
fix: libcuemol2 audit Phase 3 - input validation

### DIFF
--- a/src/modules/mdtools/AmberNetCDFReader.hpp
+++ b/src/modules/mdtools/AmberNetCDFReader.hpp
@@ -66,7 +66,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     /// File atom count (0 until the header is read).

--- a/src/modules/mdtools/DCDTrajReader.hpp
+++ b/src/modules/mdtools/DCDTrajReader.hpp
@@ -72,7 +72,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     int m_natom;

--- a/src/modules/mdtools/TrrTrajReader.hpp
+++ b/src/modules/mdtools/TrrTrajReader.hpp
@@ -68,7 +68,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     /// File atom count (0 until the first frame header is read).

--- a/src/modules/mdtools/XdrInStream.cpp
+++ b/src/modules/mdtools/XdrInStream.cpp
@@ -84,6 +84,17 @@ struct DecodeState
     quint8 lastbyte;
 };
 
+/// Next byte of the compressed block; the block length comes from the file,
+/// so a truncated block must not be read past its end.
+inline quint8 nextByte(const std::vector<char> &buf, DecodeState &state)
+{
+    if (state.count >= buf.size()) {
+        MB_THROW(qlib::FileFormatException, "XTC: compressed block is truncated");
+        return 0;
+    }
+    return static_cast<quint8>(buf[state.count++]);
+}
+
 /// decodebits: extract num_of_bits from the buffer and build an integer.
 template <typename T>
 T decodebits(const std::vector<char> &buf, DecodeState &state, quint32 num_of_bits)
@@ -95,14 +106,14 @@ T decodebits(const std::vector<char> &buf, DecodeState &state, quint32 num_of_bi
 
     quint32 num = 0;
     while (num_of_bits >= CHAR_BIT) {
-        lastbyte = (lastbyte << CHAR_BIT) | static_cast<quint8>(buf[state.count++]);
+        lastbyte = (lastbyte << CHAR_BIT) | nextByte(buf, state);
         num |= (lastbyte >> lastbits) << (num_of_bits - CHAR_BIT);
         num_of_bits -= CHAR_BIT;
     }
     if (num_of_bits > 0) {
         if (lastbits < num_of_bits) {
             lastbits += CHAR_BIT;
-            lastbyte = (lastbyte << CHAR_BIT) | static_cast<quint8>(buf[state.count++]);
+            lastbyte = (lastbyte << CHAR_BIT) | nextByte(buf, state);
         }
         lastbits -= num_of_bits;
         num |= (lastbyte >> lastbits) & (static_cast<quint32>(1 << num_of_bits) - 1);
@@ -334,8 +345,12 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
     const float precision = readF32();
     const int minint[3] = {readI32(), readI32(), readI32()};
     const int maxint[3] = {readI32(), readI32(), readI32()};
-    quint32 smallidx = readU32();
-    if (!(smallidx < LASTIDX)) {
+    // smallidx indexes MAGICINTS and moves up/down while decoding; the
+    // encoder never writes one below FIRSTIDX (MAGICINTS[FIRSTIDX-1] == 0)
+    const int kFirstIdx = static_cast<int>(FIRSTIDX);
+    const int kLastIdx = static_cast<int>(LASTIDX);
+    int smallidx = readI32();
+    if (smallidx < kFirstIdx || smallidx >= kLastIdx) {
         MB_THROW(qlib::FileFormatException, "XTC: internal overflow (smallidx)");
         return precision;
     }
@@ -344,7 +359,7 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
     quint32 bitsizeint[3];
     const quint32 bitsize = calc_sizeint(minint, maxint, sizeint, bitsizeint);
 
-    int smaller = MAGICINTS[std::max(FIRSTIDX, smallidx - 1)] / 2;
+    int smaller = MAGICINTS[std::max(kFirstIdx, smallidx - 1)] / 2;
     int smallnum = MAGICINTS[smallidx] / 2;
     quint32 sizesmall[3];
     sizesmall[0] = sizesmall[1] = sizesmall[2] = static_cast<quint32>(MAGICINTS[smallidx]);
@@ -386,14 +401,15 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
             run -= is_smaller;
             is_smaller--;
         }
-        if (run > 0 && write_idx * 3 + static_cast<size_t>(run) > data.size()) {
+        if (run > 0 && (write_idx + 1) * 3 + static_cast<size_t>(run) > data.size()) {
             MB_THROW(qlib::FileFormatException, "XTC: buffer overrun during decompression");
             return precision;
         }
         if (run > 0) {
             thiscoord = m_intbuf.data() + (read_idx + 1) * 3;
             for (int k = 0; k < run; k += 3) {
-                decodeints(m_compressed, state, smallidx, sizesmall, thiscoord);
+                decodeints(m_compressed, state, static_cast<quint32>(smallidx), sizesmall,
+                           thiscoord);
                 ++read_idx;
                 thiscoord[0] += prevcoord[0] - smallnum;
                 thiscoord[1] += prevcoord[1] - smallnum;
@@ -430,16 +446,21 @@ float XdrInStream::readCompressedCoords(std::vector<qfloat32> &data, bool bLongF
         if (is_smaller < 0) {
             --smallidx;
             smallnum = smaller;
-            if (smallidx > FIRSTIDX) {
+            if (smallidx > kFirstIdx) {
                 smaller = MAGICINTS[smallidx - 1] / 2;
             } else {
                 smaller = 0;
             }
         } else if (is_smaller > 0) {
             ++smallidx;
+            if (smallidx >= kLastIdx) {
+                MB_THROW(qlib::FileFormatException, "XTC: internal overflow (smallidx)");
+                return precision;
+            }
             smaller = smallnum;
             smallnum = MAGICINTS[smallidx] / 2;
         }
+        // MAGICINTS[smallidx] == 0 below FIRSTIDX: caught by the size check
         sizesmall[0] = sizesmall[1] = sizesmall[2] = static_cast<quint32>(MAGICINTS[smallidx]);
         if (sizesmall[0] == 0) {
             MB_THROW(qlib::FileFormatException, "XTC: invalid size during decompression");

--- a/src/modules/mdtools/XtcTrajReader.hpp
+++ b/src/modules/mdtools/XtcTrajReader.hpp
@@ -66,7 +66,8 @@ private:
 
 public:
     int getSkipNo() const { return m_nSkip; }
-    void setSkipNo(int n) { m_nSkip = n; }
+    /// nevery < 1 would divide by zero in the frame loop
+    void setSkipNo(int n) { m_nSkip = (n < 1) ? 1 : n; }
 
 private:
     /// File atom count (0 until the first frame header is read).

--- a/src/modules/molstr/NameLabelRenderer.cpp
+++ b/src/modules/molstr/NameLabelRenderer.cpp
@@ -197,8 +197,10 @@ void NameLabelRenderer::render(DisplayContext *pdc)
     for (; iter!=eiter; iter++) {
       NameLabel &nlab = *iter;
       if (nlab.m_nCacheID<0) {
-        makeLabelStr(nlab, strlab, pos);
-        nlab.m_nCacheID = m_pixCache.addString(pos, strlab);
+        // a label whose atom is gone keeps m_nCacheID<0 instead of
+        // reusing the string/position of the previous label
+        if (makeLabelStr(nlab, strlab, pos))
+          nlab.m_nCacheID = m_pixCache.addString(pos, strlab);
       }
     }
   }
@@ -270,6 +272,10 @@ bool NameLabelRenderer::addLabelByID(int aid, const LString &label /*= LString()
   MB_ASSERT(!pobj.isnull());
   
   MolAtomPtr pAtom = pobj->getAtom(aid);
+  if (pAtom.isnull()) {
+    LOG_DPRINTLN("NameLabelRenderer> atom %d not found", aid);
+    return false;
+  }
   return addLabel(pAtom, label);
 }
 

--- a/src/modules/molvis/AtomIntrRenderer.cpp
+++ b/src/modules/molvis/AtomIntrRenderer.cpp
@@ -470,7 +470,7 @@ void AtomIntrRenderer::setAt(int index, const AtomIntrData &dat)
 
 bool AtomIntrRenderer::remove(int nid)
 {
-  if (m_data.size()<=nid)
+  if (nid<0 || int(m_data.size())<=nid)
     return false;
 
   AtomIntrData dat = m_data[nid];

--- a/src/modules/molvis/DistPickDrawObj.cpp
+++ b/src/modules/molvis/DistPickDrawObj.cpp
@@ -80,5 +80,9 @@ void DistPickDrawObj::append(qlib::uid_t mol_id, int naid)
     MolCoordPtr pMol = qsys::SceneManager::getObjectS(mol_id);
     if (pMol.isnull()) return;
     molstr::MolAtomPtr pAtom = pMol->getAtom(naid);
+    if (pAtom.isnull()) {
+        LOG_DPRINTLN("DistPickDrawObj> atom %d not found in mol %d", naid, int(mol_id));
+        return;
+    }
     m_data.push_back(pAtom->getPos());
 }

--- a/src/modules/molvis/JctTable.cpp
+++ b/src/modules/molvis/JctTable.cpp
@@ -26,17 +26,17 @@ JctTable::JctTable()
 JctTable::~JctTable()
 {
   if (m_pParTab!=NULL)
-    delete m_pParTab;
+    delete [] m_pParTab;
   if (m_pEsclTab!=NULL)
-    delete m_pEsclTab;
+    delete [] m_pEsclTab;
 }
 
 void JctTable::invalidate()
 {
   if (m_pParTab!=NULL)
-    delete m_pParTab;
+    delete [] m_pParTab;
   if (m_pEsclTab!=NULL)
-    delete m_pEsclTab;
+    delete [] m_pEsclTab;
 
   m_nTabSz = 0;
   m_pParTab = NULL;
@@ -258,6 +258,10 @@ bool JctTable::setup(int ndetail, TubeSection *pts1, TubeSection *pts2, bool fre
     m_fPartition = true;
   else
     m_fPartition = false;
+
+  // setup() runs once per segment on every rebuild: release the previous
+  // tables (and leave an empty table when the setup below fails)
+  invalidate();
 
   switch (m_nType) {
   default:

--- a/src/modules/molvis/JctTable.hpp
+++ b/src/modules/molvis/JctTable.hpp
@@ -129,8 +129,7 @@ public:
 
   /** get axial param & scaling coeff */
   bool get(int index, double &par, double &e1scl, double &e2scl) const {
-    MB_ASSERT(index>=0 && index<m_nTabSz);
-    if (index<0 && index>=m_nTabSz) return false;
+    if (index<0 || index>=m_nTabSz) return false;
     par = m_pParTab[index];
     e1scl = m_pEsclTab[index].sclx;
     e2scl = m_pEsclTab[index].scly;
@@ -139,8 +138,7 @@ public:
 
   /// Get axial param & scaling coeff
   bool get(int index, double &par, Vector4D &vv) const {
-    MB_ASSERT(index>=0 && index<m_nTabSz);
-    if (index<0 && index>=m_nTabSz) return false;
+    if (index<0 || index>=m_nTabSz) return false;
     par = m_pParTab[index];
     vv.x() = m_pEsclTab[index].sclx;
     vv.y() = m_pEsclTab[index].scly;
@@ -151,8 +149,7 @@ public:
 
   /// Get axial param only
   bool get(int index, double &par) const {
-    MB_ASSERT(index>=0 && index<m_nTabSz);
-    if (index<0 && index>=m_nTabSz) return false;
+    if (index<0 || index>=m_nTabSz) return false;
     par = m_pParTab[index];
     return true;
   }

--- a/src/modules/molvis/PaintColoring.cpp
+++ b/src/modules/molvis/PaintColoring.cpp
@@ -247,7 +247,7 @@ void PaintColoring::insertBefore(int ind, const SelectionPtr &psel, const ColorP
 
 bool PaintColoring::removeAtImpl(int ind)
 {
-  if (ind>=m_coltab.size())
+  if (ind<0 || ind>=int(m_coltab.size()))
     return false;
 
   ColorTab::iterator iter = m_coltab.begin()+ind;
@@ -284,7 +284,7 @@ bool PaintColoring::removeAt(int ind)
 
 bool PaintColoring::changeAt(int ind, const SelectionPtr &psel, const ColorPtr &pcol)
 {
-  if (ind>=m_coltab.size()) return false;
+  if (ind<0 || ind>=int(m_coltab.size())) return false;
   ColorTab::iterator iter = m_coltab.begin()+ind;
 
   SelectionPtr poldsel = iter->first;

--- a/src/modules/molvis/TubeSection.hpp
+++ b/src/modules/molvis/TubeSection.hpp
@@ -120,7 +120,9 @@ public:
   int getType() const { return m_nSectType; }
 
   void setDetail(int d) {
-    m_nSectDetail = d;
+    // detail is a script property; an empty section table would divide
+    // by zero in getVec()
+    m_nSectDetail = (d < 1) ? 1 : d;
     invalidate();
     //setupSectionTable();
   }

--- a/src/modules/surface/MSMSFileReader.cpp
+++ b/src/modules/surface/MSMSFileReader.cpp
@@ -285,6 +285,16 @@ bool MSMSFileReader::readFace(qlib::LineStream &ins)
       MB_THROW(qlib::FileFormatException, msg);
       return false;
     }
+    // MSMS vertex IDs are 1-based; the renderer and the cutting code index
+    // the vertex array with them unchecked, so reject out-of-range IDs here
+    const int nverts = m_pSurf->getVertSize();
+    if (id1<1 || id1>nverts || id2<1 || id2>nverts || id3<1 || id3>nverts) {
+      LOG_DPRINTLN("MSMSRead> %s", m_recbuf.c_str());
+      LString msg = LString::format("MSMSRead> FATAL Error: face vertex index out of range at %d.", m_lineno);
+      LOG_DPRINTLN(msg);
+      MB_THROW(qlib::FileFormatException, msg);
+      return false;
+    }
     m_pSurf->setFace(i, id1-1, id2-1, id3-1);
   }
 

--- a/src/modules/surface/OpenDXPotReader.cpp
+++ b/src/modules/surface/OpenDXPotReader.cpp
@@ -12,6 +12,8 @@
 #include "OpenDXPotReader.hpp"
 #include "ElePotMap.hpp"
 
+#include <vector>
+
 using namespace surface;
 
 // default constructor
@@ -232,14 +234,18 @@ bool OpenDXPotReader::read(qlib::InStream &arg)
   //
   //  allocate memory
   //
-  float *fbuf;
-  int ntotal = m_nx*m_ny*m_nz;
-  fbuf = MB_NEW float[ntotal];
-  LOG_DPRINT("memory allocation %d bytes\n", ntotal*4);
-  if (fbuf==NULL) {
-    MB_THROW(qlib::OutOfMemoryException, "OpenDX PotFile read: cannot allocate memory");
+  if (m_nx<=0 || m_ny<=0 || m_nz<=0) {
+    MB_THROW(qlib::FileFormatException, "OpenDX PotFile read: invalid map size");
     return false;
   }
+  // the map is indexed with int arithmetic, so the element count must fit
+  const size_t ntotal = size_t(m_nx)*size_t(m_ny)*size_t(m_nz);
+  if (ntotal > size_t(0x7fffffff)) {
+    MB_THROW(qlib::FileFormatException, "OpenDX PotFile read: map size too large");
+    return false;
+  }
+  std::vector<float> fbuf(ntotal);
+  LOG_DPRINT("memory allocation %zu bytes\n", ntotal*sizeof(float));
 
   //int ii=0;
   for (int ix=0; ix<m_nx; ix++) {
@@ -265,7 +271,8 @@ bool OpenDXPotReader::read(qlib::InStream &arg)
   LOG_DPRINTLN("OpenDXPotReader> Map origin: (%f, %f, %f)", orig.x(), orig.y(), orig.z());
   const double scale = 1.0/m_hx;
 
-  m_pMap->setMapFloatArray(fbuf, m_nx, m_ny, m_nz,
+  // setMapFloatArray() copies the array
+  m_pMap->setMapFloatArray(fbuf.data(), m_nx, m_ny, m_nz,
                            m_hx, m_hy, m_hz, orig);
 
   if (m_dSmooth>0.0) {

--- a/src/modules/surface/QdfPotReader.cpp
+++ b/src/modules/surface/QdfPotReader.cpp
@@ -13,6 +13,8 @@
 
 #include "ElePotMap.hpp"
 
+#include <vector>
+
 using namespace surface;
 
 MC_DYNCLASS_IMPL(QdfPotReader, QdfPotReader, qlib::LSpecificClass<QdfPotReader>);
@@ -91,8 +93,17 @@ void QdfPotReader::readData()
   m_nx = getRecValInt32("nx");
   m_ny = getRecValInt32("ny");
   m_nz = getRecValInt32("nz");
-  const int ntotal = m_nx*m_ny*m_nz;
-  LOG_DPRINTLN("QdfPot> map size (%d,%d,%d)=%d", m_nx, m_ny, m_nz, ntotal);
+  if (m_nx<=0 || m_ny<=0 || m_nz<=0) {
+    MB_THROW(qlib::FileFormatException, "invalid map size");
+    return;
+  }
+  // the map is indexed with int arithmetic, so the element count must fit
+  const size_t ntotal = size_t(m_nx)*size_t(m_ny)*size_t(m_nz);
+  if (ntotal > size_t(0x7fffffff)) {
+    MB_THROW(qlib::FileFormatException, "map size too large");
+    return;
+  }
+  LOG_DPRINTLN("QdfPot> map size (%d,%d,%d)=%zu", m_nx, m_ny, m_nz, ntotal);
 
   const double gx = getRecValFloat32("gx");
   const double gy = getRecValFloat32("gy");
@@ -116,7 +127,7 @@ void QdfPotReader::readData()
   ///////////////////
 
   int ndata = readDataDef("data");
-  if (ndata!=ntotal) {
+  if (ndata<0 || size_t(ndata)!=ntotal) {
     MB_THROW(qlib::FileFormatException, "inconsistent data (ndata!=nx*ny*nz)");
     return;
   }
@@ -124,18 +135,15 @@ void QdfPotReader::readData()
   //
   //  allocate memory
   //
-  float *fbuf = MB_NEW float[ntotal];
-  LOG_DPRINTLN("QdfPot> memory allocation %f Mbytes", double(ntotal*4.0)/(1024.0*1024.0));
-  if (fbuf==NULL) {
-    MB_THROW(qlib::OutOfMemoryException, "cannot allocate memory");
-    return;
-  }
+  std::vector<float> fbuf(ntotal);
+  LOG_DPRINTLN("QdfPot> memory allocation %f Mbytes", double(ntotal)*4.0/(1024.0*1024.0));
 
   readRecordDef();
 
-  readDataArray(fbuf);
+  readDataArray(fbuf.data());
 
-  m_pObj->setMapFloatArray(fbuf, m_nx, m_ny, m_nz,
+  // setMapFloatArray() copies the array
+  m_pObj->setMapFloatArray(fbuf.data(), m_nx, m_ny, m_nz,
                            gx, gy, gz, orig);
 
 }

--- a/src/modules/surface/QdfSurfReader.cpp
+++ b/src/modules/surface/QdfSurfReader.cpp
@@ -78,6 +78,8 @@ bool QdfSurfReader::read(qlib::InStream &ins)
     readFaceData2();
   }
   
+  checkFaces();
+
   end();
 
   m_pObj = NULL;
@@ -133,6 +135,13 @@ void QdfSurfReader::readVertData2()
   
   readRecordDef();
 
+  // the records are copied straight into the MSVert array, so the file
+  // layout must be exactly the in-memory one
+  if (getStream().getFxRecordSize() != int(sizeof (MSVert))) {
+    MB_THROW(qlib::FileFormatException, "QdfSurf vert record size mismatch");
+    return;
+  }
+
   MSVert *pv = m_pObj->getVertPtr();
   getStream().readFxRecords(nverts, pv, sizeof (MSVert)*nverts);
 
@@ -164,6 +173,11 @@ void QdfSurfReader::readFaceData2()
   
   readRecordDef();
 
+  if (getStream().getFxRecordSize() != int(sizeof (MSFace))) {
+    MB_THROW(qlib::FileFormatException, "QdfSurf face record size mismatch");
+    return;
+  }
+
   MSFace *pf = m_pObj->getFacePtr();
   getStream().readFxRecords(nfaces, pf, sizeof (MSFace)*nfaces);
   /*
@@ -179,4 +193,21 @@ void QdfSurfReader::readFaceData2()
 */
 }
 
+void QdfSurfReader::checkFaces() const
+{
+  // the renderer and the cutting code index the vertex array with the face
+  // IDs unchecked, so a corrupt file must be rejected here
+  const int nverts = m_pObj->getVertSize();
+  const int nfaces = m_pObj->getFaceSize();
+  for (int i=0; i<nfaces; ++i) {
+    const MSFace &f = m_pObj->getFaceAt(i);
+    if (f.id1<0 || f.id1>=nverts ||
+        f.id2<0 || f.id2>=nverts ||
+        f.id3<0 || f.id3>=nverts) {
+      MB_THROW(qlib::FileFormatException,
+               LString::format("QdfSurf face %d: vertex index out of range", i));
+      return;
+    }
+  }
+}
 

--- a/src/modules/surface/QdfSurfReader.hpp
+++ b/src/modules/surface/QdfSurfReader.hpp
@@ -66,6 +66,9 @@ private:
 
   void readVertData2();
   void readFaceData2();
+
+  /// Reject faces whose vertex indices are outside the vertex array
+  void checkFaces() const;
 };
 
 }

--- a/src/modules/symm/PDBCryst1Handler.cpp
+++ b/src/modules/symm/PDBCryst1Handler.cpp
@@ -112,7 +112,13 @@ bool PDBCryst1Handler::write(LString &record, MolCoord *pMol)
 
   int nsg = pci->getSG();
   SymOpDB *pdb = SymOpDB::getInstance();
-  LString hmname = pdb->getCName(nsg);
+  const char *pcname = pdb->getCName(nsg);
+  if (pcname==NULL) {
+    // nsg is writable from scripts; an unknown number has no name to write
+    LOG_DPRINTLN("PDBCryst1Handler> unknown space group number %d, CRYST1 not written", nsg);
+    return false;
+  }
+  LString hmname(pcname);
 
   record = LString::format(
     "CRYST1"

--- a/src/modules/xtal/CCP4MapReader.cpp
+++ b/src/modules/xtal/CCP4MapReader.cpp
@@ -538,6 +538,36 @@ bool CCP4MapReader::read(qlib::InStream &arg)
     hdrin.fetch_float(origin[2]);
   }
 
+  // The axis order words select the storage axes (rotate() writes r[ax])
+  // and the counts size the chunk arrays, so a corrupt header must be
+  // rejected before either is used. MAPC=MAPR=MAPS=0 exists in the wild.
+  {
+    const int ax[3] = {axcol, axrow, axsect};
+    bool bSeen[3] = {false, false, false};
+    bool bAxesOK = true;
+    for (int i=0; i<3; ++i) {
+      if (ax[i]<1 || ax[i]>3 || bSeen[ax[i]-1]) {
+        bAxesOK = false;
+        break;
+      }
+      bSeen[ax[i]-1] = true;
+    }
+    if (!bAxesOK) {
+      LString msg = LString::format("CCP4MapReader read: invalid axis order (%d,%d,%d)",
+                                    axcol, axrow, axsect);
+      LOG_DPRINTLN(msg);
+      MB_THROW(qlib::FileFormatException, msg);
+      return false;
+    }
+    if (ncol<=0 || nrow<=0 || nsect<=0) {
+      LString msg = LString::format("CCP4MapReader read: invalid map size (%d,%d,%d)",
+                                    ncol, nrow, nsect);
+      LOG_DPRINTLN(msg);
+      MB_THROW(qlib::FileFormatException, msg);
+      return false;
+    }
+  }
+
   LOG_DPRINT("CCP4Map> Header Info:\n");
   LOG_DPRINT("  map size  : (%d,%d,%d)\n", ncol, nrow, nsect);
   LOG_DPRINT("  map start : (%d,%d,%d)\n", stacol, starow, stasect);

--- a/src/modules/xtal/MTZ2MapReader.cpp
+++ b/src/modules/xtal/MTZ2MapReader.cpp
@@ -131,6 +131,9 @@ bool MTZ2MapReader::read(qlib::InStream &arg)
                  m_nfp, m_nphi, m_nwgt);
   mapfft.doFFT();
 
+  // the reflection buffer is only needed for the FFT
+  cleanup();
+
   return true;
 }
 
@@ -146,8 +149,16 @@ void MTZ2MapReader::readData(qlib::InStream &arg)
 
   readFooter(ins);
   
-  if (m_ncol<=3 || m_nrefl==0 || m_ncol!=m_columns.size())
+  if (m_ncol<=3 || m_nrefl<=0 || m_ncol!=m_columns.size())
     MB_THROW(qlib::FileFormatException, "No refls in mtzfile");
+
+  // NCOL/NREFL come from the footer: the FFT reads nrefl*ncol floats from
+  // the body, which must actually hold them
+  if (size_t(m_nrefl)*size_t(m_ncol)*sizeof(float) > size_t(m_nrawdat)) {
+    MB_THROW(qlib::FileFormatException,
+             "MTZ body is shorter than NCOL*NREFL reflections");
+    return;
+  }
 
   LOG_DPRINT("MTZ> Unit cell a=%.2fA, b=%.2fA, c=%.2fA,\n", m_cella, m_cellb, m_cellc);
   LOG_DPRINT("MTZ> alpha=%.2f, beta=%.2f, gamma=%.2f,\n", m_alpha, m_beta, m_gamma);
@@ -193,12 +204,14 @@ void MTZ2MapReader::readHeader(qlib::InStream &ins)
 
 void MTZ2MapReader::readBody(qlib::InStream &ins)
 {
-  m_nrawdat = (m_nhdrst-1)*4 - 20*4;
-  m_pbuf = new char[m_nrawdat];
-  if (m_pbuf==NULL) {
-    MB_THROW(qlib::OutOfMemoryException, "MTZ2MapReader> cannot allocate memory");
+  // the header location word must leave room for the 80-byte header
+  if (m_nhdrst < 21) {
+    MB_THROW(qlib::FileFormatException, "MTZ header location is inside the header");
     return;
   }
+  m_nrawdat = (m_nhdrst-1)*4 - 20*4;
+  cleanup();
+  m_pbuf = new char[m_nrawdat];
   MB_DPRINTLN("MTZ2MapReader> alloc %d bytes\n", m_nrawdat);
 
   ins.readFully(m_pbuf, 0, m_nrawdat*sizeof(char));
@@ -206,6 +219,10 @@ void MTZ2MapReader::readBody(qlib::InStream &ins)
 
 void MTZ2MapReader::skipBody(qlib::InStream &ins)
 {
+  if (m_nhdrst < 21) {
+    MB_THROW(qlib::FileFormatException, "MTZ header location is inside the header");
+    return;
+  }
   m_nrawdat = (m_nhdrst-1)*4 - 20*4;
   ins.skip(m_nrawdat*sizeof(char));
 }

--- a/src/qlib/ExpatInStream.cpp
+++ b/src/qlib/ExpatInStream.cpp
@@ -94,7 +94,8 @@ void ExpatInStream::parse()
   bool done=false;
   do {
     int len = super_t::read(buf, 0, sizeof(buf));
-    done = len < sizeof(buf);
+    if (len < 0) len = 0;  // EOF: feed an empty final chunk
+    done = len < int(sizeof(buf));
     if (XML_Parse(getParser(), buf, len, done) == XML_STATUS_ERROR) {
       LString msg =
         LString::format("%s at line %d\n",
@@ -127,7 +128,8 @@ void ExpatInStream::procExtEntity(const char *fname, const char *szctxt)
     bool done=false;
     do {
       int len = fis.read(buf, 0, sizeof(buf));
-      done = len < sizeof(buf);
+      if (len < 0) len = 0;  // EOF: feed an empty final chunk
+      done = len < int(sizeof(buf));
       if (XML_Parse(expar, buf, len, done) == XML_STATUS_ERROR) {
 	LString msg =
 	  LString::format("%s at line %d\n",

--- a/src/qlib/LByteArray.cpp
+++ b/src/qlib/LByteArray.cpp
@@ -138,10 +138,10 @@ int LByteArray::getAt(int ind) const
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray getAt() out of index %d", ind));
 
@@ -183,10 +183,10 @@ void LByteArray::setAt(int ind, int value)
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray setAt() out of index %d", ind));
 
@@ -228,10 +228,10 @@ double LByteArray::getAtF(int ind) const
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray getAtF() out of index %d", ind));
 
@@ -256,10 +256,10 @@ void LByteArray::setAtF(int ind, double value)
                  LString::format("Element type %d mismatch", m_nElemType));
 
     int nElemSize = getElemSize(m_nElemType);
-    int addr = ind * nElemSize;
     const int nsize = getSize();
-    // MB_ASSERT(0<=ind && ind*nElemSize<nsize);
-    if (ind < 0 || nsize <= addr)
+    // size_t: ind * nElemSize wrapped around in int and passed the check
+    const size_t addr = size_t(ind) * size_t(nElemSize);
+    if (ind < 0 || size_t(nsize) <= addr)
         MB_THROW(IndexOutOfBoundsException,
                  LString::format("LByteArray setAtF() out of index %d", ind));
 

--- a/src/qlib/LRegExpr.cpp
+++ b/src/qlib/LRegExpr.cpp
@@ -115,6 +115,10 @@ LString LRegExpr::getSubstr(int index)
     int nstart = m_ovector[2 * index];
     int nsize = m_ovector[2 * index + 1] - m_ovector[2 * index];
 
+    // pcre marks a group that did not take part in the match with -1
+    if (nstart < 0 || nsize < 0)
+        return LString();
+
     return m_subj.substr(nstart, nsize);
 }
 

--- a/src/qlib/LScrMatrix4D.hpp
+++ b/src/qlib/LScrMatrix4D.hpp
@@ -56,13 +56,17 @@ public:
     typedef std::true_type has_fromString;
     static LScrMatrix4D *fromStringS(const LString &src);
 
+    // row/column indices are 1-based and run to 4 (aij(i,j) maps them to
+    // the 16-element array, so checking against _N_ELEM let 16 write past it)
+    static constexpr int _N_DIM = 4;
+
     static inline void indexCheck(int i, int j) {
-        if (i<=0 || Matrix4D::_N_ELEM <i) {
+        if (i<=0 || _N_DIM <i) {
             auto msg = LString::format("index i=%d out of range", i);
             MB_THROW(IndexOutOfBoundsException, msg);
             return;
         }
-        if (j<=0 || Matrix4D::_N_ELEM <j) {
+        if (j<=0 || _N_DIM <j) {
             auto msg = LString::format("index j=%d out of range", j);
             MB_THROW(IndexOutOfBoundsException, msg);
             return;

--- a/src/qsys/Object.cpp
+++ b/src/qsys/Object.cpp
@@ -177,6 +177,9 @@ RendererPtr Object::getRendererByType(const LString &type_name)
 
 RendererPtr Object::getRendererByIndex(int ind)
 {
+  // script argument: advancing past end() is undefined
+  if (ind<0 || ind>=int(m_rendtab.size()))
+    return RendererPtr();
   rendtab_t::const_iterator i = m_rendtab.begin();
   while (ind>0) {
     ++i;

--- a/src/qsys/QdfStream.cpp
+++ b/src/qsys/QdfStream.cpp
@@ -610,9 +610,17 @@ void QdfInStream::readFxRecords(int nrec, void *pbuf, int nbufsz)
 {
   const int nrecsz = getFxRecordSize();
 
+  if (nrec<0) {
+    MB_THROW(qlib::FileFormatException, "QdfInStream: negative record count");
+    return;
+  }
   const size_t ntotal = size_t(nrecsz) * size_t(nrec);
-  MB_ASSERT(size_t(nbufsz)>=ntotal);
-  MB_ASSERT(ntotal <= size_t(0x7fffffff));
+  // the record definition comes from the file: a layout the caller did not
+  // expect must not overrun its buffer
+  if (ntotal > size_t(nbufsz) || ntotal > size_t(0x7fffffff)) {
+    MB_THROW(qlib::FileFormatException, "QdfInStream: fixed record size mismatch");
+    return;
+  }
 
   m_pBinIn->readFully((char *)pbuf, 0, int(ntotal));
 

--- a/src/qsys/QdfStream.cpp
+++ b/src/qsys/QdfStream.cpp
@@ -17,6 +17,23 @@
 #endif
 
 using namespace qsys;
+
+namespace {
+
+// The record definition comes from the file, so reading (or writing) more
+// fields than it defines must fail as a format error, not as a vector
+// overrun.
+inline const qsys::QdfDataType::RecElem &recElemAt(
+    const qsys::QdfDataType::RecElemList &defs, int ind)
+{
+  if (ind < 0 || size_t(ind) >= defs.size()) {
+    MB_THROW(qlib::FileFormatException, "Qdf record index out of range");
+  }
+  return defs[ind];
+}
+
+}  // namespace
+
 using qlib::Vector4D;
 
 //static
@@ -353,7 +370,7 @@ void QdfInStream::endRecord()
 
 void QdfInStream::skipRecord()
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   const LString nm = elem.first;
   const int type = elem.second;
 
@@ -427,7 +444,7 @@ void QdfInStream::skipAllRecordsImpl()
 
 qfloat32 QdfInStream::readFloat32(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_FLOAT32) {
     MB_THROW(qlib::FileFormatException, "setRecValFloat32 inconsistent record order");
     return -0.0f;
@@ -439,7 +456,7 @@ qfloat32 QdfInStream::readFloat32(const LString &name)
 
 qint32 QdfInStream::readInt32(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT32) {
     MB_THROW(qlib::FileFormatException, "setRecValInt32 inconsistent record order");
     return 0;
@@ -452,7 +469,7 @@ qint32 QdfInStream::readInt32(const LString &name)
 
 quint32 QdfInStream::readUInt32(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT32) {
     MB_THROW(qlib::FileFormatException, "readUInt32 inconsistent record order");
     return 0;
@@ -465,7 +482,7 @@ quint32 QdfInStream::readUInt32(const LString &name)
 
 qint8 QdfInStream::readInt8(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT8) {
     MB_THROW(qlib::FileFormatException, "readInt8 inconsistent record order");
     return 0;
@@ -478,7 +495,7 @@ qint8 QdfInStream::readInt8(const LString &name)
 
 quint8 QdfInStream::readUInt8(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT8) {
     MB_THROW(qlib::FileFormatException, "readUInt8 inconsistent record order");
     return 0;
@@ -491,7 +508,7 @@ quint8 QdfInStream::readUInt8(const LString &name)
 
 bool QdfInStream::readBool(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_BOOL) {
     MB_THROW(qlib::FileFormatException, "readBool inconsistent record order");
     return 0;
@@ -506,7 +523,7 @@ bool QdfInStream::readBool(const LString &name)
 
 LString QdfInStream::readStr(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name)) {
     MB_THROW(qlib::FileFormatException, "readStr inconsistent record order");
     return LString();
@@ -540,7 +557,7 @@ LString QdfInStream::readStr(const LString &name)
 
 void QdfInStream::readVec3D(const LString &name, qfloat32 *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "readVec3f inconsistent record order");
     return;
@@ -555,7 +572,7 @@ void QdfInStream::readVec3D(const LString &name, qfloat32 *pvec)
 
 Vector4D QdfInStream::readVec3D(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "readVec3f inconsistent record order");
     return Vector4D();
@@ -572,7 +589,7 @@ Vector4D QdfInStream::readVec3D(const LString &name)
 
 quint32 QdfInStream::readColorRGBA(const LString &name)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "readColorRGBA inconsistent record order");
     return 0;
@@ -590,7 +607,7 @@ quint32 QdfInStream::readColorRGBA(const LString &name)
 
 void QdfInStream::readColorRGBA(const LString &name, qbyte *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "readColorRGBA inconsistent record order");
     return;
@@ -848,7 +865,7 @@ void QdfOutStream::endRecord()
 
 void QdfOutStream::writeStr(const LString &name, const LString &value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UTF8STR) {
     MB_THROW(qlib::FileFormatException, "writeStr inconsistent record order");
     return;
@@ -860,7 +877,7 @@ void QdfOutStream::writeStr(const LString &name, const LString &value)
 
 void QdfOutStream::writeFixedStr(const LString &name, const LString &value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name)) {
     LString msg = LString::format("writeFixStr(%s,%s) inconsistent record order", name.c_str(), value.c_str());
     MB_THROW(qlib::FileFormatException, msg);
@@ -882,7 +899,7 @@ void QdfOutStream::writeFixedStr(const LString &name, const LString &value)
 
 void QdfOutStream::writeInt32(const LString &name, int value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT32) {
     MB_THROW(qlib::FileFormatException, "writeInt inconsistent record order");
     return;
@@ -894,7 +911,7 @@ void QdfOutStream::writeInt32(const LString &name, int value)
 
 void QdfOutStream::writeUInt32(const LString &name, quint32 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT32) {
     MB_THROW(qlib::FileFormatException, "writeInt inconsistent record order");
     return;
@@ -906,7 +923,7 @@ void QdfOutStream::writeUInt32(const LString &name, quint32 value)
 
 void QdfOutStream::writeInt16(const LString &name, qint16 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT16) {
     MB_THROW(qlib::FileFormatException, "writeInt8 inconsistent record order");
     return;
@@ -918,7 +935,7 @@ void QdfOutStream::writeInt16(const LString &name, qint16 value)
 
 void QdfOutStream::writeInt8(const LString &name, qint8 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_INT8) {
     MB_THROW(qlib::FileFormatException, "writeInt8 inconsistent record order");
     return;
@@ -930,7 +947,7 @@ void QdfOutStream::writeInt8(const LString &name, qint8 value)
 
 void QdfOutStream::writeUInt8(const LString &name, quint8 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_UINT8) {
     MB_THROW(qlib::FileFormatException, "writeInt8 inconsistent record order");
     return;
@@ -942,7 +959,7 @@ void QdfOutStream::writeUInt8(const LString &name, quint8 value)
 
 void QdfOutStream::writeBool(const LString &name, bool value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_BOOL) {
     MB_THROW(qlib::FileFormatException, "writeBool inconsistent record order");
     return;
@@ -955,7 +972,7 @@ void QdfOutStream::writeBool(const LString &name, bool value)
 
 void QdfOutStream::writeFloat32(const LString &name, qfloat32 value)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_FLOAT32) {
     MB_THROW(qlib::FileFormatException, "writeFloat32 inconsistent record order");
     return;
@@ -967,7 +984,7 @@ void QdfOutStream::writeFloat32(const LString &name, qfloat32 value)
 
 void QdfOutStream::writeVec3D(const LString &name, const qlib::Vector4D &vec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "writeVec3D inconsistent record order");
     return;
@@ -982,7 +999,7 @@ void QdfOutStream::writeVec3D(const LString &name, const qlib::Vector4D &vec)
 
 void QdfOutStream::writeVec3D(const LString &name, const qfloat32 *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_VEC3) {
     MB_THROW(qlib::FileFormatException, "writeVec3D inconsistent record order");
     return;
@@ -997,7 +1014,7 @@ void QdfOutStream::writeVec3D(const LString &name, const qfloat32 *pvec)
 
 void QdfOutStream::writeColorRGBA(const LString &name, quint32 ccode)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "writeColorRGBA inconsistent record order");
     return;
@@ -1012,7 +1029,7 @@ void QdfOutStream::writeColorRGBA(const LString &name, quint32 ccode)
 
 void QdfOutStream::writeColorRGBA(const LString &name, const qbyte *pvec)
 {
-  const RecElem &elem = m_recdefs[m_nRecInd];
+  const RecElem &elem = recElemAt(m_recdefs, m_nRecInd);
   if (!elem.first.equals(name) || elem.second!=QDF_TYPE_RGBA) {
     MB_THROW(qlib::FileFormatException, "writeColorRGBA inconsistent record order");
     return;

--- a/src/qsys/UndoManager.cpp
+++ b/src/qsys/UndoManager.cpp
@@ -101,6 +101,8 @@ bool UndoManager::getUndoDesc(int n, LString &str) const
 {
   if (!isUndoable())
     return false;
+  if (n<0 || n>=int(m_udata.size()))
+    return false;
   // UndoInfo *pui = m_udata.front();
   UndoInfoList::const_iterator iter = m_udata.begin();
   for (int i=0; i<n; ++i)
@@ -115,6 +117,8 @@ bool UndoManager::getUndoDesc(int n, LString &str) const
 bool UndoManager::getRedoDesc(int n, LString &str) const
 {
   if (!isRedoable())
+    return false;
+  if (n<0 || n>=int(m_rdata.size()))
     return false;
   //UndoInfo *pui = m_rdata.front();
   UndoInfoList::const_iterator iter = m_rdata.begin();

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -178,6 +178,7 @@ add_executable(test_surface
   modules/surface/test_ply_reader.cpp
   modules/surface/test_molsurf_serialize.cpp
   modules/surface/test_ses_from_array.cpp
+  modules/surface/test_reader_validation.cpp
 )
 target_include_directories(test_surface PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -200,6 +200,7 @@ add_executable(test_xtal
   modules/xtal/test_atomposmap2.cpp
   modules/xtal/test_brix_reader.cpp
   modules/xtal/test_ccp4_origin.cpp
+  modules/xtal/test_map_reader_validation.cpp
   modules/xtal/test_ccp4map_stream.cpp
   modules/xtal/test_map_block_extract.cpp
   modules/xtal/test_map_histogram.cpp

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -158,6 +158,7 @@ add_executable(test_molvis
   modules/molvis/test_main.cpp
   modules/molvis/test_cpk2renderer.cpp
   modules/molvis/test_smoothspline.cpp
+  modules/molvis/test_script_index_checks.cpp
 )
 target_include_directories(test_molvis PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -44,6 +44,8 @@ add_executable(test_qlib
   qlib/test_chunked_array3d.cpp
   qlib/test_seekable_stream.cpp
   qlib/test_lvardict.cpp
+  qlib/test_lbytearray.cpp
+  qlib/test_expat_instream.cpp
 )
 target_include_directories(test_qlib PRIVATE
   ${CMAKE_SOURCE_DIR}/src

--- a/src/tests/modules/importers/test_trajio.cpp
+++ b/src/tests/modules/importers/test_trajio.cpp
@@ -1506,3 +1506,64 @@ TEST(TrajectoryTest, AmberNetCDFInitialFrameIsTrajFrameZero)
         EXPECT_NEAR(pos.z(), ncCoord(0, i, 2), 1e-4);
     }
 }
+
+// ---- corrupt XTC input ----
+//
+// Offsets inside one compressed frame: 56-byte frame header, then precision,
+// minint[3] and maxint[3] (28 bytes), so smallidx sits at 84, the opaque byte
+// count at 88 and the compressed bytes start at 92.
+
+TEST(TrajectoryTest, XtcTruncatedCompressedBlockThrows)
+{
+    const int natom = 12;
+    TrajectoryPtr pTraj = makeTrajectoryNAtoms(natom);
+    std::string xtc = buildXTCCompressed(natom, 1, 1000.0f);
+    ASSERT_GT(xtc.size(), 96u);
+
+    // keep only 4 bytes of the compressed block; the decoder used to read on
+    // past the end of the vector
+    std::string cut = xtc.substr(0, 96);
+    patchBE32(cut, 88, 4u);
+    EXPECT_THROW(appendXTC(pTraj, cut), qlib::FileFormatException);
+}
+
+TEST(TrajectoryTest, XtcSmallidxOutsideTableThrows)
+{
+    const int natom = 12;
+    TrajectoryPtr pTraj = makeTrajectoryNAtoms(natom);
+    const std::string xtc = buildXTCCompressed(natom, 1, 1000.0f);
+
+    // smallidx 0: MAGICINTS[smallidx - 1] wrapped around as unsigned
+    std::string bad = xtc;
+    patchBE32(bad, 84, 0u);
+    EXPECT_THROW(appendXTC(pTraj, bad), qlib::FileFormatException);
+
+    // smallidx past the end of the table
+    bad = xtc;
+    patchBE32(bad, 84, 1000u);
+    EXPECT_THROW(appendXTC(pTraj, bad), qlib::FileFormatException);
+}
+
+// nevery is a script property; 0 used to divide the frame counter by zero.
+TEST(TrajReaderNevery, BelowOneIsClampedToOne)
+{
+    XtcTrajReader xr;
+    xr.setSkipNo(0);
+    EXPECT_EQ(xr.getSkipNo(), 1);
+    xr.setSkipNo(-3);
+    EXPECT_EQ(xr.getSkipNo(), 1);
+    xr.setSkipNo(4);
+    EXPECT_EQ(xr.getSkipNo(), 4);
+
+    mdtools::DCDTrajReader dr;
+    dr.setSkipNo(0);
+    EXPECT_EQ(dr.getSkipNo(), 1);
+
+    mdtools::TrrTrajReader tr;
+    tr.setSkipNo(0);
+    EXPECT_EQ(tr.getSkipNo(), 1);
+
+    mdtools::AmberNetCDFReader ar;
+    ar.setSkipNo(0);
+    EXPECT_EQ(ar.getSkipNo(), 1);
+}

--- a/src/tests/modules/molvis/test_script_index_checks.cpp
+++ b/src/tests/modules/molvis/test_script_index_checks.cpp
@@ -1,0 +1,85 @@
+// -*-Mode: C++;-*-
+//
+// Script-visible entry points of molvis/molstr must reject bad indices and
+// unknown atoms instead of dereferencing past their tables.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "molvis/JctTable.hpp"
+#include "molvis/TubeSection.hpp"
+#include "molvis/PaintColoring.hpp"
+#include "molvis/AtomIntrRenderer.hpp"
+#include "molvis/DistPickDrawObj.hpp"
+#include "molstr/MolCoord.hpp"
+#include "molstr/NameLabelRenderer.hpp"
+
+#include <qlib/Vector4D.hpp>
+
+using qlib::Vector4D;
+
+// axialdetail=0 makes setup() fail and leaves no table; get() used to check
+// index<0 && index>=size and dereference NULL
+TEST(JctTableChecks, GetOnEmptyTableReturnsFalse)
+{
+    molvis::JctTable jt;
+    double par = 0.0, e1 = 0.0, e2 = 0.0;
+    EXPECT_FALSE(jt.get(0, par));
+    EXPECT_FALSE(jt.get(-1, par));
+    EXPECT_FALSE(jt.get(0, par, e1, e2));
+    Vector4D vv;
+    EXPECT_FALSE(jt.get(5, par, vv));
+}
+
+// detail is a script property; 0 produced an empty section table and
+// getVec() divided by it
+TEST(TubeSectionChecks, DetailBelowOneIsClamped)
+{
+    molvis::TubeSection ts;
+    ts.setDetail(0);
+    EXPECT_EQ(ts.getDetail(), 1);
+    ts.setupSectionTable();
+    ASSERT_GE(ts.getSize(), 1);
+    Vector4D e1(1, 0, 0), e2(0, 1, 0);
+    EXPECT_NO_FATAL_FAILURE(ts.getVec(7, e1, e2));
+
+    ts.setDetail(-4);
+    EXPECT_EQ(ts.getDetail(), 1);
+    ts.setDetail(12);
+    EXPECT_EQ(ts.getDetail(), 12);
+}
+
+TEST(PaintColoringChecks, NegativeIndexIsRejected)
+{
+    molvis::PaintColoring pc;
+    EXPECT_FALSE(pc.removeAt(-1));
+    EXPECT_FALSE(pc.removeAt(0));
+    EXPECT_FALSE(pc.changeAt(-1, molstr::SelectionPtr(), gfx::ColorPtr()));
+    EXPECT_FALSE(pc.changeAt(0, molstr::SelectionPtr(), gfx::ColorPtr()));
+}
+
+TEST(AtomIntrRendererChecks, NegativeIndexIsRejected)
+{
+    molvis::AtomIntrRenderer r;
+    EXPECT_FALSE(r.remove(-1));
+    EXPECT_FALSE(r.remove(0));
+}
+
+// DistPickDrawObj::append() is fed atom ids from the measure/bond-edit
+// services; an id the molecule does not have used to dereference NULL
+TEST(DistPickDrawObjChecks, UnknownAtomIsIgnored)
+{
+    molstr::MolCoordPtr pMol(new molstr::MolCoord());
+    molvis::DistPickDrawObj d;
+    EXPECT_NO_FATAL_FAILURE(d.append(pMol->getUID(), 12345));
+    EXPECT_NO_FATAL_FAILURE(d.append(qlib::invalid_uid, 0));
+}
+
+TEST(NameLabelRendererChecks, UnknownAtomIdReturnsFalse)
+{
+    molstr::MolCoordPtr pMol(new molstr::MolCoord());
+    molstr::NameLabelRenderer r;
+    r.attachObj(pMol->getUID());
+    EXPECT_FALSE(r.addLabelByID(12345));
+}

--- a/src/tests/modules/surface/test_main.cpp
+++ b/src/tests/modules/surface/test_main.cpp
@@ -6,6 +6,7 @@
 #include "qsys/RendererFactory.hpp"
 #include "molstr/molstr.hpp"
 #include "surface/surface.hpp"
+#include "symm/symm.hpp"
 
 #ifndef CUEMOL2_SYSCONFIG_PATH
 #define CUEMOL2_SYSCONFIG_PATH ""
@@ -20,8 +21,10 @@ public:
         qsys::RendererFactory::init();
         molstr::init();
         surface::init();
+        symm::init();
     }
     void TearDown() override {
+        symm::fini();
         surface::fini();
         molstr::fini();
         qsys::fini();

--- a/src/tests/modules/surface/test_reader_validation.cpp
+++ b/src/tests/modules/surface/test_reader_validation.cpp
@@ -1,0 +1,307 @@
+//
+// Input validation of the surface readers: corrupt files must be rejected
+// with a FileFormatException instead of being stored and indexed later.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+
+#include "surface/MSMSFileReader.hpp"
+#include "surface/QdfSurfReader.hpp"
+#include "surface/QdfSurfWriter.hpp"
+#include "surface/OpenDXPotReader.hpp"
+#include "surface/MolSurfObj.hpp"
+#include "surface/ElePotMap.hpp"
+#include "symm/PDBCryst1Handler.hpp"
+#include "symm/symm.hpp"
+#include "symm/CrystalInfo.hpp"
+#include "symm/SymOpDB.hpp"
+#include "molstr/MolCoord.hpp"
+
+#include <qsys/QdfAbsWriter.hpp>
+#include <qlib/LExceptions.hpp>
+#include <qlib/PipeStream.hpp>
+#include <qlib/StringStream.hpp>
+#include <qlib/Vector4D.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using qlib::LString;
+using qlib::Vector4D;
+using qlib::StrInStream;
+using qsys::ObjectPtr;
+using surface::MolSurfObj;
+
+namespace {
+
+std::string drainPipe(qlib::PipeStreamImpl &impl)
+{
+    std::string result;
+    char buf[256];
+    while (impl.ready()) {
+        int n = impl.read(buf, 0, sizeof buf);
+        if (n <= 0) break;
+        result.append(buf, static_cast<size_t>(n));
+    }
+    return result;
+}
+
+// Serialize pObj with the given qdf writer and return the bytes.
+std::string writeQdf(qsys::ObjWriter &writer, const ObjectPtr &pObj)
+{
+    auto impl = qlib::sp<qlib::PipeStreamImpl>(new qlib::PipeStreamImpl());
+    qlib::PipeOutStream out;
+    out.setImpl(impl);
+    writer.attach(pObj);
+    writer.write(out);
+    writer.detach();
+    impl->o_close();
+    return drainPipe(*impl);
+}
+
+// A surface with three vertices and one face (id1, id2, id3).
+ObjectPtr makeSurf(int id1, int id2, int id3)
+{
+    MolSurfObj *pSurf = new MolSurfObj();
+    ObjectPtr pObj(pSurf);
+    pSurf->setVertSize(3);
+    pSurf->setVertex(0, Vector4D(0, 0, 0), Vector4D(0, 0, 1));
+    pSurf->setVertex(1, Vector4D(1, 0, 0), Vector4D(0, 0, 1));
+    pSurf->setVertex(2, Vector4D(0, 1, 0), Vector4D(0, 0, 1));
+    pSurf->setFaceSize(1);
+    pSurf->setFace(0, id1, id2, id3);
+    return pObj;
+}
+
+// Writes "SRF1" whose vert records carry one float more than MSVert holds.
+class OversizedVertQdfWriter : public qsys::QdfAbsWriter
+{
+public:
+    bool write(qlib::OutStream &outs) override
+    {
+        start(outs);
+        getStream().writeFileType("SRF1");
+
+        defineData("vert", 1);
+        for (const char *nm : {"x", "y", "z", "nx", "ny", "nz", "extra"})
+            defineRecord(nm, QDF_TYPE_FLOAT32);
+        defineRecord("id", QDF_TYPE_UTF8STR);
+        startData();
+        startRecord();
+        for (const char *nm : {"x", "y", "z", "nx", "ny", "nz", "extra"})
+            setRecValFloat32(nm, 1.0f);
+        setRecValStr("id", LString());
+        endRecord();
+        endData();
+
+        defineData("face", 1);
+        defineRecord("id1", QDF_TYPE_INT32);
+        defineRecord("id2", QDF_TYPE_INT32);
+        defineRecord("id3", QDF_TYPE_INT32);
+        startData();
+        startRecord();
+        setRecValInt32("id1", 0);
+        setRecValInt32("id2", 0);
+        setRecValInt32("id3", 0);
+        endRecord();
+        endData();
+
+        end();
+        return true;
+    }
+    const char *getName() const override { return "oversized_vert_qdf"; }
+    const char *getTypeDescr() const override { return "test"; }
+    const char *getFileExt() const override { return "*.qdf"; }
+    bool canHandle(ObjectPtr) const override { return true; }
+};
+
+ObjectPtr readQdfSurf(const std::string &bytes)
+{
+    StrInStream ins(bytes.data(), static_cast<int>(bytes.size()));
+    surface::QdfSurfReader reader;
+    return reader.load(ins);
+}
+
+// MSMS reads the vertices from a side file named through the "vert" path.
+struct TempVertFile
+{
+    std::filesystem::path path;
+    explicit TempVertFile(const std::string &body)
+        : path(std::filesystem::temp_directory_path() / "cuemol_reader_validation_test.vert")
+    {
+        std::ofstream ofs(path);
+        ofs << body;
+    }
+    ~TempVertFile()
+    {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);
+    }
+};
+
+const char *const MSMS_VERT =
+    "# MSMS solvent excluded surface vertices\n"
+    "#vertex #sphere density probe_r\n"
+    "      3    3  1.00  1.50\n"
+    "    0.000     0.000     0.000     0.000     0.000     1.000\n"
+    "    1.000     0.000     0.000     0.000     0.000     1.000\n"
+    "    0.000     1.000     0.000     0.000     0.000     1.000\n";
+
+ObjectPtr readMSMS(const std::string &faceBody)
+{
+    TempVertFile vert(MSMS_VERT);
+    surface::MSMSFileReader reader;
+    reader.setPath("vert", LString(vert.path.string().c_str()));
+    StrInStream ins(faceBody.data(), static_cast<int>(faceBody.size()));
+    return reader.load(ins);
+}
+
+}  // namespace
+
+// ----------------------------------------------------------------------
+// MSMS face file
+// ----------------------------------------------------------------------
+
+TEST(MSMSFileReaderValidation, ValidFaceIsStoredZeroBased)
+{
+    ObjectPtr pObj = readMSMS(
+        "# MSMS solvent excluded surface faces\n"
+        "#faces  #sphere density probe_r\n"
+        "      1    3  1.00  1.50\n"
+        "     1      2      3\n");
+    MolSurfObj *pSurf = dynamic_cast<MolSurfObj *>(pObj.get());
+    ASSERT_NE(pSurf, nullptr);
+    ASSERT_EQ(pSurf->getFaceSize(), 1);
+    EXPECT_EQ(pSurf->getFaceAt(0).id1, 0u);
+    EXPECT_EQ(pSurf->getFaceAt(0).id3, 2u);
+}
+
+TEST(MSMSFileReaderValidation, FaceIndexOutOfRangeIsRejected)
+{
+    // 9 > 3 vertices; the renderer would index the vertex array with it
+    EXPECT_THROW(readMSMS(
+        "# MSMS solvent excluded surface faces\n"
+        "#faces  #sphere density probe_r\n"
+        "      1    3  1.00  1.50\n"
+        "     1      2      9\n"), qlib::FileFormatException);
+    // 0 would become 0xFFFFFFFF after the 1-based conversion
+    EXPECT_THROW(readMSMS(
+        "# MSMS solvent excluded surface faces\n"
+        "#faces  #sphere density probe_r\n"
+        "      1    3  1.00  1.50\n"
+        "     0      2      3\n"), qlib::FileFormatException);
+}
+
+// ----------------------------------------------------------------------
+// QDF surface file
+// ----------------------------------------------------------------------
+
+TEST(QdfSurfReaderValidation, RoundTripKeepsFaces)
+{
+    surface::QdfSurfWriter writer;
+    std::string bytes = writeQdf(writer, makeSurf(0, 1, 2));
+    ObjectPtr pObj = readQdfSurf(bytes);
+    MolSurfObj *pSurf = dynamic_cast<MolSurfObj *>(pObj.get());
+    ASSERT_NE(pSurf, nullptr);
+    ASSERT_EQ(pSurf->getVertSize(), 3);
+    ASSERT_EQ(pSurf->getFaceSize(), 1);
+    EXPECT_EQ(pSurf->getFaceAt(0).id2, 1u);
+    EXPECT_FLOAT_EQ(pSurf->getVertAt(1).x, 1.0f);
+}
+
+TEST(QdfSurfReaderValidation, FaceIndexOutOfRangeIsRejected)
+{
+    surface::QdfSurfWriter writer;
+    std::string bytes = writeQdf(writer, makeSurf(0, 1, 99));
+    EXPECT_THROW(readQdfSurf(bytes), qlib::FileFormatException);
+}
+
+TEST(QdfSurfReaderValidation, VertRecordSizeMismatchIsRejected)
+{
+    // the fixed-record path copies the records straight into the MSVert
+    // array; a different layout used to overrun it (only an assert in debug)
+    OversizedVertQdfWriter writer;
+    std::string bytes = writeQdf(writer, makeSurf(0, 1, 2));
+    EXPECT_THROW(readQdfSurf(bytes), qlib::FileFormatException);
+}
+
+// ----------------------------------------------------------------------
+// OpenDX potential map
+// ----------------------------------------------------------------------
+
+namespace {
+
+std::string dxHeader(const char *counts)
+{
+    std::string s;
+    s += "object 1 class gridpositions counts ";
+    s += counts;
+    s += "\norigin 0 0 0\ndelta 1 0 0\ndelta 0 1 0\ndelta 0 0 1\n";
+    s += "object 2 class gridconnections counts ";
+    s += counts;
+    s += "\nobject 3 class array type double rank 0 items 1 data follows\n";
+    return s;
+}
+
+ObjectPtr readDX(const std::string &body)
+{
+    StrInStream ins(body.data(), static_cast<int>(body.size()));
+    surface::OpenDXPotReader reader;
+    return reader.load(ins);
+}
+
+}  // namespace
+
+TEST(OpenDXPotReaderValidation, ValidTinyMapLoads)
+{
+    ObjectPtr pObj = readDX(dxHeader("1 1 2") + "0.5 1.5\n");
+    surface::ElePotMap *pMap = dynamic_cast<surface::ElePotMap *>(pObj.get());
+    ASSERT_NE(pMap, nullptr);
+    EXPECT_EQ(pMap->getColNo(), 1);
+    EXPECT_EQ(pMap->getSecNo(), 2);
+}
+
+TEST(OpenDXPotReaderValidation, ZeroSizedMapIsRejected)
+{
+    EXPECT_THROW(readDX(dxHeader("0 0 0") + "\n"), qlib::FileFormatException);
+}
+
+TEST(OpenDXPotReaderValidation, OverflowingMapSizeIsRejected)
+{
+    // 1626^3 wraps to about 4M in int: the old code allocated that and then
+    // wrote 4.3G values into it
+    EXPECT_THROW(readDX(dxHeader("1626 1626 1626") + "0 0 0 0\n"),
+                 qlib::FileFormatException);
+}
+
+// ----------------------------------------------------------------------
+// CRYST1 writer with an unknown space group number
+// ----------------------------------------------------------------------
+
+TEST(PDBCryst1HandlerValidation, UnknownSpaceGroupSkipsTheRecord)
+{
+    // the pre-install sysconfig points the symop table at an install-only
+    // path; use the source-tree copy next to sysconfig.xml
+    std::filesystem::path symop =
+        std::filesystem::path(CUEMOL2_SYSCONFIG_PATH).parent_path() / "symop.dat";
+    symm::SymOpDB::getInstance()->setSymLibFile(LString(symop.string().c_str()));
+
+    molstr::MolCoordPtr pMol(new molstr::MolCoord());
+    symm::CrystalInfoPtr pci = pMol->getCreateExtData("CrystalInfo");
+    ASSERT_FALSE(pci.isnull());
+    pci->setCellDimension(10.0, 10.0, 10.0, 90.0, 90.0, 90.0);
+
+    symm::PDBCryst1Handler handler;
+    LString record;
+
+    pci->setSG(1);  // P 1: the table is loaded and the record is written
+    ASSERT_TRUE(handler.write(record, pMol.get()));
+    EXPECT_TRUE(record.startsWith("CRYST1"));
+
+    record = LString();
+    pci->setSG(99999);  // writable from scripts; no such group
+    EXPECT_FALSE(handler.write(record, pMol.get()));
+    EXPECT_TRUE(record.isEmpty());
+}

--- a/src/tests/modules/xtal/test_map_reader_validation.cpp
+++ b/src/tests/modules/xtal/test_map_reader_validation.cpp
@@ -1,0 +1,154 @@
+// -*-Mode: C++;-*-
+//
+// Header validation of the CCP4/MRC and MTZ readers: corrupt size / axis /
+// length words must raise a FileFormatException instead of indexing
+// arrays with them.
+//
+
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/LExceptions.hpp>
+#include <qlib/StringStream.hpp>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include "xtal/CCP4MapReader.hpp"
+#include "xtal/MTZ2MapReader.hpp"
+#include "xtal/DensityMap.hpp"
+
+using qlib::StrInStream;
+using xtal::CCP4MapReader;
+using xtal::DensityMap;
+using xtal::MTZ2MapReader;
+
+namespace {
+
+/// Minimal MRC image (mode 2, 1024-byte header) with the given map size and
+/// axis order words, followed by nc*nr*ns floats.
+std::string makeMrc(int nc, int nr, int ns, int mapc, int mapr, int maps)
+{
+    std::string buf(1024, '\0');
+    auto putI = [&](int word, int v) { std::memcpy(&buf[(word - 1) * 4], &v, 4); };
+    auto putF = [&](int word, float v) { std::memcpy(&buf[(word - 1) * 4], &v, 4); };
+
+    putI(1, nc);
+    putI(2, nr);
+    putI(3, ns);
+    putI(4, 2);  // MODE: float32
+    putI(8, 4);
+    putI(9, 4);
+    putI(10, 4);
+    putF(11, 4.0f);
+    putF(12, 4.0f);
+    putF(13, 4.0f);
+    putF(14, 90.0f);
+    putF(15, 90.0f);
+    putF(16, 90.0f);
+    putI(17, mapc);
+    putI(18, mapr);
+    putI(19, maps);
+    putF(20, -1.0f);
+    putF(21, 1.0f);
+    putF(22, 0.0f);
+    putI(23, 1);  // ISPG
+    putI(24, 0);  // NSYMBT
+    std::memcpy(&buf[208], "MAP ", 4);
+    buf[212] = 0x44;  // MACHST: little endian
+    buf[213] = 0x44;
+    putF(55, 0.5f);  // RMS
+
+    const int ntotal = (nc > 0 && nr > 0 && ns > 0) ? nc * nr * ns : 0;
+    for (int i = 0; i < ntotal; ++i) {
+        const float v = float(i % 5) - 2.0f;
+        buf.append(reinterpret_cast<const char *>(&v), 4);
+    }
+    return buf;
+}
+
+bool readMrc(const std::string &image)
+{
+    qsys::ObjectPtr pObj(MB_NEW DensityMap());
+    CCP4MapReader reader;
+    reader.attach(pObj);
+    StrInStream ins(image.data(), static_cast<int>(image.size()));
+    const bool bOK = reader.read(ins);
+    reader.detach();
+    return bOK;
+}
+
+/// 80-character MTZ footer record.
+std::string mtzRecord(const std::string &s)
+{
+    std::string r = s;
+    r.resize(80, ' ');
+    return r;
+}
+
+/// Minimal MTZ image: 80-byte header whose header-location word is nhdrst,
+/// the reflection body that word implies, then the footer records.
+std::string makeMtz(uint32_t nhdrst, const std::string &footer)
+{
+    std::string buf = "MTZ ";
+    buf.append(reinterpret_cast<const char *>(&nhdrst), 4);
+    unsigned char mtstring[4] = {0x41, 0x41, 0, 0};  // native int/float
+    buf.append(reinterpret_cast<const char *>(mtstring), 4);
+    buf.resize(80, '\0');
+    if (nhdrst >= 21)
+        buf.resize((nhdrst - 1) * 4, '\0');
+    buf += footer;
+    return buf;
+}
+
+bool readMtz(const std::string &image)
+{
+    qsys::ObjectPtr pObj(MB_NEW DensityMap());
+    MTZ2MapReader reader;
+    reader.attach(pObj);
+    StrInStream ins(image.data(), static_cast<int>(image.size()));
+    const bool bOK = reader.read(ins);
+    reader.detach();
+    return bOK;
+}
+
+}  // namespace
+
+TEST(CCP4MapReaderValidation, ValidTinyMapLoads)
+{
+    EXPECT_TRUE(readMrc(makeMrc(4, 4, 4, 1, 2, 3)));
+    EXPECT_TRUE(readMrc(makeMrc(4, 4, 4, 3, 1, 2)));
+}
+
+TEST(CCP4MapReaderValidation, AxisOrderMustBeAPermutation)
+{
+    // MAPC=MAPR=MAPS=0 (seen in broken MRC files) made rotate() write r[-1]
+    EXPECT_THROW(readMrc(makeMrc(4, 4, 4, 0, 0, 0)), qlib::FileFormatException);
+    EXPECT_THROW(readMrc(makeMrc(4, 4, 4, 1, 1, 2)), qlib::FileFormatException);
+    EXPECT_THROW(readMrc(makeMrc(4, 4, 4, 1, 2, 4)), qlib::FileFormatException);
+}
+
+TEST(CCP4MapReaderValidation, ZeroMapSizeIsRejected)
+{
+    // NC=0 left the chunk arrays empty and sliceBytes() dereferenced them
+    EXPECT_THROW(readMrc(makeMrc(0, 4, 4, 1, 2, 3)), qlib::FileFormatException);
+    EXPECT_THROW(readMrc(makeMrc(4, 4, -1, 1, 2, 3)), qlib::FileFormatException);
+}
+
+TEST(MTZ2MapReaderValidation, HeaderLocationInsideHeaderIsRejected)
+{
+    // nhdrst < 21 made the body length negative
+    EXPECT_THROW(readMtz(makeMtz(5, mtzRecord("END"))), qlib::FileFormatException);
+}
+
+TEST(MTZ2MapReaderValidation, BodyShorterThanNcolNreflIsRejected)
+{
+    // 10 words of body (40 bytes) but NCOL*NREFL = 5*100 floats
+    std::string footer;
+    footer += mtzRecord("NCOL 5 100 0");
+    footer += mtzRecord("COLUMN H H 0 0");
+    footer += mtzRecord("COLUMN K H 0 0");
+    footer += mtzRecord("COLUMN L H 0 0");
+    footer += mtzRecord("COLUMN FWT F 0 0");
+    footer += mtzRecord("COLUMN PHWT P 0 0");
+    footer += mtzRecord("END");
+    EXPECT_THROW(readMtz(makeMtz(21 + 10, footer)), qlib::FileFormatException);
+}

--- a/src/tests/qlib/test_expat_instream.cpp
+++ b/src/tests/qlib/test_expat_instream.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qlib/ExpatInStream.hpp"
+#include "qlib/StringStream.hpp"
+
+#include <string>
+
+using qlib::LString;
+
+namespace {
+
+class CountingExpat : public qlib::ExpatInStream
+{
+public:
+    int nstart = 0;
+    int nend = 0;
+
+    explicit CountingExpat(qlib::InStream &ins) : qlib::ExpatInStream(ins) {}
+
+    void startElement(const LString &, const Attributes &) override { ++nstart; }
+    void endElement(const LString &) override { ++nend; }
+};
+
+}  // namespace
+
+// ExpatInStream reads the input in 2048-byte chunks. A document that is
+// exactly one chunk long fills the first read; the second read reports EOF
+// (-1), which used to be handed to XML_Parse() as the chunk length.
+TEST(ExpatInStream, DocumentOfExactlyOneChunkParses)
+{
+    // 6 + 500*4 + 35 + 7 = 2048 bytes
+    std::string xml = "<root>";
+    for (int i = 0; i < 500; ++i) xml += "<a/>";
+    xml += "<!--" + std::string(28, 'x') + "-->";
+    xml += "</root>";
+    ASSERT_EQ(xml.size(), 2048u);
+
+    qlib::StrInStream ins(xml.data(), static_cast<int>(xml.size()));
+    CountingExpat parser(ins);
+    EXPECT_NO_THROW(parser.parse());
+    EXPECT_EQ(parser.nstart, 501);
+    EXPECT_EQ(parser.nend, 501);
+}

--- a/src/tests/qlib/test_lbytearray.cpp
+++ b/src/tests/qlib/test_lbytearray.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <common.h>
+#include "qlib/LByteArray.hpp"
+#include "qlib/LExceptions.hpp"
+#include "qlib/LTypes.hpp"
+
+using qlib::LByteArray;
+
+// getAt/setAt are script-visible: an index whose byte offset wraps around in
+// int used to pass the bounds check and read far outside the array.
+TEST(LByteArray, HugeIndexIsRejectedNotWrapped)
+{
+    LByteArray arr(16);
+    arr.setElemType(qlib::type_consts::QTC_INT32);
+
+    arr.setAt(3, 7);
+    EXPECT_EQ(arr.getAt(3), 7);
+
+    // 0x40000000 * 4 == 0 in 32-bit int
+    EXPECT_THROW(arr.getAt(0x40000000), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.setAt(0x40000000, 1), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.getAt(4), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.getAt(-1), qlib::IndexOutOfBoundsException);
+}
+
+TEST(LByteArray, HugeFloatIndexIsRejected)
+{
+    LByteArray arr(16);
+    arr.setElemType(qlib::type_consts::QTC_FLOAT32);
+
+    arr.setAtF(1, 2.5);
+    EXPECT_DOUBLE_EQ(arr.getAtF(1), 2.5);
+
+    EXPECT_THROW(arr.getAtF(0x40000000), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(arr.setAtF(0x40000000, 1.0), qlib::IndexOutOfBoundsException);
+}

--- a/src/tests/qlib/test_lregexpr.cpp
+++ b/src/tests/qlib/test_lregexpr.cpp
@@ -101,3 +101,19 @@ TEST(LRegExpr, NamedCapture)
     EXPECT_TRUE(re.getNamedSubstr("month").equals("03"));
     EXPECT_TRUE(re.getNamedSubstr("day").equals("15"));
 }
+
+// pcre reports a group that did not take part in the match with offset -1;
+// substr(size_t(-1)) used to throw std::out_of_range past the LException
+// handlers.
+TEST(LRegExpr, UnmatchedOptionalGroupGivesEmptyString)
+{
+    LRegExpr re;
+    re.setPattern("(a)?(b)");
+    ASSERT_TRUE(re.match("b"));
+    EXPECT_TRUE(re.getSubstr(0).equals("b"));
+    EXPECT_TRUE(re.getSubstr(1).isEmpty());
+    EXPECT_TRUE(re.getSubstr(2).equals("b"));
+
+    ASSERT_TRUE(re.match("ab"));
+    EXPECT_TRUE(re.getSubstr(1).equals("a"));
+}

--- a/src/tests/qlib/test_lscrmatrix4d.cpp
+++ b/src/tests/qlib/test_lscrmatrix4d.cpp
@@ -95,3 +95,17 @@ TEST(LScrMatrix4D, FromStringMissingParentheses)
     LString s("1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16");
     EXPECT_THROW(LScrMatrix4D::fromStringS(s), qlib::RuntimeException);
 }
+
+// setAt/getAt/addAt are script-visible with 1-based row/column indices;
+// the check used to accept anything up to 16 and wrote past the array.
+TEST(LScrMatrix4D, IndicesAboveFourAreRejected)
+{
+    LScrMatrix4D m;
+    m.setAt(4, 4, 2.5);
+    EXPECT_DOUBLE_EQ(m.getAt(4, 4), 2.5);
+
+    EXPECT_THROW(m.setAt(5, 1, 1.0), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(m.setAt(16, 16, 1.0), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(m.getAt(1, 5), qlib::IndexOutOfBoundsException);
+    EXPECT_THROW(m.addAt(0, 1, 1.0), qlib::IndexOutOfBoundsException);
+}

--- a/src/tests/qsys/test_object.cpp
+++ b/src/tests/qsys/test_object.cpp
@@ -133,3 +133,13 @@ TEST(ObjectTest, ForceEmbedSetsDataChunkSource)
     EXPECT_TRUE(obj.getSource().startsWith("datachunk:"));
     EXPECT_TRUE(obj.getAltSource().isEmpty());
 }
+
+// getRendererByIndex is script-visible; an index past the table used to
+// advance the iterator beyond end().
+TEST(ObjectTest, GetRendererByIndexOutOfRangeReturnsNull)
+{
+    ConcreteObject obj;
+    EXPECT_TRUE(obj.getRendererByIndex(0).isnull());
+    EXPECT_TRUE(obj.getRendererByIndex(3).isnull());
+    EXPECT_TRUE(obj.getRendererByIndex(-1).isnull());
+}

--- a/src/tests/qsys/test_qdfstream.cpp
+++ b/src/tests/qsys/test_qdfstream.cpp
@@ -197,3 +197,35 @@ TEST(QdfStreamTest, RoundTripFloat32)
         EXPECT_NEAR(fval, 3.14f, 1e-5f);
     }
 }
+
+// The record definition comes from the file: reading one more field than it
+// defines used to index past m_recdefs.
+TEST(QdfStreamTest, ReadingPastRecordDefinitionThrows)
+{
+    qlib::StrOutStream sos;
+    {
+        QdfOutStream qos(sos);
+        qos.setVersion(0);
+        qos.start();
+        qos.writeFileType("TEST");
+        qos.defData("data", 1);
+        qos.defInt32("ival");
+        qos.startData();
+        qos.startRecord();
+        qos.writeInt32("ival", 42);
+        qos.endRecord();
+        qos.endData();
+        qos.end();
+    }
+
+    int nsize;
+    char *buf = sos.getData(nsize);
+    qlib::StrInStream sis(buf, nsize);
+    QdfInStream qis(sis);
+    qis.start();
+    EXPECT_EQ(qis.readDataDef("data"), 1);
+    qis.readRecordDef();
+    qis.startRecord();
+    EXPECT_EQ(qis.readInt32("ival"), 42);
+    EXPECT_THROW(qis.readInt32("other"), qlib::FileFormatException);
+}

--- a/src/tests/qsys/test_undomanager.cpp
+++ b/src/tests/qsys/test_undomanager.cpp
@@ -200,3 +200,24 @@ TEST(UndoManagerTest, DoubleCommitKeepsSingleEntry)
     EXPECT_EQ(um.getUndoSize(), 1);
     EXPECT_TRUE(um.isUndoable());
 }
+
+// getUndoDesc/getRedoDesc are script-visible; an index past the list used to
+// advance the iterator beyond end().
+TEST(UndoManagerTest, DescIndexOutOfRangeReturnsFalse)
+{
+    UndoManager um;
+    um.startTxn("only");
+    um.addEditInfo(new CountEditInfo());
+    um.commitTxn();
+
+    LString desc;
+    EXPECT_TRUE(um.getUndoDesc(0, desc));
+    EXPECT_EQ(desc, LString("only"));
+    EXPECT_FALSE(um.getUndoDesc(1, desc));
+    EXPECT_FALSE(um.getUndoDesc(5, desc));
+    EXPECT_FALSE(um.getUndoDesc(-1, desc));
+
+    ASSERT_TRUE(um.undo());
+    EXPECT_TRUE(um.getRedoDesc(0, desc));
+    EXPECT_FALSE(um.getRedoDesc(3, desc));
+}


### PR DESCRIPTION
## Summary

libcuemol2 bug-audit fixes, **Phase 3: input validation** (corrupt files and script arguments). Stacked on the Phase 2 PR; one commit per fix.

| Commit | Findings | Fix | Tests |
|---|---|---|---|
| surface/symm readers | surface 3, 5, 6, 7, 10 | MSMS / QdfSurf reject face indices outside the vertex array; QdfSurf checks the fixed record size against `MSVert`/`MSFace` and `QdfInStream::readFxRecords()` refuses to overrun its buffer in release builds; OpenDX / QdfPot validate the map size (int overflow of nx*ny*nz) and stop leaking the read buffer; `PDBCryst1Handler::write()` skips an unknown space group instead of `LString(NULL)`; the surface test environment initializes `symm` | `test_reader_validation` (9) |
| xtal CCP4/MTZ | xtal 3, 7 | CCP4 axis order must be a permutation of 1..3 and the counts positive (`MAPC=MAPR=MAPS=0` wrote to `r[-1]`); MTZ header location and NCOL*NREFL are checked against the body, the reflection buffer is released | `test_map_reader_validation` (5) |
| mdtools XTC/nevery | xtal 4, 9 | XTC decompression checks the block length, the MAGICINTS index range and the output size; `nevery` is clamped to >= 1 (division by zero) | `test_trajio` (+3) |
| qlib/qsys script arguments | qlib 4, 5, 9, 12 / qsys 8, 13 | `LScrMatrix4D` indices 1..4 (not 16); `LByteArray` offset in `size_t`; `LRegExpr::getSubstr()` returns "" for an unmatched group; `ExpatInStream` feeds EOF as an empty chunk; `QdfInStream/OutStream` check the record index; `getUndoDesc`/`getRedoDesc`/`getRendererByIndex` range-checked | `test_lbytearray` (2), `test_expat_instream` (1), +5 in existing files |
| molvis/molstr entry points | molvis 3, 5, 6, 10, 11, 12 / molstr 16 | `JctTable::get()` `||` check (and no assert), `setup()` frees the previous tables, `delete[]`; `TubeSection::setDetail()` >= 1; explicit negative-index checks; `DistPickDrawObj::append()` and `NameLabelRenderer::addLabelByID()` handle unknown atoms | `test_script_index_checks` (6) |

Every new test fails or crashes against the old code (the explicit negative-index checks pin behaviour that the unsigned comparison already gave). `task run_gtest`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
