### PR TITLE
fix: pasted preset groups crashed the app; deleting an animation element bricked its dependents (+ plan follow-ups)

### DIFF
--- a/src/qsys/Object.cpp
+++ b/src/qsys/Object.cpp
@@ -515,7 +515,11 @@ RendererPtr Object::createPresetRenderer(const LString &preset_name,
   RendererFactory *pRF = RendererFactory::getInstance();
 
   RendererPtr pRendGrp = pRF->create("*group");
-  pRendGrp->setName(grp_name);
+  // Through the property system, not setName(): a direct setter leaves the
+  // prop marked as default, and default-valued props are skipped when the
+  // object is serialized -- the group came back from XML with no name, and
+  // its members pointed at a name nothing carried.
+  pRendGrp->setPropStr("name", grp_name);
 
   for (pNode->firstChild(); pNode->hasMoreChild(); pNode->nextChild()) {
     qlib::LDom2Node *pChNode = pNode->getCurChild();

--- a/src/qsys/RendGroup.cpp
+++ b/src/qsys/RendGroup.cpp
@@ -39,17 +39,32 @@ void RendGroup::unloading()
 {
 }
 
+// Membership scan shared by getCenter/hasCenter. A group is never a member of
+// a group (nesting is not supported), so other RendGroups are skipped -- and
+// have to be: a group whose name matches the scan (itself, or another group
+// carrying the same name, both typically empty on a group whose name was lost
+// in serialization) would recurse through here without end. That was reachable
+// by pasting such an object and crashed on stack overflow.
+static bool isGroupMember(const RendGroup *pThis, const RendererPtr &pRend)
+{
+  if (dynamic_cast<const RendGroup *>(pRend.get()) != NULL)
+    return false;
+  return pRend->getGroupName().equals(pThis->getName());
+}
+
 qlib::Vector4D RendGroup::getCenter() const
 {
   // Calc COM of renderers in this group
   Vector4D resvec;
   int nsum = 0;
   ObjectPtr pObj = getClientObj();
+  if (pObj.isnull())
+    return qlib::Vector4D();
   Object::RendIter iter = pObj->beginRend();
   Object::RendIter eiter = pObj->endRend();
   for (;iter!=eiter;++iter) {
     RendererPtr pRend = iter->second;
-    if (!pRend->getGroupName().equals(getName()))
+    if (!isGroupMember(this, pRend))
       continue;
     if (pRend->hasCenter()) {
       resvec += pRend->getCenter();
@@ -65,11 +80,13 @@ qlib::Vector4D RendGroup::getCenter() const
 bool RendGroup::hasCenter() const
 {
   ObjectPtr pObj = getClientObj();
+  if (pObj.isnull())
+    return false;
   Object::RendIter iter = pObj->beginRend();
   Object::RendIter eiter = pObj->endRend();
   for (;iter!=eiter;++iter) {
     RendererPtr pRend = iter->second;
-    if (!pRend->getGroupName().equals(getName()))
+    if (!isGroupMember(this, pRend))
       continue;
     if (pRend->hasCenter()) {
       return true;

--- a/src/tests/qsys/test_rendgroup.cpp
+++ b/src/tests/qsys/test_rendgroup.cpp
@@ -2,6 +2,8 @@
 #include <common.h>
 #include "qsys/RendGroup.hpp"
 #include "qsys/Object.hpp"
+#include "qsys/Scene.hpp"
+#include "qsys/SceneManager.hpp"
 
 using qlib::LString;
 
@@ -61,4 +63,77 @@ TEST(RendGroupTest, DefaultGroupNameEmpty)
 {
     qsys::RendGroup rg;
     EXPECT_TRUE(rg.getGroupName().isEmpty());
+}
+
+// --- Center scan termination ---
+//
+// getCenter/hasCenter find the group's members by name: every renderer of the
+// client object whose group property equals this group's name. A group whose
+// own name matches that scan -- itself, or another group carrying the same
+// name -- recursed through hasCenter without end; both groups nameless is
+// exactly what pasting an object serialized before the createPresetRenderer
+// name fix produces. Groups are not legal members (nesting is unsupported),
+// so the scan must skip them.
+
+namespace {
+
+class CenterScanObject : public qsys::Object {
+public:
+    qlib::LCloneableObject *clone() const override { return nullptr; }
+};
+
+}  // namespace
+
+class RendGroupCenterFixture : public ::testing::Test {
+protected:
+    qsys::ScenePtr m_pScene;
+    qsys::ObjectPtr m_pObj;
+
+    void SetUp() override
+    {
+        m_pScene = qsys::SceneManager::getInstance()->createScene();
+        m_pObj = qsys::ObjectPtr(MB_NEW CenterScanObject());
+        m_pScene->addObject(m_pObj);
+    }
+
+    void TearDown() override
+    {
+        if (!m_pScene.isnull()) {
+            qlib::uid_t uid = m_pScene->getUID();
+            m_pObj = qsys::ObjectPtr();
+            m_pScene = qsys::ScenePtr();
+            qsys::SceneManager::getInstance()->destroyScene(uid);
+        }
+    }
+};
+
+TEST_F(RendGroupCenterFixture, NamelessGroupDoesNotRecurseIntoItself)
+{
+    qsys::RendererPtr pGrp(MB_NEW qsys::RendGroup());
+    m_pObj->attachRenderer(pGrp);
+
+    // Both the group's name and its group property are "": the scan matches
+    // the group itself. Without the group skip this call never returned.
+    EXPECT_FALSE(pGrp->hasCenter());
+    EXPECT_TRUE(pGrp->getCenter().equals(qlib::Vector4D()));
+}
+
+TEST_F(RendGroupCenterFixture, TwoNamelessGroupsDoNotRecurseIntoEachOther)
+{
+    qsys::RendererPtr pGrpA(MB_NEW qsys::RendGroup());
+    qsys::RendererPtr pGrpB(MB_NEW qsys::RendGroup());
+    m_pObj->attachRenderer(pGrpA);
+    m_pObj->attachRenderer(pGrpB);
+
+    // A's scan finds B and B's finds A; skipping only "self" still loops.
+    EXPECT_FALSE(pGrpA->hasCenter());
+    EXPECT_FALSE(pGrpB->hasCenter());
+}
+
+TEST(RendGroupCenterTest, DetachedGroupHasNoCenter)
+{
+    // No client object at all (never attached): the scan has nothing to walk.
+    qsys::RendGroup rg;
+    EXPECT_FALSE(rg.hasCenter());
+    EXPECT_TRUE(rg.getCenter().equals(qlib::Vector4D()));
 }

--- a/tritium/core/src/tests/qsys/ObjectClipboardXml.test.ts
+++ b/tritium/core/src/tests/qsys/ObjectClipboardXml.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Copy/paste round trip of an object that carries a preset renderer group.
+ *
+ * The clipboard serializes an object with StreamManager.toXML and restores it
+ * with fromXML + Scene.addObject (see react-gui's clipboard worker services).
+ * Two things went wrong with a preset group in that payload, and this pins
+ * both at the addon level, against the real C++:
+ *
+ * - createPresetRenderer named its group with the direct C++ setter, which
+ *   leaves the name property flagged as default -- and default-valued props
+ *   are not serialized. The group came back from XML nameless.
+ * - addObject re-applies styles, which reads the group's center; a nameless
+ *   group's member scan (group property == own name) matched the group
+ *   itself and recursed until the stack ran out. Pasting crashed the app.
+ */
+import { cm } from '../setup';
+import type { Scene } from '@/wrappers/Scene';
+import type { MolCoord } from '@/wrappers/MolCoord';
+import type { StreamManager } from '@/wrappers/StreamManager';
+
+function rendListOf(o: any): { type: string; name: string; group: string }[] {
+    const out = [];
+    for (let i = 0; i < o.getRendCount(); i++) {
+        const r = o.getRendererByIndex(i);
+        out.push({ type: r.type_name, name: r.name, group: r.group });
+    }
+    return out.sort((a, b) => a.type.localeCompare(b.type));
+}
+
+describe('object clipboard XML round trip', () => {
+    it('a preset renderer group survives toXML / fromXML / addObject', () => {
+        const strMgr = cm.getService('StreamManager') as StreamManager;
+
+        // Source: 1CRN with the Simple1 preset (a *group plus two children).
+        const scene1 = cm.createScene() as Scene;
+        const reader = strMgr.createHandler('pdb', 0) as any;
+        reader.setPath(process.cwd() + '/../../tests/test_data/1CRN.pdb');
+        const mol = cm.createObj('MolCoord') as MolCoord;
+        reader.attach(mol);
+        reader.read();
+        reader.detach();
+        mol.name = '1CRN';
+        scene1.addObject(mol);
+        const grp = (mol as any).createPresetRenderer(
+            'Simple1RendPreset', 'simple1', 'simple1');
+        expect(grp).toBeTruthy();
+
+        const xml = strMgr.toXML(mol as any);
+        expect(xml).toBeTruthy();
+
+        // Paste into a brand-new scene, exactly as pasteNode does.
+        const scene2 = cm.createScene() as Scene;
+        scene2.startUndoTxn('Paste object');
+        const restored = strMgr.fromXML(xml as any, scene2.uid) as any;
+        expect(restored).toBeTruthy();
+        restored.name = '1CRN';
+        // This call crashed on stack overflow while the group was nameless.
+        const newId = scene2.addObject(restored);
+        scene2.commitUndoTxn();
+        expect(newId).toBeTruthy();
+
+        // The group kept its name, so its members still resolve to it.
+        expect(rendListOf(restored)).toEqual(rendListOf(mol));
+        expect(rendListOf(restored)).toEqual([
+            { type: '*group', name: 'simple1', group: '' },
+            { type: 'simple', name: 'simple1simple', group: 'simple1' },
+            { type: 'trace', name: 'simple1trace', group: 'simple1' },
+        ]);
+    });
+});

--- a/tritium/react-gui/src/renderer/__test__/animationService.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/animationService.test.ts
@@ -358,6 +358,44 @@ describe("anim.service editing", () => {
     expect(res.ok).toBe(true);
   });
 
+  /*
+   * Deleting an element that others chain their start time to.
+   *
+   * A relative start is an offset from another element's end, named by
+   * `timeRefName`. Removing the named element left the dependents pointing at
+   * a name nothing carries, and C++ `resolveRelTime` throws on that -- so
+   * every later resolve failed, the strip stayed where it was drawn while the
+   * inspector showed the raw offset as if it were an absolute time, and no
+   * further edit to those elements could land. Renaming already re-points the
+   * dependents (`cascadeTimeRefRename`); deleting had no counterpart.
+   *
+   * A deleted reference cannot be re-pointed, so the dependents are cut loose
+   * where they currently sit: absolute, at the position they were resolved to.
+   */
+  it("animRemoveElement cuts loose the elements that chained to it", () => {
+    const objs = [
+      makeObj({ uid: 1, name: "A", className: "SimpleSpin", start: 0, end: 1000, absStart: 0, absEnd: 1000 }),
+      makeObj({ uid: 2, name: "B", className: "SimpleSpin", timeRefName: "A",
+                start: 0, end: 500, absStart: 1000, absEnd: 1500 }),
+      makeObj({ uid: 3, name: "C", className: "SimpleSpin", timeRefName: "other",
+                start: 0, end: 500, absStart: 4000, absEnd: 4500 }),
+    ];
+    const { ctx, removeAt, startUndoTxn } = makeCtx({ objs });
+
+    const res = services.animRemoveElement(ctx, { sceneId: 1, index: 0 });
+
+    expect(res.ok).toBe(true);
+    expect(startUndoTxn).toHaveBeenCalledWith("Delete animation element");
+    expect(removeAt).toHaveBeenCalledWith(0);
+    // B kept its place on the timeline and no longer names a missing element.
+    expect(objs[1].timeRefName).toBe("");
+    expect(objs[1].start.millisec).toBe(1000);
+    expect(objs[1].end.millisec).toBe(1500);
+    // C chained to something else and is left alone.
+    expect(objs[2].timeRefName).toBe("other");
+    expect(objs[2].start.millisec).toBe(0);
+  });
+
   it("animMoveElement removes then re-inserts at the target index", () => {
     const objs = [
       makeObj({ uid: 1, name: "A", className: "SimpleSpin", start: 0, end: 1000, absStart: 0, absEnd: 1000 }),

--- a/tritium/react-gui/src/renderer/contexts/ApbsConfigContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/ApbsConfigContext.tsx
@@ -28,6 +28,7 @@ import React, {
   useMemo,
 } from 'react';
 import { IPC } from '@shared/ipcChannels';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 import {
   type ApbsBinaries,
   DEFAULT_APBS_BINARIES,
@@ -71,15 +72,16 @@ export const ApbsConfigProvider: React.FC<ApbsConfigProviderProps> = ({
   // default (APP_PATH: bundled apbs in a packaged build / BUNDLE_APPS in dev)
   // -> compiled-in default. Do not early-return when UI_LOAD is empty: a fresh
   // profile with no persisted paths is exactly when the bundled default applies.
+  const guard = useStaleGuard();
   useEffect(() => {
-    let cancelled = false;
+    const token = guard.next();
     (async () => {
       try {
         const [ui, appInfo] = await Promise.all([
           window.electronAPI?.invoke(IPC.UI_LOAD),
           window.electronAPI?.invoke(IPC.APP_PATH),
         ]);
-        if (cancelled) return;
+        if (!guard.isCurrent(token)) return;
         const def = appInfo?.defaultApbsBinaries;
         setConfig({
           apbsExe: ui?.apbsExe || def?.apbsExe || DEFAULT_APBS_CONFIG.apbsExe,
@@ -90,10 +92,8 @@ export const ApbsConfigProvider: React.FC<ApbsConfigProviderProps> = ({
         // Electron not available (Vite dev server) -- keep defaults.
       }
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => guard.invalidate();
+  }, [guard]);
 
   const setValue = useCallback((key: ApbsConfigKey, value: string) => {
     setConfig((prev) => ({ ...prev, [key]: value }));

--- a/tritium/react-gui/src/renderer/contexts/AppSettingsContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/AppSettingsContext.tsx
@@ -23,6 +23,7 @@ import React, {
   useMemo,
 } from 'react'
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 import type {
   LabelDefaults,
   SetLabelDefaultsArgs,
@@ -61,26 +62,25 @@ export const AppSettingsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Read the live C++ values on mount (reflects the user style file loaded at
   // startup). Falls back to defaults when the core is not ready yet.
+  const guard = useStaleGuard()
   useEffect(() => {
     if (!cm) return
-    let cancelled = false
+    const token = guard.next()
     ;(async () => {
       try {
         const [labels, view] = await Promise.all([
           cm.invokeService('getLabelDefaults', {}),
           cm.invokeService('getViewInputParams', {}),
         ])
-        if (cancelled) return
+        if (!guard.isCurrent(token)) return
         if (labels?.ok) setLabelDefaults(labels.defaults)
         if (view?.ok) setViewInputParams(view.params)
       } catch {
         // core unavailable -- keep defaults
       }
     })()
-    return () => {
-      cancelled = true
-    }
-  }, [cm])
+    return () => guard.invalidate()
+  }, [cm, guard])
 
   const setLabelDefault = useCallback(
     (key: keyof LabelDefaults, value: string | number | boolean) => {

--- a/tritium/react-gui/src/renderer/contexts/RenderConfigContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/RenderConfigContext.tsx
@@ -24,6 +24,7 @@ import React, {
   useMemo,
 } from "react";
 import { IPC } from "@shared/ipcChannels";
+import { useStaleGuard } from "@renderer/hooks/react/useStaleGuard";
 import {
   type RenderBinaries,
   DEFAULT_RENDER_BINARIES,
@@ -53,15 +54,16 @@ export const RenderConfigProvider: React.FC<RenderConfigProviderProps> = ({
   //       -> compiled-in DEFAULT_RENDER_BINARIES.
   // Do not early-return when UI_LOAD is empty: a fresh profile with no persisted
   // paths is exactly when the Main-resolved default must take effect.
+  const guard = useStaleGuard();
   useEffect(() => {
-    let cancelled = false;
+    const token = guard.next();
     (async () => {
       try {
         const [ui, appInfo] = await Promise.all([
           window.electronAPI?.invoke(IPC.UI_LOAD),
           window.electronAPI?.invoke(IPC.APP_PATH),
         ]);
-        if (cancelled) return;
+        if (!guard.isCurrent(token)) return;
         const def = appInfo?.defaultRenderBinaries;
         setBinaries({
           povrayExe: ui?.povrayExe || def?.povrayExe || DEFAULT_RENDER_BINARIES.povrayExe,
@@ -73,10 +75,8 @@ export const RenderConfigProvider: React.FC<RenderConfigProviderProps> = ({
         // Electron not available (Vite dev server) -- keep defaults.
       }
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => guard.invalidate();
+  }, [guard]);
 
   const setBinary = useCallback((key: keyof RenderBinaries, value: string) => {
     setBinaries((prev) => ({ ...prev, [key]: value }));

--- a/tritium/react-gui/src/renderer/contexts/ThemeContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/ThemeContext.tsx
@@ -36,6 +36,7 @@ import React, {
   useMemo,
 } from "react";
 import { IPC } from "@shared/ipcChannels";
+import { useStaleGuard } from "@renderer/hooks/react/useStaleGuard";
 
 // ------------------------------------------------------------
 // Types
@@ -91,26 +92,25 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   const [loaded, setLoaded] = useState(false);
 
   // -- Load persisted theme on mount -----------------------
+  const guard = useStaleGuard();
   useEffect(() => {
-    let cancelled = false;
+    const token = guard.next();
 
     (async () => {
       try {
         const ui = await window.electronAPI?.invoke(IPC.UI_LOAD);
-        if (!cancelled && ui?.theme) {
+        if (guard.isCurrent(token) && ui?.theme) {
           setThemeState(ui.theme);
           applyThemeToDOM(ui.theme);
         }
       } catch {
         // Electron not available (Vite dev server) -- keep default.
       }
-      if (!cancelled) setLoaded(true);
+      if (guard.isCurrent(token)) setLoaded(true);
     })();
 
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => guard.invalidate();
+  }, [guard]);
 
   // -- Keep DOM in sync whenever theme changes -------------
   useEffect(() => {

--- a/tritium/react-gui/src/renderer/contexts/ViewInputConfigContext.tsx
+++ b/tritium/react-gui/src/renderer/contexts/ViewInputConfigContext.tsx
@@ -37,6 +37,7 @@ import {
 } from '@renderer/viewInputConfig'
 import { InputDeviceDetector } from '@renderer/input/inputDeviceDetector'
 import type { WheelSample } from '@renderer/input/wheelDeviceClassifier'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 interface ViewInputConfigContextValue {
   /** Persisted preference (mouse / trackpad / auto). */
@@ -100,12 +101,13 @@ export const ViewInputConfigProvider: React.FC<{ children: React.ReactNode }> = 
 
   // Load persisted preference + detected seed on mount. Does NOT re-apply the
   // style (createAndInitCueMol already applied the same seed).
+  const guard = useStaleGuard()
   useEffect(() => {
-    let cancelled = false
+    const token = guard.next()
     ;(async () => {
       try {
         const ui = await window.electronAPI?.invoke(IPC.UI_LOAD)
-        if (cancelled || !ui) return
+        if (!guard.isCurrent(token) || !ui) return
         const pref = normalizeInputDevicePreference(ui.inputDeviceMode)
         const seed =
           pref === 'auto' ? normalizeInputDeviceMode(ui.inputDeviceDetected) : pref
@@ -117,10 +119,8 @@ export const ViewInputConfigProvider: React.FC<{ children: React.ReactNode }> = 
         // Electron not available (Vite dev server) -- keep the defaults.
       }
     })()
-    return () => {
-      cancelled = true
-    }
-  }, [])
+    return () => guard.invalidate()
+  }, [guard])
 
   const setInputDevicePreference = useCallback(
     (p: InputDevicePreference) => {

--- a/tritium/react-gui/src/renderer/dialogs/CalcApbsPotDialog.tsx
+++ b/tritium/react-gui/src/renderer/dialogs/CalcApbsPotDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { DialogShell } from './DialogShell'
 import { MolPicker } from './MolPicker'
 import { MolSelList, pushHistory } from '@renderer/h3-kit/MolSelList'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 import {
     PDB2PQR_FORCE_FIELDS,
     type ApbsChargeMethod,
@@ -112,21 +113,20 @@ export function CalcApbsPotDialog({
 
     // Prefill the elepot name with a unique `pot_<molname>` on open / molecule
     // change (UXP `makeSugName` / `onObjBoxChanged`).
+    const guard = useStaleGuard()
     useEffect(() => {
         if (!visible || !cm || objId === undefined) return
-        let cancelled = false
+        const token = guard.next()
         void (async () => {
             try {
                 const res = await cm.invokeService('proposeElepotName', { sceneId, objId })
-                if (!cancelled && res?.name) setElepotName(res.name)
+                if (guard.isCurrent(token) && res?.name) setElepotName(res.name)
             } catch {
                 // Best-effort prefill; leave the field as-is on failure.
             }
         })()
-        return () => {
-            cancelled = true
-        }
-    }, [visible, cm, sceneId, objId])
+        return () => guard.invalidate()
+    }, [visible, cm, sceneId, objId, guard])
 
     // --- Not-configured gate (exe paths live in Settings) ---
     const apbsExe = apbsConfig.apbsExe.trim()

--- a/tritium/react-gui/src/renderer/dialogs/MakeMolSurfDialog.tsx
+++ b/tritium/react-gui/src/renderer/dialogs/MakeMolSurfDialog.tsx
@@ -28,6 +28,7 @@ import { MolPicker } from './MolPicker'
 import { MolSelList, pushHistory } from '@renderer/h3-kit/MolSelList'
 import { DEFAULT_DENSITY, DENSITY_MAX, DENSITY_MIN } from './molSurfDensity'
 import { asBackend, BACKEND_OPTIONS, DEFAULT_BACKEND, MolSurfBackend } from './molSurfBackend'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 export interface MakeMolSurfDialogResult {
     ok: boolean
@@ -100,24 +101,23 @@ export function MakeMolSurfDialog({
     // dialog opens or the target molecule changes (UXP `makeSugName` /
     // `onObjBoxChanged`). User edits made afterwards are not clobbered because
     // this effect only re-runs on open / molecule change, not on keystrokes.
+    const guard = useStaleGuard()
     useEffect(() => {
         if (!visible || !cm || objId === undefined) return
-        let cancelled = false
+        const token = guard.next()
         void (async () => {
             try {
                 const res = await cm.invokeService('proposeMolSurfName', {
                     sceneId,
                     objId,
                 })
-                if (!cancelled && res?.name) setSurfName(res.name)
+                if (guard.isCurrent(token) && res?.name) setSurfName(res.name)
             } catch {
                 // Best-effort prefill; leave the field as-is on failure.
             }
         })()
-        return () => {
-            cancelled = true
-        }
-    }, [visible, cm, sceneId, objId])
+        return () => guard.invalidate()
+    }, [visible, cm, sceneId, objId, guard])
 
     return (
         <DialogShell

--- a/tritium/react-gui/src/renderer/dialogs/MolSuperposeDialog.tsx
+++ b/tritium/react-gui/src/renderer/dialogs/MolSuperposeDialog.tsx
@@ -30,6 +30,7 @@ import { MolPicker } from './MolPicker'
 import { MolSelList, pushHistory } from '@renderer/h3-kit/MolSelList'
 import type { SceneObjectEntry } from '@renderer/worker/server/services/scene/listSceneObjects'
 import type { SuperposeAlgo } from '@renderer/worker/server/services/molops/superposeMol'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 import {
     loadMolSuperposeHistory,
     saveMolSuperposeHistory,
@@ -71,9 +72,10 @@ export function MolSuperposeDialog({
     // initial molecule selection -- last-used uids when still present, else
     // ref=first / mov=second (UXP `onLoad` default). Selection strings start
     // empty; the user picks from the MolSelList history dropdown. This effect
-    // owns its own field resets (and the async cancelled-flag fetch), so the
+    // owns its own field resets (and the async !guard.isCurrent(token)-flag fetch), so the
     // commit hook below is given no onReset -- it only clears submitting /
     // errorMsg on open.
+    const guard = useStaleGuard()
     useEffect(() => {
         if (!visible) return
         setRefSel('')
@@ -89,10 +91,10 @@ export function MolSuperposeDialog({
             setMovObjId(hist.movObjId)
             return
         }
-        let cancelled = false
+        const token = guard.next()
         cm.invokeService('listSceneObjects', { sceneId })
             .then((res) => {
-                if (cancelled) return
+                if (!guard.isCurrent(token)) return
                 const mols = (res?.objects ?? []).filter(objectFilters.molCoord)
                 const uids = mols.map((m: SceneObjectEntry) => m.uid)
                 const has = (id: number | undefined): boolean =>
@@ -107,14 +109,12 @@ export function MolSuperposeDialog({
                 )
             })
             .catch(() => {
-                if (cancelled) return
+                if (!guard.isCurrent(token)) return
                 setRefObjId(hist.refObjId)
                 setMovObjId(hist.movObjId)
             })
-        return () => {
-            cancelled = true
-        }
-    }, [visible, cm, sceneId])
+        return () => guard.invalidate()
+    }, [visible, cm, sceneId, guard])
 
     const { submitting, errorMsg, run: handleOk } =
         useMolEditCommit({

--- a/tritium/react-gui/src/renderer/dialogs/SymmetryChangeDialog.tsx
+++ b/tritium/react-gui/src/renderer/dialogs/SymmetryChangeDialog.tsx
@@ -17,6 +17,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { Checkbox, FormGroup, HTMLSelect, InputGroup, NumericInput } from '@blueprintjs/core'
 import { DialogShell } from './DialogShell';
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 import type {
     SpaceGroupEntry,
     SymmetryInfo,
@@ -170,10 +171,15 @@ export function SymmetryChangeDialog({
      *  "unchanged" short-circuit (UXP). */
     const [openInfo, setOpenInfo] = useState<SymmetryInfo | null>(null)
 
+    // Two independent fetches, so two guards: a space-group reload must not
+    // make the crystal-info fetch look stale, or the reverse.
+    const infoGuard = useStaleGuard()
+    const sgGuard = useStaleGuard()
+
     // Fetch the initial CrystalInfo when the dialog opens.
     useEffect(() => {
         if (!visible || !cm) return
-        let cancelled = false
+        const token = infoGuard.next()
         ;(async () => {
             // Reset transient flags from the previous open -- the dialog
             // component stays mounted across show/hide cycles (the Dialog
@@ -185,7 +191,7 @@ export function SymmetryChangeDialog({
             setErrorMsg(null)
             try {
                 const res = await cm.invokeService('getSymmetryPanelInfo', { sceneId, objId })
-                if (cancelled) return
+                if (!infoGuard.isCurrent(token)) return
                 const info = res?.info ?? DEFAULT_INFO
                 setOpenInfo(res?.hasInfo ? info : null)
                 setLattice((info.lattice as CrystalSystem) ?? 'TRICLINIC')
@@ -196,7 +202,7 @@ export function SymmetryChangeDialog({
                 })
                 setRestrict(false)
             } catch (err) {
-                if (cancelled) return
+                if (!infoGuard.isCurrent(token)) return
                 console.warn('getSymmetryPanelInfo failed:', err)
                 setOpenInfo(null)
                 setLattice('TRICLINIC')
@@ -204,20 +210,20 @@ export function SymmetryChangeDialog({
                 setCell({ a: 1, b: 1, c: 1, alpha: 90, beta: 90, gamma: 90 })
                 setRestrict(false)
             } finally {
-                if (!cancelled) setLoaded(true)
+                if (infoGuard.isCurrent(token)) setLoaded(true)
             }
         })()
-        return () => { cancelled = true }
-    }, [visible, cm, sceneId, objId])
+        return () => infoGuard.invalidate()
+    }, [visible, cm, sceneId, objId, infoGuard])
 
     // Populate space-group dropdown whenever lattice changes (or on open).
     useEffect(() => {
         if (!visible || !cm) return
-        let cancelled = false
+        const token = sgGuard.next()
         ;(async () => {
             try {
                 const res = await cm.invokeService('getSpaceGroupNames', { lattice })
-                if (cancelled) return
+                if (!sgGuard.isCurrent(token)) return
                 const items = res?.items ?? []
                 setSgItems(items)
                 // Preserve nsg if still in the list; otherwise pick first.
@@ -226,13 +232,13 @@ export function SymmetryChangeDialog({
                     return items.length > 0 ? items[0].id : 1
                 })
             } catch (err) {
-                if (cancelled) return
+                if (!sgGuard.isCurrent(token)) return
                 console.warn('getSpaceGroupNames failed:', err)
                 setSgItems([])
             }
         })()
-        return () => { cancelled = true }
-    }, [visible, cm, lattice])
+        return () => sgGuard.invalidate()
+    }, [visible, cm, lattice, sgGuard])
 
     // Apply lattice restriction after sgItems / restrict / lattice / cell-source change.
     const sgLabel = sgItems.find((i) => i.id === nsg)?.cname ?? ''

--- a/tritium/react-gui/src/renderer/features/coloring/ColorPane.tsx
+++ b/tritium/react-gui/src/renderer/features/coloring/ColorPane.tsx
@@ -58,6 +58,7 @@ import { RendererSelector } from '@renderer/features/coloring/colorPane/Renderer
 import { usePaintSelection } from '@renderer/features/coloring/colorPane/usePaintSelection'
 import { useColorPaneActions } from '@renderer/features/coloring/colorPane/useColorPaneActions'
 import { PaintTable } from '@renderer/features/coloring/colorPane/PaintTable'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 import {
     BfacDeck,
     CpkDeck,
@@ -121,13 +122,14 @@ export const ColorPane: React.FC<ColorPaneProps> = ({ collapsed, onToggleCollaps
     // and on every window focus -- which is exactly the moment the user
     // comes back from copying rows in CueMol2 or another CueMol3 window.
     const [canPastePaint, setCanPastePaint] = useState(false)
+    const guard = useStaleGuard()
     useEffect(() => {
-        let cancelled = false
+        const token = guard.next()
         const refresh = (): void => {
             window.electronAPI
                 ?.invoke(IPC.CLIPBOARD_CUEMOL_PEEK)
                 .then((res) => {
-                    if (!cancelled) setCanPastePaint(res?.kind === 'paint')
+                    if (guard.isCurrent(token)) setCanPastePaint(res?.kind === 'paint')
                 })
                 .catch((err: unknown) =>
                     console.warn('clipboard peek failed:', err),
@@ -136,10 +138,10 @@ export const ColorPane: React.FC<ColorPaneProps> = ({ collapsed, onToggleCollaps
         refresh()
         window.addEventListener('focus', refresh)
         return () => {
-            cancelled = true
+            guard.invalidate()
             window.removeEventListener('focus', refresh)
         }
-    }, [])
+    }, [guard])
 
     const target = selectedKey ? parseTargetKey(selectedKey) : null
 

--- a/tritium/react-gui/src/renderer/features/file-io/useRecentFiles.ts
+++ b/tritium/react-gui/src/renderer/features/file-io/useRecentFiles.ts
@@ -7,25 +7,27 @@
 import { useEffect, useState } from 'react'
 import { IPC } from '@shared/ipcChannels'
 import type { RecentFileEntry } from '@shared/types/recent'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 export function useRecentFiles(): RecentFileEntry[] {
   const [recents, setRecents] = useState<RecentFileEntry[]>([])
 
+  const guard = useStaleGuard()
   useEffect(() => {
     const api = window.electronAPI
     if (!api) return
-    let cancelled = false
+    const token = guard.next()
     api.invoke(IPC.RECENT_LOAD).then((list) => {
-      if (!cancelled && Array.isArray(list)) setRecents(list)
+      if (guard.isCurrent(token) && Array.isArray(list)) setRecents(list)
     }).catch((e: unknown) => console.error('recent load failed:', e))
     const unsub = api.onPush(IPC.RECENT_UPDATED, (list) => {
       setRecents(Array.isArray(list) ? list : [])
     })
     return () => {
-      cancelled = true
+      guard.invalidate()
       unsub()
     }
-  }, [])
+  }, [guard])
 
   return recents
 }

--- a/tritium/react-gui/src/renderer/features/inspector/rows/AsyncSelectRow.tsx
+++ b/tritium/react-gui/src/renderer/features/inspector/rows/AsyncSelectRow.tsx
@@ -20,6 +20,7 @@ import { objectFilters } from '@renderer/h3-kit/ObjectSelect'
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol'
 import type { GenericPropEntry } from '@renderer/worker/shared/genericProps'
 import type { RendererPropSectionProps } from '@renderer/features/inspector/rendererPropSections'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 type SetFn = RendererPropSectionProps['onSet']
 type ResetFn = RendererPropSectionProps['onReset']
@@ -44,6 +45,7 @@ export function useAsyncNames(
   // Serialised so a new object literal per render does not refetch.
   const sourceKey = JSON.stringify(source)
 
+  const guard = useStaleGuard()
   useEffect(() => {
     const src = JSON.parse(sourceKey) as AsyncNameSource
     const needsNode = src.kind === 'siblingRenderers'
@@ -51,7 +53,7 @@ export function useAsyncNames(
       setNames([])
       return
     }
-    let cancelled = false
+    const token = guard.next()
     const fetched =
       src.kind === 'materials'
         ? cm.invokeService('getMaterialNames', { sceneId }).then((r) => r.names)
@@ -71,15 +73,13 @@ export function useAsyncNames(
               .then((r) => r.names)
     fetched
       .then((n) => {
-        if (!cancelled) setNames(n)
+        if (guard.isCurrent(token)) setNames(n)
       })
       .catch(() => {
-        if (!cancelled) setNames([])
+        if (guard.isCurrent(token)) setNames([])
       })
-    return () => {
-      cancelled = true
-    }
-  }, [cm, sceneId, nodeId, sourceKey])
+    return () => guard.invalidate()
+  }, [cm, sceneId, nodeId, sourceKey, guard])
 
   return names
 }

--- a/tritium/react-gui/src/renderer/features/inspector/rows/LimitDisplayRows.tsx
+++ b/tritium/react-gui/src/renderer/features/inspector/rows/LimitDisplayRows.tsx
@@ -23,33 +23,33 @@ import type { SceneObjectEntry } from '@renderer/worker/server/services/scene/li
 import type { GenericPropEntry } from '@renderer/worker/shared/genericProps'
 import type { PropMultiWrite } from '@renderer/features/inspector/rendererPropSections'
 import type { CustomRowProps } from '@renderer/features/inspector/schema/types'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 /** The scene's molecule (MolCoord) object names, for the target selector. */
 export function useMolObjectNames(sceneId: number | undefined): string[] {
   const { cm } = useCueMol()
   const [names, setNames] = useState<string[]>([])
 
+  const guard = useStaleGuard()
   useEffect(() => {
     if (!cm || sceneId === undefined) {
       setNames([])
       return
     }
-    let cancelled = false
+    const token = guard.next()
     cm.invokeService('listSceneObjects', { sceneId })
       .then((r) => {
-        if (cancelled) return
+        if (!guard.isCurrent(token)) return
         const mols = (r?.objects ?? []).filter((o: SceneObjectEntry) =>
           objectFilters.molCoord(o),
         )
         setNames(mols.map((o: SceneObjectEntry) => o.name).filter(Boolean))
       })
       .catch(() => {
-        if (!cancelled) setNames([])
+        if (guard.isCurrent(token)) setNames([])
       })
-    return () => {
-      cancelled = true
-    }
-  }, [cm, sceneId])
+    return () => guard.invalidate()
+  }, [cm, sceneId, guard])
 
   return names
 }

--- a/tritium/react-gui/src/renderer/features/molview/MeasureOptionsPopover.tsx
+++ b/tritium/react-gui/src/renderer/features/molview/MeasureOptionsPopover.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useState } from 'react';
 import { useCueMol } from '@renderer/hooks/cuemol/useCueMol';
 import { useActiveScene } from '@renderer/state/workspace';
 import { TextField } from '@renderer/h3-kit/form';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 interface Props {
     /** Current target label-set name (defaults to "measure"). */
@@ -27,16 +28,15 @@ export const MeasureOptionsPopover: React.FC<Props> = ({ target, onTargetChange 
 
     // Fetch existing atomintr renderer names when the popover mounts (it mounts
     // on open). The list is advisory -- typing a new name creates a new set.
+    const guard = useStaleGuard();
     useEffect(() => {
         if (!cm || activeViewID == null) return;
-        let cancelled = false;
+        const token = guard.next();
         void cm.invokeService('measureListTargets', { viewId: activeViewID }).then((r) => {
-            if (!cancelled && r) setNames(r.names);
+            if (guard.isCurrent(token) && r) setNames(r.names);
         });
-        return () => {
-            cancelled = true;
-        };
-    }, [cm, activeViewID]);
+        return () => guard.invalidate();
+    }, [cm, activeViewID, guard]);
 
     return (
         <div className="measure-options-popover">

--- a/tritium/react-gui/src/renderer/features/render/renderwindow/RenderWindowApp.tsx
+++ b/tritium/react-gui/src/renderer/features/render/renderwindow/RenderWindowApp.tsx
@@ -37,6 +37,7 @@ import { useRenderWindowClient } from "@renderer/features/render/useRenderWindow
 import { RENDER_BACKEND_IDS } from "@renderer/data/renderBackends";
 import { sizePresetsForMode } from "@renderer/data/renderSettings";
 import { IPC } from "@shared/ipcChannels";
+import { useStaleGuard } from "@renderer/hooks/react/useStaleGuard";
 
 export const RenderWindowApp: React.FC = () => {
   // Main registers the text context menu on this window too; on Windows /
@@ -234,23 +235,24 @@ export const RenderWindowApp: React.FC = () => {
   const targetViewId = client.targetViewId;
   const [cameraPending, setCameraPending] = useState(false);
   useHoldReveal(cameraPending);
+  const guard = useStaleGuard();
   useEffect(() => {
     if (targetViewId === null) return;
-    let cancelled = false;
+    const token = guard.next();
     setCameraPending(true);
     void clientRef.current
       .getViewCamera(targetViewId)
       .then((camera) => {
-        if (!cancelled && camera) settingsRef.current.applyViewCamera(camera);
+        if (guard.isCurrent(token) && camera) settingsRef.current.applyViewCamera(camera);
       })
       .finally(() => {
-        if (!cancelled) setCameraPending(false);
+        if (guard.isCurrent(token)) setCameraPending(false);
       });
     return () => {
-      cancelled = true;
+      guard.invalidate();
       setCameraPending(false);
     };
-  }, [targetViewId]);
+  }, [targetViewId, guard]);
 
   // The window is created hidden. It goes on screen once the main window's
   // context has arrived (target views, mode) and every load that started on

--- a/tritium/react-gui/src/renderer/features/render/useHatchTemplate.ts
+++ b/tritium/react-gui/src/renderer/features/render/useHatchTemplate.ts
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from "react";
 import { useHoldReveal } from "@renderer/shell/reveal/useRevealWindow";
 import { parseHatchSpec, type HatchSpec } from "@renderer/data/hatchSpec";
 import type { HatchStyleSpecReply } from "@shared/types/renderWindow";
+import { useStaleGuard } from "@renderer/hooks/react/useStaleGuard";
 
 export type HatchTemplateStatus = "idle" | "loading" | "ready" | "error";
 
@@ -49,6 +50,7 @@ export function useHatchTemplate({
   // A template loading on open keeps the window off screen until it is in.
   useHoldReveal(status === "loading");
 
+  const guard = useStaleGuard();
   useEffect(() => {
     if (!enabled || !style) {
       setStatus("idle");
@@ -60,13 +62,13 @@ export function useHatchTemplate({
       setError(null);
       return;
     }
-    let cancelled = false;
+    const token = guard.next();
     setStatus("loading");
     setError(null);
     fetchRef
       .current(style)
       .then((reply) => {
-        if (cancelled) return;
+        if (!guard.isCurrent(token)) return;
         if (reply.ok) {
           loadedRef.current(style, parseHatchSpec(reply.spec));
           setStatus("ready");
@@ -76,14 +78,12 @@ export function useHatchTemplate({
         }
       })
       .catch((e: unknown) => {
-        if (cancelled) return;
+        if (!guard.isCurrent(token)) return;
         setStatus("error");
         setError(e instanceof Error ? e.message : String(e));
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [enabled, style, loaded]);
+    return () => guard.invalidate();
+  }, [enabled, style, loaded, guard]);
 
   return { status, error };
 }

--- a/tritium/react-gui/src/renderer/features/render/useMovieOutputPrefs.ts
+++ b/tritium/react-gui/src/renderer/features/render/useMovieOutputPrefs.ts
@@ -29,6 +29,7 @@ import {
   type MovieSettings,
 } from "@renderer/data/renderSettings";
 import { PERSIST_DEBOUNCE_MS } from "@renderer/utils/timing";
+import { useStaleGuard } from "@renderer/hooks/react/useStaleGuard";
 
 /** How long an edit rests before it is written back (base name is typed). */
 
@@ -108,8 +109,9 @@ export function useMovieOutputPrefs(
   updateRef.current = updateMovie;
 
   // Load once: persisted preferences, plus the folder main manages for this run.
+  const guard = useStaleGuard();
   useEffect(() => {
-    let cancelled = false;
+    const token = guard.next();
     void (async () => {
       let prefs: MovieRenderPrefs | undefined;
       let dir = "";
@@ -123,7 +125,7 @@ export function useMovieOutputPrefs(
       } catch {
         // Electron not available (Vite dev server) -- keep the defaults.
       }
-      if (cancelled) return;
+      if (!guard.isCurrent(token)) return;
       setTempDir(dir);
       const patch = patchFromPrefs(prefs);
       if (patch.outputDir) lastCustomRef.current = patch.outputDir;
@@ -137,10 +139,8 @@ export function useMovieOutputPrefs(
       updateRef.current(patch);
       loadedRef.current = true;
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    return () => guard.invalidate();
+  }, [guard]);
 
   // Write back after the edits settle. Skipped until the load has landed, so
   // the defaults cannot overwrite what was stored.

--- a/tritium/react-gui/src/renderer/features/render/useRenderWindowClient.ts
+++ b/tritium/react-gui/src/renderer/features/render/useRenderWindowClient.ts
@@ -24,6 +24,7 @@ import { IPC } from "@shared/ipcChannels";
 import type { RenderFramePreviewWire, RenderTargetViewWire, RenderWindowCommand, RenderWindowModeRequest, RenderWindowStateUpdate, RenderViewCamera, HatchStyleSpecReply, ViewSizePx, RelayKind, RelayReq, RelayRes } from "@shared/types/renderWindow";
 import type { RenderJob } from "./useRenderJob";
 import { useHoldReveal } from "@renderer/shell/reveal/useRevealWindow";
+import { useStaleGuard } from "@renderer/hooks/react/useStaleGuard";
 import type {
   RenderResult,
   RenderSettingsSnapshot,
@@ -325,30 +326,31 @@ export function useRenderWindowClient(): {
   // newest render is shown on open, and it is the largest thing on screen).
   const [imagePending, setImagePending] = useState(false);
   useHoldReveal(imagePending);
+  const guard = useStaleGuard();
   useEffect(() => {
     if (shownId === null) {
       setShownImage(null);
       return;
     }
-    let cancelled = false;
+    const token = guard.next();
     setShownImage(null);
     setImagePending(true);
     void window.electronAPI
       ?.invoke(IPC.RENDER_HISTORY_READ, { resultId: shownId })
       .then((res) => {
-        if (!cancelled) setShownImage(res?.dataUrl ?? null);
+        if (guard.isCurrent(token)) setShownImage(res?.dataUrl ?? null);
       })
       .catch(() => {
-        if (!cancelled) setShownImage(null);
+        if (guard.isCurrent(token)) setShownImage(null);
       })
       .finally(() => {
-        if (!cancelled) setImagePending(false);
+        if (guard.isCurrent(token)) setImagePending(false);
       });
     return () => {
-      cancelled = true;
+      guard.invalidate();
       setImagePending(false);
     };
-  }, [shownId]);
+  }, [shownId, guard]);
 
   const getViewCamera = useCallback(
     (viewId: number): Promise<RenderViewCamera | null> =>

--- a/tritium/react-gui/src/renderer/features/selection/selection/useSelectionValidation.ts
+++ b/tritium/react-gui/src/renderer/features/selection/selection/useSelectionValidation.ts
@@ -5,7 +5,7 @@
  * The field shows an invalid state, so the answer has to be current -- but a
  * selection compiles in C++, and asking on every keystroke would compile a
  * dozen half-written expressions per word. Hence the debounce, and the
- * cancelled flag: a reply that arrives after the text moved on would mark the
+ * !guard.isCurrent(token) flag: a reply that arrives after the text moved on would mark the
  * wrong expression.
  *
  * The empty string, `*` and `none` are answered without asking. They are
@@ -14,6 +14,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 /** Wait this long after the last keystroke before compiling. */
 export const VALIDATE_DEBOUNCE_MS = 500;
@@ -39,6 +40,7 @@ export function useSelectionValidation({
     const [isValid, setIsValid] = useState(true);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    const guard = useStaleGuard();
     useEffect(() => {
         if (!cm || sceneId === undefined) {
             setIsValid(true);
@@ -50,21 +52,21 @@ export function useSelectionValidation({
             setIsValid(true);
             return;
         }
-        let cancelled = false;
+        const token = guard.next();
         debounceRef.current = setTimeout(() => {
             cm.invokeService('validateSelection', { selStr: trimmed, sceneId })
                 .then((res) => {
-                    if (!cancelled) setIsValid(res.ok);
+                    if (guard.isCurrent(token)) setIsValid(res.ok);
                 })
                 .catch(() => {
-                    if (!cancelled) setIsValid(true);
+                    if (guard.isCurrent(token)) setIsValid(true);
                 });
         }, VALIDATE_DEBOUNCE_MS);
         return () => {
-            cancelled = true;
+            guard.invalidate();
             if (debounceRef.current !== null) clearTimeout(debounceRef.current);
         };
-    }, [cm, text, sceneId]);
+    }, [cm, text, sceneId, guard]);
 
     return isValid;
 }

--- a/tritium/react-gui/src/renderer/features/selection/useMolStructure.ts
+++ b/tritium/react-gui/src/renderer/features/selection/useMolStructure.ts
@@ -26,6 +26,7 @@ import type {
 } from '@renderer/worker/server/services/select/getMolStructure';
 import { SEM_OBJECT, SEM_ANY } from '@renderer/event';
 import { useCueMolEventListener } from '@renderer/hooks/cuemol/useCueMolEventListener';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 export interface UseMolStructureOptions {
     cm: AsyncCueMol | null;
@@ -86,6 +87,7 @@ export function useMolStructure(
         inflightAtomsRef.current.clear();
     }, []);
 
+    const guard = useStaleGuard();
     const fetchChains = useCallback(() => {
         const sid = sceneIdRef.current;
         const mid = molIdRef.current;
@@ -94,24 +96,22 @@ export function useMolStructure(
             return;
         }
         setChainsLoading(true);
-        let cancelled = false;
+        const token = guard.next();
         cm.invokeService('getMolChains', { sceneId: sid, molId: mid })
             .then((res) => {
-                if (cancelled) return;
+                if (!guard.isCurrent(token)) return;
                 setChains(res?.chains ?? []);
             })
             .catch((err: unknown) => {
-                if (cancelled) return;
+                if (!guard.isCurrent(token)) return;
                 console.warn('getMolChains failed:', err);
                 setChains([]);
             })
             .finally(() => {
-                if (!cancelled) setChainsLoading(false);
+                if (guard.isCurrent(token)) setChainsLoading(false);
             });
-        return () => {
-            cancelled = true;
-        };
-    }, [cm]);
+        return () => guard.invalidate();
+    }, [cm, guard]);
 
     const refetch = useCallback(() => {
         clearLazyCaches();

--- a/tritium/react-gui/src/renderer/features/settings/useSystemFonts.ts
+++ b/tritium/react-gui/src/renderer/features/settings/useSystemFonts.ts
@@ -12,6 +12,7 @@
  */
 
 import { useEffect, useState } from 'react'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 import {
   GENERIC_FONT_FAMILIES,
   FALLBACK_FONT_LIST,
@@ -71,19 +72,18 @@ async function loadSystemFonts(): Promise<string[]> {
 export function useSystemFonts(): string[] {
   const [fonts, setFonts] = useState<string[]>(cachedFonts ?? FALLBACK_FONT_LIST)
 
+  const guard = useStaleGuard()
   useEffect(() => {
     if (cachedFonts) {
       setFonts(cachedFonts)
       return
     }
-    let cancelled = false
+    const token = guard.next()
     loadSystemFonts().then((list) => {
-      if (!cancelled) setFonts(list)
+      if (guard.isCurrent(token)) setFonts(list)
     })
-    return () => {
-      cancelled = true
-    }
-  }, [])
+    return () => guard.invalidate()
+  }, [guard])
 
   return fonts
 }

--- a/tritium/react-gui/src/renderer/h3-kit/MolSelList/MolSelList.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/MolSelList/MolSelList.tsx
@@ -40,6 +40,7 @@ import {
 } from '@renderer/h3-kit/selection';
 import { getHistory } from './selHistory';
 import { useHitCountResolver } from './useSelHitCount';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 const VALIDATE_DEBOUNCE_MS = 500;
 
@@ -101,6 +102,11 @@ export const MolSelList: React.FC<MolSelListProps> = ({
     const [historyItems, setHistoryItems] = useState<string[]>(() => getHistory());
     const [isValid, setIsValid] = useState(true);
     const [isOpen, setIsOpen] = useState(false);
+    // Two independent fetches: the definition list and the live validation of
+    // what the user typed. One guard for both would let either make the
+    // other's answer look stale.
+    const defsGuard = useStaleGuard();
+    const validateGuard = useStaleGuard();
 
     // Operand draft for the builder (kept for the widget's lifetime so the last
     // keyword / value survives reopening the popover).
@@ -116,25 +122,23 @@ export const MolSelList: React.FC<MolSelListProps> = ({
             setMolCurrentSel(undefined);
             return;
         }
-        let cancelled = false;
+        const token = defsGuard.next();
         const args = molID !== undefined ? { sceneId: sceneID, molId: molID } : { sceneId: sceneID };
         cm.invokeService('getSelDefs', args)
             .then((res) => {
-                if (cancelled) return;
+                if (!defsGuard.isCurrent(token)) return;
                 setSceneDefs(res.scene);
                 setGlobalDefs(res.global);
                 setMolCurrentSel(res.currentSel);
             })
             .catch(() => {
-                if (cancelled) return;
+                if (!defsGuard.isCurrent(token)) return;
                 setSceneDefs([]);
                 setGlobalDefs([]);
                 setMolCurrentSel(undefined);
             });
-        return () => {
-            cancelled = true;
-        };
-    }, [cm, sceneID, molID, refreshKey]);
+        return () => defsGuard.invalidate();
+    }, [cm, sceneID, molID, refreshKey, defsGuard]);
 
     // ---- Live validation (debounced) ----
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -150,21 +154,21 @@ export const MolSelList: React.FC<MolSelListProps> = ({
             setIsValid(true);
             return;
         }
-        let cancelled = false;
+        const token = validateGuard.next();
         debounceRef.current = setTimeout(() => {
             cm.invokeService('validateSelection', { selStr: trimmed, sceneId: sceneID })
                 .then((res) => {
-                    if (!cancelled) setIsValid(res.ok);
+                    if (validateGuard.isCurrent(token)) setIsValid(res.ok);
                 })
                 .catch(() => {
-                    if (!cancelled) setIsValid(true); // don't flag on transport error
+                    if (validateGuard.isCurrent(token)) setIsValid(true); // don't flag on transport error
                 });
         }, VALIDATE_DEBOUNCE_MS);
         return () => {
-            cancelled = true;
+            validateGuard.invalidate();
             if (debounceRef.current !== null) clearTimeout(debounceRef.current);
         };
-    }, [cm, selectedSel, sceneID]);
+    }, [cm, selectedSel, sceneID, validateGuard]);
 
     // On open, refresh history (another pane may have appended while we were
     // idle). On close, commit the composed value once -- builder ops only

--- a/tritium/react-gui/src/renderer/h3-kit/MolSelList/useSelHitCount.ts
+++ b/tritium/react-gui/src/renderer/h3-kit/MolSelList/useSelHitCount.ts
@@ -11,6 +11,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 /** number = count, 'loading' = in flight, null = uncountable, undefined = N/A. */
 export type HitCount = number | 'loading' | null | undefined;
@@ -63,6 +64,7 @@ export function useSelHitCount(
     const [count, setCount] = useState<HitCount>(undefined);
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    const guard = useStaleGuard();
     useEffect(() => {
         if (timerRef.current !== null) clearTimeout(timerRef.current);
         const trimmed = (expr ?? '').trim();
@@ -70,22 +72,22 @@ export function useSelHitCount(
             setCount(undefined);
             return;
         }
-        let cancelled = false;
+        const token = guard.next();
         setCount('loading');
         timerRef.current = setTimeout(() => {
             getHitCount(trimmed)
                 .then((n) => {
-                    if (!cancelled) setCount(n);
+                    if (guard.isCurrent(token)) setCount(n);
                 })
                 .catch(() => {
-                    if (!cancelled) setCount(null);
+                    if (guard.isCurrent(token)) setCount(null);
                 });
         }, DEBOUNCE_MS);
         return () => {
-            cancelled = true;
+            guard.invalidate();
             if (timerRef.current !== null) clearTimeout(timerRef.current);
         };
-    }, [getHitCount, expr, enabled]);
+    }, [getHitCount, expr, enabled, guard]);
 
     return count;
 }

--- a/tritium/react-gui/src/renderer/h3-kit/colorpicker/ColorPicker.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/colorpicker/ColorPicker.tsx
@@ -29,6 +29,7 @@ import { packToHex, type Rgb } from './colorMath'
 import { RgbHsbPanel } from './RgbHsbPanel'
 import { NamedListPanel } from './NamedListPanel'
 import { PalettePanel } from './PalettePanel'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 const MOL_COLOR = '$molcol'
 
@@ -120,10 +121,11 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({
     const liveValueRef = useRef(value)
 
     // Resolve the authoritative colour whenever the parent value changes.
+    const guard = useStaleGuard()
     useEffect(() => {
         setDraft(value)
         liveValueRef.current = value
-        let cancelled = false
+        const token = guard.next()
         if (!cm) {
             setResolved(null)
             setLiveRgb(null)
@@ -135,20 +137,18 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({
                     colorStr: value,
                     sceneId: sceneId ?? 0,
                 })
-                if (cancelled) return
+                if (!guard.isCurrent(token)) return
                 setResolved(res ?? null)
                 setLiveRgb(res?.ok && res.r !== undefined ? [res.r, res.g!, res.b!] : null)
             } catch (err: unknown) {
-                if (cancelled) return
+                if (!guard.isCurrent(token)) return
                 console.warn('compileColor failed:', err)
                 setResolved(null)
                 setLiveRgb(null)
             }
         })()
-        return () => {
-            cancelled = true
-        }
-    }, [value, sceneId, cm])
+        return () => guard.invalidate()
+    }, [value, sceneId, cm, guard])
 
     const isMol = value === MOL_COLOR
     const swatchColor = liveRgb ? packToHex(liveRgb) : 'transparent'

--- a/tritium/react-gui/src/renderer/h3-kit/colorpicker/NamedListPanel.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/colorpicker/NamedListPanel.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Spinner } from '@blueprintjs/core'
 import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol'
 import type { NamedColorEntry } from '@renderer/worker/server/services/colorPicker.service'
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard'
 
 interface NamedListPanelProps {
     cm: AsyncCueMol | null
@@ -45,8 +46,9 @@ export const NamedListPanel: React.FC<NamedListPanelProps> = ({
     const [entries, setEntries] = useState<NamedColorEntry[] | null>(null)
     const selectedRef = useRef<HTMLButtonElement | null>(null)
 
+    const guard = useStaleGuard()
     useEffect(() => {
-        let cancelled = false
+        const token = guard.next()
         if (!cm) {
             setEntries([])
             return
@@ -55,14 +57,12 @@ export const NamedListPanel: React.FC<NamedListPanelProps> = ({
             const res = await cm.invokeService('getNamedColors', {
                 sceneId: sceneId ?? 0,
             })
-            if (cancelled) return
+            if (!guard.isCurrent(token)) return
             // Scene definitions first (UXP order), then global.
             setEntries([...res.scene, ...res.global])
         })()
-        return () => {
-            cancelled = true
-        }
-    }, [cm, sceneId])
+        return () => guard.invalidate()
+    }, [cm, sceneId, guard])
 
     const selectedKey = selectedName !== undefined ? normalizeName(selectedName) : undefined
 

--- a/tritium/react-gui/src/renderer/h3-kit/selection/SelectionBuilder.tsx
+++ b/tritium/react-gui/src/renderer/h3-kit/selection/SelectionBuilder.tsx
@@ -64,6 +64,7 @@ import { canApplyUnary, selectTerm } from './selBuilderReducer';
 import { useSelHitCount, type GetHitCount } from '@renderer/h3-kit/MolSelList/useSelHitCount';
 import { CountTag } from '@renderer/h3-kit/MolSelList/CountTag';
 import { NamedSelMenu, HistoryMenu } from '@renderer/h3-kit/MolSelList/SelMenus';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 /* --- Props --- */
 
@@ -187,24 +188,23 @@ export const SelectionBuilder: React.FC<SelectionBuilderProps> = ({
 
     // --- Autocomplete values for the active keyword ---
     const [suggestItems, setSuggestItems] = useState<string[]>(VALUE_LIST_EMPTY);
+    const guard = useStaleGuard();
     useEffect(() => {
         const kind = keywordDef.autocomplete;
         if (!kind || !resolveValues) {
             setSuggestItems(VALUE_LIST_EMPTY);
             return;
         }
-        let cancelled = false;
+        const token = guard.next();
         resolveValues(kind)
             .then((vals) => {
-                if (!cancelled) setSuggestItems(vals);
+                if (guard.isCurrent(token)) setSuggestItems(vals);
             })
             .catch(() => {
-                if (!cancelled) setSuggestItems(VALUE_LIST_EMPTY);
+                if (guard.isCurrent(token)) setSuggestItems(VALUE_LIST_EMPTY);
             });
-        return () => {
-            cancelled = true;
-        };
-    }, [keywordDef.autocomplete, resolveValues]);
+        return () => guard.invalidate();
+    }, [keywordDef.autocomplete, resolveValues, guard]);
 
     const setField = (name: string, v: string): void =>
         dispatch({ type: 'SET_FIELD', name, value: v });

--- a/tritium/react-gui/src/renderer/hooks/useSceneExportCaps.ts
+++ b/tritium/react-gui/src/renderer/hooks/useSceneExportCaps.ts
@@ -14,6 +14,7 @@
 import { useEffect, useState } from 'react';
 import { IPC } from '@shared/ipcChannels';
 import type { AsyncCueMol } from '@renderer/worker/client/AsyncCueMol';
+import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 
 interface UseSceneExportCapsOptions {
   cm: AsyncCueMol | null;
@@ -30,12 +31,13 @@ export function useSceneExportCaps({
 }: UseSceneExportCapsOptions): string[] | null {
   const [available, setAvailable] = useState<string[] | null>(null);
 
+  const guard = useStaleGuard();
   useEffect(() => {
     if (!cm || !cueMolReady) return;
-    let cancelled = false;
+    const token = guard.next();
     cm.invokeService('getAvailableSceneExporters', undefined)
       .then((res) => {
-        if (cancelled || !res?.ok) return;
+        if (!guard.isCurrent(token) || !res?.ok) return;
         setAvailable(res.names);
         window.electronAPI
           ?.invoke(IPC.MENU_UPDATE_STATE, { exportCaps: { available: res.names } })
@@ -46,10 +48,8 @@ export function useSceneExportCaps({
       .catch((err: unknown) => {
         console.warn('probe scene exporters failed:', err);
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [cm, cueMolReady]);
+    return () => guard.invalidate();
+  }, [cm, cueMolReady, guard]);
 
   return available;
 }

--- a/tritium/react-gui/src/renderer/worker/server/services/anim/edit.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/anim/edit.ts
@@ -10,7 +10,13 @@ import type { AnimObj } from "@cuemol/core/src/wrappers/AnimObj";
 import type { Scene } from "@cuemol/core/src/wrappers/Scene";
 import type { WorkerContext } from "@renderer/worker/server/types/WorkerContext";
 import type { AnimAddType } from "@renderer/types";
-import { safeStr, resolveSceneMgr, makeTimeValue } from "./resolve";
+import {
+  forEachAnimObj,
+  makeTimeValue,
+  resolveSceneMgr,
+  safeNum,
+  safeStr,
+} from "./resolve";
 import { withUndoTxn } from "../withUndoTxn";
 import { readMgrState } from "./read";
 import type {
@@ -188,6 +194,45 @@ export function addElement(ctx: WorkerContext, args: AnimAddElementArgs): AnimAd
 }
 
 /** Remove the element at `index`. */
+/**
+ * Cut loose the elements whose start time chains to the one at `index`.
+ *
+ * A relative start is an offset from another element's end, named by
+ * `timeRefName`. Once that element is gone the name resolves to nothing, and
+ * C++ `resolveRelTime` throws for the whole manager -- so every later resolve
+ * fails, the strip keeps whatever absolute times it was last drawn with, and
+ * no further edit to any element can land.
+ *
+ * A deleted reference cannot be re-pointed the way a renamed one is
+ * (`cascadeTimeRefRename`), so each dependent is made absolute at the position
+ * it currently occupies: the timeline looks unchanged, and the chain is gone
+ * rather than dangling.
+ */
+function detachDependents(ctx: WorkerContext, mgr: AnimMgr, index: number): void {
+  const target = mgr.getAt(index) as AnimObj | null;
+  if (!target) return;
+  const name = safeStr(() => target.name);
+  if (!name) return;
+  // Absolute times have to be current before they are copied. A resolve that
+  // already fails leaves nothing worth preserving, so the offsets stand.
+  try {
+    mgr.resolveRelTime();
+  } catch {
+    /* already dangling elsewhere */
+  }
+  forEachAnimObj(mgr, (obj) => {
+    if (safeStr(() => obj.timeRefName) !== name) return undefined;
+    const tvS = makeTimeValue(ctx, safeNum(() => obj.absStart.millisec) ?? 0);
+    const tvE = makeTimeValue(ctx, safeNum(() => obj.absEnd.millisec) ?? 0);
+    if (tvS && tvE) {
+      obj.start = tvS;
+      obj.end = tvE;
+    }
+    (obj as unknown as Record<string, unknown>).timeRefName = "";
+    return undefined;
+  });
+}
+
 export function removeElement(
   ctx: WorkerContext,
   args: AnimRemoveElementArgs,
@@ -197,7 +242,9 @@ export function removeElement(
   const { scene, mgr } = sm;
   try {
     withUndoTxn(scene, "Delete animation element", () => {
+      detachDependents(ctx, mgr, args.index);
       mgr.removeAt(args.index);
+      mgr.resolveRelTime();
     });
   } catch {
     return { ok: false };

--- a/tritium/react-gui/src/renderer/worker/server/services/helpers/defPaintColoring.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/helpers/defPaintColoring.ts
@@ -30,14 +30,16 @@ const DEFAULT_PAINT_ENTRIES: { sel: string; color: string }[] = [
  * Build a `PaintColoring` carrying the default painting.
  *
  * @param ctx - worker context.
- * @param sceneUid - scene scope for compiling the selections / named colours;
- *   omit (0) for the global scope.
+ * @param sceneUid - scene scope for compiling the selections and named
+ *   colours. Required: a scene-local name compiled in the global scope
+ *   (uid 0) silently fails to resolve, and every caller has a scene in hand,
+ *   so a default here would only make that mistake reachable.
  * @returns the coloring, or null when the object or any selection could not be
  *   built (the caller then leaves the renderer's coloring alone).
  */
 export function createDefPaintColoring(
     ctx: WorkerContext,
-    sceneUid = 0,
+    sceneUid: number,
 ): PaintColoring | null {
     const coloring = ctx.svc.createObj('PaintColoring') as PaintColoring;
     if (!coloring) return null;

--- a/tritium/react-gui/src/renderer/worker/server/services/molops/changeChainName.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/molops/changeChainName.ts
@@ -14,7 +14,7 @@
 import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
 import type { MolSelection } from '@cuemol/core/src/wrappers/MolSelection';
 import type { WorkerContext } from '@renderer/worker/server/types/WorkerContext';
-import { resolveMolTool } from '@renderer/worker/server/services/helpers/molAnlTool';
+import { resolveMolTool } from '@renderer/worker/server/services/molops/molAnlTool';
 import { undoTxnResult } from '../withUndoTxn';
 import { ok, type Result } from '@renderer/worker/shared/result';
 

--- a/tritium/react-gui/src/renderer/worker/server/services/molops/changeResidueIndex.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/molops/changeResidueIndex.ts
@@ -16,7 +16,7 @@
 import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
 import type { MolSelection } from '@cuemol/core/src/wrappers/MolSelection';
 import type { WorkerContext } from '@renderer/worker/server/types/WorkerContext';
-import { resolveMolTool } from '@renderer/worker/server/services/helpers/molAnlTool';
+import { resolveMolTool } from '@renderer/worker/server/services/molops/molAnlTool';
 import { undoTxnResult } from '../withUndoTxn';
 import { ok, fail, type Result } from '@renderer/worker/shared/result';
 

--- a/tritium/react-gui/src/renderer/worker/server/services/molops/deleteMolAtoms.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/molops/deleteMolAtoms.ts
@@ -14,7 +14,7 @@
 import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
 import type { MolSelection } from '@cuemol/core/src/wrappers/MolSelection';
 import type { WorkerContext } from '@renderer/worker/server/types/WorkerContext';
-import { resolveMolTool } from '@renderer/worker/server/services/helpers/molAnlTool';
+import { resolveMolTool } from '@renderer/worker/server/services/molops/molAnlTool';
 import { undoTxnResult } from '../withUndoTxn';
 import { ok, fail, type Result } from '@renderer/worker/shared/result';
 

--- a/tritium/react-gui/src/renderer/worker/server/services/molops/molAnlTool.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/molops/molAnlTool.ts
@@ -1,5 +1,5 @@
 /**
- * @file worker/server/services/helpers/molAnlTool.ts
+ * @file worker/server/services/molops/molAnlTool.ts
  * @description Shared preamble for the single-object MolAnlManager tool
  * services (Change chain ID / Delete atoms / Change residue index).
  *
@@ -20,8 +20,8 @@ import type { MolSelection } from '@cuemol/core/src/wrappers/MolSelection';
 import type { MolAnlManager } from '@cuemol/core/src/wrappers/MolAnlManager';
 import type { Object as CueMolObject } from '@cuemol/core/src/wrappers/Object';
 import type { WorkerContext } from '@renderer/worker/server/types/WorkerContext';
-import { getSceneOrNull } from './sceneResolver';
-import { makeSel } from './makeSel';
+import { getSceneOrNull } from '../helpers/sceneResolver';
+import { makeSel } from '../helpers/makeSel';
 
 /**
  * Resolve the global `MolAnlManager` service, or `null` when unavailable.

--- a/tritium/react-gui/src/renderer/worker/server/services/select/applySelectionHits.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/select/applySelectionHits.ts
@@ -1,5 +1,5 @@
 /**
- * @file worker/server/services/helpers/applySelectionHits.ts
+ * @file worker/server/services/select/applySelectionHits.ts
  * @description Shared tail for the rectangle / lasso selection services.
  *
  * Both `rectSelect` (View.hitTestRect) and `lassoSelect` (View.hitTestPolygon)
@@ -16,7 +16,7 @@
 import type { MolCoord } from '@cuemol/core/src/wrappers/MolCoord';
 import type { Scene } from '@cuemol/core/src/wrappers/Scene';
 import type { WorkerContext } from '@renderer/worker/server/types/WorkerContext';
-import { makeSel } from './makeSel';
+import { makeSel } from '../helpers/makeSel';
 import { withUndoTxn } from '@renderer/worker/server/services/withUndoTxn';
 
 /** One element of a hit-test JSON array (View.hitTestRect / hitTestPolygon). */

--- a/tritium/react-gui/src/renderer/worker/server/services/select/lassoSelect.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/select/lassoSelect.ts
@@ -15,7 +15,7 @@ import {
     applySelectionHits,
     parseSelectionHits,
     type SelectionResult,
-} from '@renderer/worker/server/services/helpers/applySelectionHits';
+} from '@renderer/worker/server/services/select/applySelectionHits';
 
 export interface LassoPoint {
     x: number;

--- a/tritium/react-gui/src/renderer/worker/server/services/select/rectSelect.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/select/rectSelect.ts
@@ -4,7 +4,7 @@
 // `navi-toolribbon.js` rectSel(): hit-test the dragged rectangle, group the
 // hits by molecule object, and replace each molecule's selection with the
 // union of the matched atoms. The grouping / assignment / undo-txn tail is
-// shared with lassoSelect (see helpers/applySelectionHits).
+// shared with lassoSelect (see ./applySelectionHits).
 
 import type { WorkerContext } from '@renderer/worker/server/types/WorkerContext';
 import { getViewSceneOrNull } from '@renderer/worker/server/services/helpers/sceneResolver';
@@ -12,7 +12,7 @@ import {
     applySelectionHits,
     parseSelectionHits,
     type SelectionResult,
-} from '@renderer/worker/server/services/helpers/applySelectionHits';
+} from '@renderer/worker/server/services/select/applySelectionHits';
 
 export interface RectSelectArgs {
     viewId: number;


### PR DESCRIPTION
Two bugs found in the visual verification of the Phase 5-A folders, plus the
three follow-ups the refactoring plan left open. Both bugs turned out to be
pre-existing -- the code involved is byte-identical to the pre-refactoring
baseline -- and both are pinned by tests that fail on the old behaviour.

## 1. Pasting a preset renderer group crashed the app (C++)

Pasting a MolCoord that carried a preset renderer group (e.g. the Simple1
preset) into a new scene took the whole app down. Two defects, one behind
the other:

- **`createPresetRenderer` named its group with the direct C++ setter**,
  which leaves the property still flagged as default -- and default-valued
  properties are skipped at serialization. The copied XML carried
  `<renderer type="*group" group=""/>` with **no name**, while the children
  (named through the property system) kept theirs and kept pointing at
  `simple1`. The group now gets its name the way its children do.
- **A nameless group's centre scan recursed into itself.**
  `RendGroup::getCenter`/`hasCenter` find members by name -- every renderer
  whose `group` property equals this group's name -- and a nameless group
  matches itself (both strings empty). `Scene::addObject` re-applies styles,
  applying styles reads the centre, and `hasCenter` called itself until the
  stack ran out (SIGSEGV, confirmed in the crash report's native stack). The
  scan now skips renderer groups, which are never legal members (nesting is
  unsupported) -- itself included, and also a *second* nameless group, which
  a self-check alone would still recurse through. Both scans also tolerate a
  detached renderer's null client object.

Pinned at two levels: gtests for the three terminations (self, mutual,
detached), and a tritium/core addon test for the whole round trip -- toXML,
fromXML, addObject -- asserting the restored renderer list is identical to
the source's, group name included.

Payloads copied before this fix still paste a nameless group: no crash any
more, but its members point at a name nothing carries. Copying again from a
live scene produces a correct payload.

## 2. Deleting an animation element bricked its dependents (worker)

A relative start is an offset from another element's end, named by
`timeRefName`. Deleting the named element left its dependents pointing at a
name nothing carries, and C++ `resolveRelTime` throws on that for the whole
manager -- so every later resolve failed, the strip kept the positions it
was last drawn with while the inspector showed the raw offsets as if they
were absolute, and no further edit to any element could land.

Renaming already re-points the dependents (`cascadeTimeRefRename`); deleting
had no counterpart. A deleted reference cannot be re-pointed, so each
dependent is cut loose where it currently sits: made absolute at the
position it was resolved to. The timeline looks unchanged and the chain is
gone rather than dangling.

## 3. The plan's remaining follow-ups

**Every fetch gets a stale guard.** Twenty-five effects each kept a
`let cancelled` flag, and a flag only guards one of the two races: it stops
a result landing after unmount, and does nothing about a result landing
after a *newer request for a different key*. All twenty-five re-run on a
changing key -- `[cm, sceneId, objId]`, `[visible, cm, lattice]`,
`[cm, selectedSel]` -- so switching scene, object or dialog while a request
was in flight could let the old answer overwrite the new one. That is the
race `useStaleGuard` exists for (B4, fixed in the scene tree in Phase 2-1);
these flags were the last places still open to it.

Two components run two independent fetches and get a guard each
(`infoGuard`/`sgGuard`, `defsGuard`/`validateGuard`) -- sharing one would
let either fetch make the other's answer look stale.

Five flags stay: `useCueMol`, `useCueMolEventListener`, `useLogEvent`,
`useAppInitialization` and `MolViewPane` guard a *subscription's* lifetime
rather than a fetch's freshness, which is what a plain flag is right for.

**Two helpers move.** `applySelectionHits` is read only by `select/` and
`molAnlTool` only by `molops/`. The other candidates stay: `defPaintColoring`
and `readerFilter` look single-domain, but each is also read by another
helper that several folders use, so moving them would point a helper at a
domain folder. (This corrects #579's follow-up note, which named `makeSel`,
`styleutil` and `pickReaderName` as single-domain -- they are used by 7, 2
and 3 folders respectively.)

**B89.** `createDefPaintColoring`'s `sceneUid` loses its `= 0` default. A
scene-local name compiled in the global scope silently fails to resolve, and
both callers already pass a real scene, so the default only kept that
mistake reachable.

## Verification

Both bugs confirmed fixed on screen by the user, along with the rest of the
Phase 5-A visual checklist (Generic tab, copy/paste of every node kind with
rename-on-conflict, density maps, APBS run and cancel, still and movie
renders) -- all clean.

gtest 1440 pass / tritium core jest 765 pass / react-gui typecheck (web +
node), vitest 373 files 3496 tests, eslint 0 errors with warnings 68 -> 63
(the exhaustive-deps complaints the flags drew) / `task build_tritium` +
launch to `shader program created OK`.
