### PR TITLE
docs(architecture): measure the transport change against the pre-refactor build

### DIFF
--- a/docs/architecture/react-gui-refactoring.md
+++ b/docs/architecture/react-gui-refactoring.md
@@ -202,6 +202,59 @@ dead ではなく、pin テストを書いてから畳んだ。
 **UXP parity は正しさの保証ではない。** coloring の potential 出口欠落は
 UXP にも同じバグがあり、移植で継承していた。C++ の実際の enum を確認する。
 
+## 計測 (2026-08-31)
+
+ベースラインは Phase 0 で取り損ねたが、**リファクタ開始前の commit
+(`c80fb39a`) を checkout して同じ instrumentation を当て、両方ビルドして
+比べれば後から取れる** (ウィンドウ表示の調査で使ったのと同じ手口)。
+GUI 操作を人手に頼らず済むよう、drag は main から
+`webContents.executeJavaScript` で canvas に `MouseEvent` を dispatch して
+駆動した (両ツリーとも canvas に素の DOM listener を張っているので同じ
+driver が使える)。各ツリー 3 回、全て同値。
+
+### mouse drag (mousemove 120 回)
+
+| | before (`c80fb39a`) | after |
+|---|---|---|
+| 送信 (postMessage) | 122 | 122 |
+| **入力イベントへの返信** | **122** | **0** |
+
+**pointer event 1 件あたりのメッセージが 2 (要求 + 返信) から 1 (要求のみ) に
+なった。** Phase 5-B の `NO_REPLY_SEQ` が設計どおり効いていることの確認。
+`mouseDown` / `mouseMove` / `mouseUp` の返信は 1 件も来ない。
+
+### 比較できなかったもの
+
+同じ drag で `viewPropChanged` イベントの受信数が **before 0 / after 234**
+と大きく違ったが、**これはツリーの差ではなく購読の差**なので比較として
+成立しない。C++ の `ScrEventManager` は登録されたフィルタに一致する
+イベントだけを配送するので、受信数は「その瞬間どの pane が mount されていて
+何を購読しているか」で決まる。2 つのビルドで pane の状態を揃える手段が
+無かった (揃えるには GUI 操作が要る)。
+
+したがって **drag 中の総メッセージ数については何も主張できない**。計画の
+Phase 5 ゲート「mouse drag 中の postMessage 数が半減」は、送信のみを見れば
+122 -> 122 で**変わっておらず**、往復回数で見れば 2 -> 1 で半減している。
+どちらの意味で書かれたゲートなのかが曖昧だったので、ここに実測を残す。
+
+### 計測して分かった実装漏れ
+
+worker 側にカウンタを入れて測ると `cb=240 posted=240` で、**C++ からの
+コールバック 240 回に対して post も 240 回**。Phase 5-B の T2-1(a)
+「`WorkerService` が `_liveSlots` を持ち、購読者のいない slot への post を
+skip する」は**実装されていない** (`registerWorkerEventListener` に
+`isLive` 引数が無い)。5-B で実際に入ったのは (b) の lazy parse と
+`NO_REPLY_SEQ` だけだった。
+
+### 測っていないもの
+
+タブ切替と splitter drag の React commit 数は、どちらのツリーにも
+`<React.Profiler>` が入っておらず (Phase 2-5 の `RenderProfiler` は結局
+実装しなかった)、駆動にも DOM 操作が要るため未計測。animation 再生の
+IPC 数も、アニメーションを持つ scene を headless で用意する必要があり未計測。
+これらは代わりに性質を test で固定してある (`renderIsolation` /
+`LayoutProvider` の drag / `sceneTreeStability`)。
+
 ## 残課題
 
 - **Phase 5-A Tier 2**: 残り ~85 の flat service を calls slice と 1:1 の
@@ -210,6 +263,7 @@ UXP にも同じバグがあり、移植で継承していた。C++ の実際の
   値を渡しているので実害はないが、型で再発防止するなら既定を外す
 - **`cancelled` flag の one-shot fetch** 13 箇所と component 内 fetch guard
   16 箇所を `useStaleGuard` / `useLiveFetch` へ (Phase 2-1 から外した分)
-- **perf ベースライン**: Phase 0-3 で決めた DevTools Profiler のプロトコルは
-  未実施。代わりに再現可能な性質を test で pin してある
-  (`renderIsolation` / `LayoutProvider` の drag / `sceneTreeStability`)
+- **T2-1(a) の実装**: 購読者のいない slot への `event-notify` post を skip
+  する worker 側フィルタ (上記「計測して分かった実装漏れ」)
+- **React commit 数の計測**: `<React.Profiler>` を両ツリーに入れて
+  タブ切替 / splitter drag を測る (上記「測っていないもの」)


### PR DESCRIPTION
The perf baseline was never taken before the refactoring started, which
looked like it made a before/after impossible. It does not: check out the
commit the work began from, apply the same instrumentation to both trees,
build each, and the comparison exists after the fact. (Same technique that
settled whether the window-reveal flash was a regression.)

Driving it needs no one at the keyboard: main dispatches `MouseEvent`s at
the canvas through `executeJavaScript`, and both trees attach plain DOM
listeners there, so one driver works on both. Three runs per tree, identical
each time.

## What the numbers say

**Confirmed** -- a 120-step drag:

| | before (`c80fb39a`) | after |
|---|---|---|
| outbound postMessage | 122 | 122 |
| **replies to input events** | **122** | **0** |

One message per pointer event instead of two. That is exactly what
`NO_REPLY_SEQ` was for, and it holds.

**Cannot be compared** -- the same drag delivered 0 view property events on
the old build and 234 on the new. That is a difference in *subscriptions*,
not in either tree's efficiency: the C++ event manager only delivers what
some registered filter asks for, so the count depends on which panes were
mounted at that moment. Matching that between two builds needs GUI work,
so **nothing can be claimed about total drag traffic**.

Which also shows the Phase 5 gate ("half the postMessages during a drag")
was ambiguous: outbound is unchanged, round trips did halve.

## An implementation gap the measurement found

Worker-side counters read `cb=240 posted=240` -- every callback from C++
results in a post. The dead-slot filter that Phase 5-B's T2-1(a) described
(`WorkerService` holding `_liveSlots` and skipping posts nobody subscribes
to) **was never written**; `registerWorkerEventListener` has no `isLive`
parameter. Only the lazy parse and `NO_REPLY_SEQ` landed. It moves to the
open items rather than being implied done.

## Not measured

React commit counts for tab switch and splitter drag: neither tree has a
`<React.Profiler>` (Phase 2-5's `RenderProfiler` was never built) and
driving them needs DOM work. Animation playback IPC: needs a scene with an
animation set up headlessly. Both are recorded as open, with the existing
render-isolation tests standing in qualitatively.

Docs only; no code touched.
