### PR TITLE
feat(xtal): make the map surface border cap a policy of its own (cap_mode)

### DIFF
--- a/src/modules/xtal/MapSurfRenderer.cpp
+++ b/src/modules/xtal/MapSurfRenderer.cpp
@@ -56,6 +56,7 @@ MapSurfRenderer::MapSurfRenderer()
   m_nMaxGrid = 100;
   m_nStep = 1;
   m_bCapDisplay = false;
+  m_nCapMode = CAP_AUTO;
 
   m_bGenSurfMode = false;
 
@@ -848,6 +849,18 @@ Vector4D MapSurfRenderer::getGrdNorm2(int ix, int iy, int iz) const
   return rval;
 }
 
+/// True when all four cube corners of border face iBorder are inside the
+/// molecule boundary (bdr_verts[iBorder][0..3] hold the corner indices;
+/// [4..7] hold the edge indices, offset by 8).
+inline bool isBorderFaceInBndry(const bool bary[8], int iBorder)
+{
+  const int *iverts = bdr_verts[iBorder];
+  for (int i=0; i<4; ++i)
+    if (!bary[iverts[i]])
+      return false;
+  return true;
+}
+
 inline int getVertFlag4(int iVertFlag, const int *iv)
 {
   int ires = 0;
@@ -899,10 +912,10 @@ void MapSurfRenderer::marchCubeCell(int fx, int fy, int fz,
   if (m_nActSec<=fz+m_nStep)
     border_flag |= 1<<5;
 
-  // Border caps close the surface at the range boundary: always for the
-  // generated surface object, and in the display path in full region
-  // mode (m_bCapDisplay).
-  const bool bCap = bGenSurf || m_bCapDisplay;
+  // Border caps close the surface at the range boundary. The policy is
+  // the cap_mode property; CAP_AUTO keeps the historical coupling to the
+  // region mode and the gen-surf path.
+  const bool bCap = isCapEnabled(bGenSurf);
 
   if(iFlagIndex == 0 && bCap) {
     // Fill the border of the extent
@@ -912,6 +925,12 @@ void MapSurfRenderer::marchCubeCell(int fx, int fy, int fz,
     for (int i=0; i<6; ++i) {
       int mask = 1<<i;
       if (border_flag & mask) {
+
+        // The surface is clipped at the molecule boundary (an edge with
+        // an outside endpoint is dropped below), so a cap face outside the
+        // boundary would stick out where the surface was removed.
+        if (!isBorderFaceInBndry(bary, i))
+          continue;
 
         nx = border_normal[i][0];
         ny = border_normal[i][1];
@@ -1045,6 +1064,14 @@ void MapSurfRenderer::marchCubeCell(int fx, int fy, int fz,
     for (int iBorder=0; iBorder<6; ++iBorder) {
       int mask = 1<<iBorder;
       if (border_flag & mask) {
+
+        // Same clipping as above. This face also refers to the edge
+        // vertices v[8..19]: an edge dropped at the molecule boundary
+        // never had asEdgeVertex[] computed, and using it put a cap
+        // corner at the grid origin (a spike). All four corners being
+        // inside guarantees every edge of the face was computed.
+        if (!isBorderFaceInBndry(bary, iBorder))
+          continue;
         
         Vector4D norm(border_normal[iBorder][0], border_normal[iBorder][1], border_normal[iBorder][2]);
         

--- a/src/modules/xtal/MapSurfRenderer.hpp
+++ b/src/modules/xtal/MapSurfRenderer.hpp
@@ -194,8 +194,45 @@ namespace xtal {
     int m_nStep;
 
     /// Close the surface at the range boundary in the display path too
-    /// (full region mode; the gen-surf path always caps)
+    /// (full region mode; the gen-surf path always caps). This is the
+    /// value CAP_AUTO resolves to; cap_mode can override it.
     bool m_bCapDisplay;
+
+  public:
+    /// Border cap policy (cap_mode property values)
+    enum {
+      CAP_AUTO = 0,
+      CAP_ON = 1,
+      CAP_OFF = 2,
+    };
+
+  private:
+    /// Border cap policy (CAP_*). Independent of the region policy: AUTO
+    /// keeps the historical coupling (generated surface objects and the
+    /// full region mode close the surface, the box region mode does not),
+    /// ON and OFF decide it regardless of the region mode.
+    int m_nCapMode;
+
+  public:
+    int getCapMode() const { return m_nCapMode; }
+    void setCapMode(int n) {
+      if (m_nCapMode == n)
+        return;
+      m_nCapMode = n;
+      // the cap faces are part of the mesh
+      invalidateGeomCache();
+    }
+
+    /// Resolved cap policy of the current build (bGenSurf: the surface
+    /// object path, which caps by default)
+    bool isCapEnabled(bool bGenSurf) const
+    {
+      if (m_nCapMode == CAP_ON) return true;
+      if (m_nCapMode == CAP_OFF) return false;
+      return bGenSurf || m_bCapDisplay;
+    }
+
+  private:
 
     /// for debug
     std::deque<Vector4D> m_tmpv;

--- a/src/modules/xtal/MapSurfRenderer.qif
+++ b/src/modules/xtal/MapSurfRenderer.qif
@@ -42,6 +42,18 @@ runtime_class MapSurfRenderer extends MapRenderer
   property real width => redirect(getLineWidth, setLineWidth);
   default width = 1.2;
 
+  /// Border cap policy, independent of region_mode: auto (generated
+  /// surface objects and the full region mode close the surface at the
+  /// region boundary, the box region mode leaves it open), on (always
+  /// close it) or off (never close it)
+  enumdef cap_mode {
+    auto = xtal::MapSurfRenderer::CAP_AUTO;
+    on = xtal::MapSurfRenderer::CAP_ON;
+    off = xtal::MapSurfRenderer::CAP_OFF;
+  }
+  property enum cap_mode => redirect(getCapMode, setCapMode);
+  default cap_mode = "auto";
+
   /// Binning factor (marching stride in box region mode; superseded by the
   /// lod property of MapRenderer)
   property integer binning => redirect(getBinFac, setBinFac);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -207,6 +207,7 @@ endif()
 gtest_discover_tests(test_surface PROPERTIES LABELS "test_surface")
 
 add_executable(test_xtal
+  modules/xtal/test_mapsurf_cap.cpp
   modules/xtal/test_map_uniform.cpp
   modules/xtal/test_main.cpp
   modules/xtal/test_atomposmap2.cpp

--- a/src/tests/modules/xtal/test_mapsurf_cap.cpp
+++ b/src/tests/modules/xtal/test_mapsurf_cap.cpp
@@ -1,0 +1,185 @@
+// MapSurfRenderer cap_mode: the border cap is an independent policy, not a
+// side effect of the region mode, and the cap faces are clipped at the
+// molecule boundary like the surface itself.
+#include <gtest/gtest.h>
+#include <common.h>
+#include <qlib/Vector4D.hpp>
+#include <qsys/Scene.hpp>
+#include <qsys/SceneManager.hpp>
+#include <vector>
+#include "molstr/ElemSym.hpp"
+#include "molstr/MolAtom.hpp"
+#include "molstr/MolCoord.hpp"
+#include "molstr/ResidIndex.hpp"
+#include "surface/MolSurfObj.hpp"
+#include "xtal/DensityMap.hpp"
+#include "xtal/MapRenderer.hpp"
+#include "xtal/MapSurfRenderer.hpp"
+
+using molstr::MolAtomPtr;
+using molstr::MolCoordPtr;
+using qlib::Vector4D;
+
+namespace {
+
+class MapSurfCapTest : public ::testing::Test
+{
+protected:
+    qsys::ScenePtr m_pScene;
+    qsys::ObjectPtr m_pObj;
+    qsys::RendererPtr m_pRend;
+    xtal::MapSurfRenderer *m_pMSR;
+
+    void SetUp() override
+    {
+        m_pScene = qsys::SceneManager::getInstance()->createScene();
+
+        xtal::DensityMap *pMap = MB_NEW xtal::DensityMap();
+        // 4x4x4 ramp covering [0, 63]; the default iso-level cuts through
+        // the cell, so the surface reaches the range boundary.
+        std::vector<float> data(64);
+        for (int i = 0; i < 64; ++i) data[i] = float(i);
+        pMap->setMapFloatArray(data.data(), 4, 4, 4, 0, 1, 2);
+        pMap->setMapParams(0, 0, 0, 4, 4, 4);
+        pMap->setXtalParams(4.0, 4.0, 4.0, 90.0, 90.0, 90.0);
+
+        m_pObj = qsys::ObjectPtr(pMap);
+        m_pObj->setName("testmap");
+        m_pScene->addObject(m_pObj);
+
+        m_pRend = m_pObj->createRenderer("isosurf");
+        m_pMSR = dynamic_cast<xtal::MapSurfRenderer *>(m_pRend.get());
+        ASSERT_NE(m_pMSR, nullptr);
+        m_pMSR->setUsePBC(false);
+    }
+
+    void TearDown() override
+    {
+        qsys::SceneManager::getInstance()->destroyScene(m_pScene->getUID());
+    }
+
+    /// Vertex count of the generated surface (-1 if it could not be made)
+    int genSurfVertSize()
+    {
+        qsys::ObjectPtr pSurfObj = m_pMSR->generateSurfObj();
+        surface::MolSurfObj *pSurf =
+            dynamic_cast<surface::MolSurfObj *>(pSurfObj.get());
+        if (pSurf == nullptr) return -1;
+        return pSurf->getVertSize();
+    }
+};
+
+}  // namespace
+
+TEST_F(MapSurfCapTest, DefaultIsAuto)
+{
+    EXPECT_EQ(m_pMSR->getCapMode(), xtal::MapSurfRenderer::CAP_AUTO);
+}
+
+TEST_F(MapSurfCapTest, CapOffDropsTheBorderFaces)
+{
+    // The gen-surf path caps by default (CAP_AUTO), so turning the cap off
+    // must leave fewer vertices: the border faces are gone.
+    m_pMSR->setCapMode(xtal::MapSurfRenderer::CAP_AUTO);
+    const int nauto = genSurfVertSize();
+    ASSERT_GT(nauto, 0);
+
+    m_pMSR->setCapMode(xtal::MapSurfRenderer::CAP_OFF);
+    const int noff = genSurfVertSize();
+    ASSERT_GT(noff, 0);
+    EXPECT_LT(noff, nauto);
+}
+
+TEST_F(MapSurfCapTest, CapPolicyIsIndependentOfTheRegionMode)
+{
+    // The point of the property: the cap no longer follows region_mode.
+    // "on" caps in box region mode, where AUTO would not, and the two
+    // explicit settings differ there.
+    m_pMSR->setRegionMode(xtal::MapRenderer::REGION_BOX);
+    ASSERT_EQ(m_pMSR->getEffectiveRegionMode(), xtal::MapRenderer::REGION_BOX);
+
+    // The display path of the box region mode does not cap under AUTO...
+    EXPECT_FALSE(m_pMSR->isCapEnabled(false));
+    // ...but "on" does, and "off" turns the gen-surf cap off as well.
+    m_pMSR->setCapMode(xtal::MapSurfRenderer::CAP_ON);
+    EXPECT_TRUE(m_pMSR->isCapEnabled(false));
+    EXPECT_TRUE(m_pMSR->isCapEnabled(true));
+
+    m_pMSR->setCapMode(xtal::MapSurfRenderer::CAP_OFF);
+    EXPECT_FALSE(m_pMSR->isCapEnabled(false));
+    EXPECT_FALSE(m_pMSR->isCapEnabled(true));
+}
+
+TEST_F(MapSurfCapTest, CapFacesAreClippedAtTheMoleculeBoundary)
+{
+    // The border cap used to be emitted without consulting the molecule
+    // boundary, so it stuck out where the surface itself had been clipped
+    // away (and, on a partially filled cell, reused an edge whose
+    // intersection was never computed).
+    //
+    // Geometry: an 8x8x8 map whose density falls off along x, so the
+    // iso-surface is the plane x = 6.5 and everything at low x is inside.
+    // The boundary is a 1.2 angstrom sphere around (3.5, 0.5, 3.5), which
+    // the map's own y = 0 face cuts through: the cells on that face are
+    // inside the surface (so they cap) and straddle the sphere.
+    xtal::DensityMap *pMap = MB_NEW xtal::DensityMap();
+    std::vector<float> data(8 * 8 * 8);
+    for (int k = 0; k < 8; ++k)
+        for (int j = 0; j < 8; ++j)
+            for (int i2 = 0; i2 < 8; ++i2)
+                data[i2 + 8 * (j + 8 * k)] = float(7 - i2) * 10.0f;
+    pMap->setMapFloatArray(data.data(), 8, 8, 8, 0, 1, 2);
+    pMap->setMapParams(0, 0, 0, 8, 8, 8);
+    pMap->setXtalParams(8.0, 8.0, 8.0, 90.0, 90.0, 90.0);
+
+    qsys::ObjectPtr pMapObj(pMap);
+    pMapObj->setName("rampmap");
+    m_pScene->addObject(pMapObj);
+    qsys::RendererPtr pRend = pMapObj->createRenderer("isosurf");
+    xtal::MapSurfRenderer *pMSR =
+        dynamic_cast<xtal::MapSurfRenderer *>(pRend.get());
+    ASSERT_NE(pMSR, nullptr);
+    pMSR->setUsePBC(false);
+    pMSR->setLevel(5.0);
+
+    MolCoordPtr pMol(MB_NEW molstr::MolCoord());
+    MolAtomPtr pAtom(MB_NEW molstr::MolAtom());
+    pAtom->setChainName("A");
+    pAtom->setResName("ALA");
+    pAtom->setResIndex(molstr::ResidIndex(1));
+    pAtom->setName("CA");
+    pAtom->setElement(molstr::ElemSym::C);
+    pAtom->setPos(Vector4D(3.5, 0.5, 3.5));
+    ASSERT_GE(pMol->appendAtom(pAtom), 0);
+
+    qsys::ObjectPtr pMolObj(pMol);
+    pMolObj->setName("testmol");
+    m_pScene->addObject(pMolObj);
+
+    pMSR->setBndryMolName("testmol");
+    pMSR->setBndryRng(1.2);
+    pMSR->setCapMode(xtal::MapSurfRenderer::CAP_ON);
+    // generateSurfObj() calls makerange() but not setupMolBndry(), so the
+    // boundary has to be resolved explicitly here (the display path does
+    // it in render()).
+    pMSR->setupMolBndry();
+
+    qsys::ObjectPtr pSurfObj = pMSR->generateSurfObj();
+    surface::MolSurfObj *pSurf =
+        dynamic_cast<surface::MolSurfObj *>(pSurfObj.get());
+    ASSERT_NE(pSurf, nullptr);
+    const int nvert = pSurf->getVertSize();
+    ASSERT_GT(nvert, 0);
+
+    // The surface is clipped at the boundary (an edge with an outside
+    // endpoint is dropped), so with the cap clipped the same way no vertex
+    // may sit outside the sphere. An unclipped border face reaches the
+    // corners of the cells it covers, well beyond it.
+    const Vector4D vCen(3.5, 0.5, 3.5);
+    const double kMaxDist = 1.4;  // boundary range 1.2 plus a margin
+    for (int i2 = 0; i2 < nvert; ++i2) {
+        const Vector4D v = pSurf->getVertAt(i2).v3d();
+        EXPECT_LT((v - vCen).length(), kMaxDist)
+            << "vertex " << i2 << " at " << v.x() << "," << v.y() << "," << v.z();
+    }
+}


### PR DESCRIPTION
## Summary

`MapSurfRenderer` の border cap (表示範囲の端で等値面を閉じる面) を **`region_mode` から独立した `cap_mode` プロパティ**にします。あわせて、cap 面が分子境界でクリップされていなかった不具合 (監査 finding xtal 10) を直します。

### なぜ

これまで cap の有無は表示範囲モードの副作用でした:

| 経路 | cap |
|---|---|
| box region mode (X 線マップの既定) | なし |
| full region mode (cryo-EM マップの既定) | あり |
| surface object 生成 (`generateSurfObj`) | 常にあり |

cryo-EM のときだけ cap がつくのは不自然で、box mode でも cap が欲しいケースがあります (図を作る場合など、cap があるとサーフェスの裏面が露出せず見やすい)。cap 生成コード自体は range 相対のインデックス (`fx==0` / `m_nActCol<=fx+m_nStep`) しか使っておらず box mode でも成立するので、ゲートだけを独立させました。

### `cap_mode`

```
enumdef cap_mode { auto; on; off }
property enum cap_mode => redirect(getCapMode, setCapMode);
default cap_mode = "auto";
```

- `auto` (既定) — 従来どおり: surface object 生成と full region mode は cap あり、box region mode はなし。**既存シーンの見た目は変わりません**
- `on` — region mode に関係なく常に cap する (box mode でも閉じる)
- `off` — 常に cap しない (surface object 生成でも)

`region_mode` / `lod` が既に `auto` を持つファイル内の慣例に合わせ、3 値にしています。解決は `isCapEnabled(bGenSurf)` の 1 箇所です。

### cap 面の分子境界クリップ (xtal 10)

サーフェス本体は分子境界の外側の辺を落として (`bary[ec0] || bary[ec1]` が false なら drop) クリップされますが、**cap 面は `bary` を全く見ていません**でした。結果:

- 完全に等値面の内側のセル (cap 経路 1) — 境界の外なのに cap 面が出て、クリップされたサーフェスの外側に飛び出す
- 部分的に埋まったセル (cap 経路 2) — 落とされた辺の `asEdgeVertex[]` (未計算 = グリッド原点) を参照し、原点へ伸びるスパイクになる

面の 4 隅 (`bdr_verts[iBorder][0..3]`) がすべて境界内のときだけ cap を出すようにしました。4 隅が内側なら面上のどの辺も両端が内側なので、経路 2 の未計算頂点参照も同時に閉じます。box mode で cap を有効にすると踏みやすくなる不具合なので、セットで直しています。

## Tests

`test_mapsurf_cap` (4): 既定が auto であること、`off` で border 面が消えること、cap 判定が region mode と独立であること、境界が効いているとき全頂点が境界球の内側に収まること。

旧コード (`MapSurfRenderer.cpp` を戻してビルド) では `CapOffDropsTheBorderFaces` と `CapFacesAreClippedAtTheMoleculeBoundary` の 2 件が失敗し、修正後は 4 件とも pass します。`task run_gtest`: 100% tests passed, 0 tests failed out of 1530。

## 補足 (この PR では直していません)

`generateSurfObj()` は `makerange()` は呼びますが `setupMolBndry()` を呼ばないため、`bndry_molname` を設定していても **surface object 生成時には分子境界クリップが効きません** (表示経路は `render()` で呼ぶので効きます)。挙動が変わるため別途の判断が要ると考え、テストからは `setupMolBndry()` を明示的に呼んでいます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCZNANXmRpwHnWmtx3rNRg
