### PR TITLE
build: libcuemol2 audit Phase 5 - exclude the unported X11 sysdep on Linux

### DIFF
--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -33,6 +33,11 @@ architecture, it belongs here.
   mechanism (64 KiB, x8 for readers the budget cut off, up to a
   ceiling), and the text / binary implementation patterns shared by
   every reader.
+- [Linux (X11) sysdep and the CLI build configuration](x11-sysdep-build.md) --
+  why the `Xgl*` backend no longer compiles, and why Linux now builds the
+  CLI configuration (`BUILD_OPENGL_SYSDEP=FALSE`, `TTYView` factory) instead
+  of stopping in `sysdep`; the `ENABLE_X11_SYSDEP` escape hatch for the port,
+  and why tritium (which brings its own `ElecView`) is unaffected.
 - [GTAO Screen-Space AO](gtao-screen-space-ao.md) (日本語) -- リアルタイム
   GTAO のパイプライン、projection 由来の view-space 復元と GL 座標系、MRT
   geometry 法線、Apple Metal-GL の MRT/ブレンドのハマりどころ、tritium

--- a/docs/architecture/x11-sysdep-build.md
+++ b/docs/architecture/x11-sysdep-build.md
@@ -1,0 +1,74 @@
+# Linux (X11) sysdep and the CLI build configuration
+
+## Context
+
+`src/sysdep/` holds the per-platform OpenGL view / display-context backends
+(`Wgl*` for Win32, `Cgl*` for macOS, `Xgl*` for X11) plus the shared
+`ogl_core/` (`Oc*`) implementation that carries the actual GL 3.2 core-profile
+rendering.
+
+The X11 backend was never ported to the `Oc*` classes and no longer compiles:
+
+- `XglView::XglView()` initializes members of the base class in its member
+  initializer list (`m_bInitOK`, ...), which is not valid C++.
+- `XglView.hpp` does not declare `super_t`, yet `XglView.cpp` uses it.
+- `XglView.cpp` calls `OglView::setup()` and `XglDisplayContext` derives from
+  `OglDisplayContext`; both classes were removed when `ogl_core` replaced the
+  legacy OpenGL layer.
+
+`src/CMakeLists.txt` selected the GL sysdep purely from
+`find_package(OpenGL)` + `find_package(GLEW)`, and `src/sysdep/CMakeLists.txt`
+added the `Xgl*` sources for every platform that is neither Win32 nor Apple.
+A Linux machine with OpenGL and GLEW available (which the deplibs bundle
+provides) therefore stopped in `sysdep` compilation, with no way to get a
+usable build short of removing the dependency.
+
+## Decision
+
+Linux builds the **CLI configuration** instead of the (unbuildable) X11 GL
+configuration:
+
+```cmake
+option(ENABLE_X11_SYSDEP "Build the unported X11 OpenGL sysdep backend" OFF)
+
+if (OPENGL_FOUND AND GLEW_FOUND)
+  if (WIN32 OR APPLE OR ENABLE_X11_SYSDEP)
+    SET(BUILD_OPENGL_SYSDEP "TRUE")
+    SET(USE_OPENGL "1")
+  else ()
+    SET(BUILD_OPENGL_SYSDEP "FALSE")   # -> GUI_ARCH = MB_GUI_ARCH_CLI
+  endif ()
+else ()
+  SET(BUILD_OPENGL_SYSDEP "FALSE")
+endif ()
+```
+
+`BUILD_OPENGL_SYSDEP=FALSE` is an existing, supported configuration: the
+`sysdep` subdirectory is skipped, `libcuemol2` does not link it, `GUI_ARCH`
+becomes `MB_GUI_ARCH_CLI` and `cuemol2::registerViewFactory()` installs the
+`qsys::TTYView` factory (`src/libcuemol2_api/gui.cpp`). It is what a machine
+without OpenGL/GLEW already built.
+
+`ENABLE_X11_SYSDEP=ON` restores the old behaviour for anyone doing the port;
+`src/sysdep/CMakeLists.txt` emits a warning in that case so the failure is not
+a surprise.
+
+## Why this does not affect tritium
+
+The tritium Electron app does not use the sysdep backends. Its native addon
+(`tritium/core/cxx_src/`) brings its own `ElecView` / `ElecDisplayContext` /
+`ElecViewCap` and registers them with `node_jsbr::registerViewFactory()`; the
+GL context lives on the JS (WebGL2) side. Nothing in the addon links or
+references `sysdep`, so a Linux build of `libcuemol2` without the GL sysdep
+still supports the full tritium rendering path. The desktop UXP GUI is the
+only consumer of `Xgl*`, and it is not built on Linux either.
+
+## Consequences
+
+- Linux `task build_libcuemol2` succeeds and produces a `libcuemol2` with the
+  CLI view factory; the C++ tests (which use `TTYView`) run unchanged.
+- Nothing changes on Windows or macOS: `WIN32` / `APPLE` keep taking the GL
+  path.
+- Porting `Xgl*` to the `Oc*` API remains open. When it is done, the port
+  should flip the default of `ENABLE_X11_SYSDEP` (or drop the option and the
+  platform condition again).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,9 +75,23 @@ message(STATUS "OPENGL_INCLUDE_DIR: ${OPENGL_INCLUDE_DIR}")
 SET(GLEW_USE_STATIC_LIBS YES)
 find_package(GLEW)
 message(STATUS "GLEW_FOUND: ${GLEW_FOUND} ${GLEW_LIBRARIES}")
+# The X11 backend (sysdep/Xgl*) still targets the removed OglView /
+# OglDisplayContext API and does not compile. Until it is ported to the
+# ogl_core (Oc*) classes, Linux builds the CLI configuration instead of
+# stopping in sysdep. Configure with -DENABLE_X11_SYSDEP=ON to build it
+# anyway (for that porting work).
+option(ENABLE_X11_SYSDEP "Build the unported X11 OpenGL sysdep backend" OFF)
+
 if (OPENGL_FOUND AND GLEW_FOUND)
-   SET(BUILD_OPENGL_SYSDEP "TRUE")
-   SET(USE_OPENGL "1")
+  if (WIN32 OR APPLE OR ENABLE_X11_SYSDEP)
+    SET(BUILD_OPENGL_SYSDEP "TRUE")
+    SET(USE_OPENGL "1")
+  else ()
+    SET(BUILD_OPENGL_SYSDEP "FALSE")
+    message(STATUS
+      "OpenGL found, but the X11 sysdep backend is not ported "
+      "(see ENABLE_X11_SYSDEP): building the CLI configuration")
+  endif ()
 else ()
    SET(BUILD_OPENGL_SYSDEP "FALSE")
 endif ()

--- a/src/sysdep/CMakeLists.txt
+++ b/src/sysdep/CMakeLists.txt
@@ -44,7 +44,10 @@ elseif(APPLE)
     CglDisplayContext.hpp
   )
 else()
-  # Linux/X11
+  # Linux/X11: reached only with -DENABLE_X11_SYSDEP=ON. These sources do
+  # not compile against the current ogl_core (Oc*) API; see src/CMakeLists.txt.
+  message(WARNING
+    "Building the unported X11 sysdep backend (ENABLE_X11_SYSDEP=ON)")
   list(APPEND SYSDEP_SRCS
     XglView.cpp
     XglDisplayContext.cpp


### PR DESCRIPTION
## Summary

libcuemol2 bug-audit fixes, **Phase 5: the decisions that were open** — starting with the X11 sysdep (audit finding gfx/sysdep 1, `high`). Stacked on the Phase 4 PR.

`sysdep/Xgl*` was never ported to the `ogl_core` (`Oc*`) classes and does not compile:

- `XglView::XglView()` initializes base-class members (`m_bInitOK`, ...) in its member initializer list.
- `XglView.hpp` does not declare the `super_t` that `XglView.cpp` uses.
- `XglView.cpp` calls `OglView::setup()` and `XglDisplayContext` derives from `OglDisplayContext`; both were removed when `ogl_core` replaced the legacy layer.

`src/CMakeLists.txt` picked the GL sysdep from `find_package(OpenGL)` + `find_package(GLEW)` alone, and `src/sysdep/CMakeLists.txt` added the `Xgl*` sources on every non-Win32, non-Apple platform — so a Linux box with the deplibs bundle (which ships GLEW) stopped in the `sysdep` compilation.

**Chosen option: (b) exclude it in CMake.** Linux now builds the CLI configuration: `BUILD_OPENGL_SYSDEP=FALSE` skips the `sysdep` subdirectory, leaves it out of `libcuemol2`, and selects `GUI_ARCH=MB_GUI_ARCH_CLI`, whose `registerViewFactory()` installs the `qsys::TTYView` factory. That configuration already existed for machines without OpenGL. `-DENABLE_X11_SYSDEP=ON` restores the old behaviour for the porting work (with a CMake warning).

tritium is unaffected: its addon brings its own `ElecView` / `ElecDisplayContext` / `ElecViewCap` and registers them through `node_jsbr::registerViewFactory()`; it references no `sysdep` symbol. `docs/architecture/x11-sysdep-build.md` records the reasoning and what a future port should change.

## Verification (macOS box, so the Linux path is exercised indirectly)

- Configure with the branch forced to the non-Apple side: `Build OGL sysdep: FALSE`, `GUI_ARCH: MB_GUI_ARCH_CLI` and the new status message; with `-DENABLE_X11_SYSDEP=ON` it goes back to `TRUE`.
- A full CLI-configuration build (GLEW hidden, i.e. the same `BUILD_OPENGL_SYSDEP=FALSE` path Linux now takes): builds clean and `ctest` passes.
- Unchanged on macOS: `Build OGL sysdep: TRUE`, `GUI_ARCH: MB_GUI_ARCH_OSX`; `task build_libcuemol2` + `task run_gtest` pass, and tritium builds and starts.

Still open from Phase 5: the `IOThread` synchronization decision, the `OcView` default VAO, and the remaining low findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
