### PR TITLE
Rebalance umbreon GI lighting; GI lighting ladder, Lights group and gradient sky in the render window

### DIFF
--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -63,8 +63,9 @@ architecture, it belongs here.
   GI 有効時に POV radiosity の配分をそのまま使うと白く平坦になる原因 (umbreon は
   ambient を材質の diffuse 係数で受ける) と、開放面の輝度を GI off に揃える parity 制約から
   決めた配分。`lightIntensity` / `flashFraction` / `ambientFraction` を POV backend と同じ
-  意味の exporter property として露出し、既定値は `UmbreonBackend.ts` の `LIGHT_BALANCE`
-  を SSOT とする (C++ は auto フォールバックのみ)。render window には knob を出さない。
+  意味の exporter property として露出し、render window では Lights グループ (全方式共通の
+  Light intensity / Flash fraction) と GI lighting axis (raytrace 一致から headlight をほぼ
+  無くすまでの 5 段、明るさ一定) と勾配 sky で操作する。C++ は auto フォールバックのみ。
 - [umbreon group-alpha blend](umbreon-group-alpha-blend.md) -- section 透過
   (group alpha) を多重パスで合成する際の不変条件: パスの重みは単位分割
   (合計ちょうど 1) でなければならず、合計が 1 を超えたときに背景係数が**負に

--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -59,6 +59,12 @@ architecture, it belongs here.
   昇格した時点で絵が黙って変わる。UI/`.qif` には露出しない理由、GI オン時に metal 材質の
   反射が背景色から実ジオメトリに変わる影響、principled BSDF material 採用を見送った理由、
   umbreon 側 API doc が古くヘッダを SSOT とすべき点。
+- [Umbreon GI 時の照明エネルギー配分](umbreon-gi-lighting-balance.md) (日本語) --
+  GI 有効時に POV radiosity の配分をそのまま使うと白く平坦になる原因 (umbreon は
+  ambient を材質の diffuse 係数で受ける) と、開放面の輝度を GI off に揃える parity 制約から
+  決めた配分。`lightIntensity` / `flashFraction` / `ambientFraction` を POV backend と同じ
+  意味の exporter property として露出し、既定値は `UmbreonBackend.ts` の `LIGHT_BALANCE`
+  を SSOT とする (C++ は auto フォールバックのみ)。render window には knob を出さない。
 - [umbreon group-alpha blend](umbreon-group-alpha-blend.md) -- section 透過
   (group alpha) を多重パスで合成する際の不変条件: パスの重みは単位分割
   (合計ちょうど 1) でなければならず、合計が 1 を超えたときに背景係数が**負に

--- a/docs/architecture/umbreon-gi-lighting-balance.md
+++ b/docs/architecture/umbreon-gi-lighting-balance.md
@@ -1,0 +1,117 @@
+# Umbreon GI 時の照明エネルギー配分
+
+umbreon の in-process レンダリングで GI を有効にしたときの照明配分
+(key light / headlight / GI が gather する ambient エネルギー) を決めた記録 (2026-09-03)。
+あわせて、この配分を POV backend と同じ 3 つの property として umbreon exporter に露出し、
+既定値の置き場所を tritium 側に移した。
+
+Related: [umbreon pt2 integrator](umbreon-pt2-integrator.md),
+[ADR-0042 umbreon quality presets](../migration/adr/ADR-0042-umbreon-quality-presets.md)。
+
+## Context
+
+render window で GI を有効にすると、GL view や POV-Ray (radiosity なし) より白っぽく
+陰影の弱い絵になっていた。`UmbreonDisplayContext.cpp` は GI 時に POV radiosity 用の配分
+(`_light_inten=1.6 / _amb_frac=0.5 / _flash_frac=0.5`) をそのまま採用していたが、
+umbreon の GI は POV の radiosity と ambient の受け方が違う。
+
+- GI off: flat ambient 項 = `material.ambient (default 0.2) * pigment * ambientColor (1.0)`。
+- GI on: umbreon は flat ambient 項を捨て、gather した ambient を
+  `giIntensity * material.diffuse (default 0.8) * pigment * E` で受ける
+  (`umbreon/src/umbreon/shading/hit_shader.hpp`)。開放面では `E == ambientColor`
+  (cos 加重平均、1/pi なし)。
+
+つまり ambient エネルギーの受け係数が 0.2 から 0.8 へ 4 倍になるのに、cuemol2 側は
+ambientColor に 0.8 (= 1.6 × 0.5) を載せていた。default 材質・gray 0.8 での概算:
+
+| 面の向き | GI off (spec .52 / flash .78 / amb .2) | GI on 旧配分 (spec .4 / flash .4 / amb .8) |
+|---|---|---|
+| カメラ正面 | 1.06 | 1.15 |
+| 横向き (key のみ) | 0.44 | 0.83 |
+| key の裏側 | 0.20 | 0.64 |
+
+向き依存の明暗比が 2.4 倍から 1.4 倍に潰れていたのが「平坦・白い」の正体。
+`giIntensity` / `giEnvIntensity` は間接光項を縮めることしかできず、key light を戻すことも
+headlight を減らすこともできないので、配分側を直す。両 knob の既定 1.0 は umbreon にとって
+中立な値なので触らない。
+
+参考の見た目:
+
+- GL view (`src/sysdep/ogl_core/lighting_inc.glsl`): ambient 床 0.4·color、diffuse 0.8·N·L、headlight なし
+- POV 非 radiosity (`PovDisplayContext.cpp`): spec 0.50 / flash 0.80 / 材質 ambient 0.2
+
+## Decision
+
+### 配分 (parity 制約)
+
+目標は「GI on の絵 = GI off の絵 + 遮蔽を考慮した ambient」。
+
+- key light (spec) は GI off と同じ 0.52 に固定する (方向性の陰影の源)。
+- カメラ正面の開放面輝度を GI off と一致させる (default 材質):
+  `0.8*(0.577*0.52 + flash) + 0.8*amb = 0.8*(0.577*0.52 + 0.78) + 0.2`
+  → `flash + amb = 1.03`、総光量 `li = 0.52 + flash + amb = 1.55` (amb によらず一定)。
+- 自由度は ambient エネルギー `amb` だけで、headlight (flash) と trade する。
+  headlight は視線方向・影なしで平坦化の最大要因、ambient は遮蔽情報を運ぶ唯一の項。
+
+| amb | flash | li | af | ff | ambient 床 (×pigment) | 位置づけ |
+|---|---|---|---|---|---|---|
+| **0.25** | **0.78** | **1.55** | **0.16** | **0.60** | **0.20** | **採用。直接光も sky 項も GI off と一致** |
+| 0.40 | 0.63 | 1.55 | 0.26 | 0.55 | 0.32 | 試行。床は GI off (0.20) と GL (0.40) の間 |
+| 0.50 | 0.53 | 1.55 | 0.32 | 0.50 | 0.40 | GL の床相当 (遮蔽は強いが横向き面が明るい) |
+
+調整するときは `li = 1.55` を固定し、`af` と `ff` を parity 線上で一緒に動かす。
+
+目視確認の経緯: まず amb 0.40 を試したところ、白い材質 (pigment 1.0) のチューブや stick で
+側面まで持ち上がり、正面が clip しているため陰影のない真っ白な塊になった。sky 項は向きに
+依存しない一様な fill なので、raytrace の flat ambient (0.2) を超えた分だけ headlight の
+cos 減衰による円筒の陰影を埋める。`giEnvIntensity` 0.6 で陰影は戻るが headlight を減らした
+ままなので全体が暗くなる。parity 線上で amb 0.25 に下げると直接光が GI off と完全に一致し、
+side の fill も env 0.6 相当になり、raytrace とほぼ同じ絵に GI の遮蔽とバウンスだけが
+乗る状態になった (ユーザー確認済み)。
+
+### property として露出し、既定値は tritium 側に置く
+
+POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` として `Declare=` で
+渡され、C++ 側はフォールバックしか持たない (`PovrayBackend.ts`)。umbreon だけが C++ 定数
+だったので同じ構造に揃えた。
+
+- `UmbreonSceneExporter.qif`: `lightIntensity` / `flashFraction` / `ambientFraction`。
+  意味は POV と同じ。`spec = li*(1-af)*(1-ff)`, `flash = li*(1-af)*ff`,
+  GI on では `ambientColor = li*af`、GI off では ambientColor は 1.0 のままで af は直接光を
+  減らすだけ (POV 非 radiosity と同じ)。**負値 = auto**。
+- `UmbreonDisplayContext.cpp`: auto は GI off で `1.3 / 0.6 / 0` (従来どおり)、GI on で
+  `1.55 / 0.6 / 0.16`。スクリプトから `useGI` だけを立てても妥当な配分になるための写し。
+- `tritium/react-gui/.../UmbreonBackend.ts` の `LIGHT_BALANCE` が**アプリの SSOT**。
+  GI on なら `gi`、raytrace / AO / NPR なら `direct` の 3 値を常に明示的に送る。
+  既定値の調整は TS を編集して `task build_tritium` するだけで済み、C++ の再ビルドは不要。
+- render window には knob を出さない。必要になれば PropDef を足して
+  `UmbreonBackend.ts` を `numVal` 参照に変えるだけで載る。
+
+## Consequences
+
+- GI on の開放面の明るさと向き依存の陰影が GI off と同等になり、ポケット・接触部だけが
+  GI で暗くなる。直接光は 0.8 から GI off と同じ 1.3 (key 0.52 / headlight 0.78) に戻る。
+- 白が密集した領域では隣接面からのバウンスで側面がやや持ち上がる。これは sky 項ではなく
+  間接光全体の話なので、配分ではなく `giIntensity` で調整する。
+- **トレードオフ**: amb を下げるほど、直接光で照らされた隣接面からのバウンス
+  (≈ 0.8·pigment·直接光) が sky 項より明るくなり、浅い接触部は暗くならず color bleeding が
+  目立つ。深いポケットは隣接面自体が暗いので遮蔽の暗さは残る。旧配分の amb=0.8 は
+  バウンスの最大値と sky が釣り合う点で、ポケットは最も暗くなるが平坦になる。
+- ambientColor は scene で 1 値なので default 材質基準で合わせている。matte (ambient 0.3) や
+  diff_metal (ambient 0.35 / diffuse 0.30) は GI on で GI off よりやや暗くなる。
+- 既定値が C++ (auto) と TS (`LIGHT_BALANCE`) の 2 か所にある。アプリは常に TS の値を送るので
+  実害はないが、TS を確定したら C++ の auto も揃えること。
+
+## Notes
+
+- テストは配線の確認だけに留める (明るさの妥当性は目視で確定するもので、輝度を pin すると
+  調整のたびに追随が要る):
+  - `UmbreonExport.LightBalancePropertiesChangeTheOutput` — 3 つの property をそれぞれ
+    単独で変えると出力が変わる (`ambientFraction` は GI on で確認)
+  - `umbreonBackend.test.ts` — GI on で `gi`、GI 無しで `direct` の 3 値が exporter に書かれる
+- GI off 側の `ff=0.6` と POV exporter の `0.8/1.3 = 0.615` のずれ、`DistantLight::angularRadius`
+  の parity は従来どおり deferred ([umbreon pt2 integrator](umbreon-pt2-integrator.md))。
+- umbreon 側の根拠: `umbreon/docs/quality_presets.md` (client は `scene.ambientColor` に
+  ambient エネルギーを載せ、direct light を対応して下げる)、`umbreon/docs/pt1_tuning.md`
+  (`_amb_frac` を通るエネルギーだけが遮蔽情報を運ぶ)、
+  `umbreon/src/umbreon/render/render_options.hpp` の `giEnvIntensity` コメント。

--- a/docs/architecture/umbreon-gi-lighting-balance.md
+++ b/docs/architecture/umbreon-gi-lighting-balance.md
@@ -59,7 +59,8 @@ headlight を減らすこともできないので、配分側を直す。両 kno
 | 0.40 | 0.63 | 1.55 | 0.26 | 0.55 | 0.32 | 試行。床は GI off (0.20) と GL (0.40) の間 |
 | 0.50 | 0.53 | 1.55 | 0.32 | 0.50 | 0.40 | GL の床相当 (遮蔽は強いが横向き面が明るい) |
 
-調整するときは `li = 1.55` を固定し、`af` と `ff` を parity 線上で一緒に動かす。
+この parity 線は step 0 (raytrace 一致点) を決めるためのもの。GI lighting axis の上の段は
+別の制約 (平均輝度一定、後述) で決めている。
 
 目視確認の経緯: まず amb 0.40 を試したところ、白い材質 (pigment 1.0) のチューブや stick で
 側面まで持ち上がり、正面が clip しているため陰影のない真っ白な塊になった。sky 項は向きに
@@ -80,12 +81,71 @@ POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` と�
   GI on では `ambientColor = li*af`、GI off では ambientColor は 1.0 のままで af は直接光を
   減らすだけ (POV 非 radiosity と同じ)。**負値 = auto**。
 - `UmbreonDisplayContext.cpp`: auto は GI off で `1.3 / 0.6 / 0` (従来どおり)、GI on で
-  `1.55 / 0.6 / 0.16`。スクリプトから `useGI` だけを立てても妥当な配分になるための写し。
-- `tritium/react-gui/.../UmbreonBackend.ts` の `LIGHT_BALANCE` が**アプリの SSOT**。
-  GI on なら `gi`、raytrace / AO / NPR なら `direct` の 3 値を常に明示的に送る。
-  既定値の調整は TS を編集して `task build_tritium` するだけで済み、C++ の再ビルドは不要。
-- render window には knob を出さない。必要になれば PropDef を足して
-  `UmbreonBackend.ts` を `numVal` 参照に変えるだけで載る。
+  app の既定 (GI lighting step 4 = `1.2 / 0.05 / 0.4`、勾配 sky on)。スクリプトから `useGI`
+  だけを立てても app と同じ絵になるための写し。
+- `tritium/react-gui/.../UmbreonBackend.ts` は 3 値を常に明示的に送る。`lightIntensity` /
+  `flashFraction` は Lights グループの値、`ambientFraction` は GI on のときだけ GI グループの
+  値で、GI off では `LIGHT_DEFAULTS` の 0.16 に固定する (GI off では直接光を減らすだけの
+  knob なので、GI 側で動かした値が隠れたまま raytrace を暗くしないため)。
+  `LIGHT_DEFAULTS` (1.55 / 0.6 / 0.16) は GI lighting axis の step 0 と同じ値。
+- `giSkyGradient` / `giGroundColor` (`pt1SkyMode` 1 と `aoGroundColor`): 天頂白・地面色の
+  勾配 sky。カメラ正面の面は sky と地面を半分ずつ見るので gather する ambient が
+  `(1 + 地面輝度) / 2` 倍に落ちる。C++ 側で ambientColor を `2 / (1 + 地面輝度)` 倍して
+  打ち消し、勾配は「向きによる陰影」だけを変え全体の明るさを変えないようにした。
+
+### render window の knob
+
+当初は knob を出さない予定だったが、実験で「headlight を弱めるほど奥行きが出る」
+「勾配 sky + ambient 増は raytrace では得られない見た目になる」ことが確認できたので露出した。
+
+- **Lights** グループ (全 lighting method 共通、NPR 含む): `Light intensity` (総光量、明るさの
+  knob) と `Flash fraction` (直接光のうち headlight の割合)。raytrace / AO でも効く。
+- **Global Illumination** グループ: `Ambient fraction`、`Sky gradient` (既定 on)、`Ground color`。
+  `GI intensity` / `GI environment` は UI から外した (Ambient fraction と重複。qif には残る)。
+  Sky gradient を既定 on にしたのは、既定の step 4 ではエネルギーの 40% が sky を通り、一様な
+  sky だとその fill が向きに無関係になるため。勾配は ladder には入れず独立の knob のままにする
+  (軸がカメラの上方向なので構図に依存するスタイルであり、配分の段とは性質が違う)。
+- **GI lighting axis** (5 段、GI 選択時のみ): 他の quality axis と違い**絵を変えるための axis**。
+  headlight (ff) を 0.60 → 0.05 まで等間隔に減らし、そのエネルギーを key light と GI の
+  ambient に配りつつ、総光量 (li) を 1.55 → 1.2 まで線形に下げる。axis は 3 値すべてを
+  持つので、どれかを手で編集すると Custom になる。
+
+| step | li | ff | af | key | headlight | ambient | 位置づけ |
+|---|---|---|---|---|---|---|---|
+| 0 | 1.55 | 0.60 | 0.16 | 0.52 | 0.78 | 0.25 | raytrace 一致 |
+| 1 | 1.46 | 0.46 | 0.23 | 0.61 | 0.52 | 0.34 | |
+| 2 | 1.38 | 0.32 | 0.30 | 0.66 | 0.31 | 0.41 | |
+| 3 | 1.29 | 0.18 | 0.35 | 0.69 | 0.15 | 0.45 | |
+| 4 | 1.20 | 0.05 | 0.40 | 0.68 | 0.04 | 0.48 | headlight ほぼ無し (**既定**) |
+
+  既定は step 4。GI が既定の depth cue である理由がこの見た目なので、step 0 は raytrace の絵に
+  戻すための逃げ道と位置づける。
+
+  **li を下げる理由**: li 1.55 のままだと step 4 で key light が 0.88 になり、白い材質の
+  key 側 (右上) が `0.8*0.88 + 0.8*0.62 = 1.2` で clip する。目視で 1.1〜1.2 が最も立体感が
+  出たので、端点を 1.2 にして線形に刻んだ。結果として段を上げるほど絵は少し暗くなるが、
+  key light は 0.6〜0.7 でほぼ一定に保たれ、headlight の flat な fill が GI の遮蔽付き
+  ambient に置き換わっていく。
+- **照明方式切り替え時の Lights の既定**: Lights グループは全方式で共有なので、GI の段で
+  下げた li / ff が raytrace / AO に持ち越されないよう、`RenderLightingOption.defaults`
+  (方式の判定には使わない look 既定) に raytrace / AO の `1.55 / 0.6 / 0.16` を持たせ、方式を
+  選んだときに書き戻す。この値は GI lighting の step 0 と同じなので、GI を離れると GI lighting
+  は step 0 に戻る (段は共有 prop の値から導出されるため、書き戻しをまたいで残せない)。
+  GI は axis が段を書き戻すので defaults を持たない。
+
+  **af の決め方 (平均輝度一定)**: 最初は「カメラ正面の開放面の輝度一定」(key 0.52 固定、
+  `flash + amb = 1.03`) で af を出したが、ff 0.05 で af 0.65 となり全体が明るすぎた。
+  headlight は視線との cos で横向きの面をほとんど照らさないのに、一様 sky は向きに関係なく
+  足すので、正面を揃えると横向きの面 (画面の大半) が明るくなる。そこで制約を
+  「カメラから見える球の平均輝度が step 0 と同じ」に変えた。可視円板上の平均は headlight が
+  強度の 2/3、key light (1,1,1 方向) が 0.44、sky が 1 なので、
+  `0.8*(0.44*key + 0.667*flash) + 0.8*amb = 0.80` を af について解く。ff 0.05 で af 0.35 と
+  なり、目視で良かった 0.40 とほぼ一致した (実シーンでは遮蔽で gather が amb より減るぶん
+  少し多め)。端点は観察値 0.40 を採り、中間は同じ曲線の形で刻んでいる。余った
+  エネルギーは key light に行くので、段を上げると方向性の陰影も強くなる。
+
+  照明方式を GI に切り替えると axis が選択中の step を書き戻すので、GI の既定配分は
+  自動的に揃う。手で fraction を編集すると Custom になる (他の axis と同じ)。
 
 ## Consequences
 
@@ -99,16 +159,21 @@ POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` と�
   バウンスの最大値と sky が釣り合う点で、ポケットは最も暗くなるが平坦になる。
 - ambientColor は scene で 1 値なので default 材質基準で合わせている。matte (ambient 0.3) や
   diff_metal (ambient 0.35 / diffuse 0.30) は GI on で GI off よりやや暗くなる。
-- 既定値が C++ (auto) と TS (`LIGHT_BALANCE`) の 2 か所にある。アプリは常に TS の値を送るので
-  実害はないが、TS を確定したら C++ の auto も揃えること。
+- 既定値が C++ (auto) と TS (`LIGHT_DEFAULTS` = GI lighting axis の step 0) の 2 か所にある。
+  アプリは常に TS の値を送るので実害はないが、step 0 を変えたら C++ の auto も揃えること。
+- 勾配 sky は上を向いた面を明るく、下を向いた面を暗くする。輝度補正で正面の明るさは保つが、
+  下向きの面は一様 sky より暗くなる。
 
 ## Notes
 
 - テストは配線の確認だけに留める (明るさの妥当性は目視で確定するもので、輝度を pin すると
   調整のたびに追随が要る):
-  - `UmbreonExport.LightBalancePropertiesChangeTheOutput` — 3 つの property をそれぞれ
-    単独で変えると出力が変わる (`ambientFraction` は GI on で確認)
-  - `umbreonBackend.test.ts` — GI on で `gi`、GI 無しで `direct` の 3 値が exporter に書かれる
+  - `UmbreonExport.LightBalancePropertiesChangeTheOutput` — 3 つの property と勾配 sky を
+    それぞれ単独で変えると出力が変わる (`ambientFraction` / 勾配 sky は GI on で確認)
+  - `umbreonBackend.test.ts` — Lights の 2 値と GI の ambient fraction / sky が exporter に
+    書かれ、GI off では ambient fraction が 0.16 に固定される
+  - `useRenderSettings.test.ts` — GI lighting axis が ff / af を書き、`lightIntensity` の編集は
+    axis を Custom にしない
 - GI off 側の `ff=0.6` と POV exporter の `0.8/1.3 = 0.615` のずれ、`DistantLight::angularRadius`
   の parity は従来どおり deferred ([umbreon pt2 integrator](umbreon-pt2-integrator.md))。
 - umbreon 側の根拠: `umbreon/docs/quality_presets.md` (client は `scene.ambientColor` に

--- a/docs/architecture/umbreon-pt2-integrator.md
+++ b/docs/architecture/umbreon-pt2-integrator.md
@@ -75,6 +75,9 @@ GI オフ (`UmbreonSceneExporter::m_bGI = false`)。GI を有効にしたとき�
     `spec_metal` パネルの鏡面方向 (-X) に、視錐台外かつカメラから edge-on の赤い `matte` パネルを置き、
     metal 中心画素の R-B を見る。実測値: **pt2 = 119 / pt1 = 2** (閾値 40)。
     切替を pt1 に戻すと確実に fail することを確認済み
+  - `LightBalancePropertiesChangeTheOutput` — 照明配分 property
+    (`lightIntensity` / `flashFraction` / `ambientFraction`) が light に届くことの配線確認。
+    配分の決定は [umbreon-gi-lighting-balance](umbreon-gi-lighting-balance.md)
 
   > 反射させる面に `nolighting` を使うと機能しない。`diffuse = 0` のため `diffuseWeight()` が 0 になり、
   > gather に一切ラディアンスを供給しない (ambient-only の見た目はカメラから見える自己照明限定)。
@@ -131,5 +134,8 @@ gather core を共有しているため)。cuemol2 の `giSamples` / `giDenoise`
   見た目軸 (`giBounces` / `giIntensity`) を分離し `giBounces` は段間で固定すべき、という設計指針を含む
 - **`aoDistance` の既定値**: C++ は `1e20` (実質無限)、UI は `100`。docs は bbox 対角の 0.5-0.85 倍を
   client が計算することを要求している
+- **GI 時の照明エネルギー配分**: POV radiosity の配分をそのまま使うと白く平坦になる問題は
+  [umbreon-gi-lighting-balance](umbreon-gi-lighting-balance.md) で解決済み
+  (配分は exporter property 化し、既定値は `UmbreonBackend.ts` が持つ)
 - **`DistantLight::angularRadius` のパリティ**: umbreon の POV reader は SpecLighting に
   `atan(spread/40)` を設定するが、cuemol2 の in-process 経路は 0 のまま。pt2 のみが読む per-light soft shadow

--- a/docs/migration/adr/ADR-0042-umbreon-quality-presets.md
+++ b/docs/migration/adr/ADR-0042-umbreon-quality-presets.md
@@ -73,9 +73,15 @@ method.
   so a scripted caller cannot hit umbreon's warning-and-fallback path. The
   step also governs edge-line quality, which resolves at the supersample
   factor regardless of any AA refinement -- hence 3x as the default.
-- **Look knobs stay out of the ladders.** GI intensity / environment, AO
-  distance / intensity and the edge settings are in no patch, so a step only
-  trades noise and edge quality for time.
+- **Look knobs stay out of the quality ladders.** AO distance / intensity,
+  the Lights group and the edge settings are in no quality patch, so a step
+  only trades noise and edge quality for time. The one axis that changes
+  the picture on purpose is "GI lighting" (added later, see
+  [umbreon-gi-lighting-balance](../../architecture/umbreon-gi-lighting-balance.md)):
+  its five steps move light energy from the headlight into the GI gather at
+  constant brightness, and it is labelled as a look axis rather than a
+  quality one. GI intensity / environment were dropped from the UI at the
+  same time (the energy balance covers them).
 - **Lighting is derived, never stored.** `lightingOf()` reads the method from
   `aoEnabled` / `useGI`, so the selector cannot disagree with the props it
   represents. Switching method writes the exclusive pair and re-applies that
@@ -170,6 +176,13 @@ libcuemol2 gained the properties these axes need:
     `AoRecipeFlagsReachTheRenderer`.
 - Upstream source of the values: umbreon `docs/quality_presets.md` sections
   1 (axis A), 2a (AO), 2b (GI), 3 (shadows) and 6 (the composite bundle).
+- Later amendment (2026-09): the GI quality axis (Low / Medium / High /
+  Reference = 8 / 32 / 64 / 256 samples, denoiser on throughout) was
+  dropped. With OIDN on, its steps render near-identical pictures -- they
+  differ only in residual pocket detail and animation stability -- so a
+  ladder promised more than it showed. The sample count is now a plain
+  dropdown of those four counts in the Global Illumination group, and the
+  GI method carries the "GI lighting" look axis instead.
 - Known gaps, deliberately out of scope here:
   - GI's lighting energy split (key / headlight / gathered ambient) is a
     look setting outside the ladders; its values and the exporter

--- a/docs/migration/adr/ADR-0042-umbreon-quality-presets.md
+++ b/docs/migration/adr/ADR-0042-umbreon-quality-presets.md
@@ -171,8 +171,10 @@ libcuemol2 gained the properties these axes need:
 - Upstream source of the values: umbreon `docs/quality_presets.md` sections
   1 (axis A), 2a (AO), 2b (GI), 3 (shadows) and 6 (the composite bundle).
 - Known gaps, deliberately out of scope here:
-  - GI's ambient energy split (`scene.ambientColor`) is fixed in
-    `UmbreonDisplayContext`; the guide treats it as a client-tuned balance.
+  - GI's lighting energy split (key / headlight / gathered ambient) is a
+    look setting outside the ladders; its values and the exporter
+    properties that carry them are decided in
+    [umbreon-gi-lighting-balance](../../architecture/umbreon-gi-lighting-balance.md).
   - Adaptive AA is reachable only from a script (`aaMode` / `aaDepth` on the
     exporter). Offering it in the UI needs a per-method answer to "what does
     this step mean under GI"; `aaThreshold` stays unexposed either way.

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -840,9 +840,9 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
 
   // Lighting energy balance, in the POV exporter's terms (_light_inten /
   // _amb_frac / _flash_frac). The caller normally supplies all three (the
-  // tritium render window sends UmbreonBackend.ts LIGHT_BALANCE); a negative
-  // value falls back to the auto defaults below, so a scripted caller that
-  // only flips useGI still gets a sensible balance.
+  // tritium render window sends its Lights group / GI lighting step); a
+  // negative value falls back to the auto defaults below, so a scripted
+  // caller that only flips useGI still gets the app's default balance.
   //
   // Without GI: the POV defaults _light_inten=1.3, _amb_frac=0, _flash_frac=0.6
   // (SpecLighting=0.52 / FlashLighting=0.78) plus POV's unit ambient_light,
@@ -853,29 +853,27 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   // DIFFUSE weight (default finish: 0.8), i.e. 4x the coefficient of the flat
   // term. The POV radiosity split (1.6 / 0.5 / 0.5) taken literally therefore
   // gives an open surface 3.2x the fill of the non-GI render while cutting
-  // the direct lights, which is a brighter and flatter picture. The auto
-  // defaults instead keep the key light at its non-GI value and hold an open
-  // camera-facing surface at the non-GI brightness:
-  //   0.8*(0.577*key + flash) + 0.8*amb == 0.8*(0.577*0.52 + 0.78) + 0.2
-  //   => flash + amb = 1.03, li = 0.52 + flash + amb = 1.55 (for any amb)
-  // so the only free choice is how much headlight (flat, view-aligned) is
-  // traded for gathered ambient (the term that carries occlusion). amb=0.25
-  // keeps the direct lights identical to the non-GI ones and makes the sky
-  // fill (0.20*pigment through the diffuse weight) equal to the non-GI flat
-  // ambient: a white tube then keeps its headlight shading, whereas a higher
-  // sky fill (0.40 was tried) lifted its sides into a clipped white blob. GI
-  // adds only occlusion and bounce on top. Retune along that line: keep
-  // li=1.55 and move af / ff together. Derivation and trade-offs:
+  // the direct lights, which is a brighter and flatter picture.
+  //
+  // The GI auto defaults are the render window's default "GI lighting" step
+  // (the top of its five): the flat, view-aligned headlight is all but gone
+  // (flash 0.04), its energy moved into the directional key light (0.68)
+  // and the gathered ambient (0.48), and the total is lowered to 1.2 so the
+  // key-lit side of a white surface does not clip. The step ladder's other
+  // end, li 1.55 / af 0.16 / ff 0.6, reproduces the non-GI picture exactly
+  // (same key 0.52 / headlight 0.78, and a gathered ambient of 0.25 that
+  // through the diffuse weight equals the 0.2 flat ambient). Derivation of
+  // the ladder and its trade-offs:
   // docs/architecture/umbreon-gi-lighting-balance.md
   const double li = (prm.lightIntensity >= 0.0)
                         ? prm.lightIntensity
-                        : (prm.giEnabled ? 1.55 : 1.3);
+                        : (prm.giEnabled ? 1.2 : 1.3);
   const double af = (prm.ambientFraction >= 0.0)
                         ? prm.ambientFraction
-                        : (prm.giEnabled ? 0.16 : 0.0);
+                        : (prm.giEnabled ? 0.4 : 0.0);
   const double ff = (prm.flashFraction >= 0.0)
                         ? prm.flashFraction
-                        : (prm.giEnabled ? 0.6 : 0.6);
+                        : (prm.giEnabled ? 0.05 : 0.6);
   if (scene.lights.empty()) {
     // SpecLighting: directional key light from the upper-front-right
     // (positioned at normalize(1,1,1), pointing at the origin). CueMol calls it
@@ -899,7 +897,19 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   scene.ambientIntensity = 1.0f;
   // The GI gathers this ambient occlusion-aware; carry the ambient light energy
   // (light_inten * amb_frac) when GI is on, else a flat white ambient.
-  const float amb = prm.giEnabled ? float(li * af) : 1.0f;
+  float amb = prm.giEnabled ? float(li * af) : 1.0f;
+  // Gradient sky (zenith white, ground = giGroundColor): a camera-facing
+  // surface sees half sky and half ground, so its gathered ambient drops to
+  // (1 + ground) / 2 of the uniform-sky value. Scale the ambient energy back
+  // up by the inverse so the gradient changes only how the ambient shades by
+  // orientation (up-facing brighter, down-facing darker), not the overall
+  // brightness of the picture.
+  if (prm.giEnabled && prm.giSkyGradient && prm.giGroundColorSet) {
+    const float lum = 0.2126f * prm.giGroundColor[0] +
+                      0.7152f * prm.giGroundColor[1] +
+                      0.0722f * prm.giGroundColor[2];
+    amb *= 2.0f / (1.0f + lum);
+  }
   scene.ambientColor = umbreon::Vec3(amb, amb, amb);
 
   // No assumed_gamma: keep umbreon's framebuffer linear (assumedGamma = 1.0 is
@@ -974,6 +984,15 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     opt.giIntensity = float(prm.giIntensity);
     opt.giEnvIntensity = float(prm.giEnvIntensity);
     opt.pt1Denoise = prm.giDenoise;
+    // Gather sky: uniform white (umbreon default) or a zenith-white /
+    // ground-tinted gradient along the camera up axis (aoUseCameraUp stays at
+    // umbreon's default), so the ambient itself shades by orientation.
+    // aoGroundColor is shared with the AO bent-normal gradient, but AO and GI
+    // are alternatives, so it is only ever written here while GI renders.
+    opt.pt1SkyMode = prm.giSkyGradient ? 1 : 0;
+    if (prm.giSkyGradient && prm.giGroundColorSet) {
+      for (int k = 0; k < 3; ++k) opt.aoGroundColor[k] = prm.giGroundColor[k];
+    }
   }
 
   // Full-frame post-pass denoiser on the final HDR color (0 = None, 1 =

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -838,15 +838,44 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   // frame to the background color; skip fog entirely in that case.
   scene.fog.enabled = (fogEnd > fogStart);
 
-  // Default lighting matching CueMol's POV output (the scene the umbreon CLI
-  // builds from a .pov). Without GI the POV defaults are _light_inten=1.3,
-  // _amb_frac=0, _flash_frac=0.6, giving SpecLighting=0.52 / FlashLighting=0.78.
-  // With GI on, adopt the POV radiosity balance (_light_inten=1.6, _amb_frac=0.5,
-  // _flash_frac=0.5): move half the energy into the ambient the GI gathers and
-  // dim the direct lights, matching the umbreon CLI's scene_setup.
-  const double li = prm.giEnabled ? 1.6 : 1.3;
-  const double af = prm.giEnabled ? 0.5 : 0.0;
-  const double ff = prm.giEnabled ? 0.5 : 0.6;
+  // Lighting energy balance, in the POV exporter's terms (_light_inten /
+  // _amb_frac / _flash_frac). The caller normally supplies all three (the
+  // tritium render window sends UmbreonBackend.ts LIGHT_BALANCE); a negative
+  // value falls back to the auto defaults below, so a scripted caller that
+  // only flips useGI still gets a sensible balance.
+  //
+  // Without GI: the POV defaults _light_inten=1.3, _amb_frac=0, _flash_frac=0.6
+  // (SpecLighting=0.52 / FlashLighting=0.78) plus POV's unit ambient_light,
+  // which the material ambient term (default finish: ambient 0.2) multiplies.
+  //
+  // With GI: umbreon drops that flat ambient term and instead gathers the
+  // ambient energy li*af occlusion-aware, receiving it through the material
+  // DIFFUSE weight (default finish: 0.8), i.e. 4x the coefficient of the flat
+  // term. The POV radiosity split (1.6 / 0.5 / 0.5) taken literally therefore
+  // gives an open surface 3.2x the fill of the non-GI render while cutting
+  // the direct lights, which is a brighter and flatter picture. The auto
+  // defaults instead keep the key light at its non-GI value and hold an open
+  // camera-facing surface at the non-GI brightness:
+  //   0.8*(0.577*key + flash) + 0.8*amb == 0.8*(0.577*0.52 + 0.78) + 0.2
+  //   => flash + amb = 1.03, li = 0.52 + flash + amb = 1.55 (for any amb)
+  // so the only free choice is how much headlight (flat, view-aligned) is
+  // traded for gathered ambient (the term that carries occlusion). amb=0.25
+  // keeps the direct lights identical to the non-GI ones and makes the sky
+  // fill (0.20*pigment through the diffuse weight) equal to the non-GI flat
+  // ambient: a white tube then keeps its headlight shading, whereas a higher
+  // sky fill (0.40 was tried) lifted its sides into a clipped white blob. GI
+  // adds only occlusion and bounce on top. Retune along that line: keep
+  // li=1.55 and move af / ff together. Derivation and trade-offs:
+  // docs/architecture/umbreon-gi-lighting-balance.md
+  const double li = (prm.lightIntensity >= 0.0)
+                        ? prm.lightIntensity
+                        : (prm.giEnabled ? 1.55 : 1.3);
+  const double af = (prm.ambientFraction >= 0.0)
+                        ? prm.ambientFraction
+                        : (prm.giEnabled ? 0.16 : 0.0);
+  const double ff = (prm.flashFraction >= 0.0)
+                        ? prm.flashFraction
+                        : (prm.giEnabled ? 0.6 : 0.6);
   if (scene.lights.empty()) {
     // SpecLighting: directional key light from the upper-front-right
     // (positioned at normalize(1,1,1), pointing at the origin). CueMol calls it

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -58,9 +58,18 @@ namespace render {
     bool shadows = false;
     int shadowSamples = 1;
     double lightRadius = 0.0;
+    /// Lighting energy balance, the POV exporter's _light_inten / _flash_frac
+    /// / _amb_frac: key light = li*(1-af)*(1-ff), headlight = li*(1-af)*ff,
+    /// and with GI on the gathered ambient energy = li*af (without GI the
+    /// ambient stays POV's unit ambient_light and af only dims the direct
+    /// lights). Negative = auto: resolved per GI state in
+    /// buildSceneAndOptions(); see docs/architecture/umbreon-gi-lighting-balance.md.
+    double lightIntensity = -1.0;
+    double flashFraction = -1.0;
+    double ambientFraction = -1.0;
     /// diffuse global illumination (umbreon pt2 path-traced integrator). When
-    /// on, the lighting is rebalanced to the POV radiosity split (energy moved
-    /// into the GI-gathered ambient). giSamples = gather rays per pixel;
+    /// on, the flat material ambient is replaced by the occlusion-aware gather
+    /// of the ambient energy above (li*af). giSamples = gather rays per pixel;
     /// giIntensity = indirect gain; giEnvIntensity = environment (sky)
     /// multiplier; giDenoise runs Intel OIDN on the indirect irradiance.
     bool giEnabled = false;

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -77,6 +77,13 @@ namespace render {
     double giIntensity = 1.0;
     double giEnvIntensity = 1.0;
     bool giDenoise = true;
+    /// GI sky model: gradient sky (zenith white, ground = giGroundColor along
+    /// the camera up axis) instead of umbreon's uniform white sky, so the
+    /// gathered ambient carries a shape cue independent of occlusion.
+    /// giGroundColor applies only when giGroundColorSet (parsed "#rrggbb").
+    bool giSkyGradient = false;
+    bool giGroundColorSet = false;
+    float giGroundColor[3] = {0.4f, 0.4f, 0.4f};
     /// Full-frame post-pass denoiser on the final HDR color (umbreon
     /// RenderOptions::denoiser): 0 = None, 1 = AtrousBilateral, 2 = OIDN. This
     /// is independent of giDenoise, which denoises only the GI indirect buffer.

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -140,6 +140,8 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_dAoDiffuseFactor(0.0), m_bAoMultiScale(false), m_bAoBentNormal(false),
        m_bAoLowDiscrepancy(false), m_nAoResDiv(0),
        m_bShadows(false), m_nShadowSamples(1), m_dLightRadius(0.0),
+       m_dLightIntensity(-1.0), m_dFlashFraction(-1.0),
+       m_dAmbientFraction(-1.0),
        m_bEnableEdgeLines(true), m_dCreaseLimit(-1.0), m_dEdgeRise(0.5),
        m_bContactEdges(false),
        m_bTransparentBackground(false),
@@ -232,6 +234,9 @@ void UmbreonSceneExporter::setupContext(UmbreonDisplayContext &ctx,
   prm.shadows = m_bShadows;
   prm.shadowSamples = m_nShadowSamples;
   prm.lightRadius = m_dLightRadius;
+  prm.lightIntensity = m_dLightIntensity;
+  prm.flashFraction = m_dFlashFraction;
+  prm.ambientFraction = m_dAmbientFraction;
   prm.contactEdges = m_bContactEdges;
   prm.transparentBackground = m_bTransparentBackground;
   prm.giEnabled = m_bGI;

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -147,6 +147,7 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_bTransparentBackground(false),
        m_bGI(false), m_nGiSamples(32), m_dGiIntensity(1.0),
        m_dGiEnvIntensity(1.0), m_bGiDenoise(true), m_nDenoiser(0),
+       m_bGiSkyGradient(true), m_sGiGroundColor("#666666"),
        m_bHatchEnable(false), m_sHatchStyle("richardson"),
        m_dHatchDensity(1.0), m_dHatchWidthScale(1.0),
        m_sHatchLayersSpec(""), m_sHatchToneSpec(""),
@@ -245,6 +246,8 @@ void UmbreonSceneExporter::setupContext(UmbreonDisplayContext &ctx,
   prm.giEnvIntensity = m_dGiEnvIntensity;
   prm.giDenoise = m_bGiDenoise;
   prm.denoiser = m_nDenoiser;
+  prm.giSkyGradient = m_bGiSkyGradient;
+  prm.giGroundColorSet = parseHexColor(m_sGiGroundColor, prm.giGroundColor);
   prm.hatchEnable = m_bHatchEnable;
   prm.hatchStyle = m_sHatchStyle;
   prm.hatchDensity = m_dHatchDensity;

--- a/src/modules/rendering/UmbreonSceneExporter.hpp
+++ b/src/modules/rendering/UmbreonSceneExporter.hpp
@@ -86,6 +86,12 @@ namespace render {
     /// light angular radius in degrees (>0 = soft shadows)
     double m_dLightRadius;
 
+    /// lighting energy balance (POV _light_inten / _flash_frac / _amb_frac);
+    /// negative = auto (resolved per GI state in UmbreonDisplayContext)
+    double m_dLightIntensity;
+    double m_dFlashFraction;
+    double m_dAmbientFraction;
+
     /// draw silhouette/edge outline lines (CueMol toon edges)
     bool m_bEnableEdgeLines;
 

--- a/src/modules/rendering/UmbreonSceneExporter.hpp
+++ b/src/modules/rendering/UmbreonSceneExporter.hpp
@@ -128,6 +128,13 @@ namespace render {
     /// full-frame post-pass denoiser (0 = None, 1 = AtrousBilateral, 2 = OIDN)
     int m_nDenoiser;
 
+    /// GI sky model: gradient (zenith white / ground = m_sGiGroundColor along
+    /// the camera up axis) instead of the uniform white sky
+    bool m_bGiSkyGradient;
+
+    /// ground hemisphere color of the gradient sky ("#rrggbb")
+    LString m_sGiGroundColor;
+
     /// NPR tone-hatching pass (ink drawing); default off
     bool m_bHatchEnable;
 

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -82,6 +82,29 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   property real lightRadius => m_dLightRadius;
 
   //////////
+  // lighting energy balance. Same meaning as the POV exporter's
+  // _light_inten / _flash_frac / _amb_frac declares:
+  //   key light (SpecLighting)  = lightIntensity * (1 - ambientFraction) * (1 - flashFraction)
+  //   headlight (FlashLighting) = lightIntensity * (1 - ambientFraction) * flashFraction
+  //   GI ambient energy         = lightIntensity * ambientFraction  (useGI only;
+  //                               without GI the ambient stays POV's unit
+  //                               ambient_light and the fraction only dims the
+  //                               direct lights, as in POV without radiosity)
+  // A negative value means auto: the GI-off defaults (1.3 / 0.6 / 0) or, with
+  // GI on, the rebalanced defaults documented in
+  // docs/architecture/umbreon-gi-lighting-balance.md. The tritium render
+  // window always sends explicit values (UmbreonBackend.ts LIGHT_BALANCE).
+
+  /// total light energy (<0 = auto)
+  property real lightIntensity => m_dLightIntensity;
+
+  /// share of the direct light given to the headlight (<0 = auto)
+  property real flashFraction => m_dFlashFraction;
+
+  /// share of the total energy moved into the GI-gathered ambient (<0 = auto)
+  property real ambientFraction => m_dAmbientFraction;
+
+  //////////
   // edge / silhouette outline lines (CueMol toon edges)
 
   property boolean showEdgeLines => m_bEnableEdgeLines;

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -147,6 +147,18 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   /// full-frame post-pass denoiser (0 = None, 1 = AtrousBilateral, 2 = OIDN)
   property integer denoiser => m_nDenoiser;
 
+  /// GI sky model: false = uniform white sky (umbreon default), true (the
+  /// default here) = gradient (zenith white, ground = giGroundColor along the
+  /// camera up axis), which makes the gathered ambient depend on the surface
+  /// orientation and so adds a shape cue that is independent of occlusion
+  /// (umbreon --sky gradient). The ambient energy is rescaled so a
+  /// camera-facing surface keeps the uniform-sky brightness.
+  property boolean giSkyGradient => m_bGiSkyGradient;
+
+  /// ground hemisphere color of the gradient sky, "#rrggbb" (umbreon
+  /// --ao-ground); ignored unless giSkyGradient is on
+  property string giGroundColor => m_sGiGroundColor;
+
   //////////
   // NPR tone-hatching pass (umbreon --hatch): the image becomes an ink
   // drawing where hatch marks carry the shading tone on a paper base. GI is

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -902,6 +902,14 @@ TEST(UmbreonExport, LightBalancePropertiesChangeTheOutput)
     UmbreonRenderParams giNoAmbient = gi;
     giNoAmbient.ambientFraction = 0.0;
     EXPECT_NE(giRef, renderAoRecipe(giNoAmbient));
+
+    // The gradient sky is GI-only as well: the ground tint must reach the gather.
+    UmbreonRenderParams giGradient = gi;
+    giGradient.giSkyGradient = true;
+    giGradient.giGroundColorSet = true;
+    giGradient.giGroundColor[0] = giGradient.giGroundColor[1] =
+        giGradient.giGroundColor[2] = 0.2f;
+    EXPECT_NE(giRef, renderAoRecipe(giGradient));
 }
 
 TEST(UmbreonExport, GlobalIlluminationAffectsOutput)

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -873,6 +873,37 @@ TEST(UmbreonExport, AoRecipeFlagsReachTheRenderer)
 // Smoke test for the pt1 path-traced GI integrator + Intel OIDN denoiser:
 // enabling GI must run without crashing, produce a lit frame, and (via the
 // radiosity lighting rebalance) differ from the local-shading render.
+// The lighting balance properties (POV _light_inten / _flash_frac / _amb_frac)
+// must reach the lights umbreon renders with: each one, changed on its own,
+// changes the picture. Compared one at a time so a single unwired property
+// cannot hide behind the other two. ambientFraction is checked under GI, the
+// only mode where it feeds the gathered ambient energy rather than merely
+// dimming the direct lights (which lightIntensity already covers).
+TEST(UmbreonExport, LightBalancePropertiesChangeTheOutput)
+{
+    UmbreonRenderParams base;
+    base.supersample = 1;
+    const std::vector<unsigned char> ref = renderAoRecipe(base);
+    ASSERT_EQ(ref.size(), static_cast<std::size_t>(64 * 64 * 3));
+
+    UmbreonRenderParams dim = base;
+    dim.lightIntensity = 0.65;
+    EXPECT_NE(ref, renderAoRecipe(dim));
+
+    UmbreonRenderParams keyOnly = base;
+    keyOnly.flashFraction = 0.0;
+    EXPECT_NE(ref, renderAoRecipe(keyOnly));
+
+    UmbreonRenderParams gi = base;
+    gi.giEnabled = true;
+    gi.giSamples = 16;
+    gi.giDenoise = false;
+    const std::vector<unsigned char> giRef = renderAoRecipe(gi);
+    UmbreonRenderParams giNoAmbient = gi;
+    giNoAmbient.ambientFraction = 0.0;
+    EXPECT_NE(giRef, renderAoRecipe(giNoAmbient));
+}
+
 TEST(UmbreonExport, GlobalIlluminationAffectsOutput)
 {
     auto renderBox = [](bool useGi) {

--- a/tritium/react-gui/src/renderer/__test__/renderBackendsRegistry.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/renderBackendsRegistry.test.ts
@@ -48,7 +48,7 @@ describe('render backends registry', () => {
             if (!backend.quality) continue
             const propKeys = new Set(backend.props.map((p) => p.key))
             for (const lighting of backend.quality.lightings) {
-                for (const key of Object.keys(lighting.enable)) {
+                for (const key of Object.keys({ ...lighting.enable, ...lighting.defaults })) {
                     expect(
                         propKeys.has(key),
                         `${id}: lighting "${lighting.id}" patches unknown prop "${key}"`,

--- a/tritium/react-gui/src/renderer/__test__/renderSettingsEditor.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/renderSettingsEditor.test.tsx
@@ -118,7 +118,7 @@ describe('RenderSettingsEditor quality section', () => {
     expect(qualityLabels(container)).toEqual([
       'Lighting',
       'Supersampling',
-      'GI quality',
+      'GI lighting',
       'Shadows',
     ]);
     const [lightingSel, aaSel] = qualitySelects(container);
@@ -164,7 +164,7 @@ describe('RenderSettingsEditor quality section', () => {
   it('swaps the depth-cue axis with the method', () => {
     const { container, unmount } = mountFor('umbreon', { lighting: 'ao' });
     expect(qualityLabels(container)).toContain('AO quality');
-    expect(qualityLabels(container)).not.toContain('GI quality');
+    expect(qualityLabels(container)).not.toContain('GI lighting');
     unmount();
   });
 
@@ -189,11 +189,12 @@ describe('RenderSettingsEditor quality section', () => {
         backendProps={RENDER_BACKENDS.umbreon.props}
         onChange={vi.fn()}
         lighting="gi"
-        qualitySteps={{ aa: 'medium', gi: 'medium', shadows: 'off' }}
+        qualitySteps={{ aa: 'medium', giLighting: '0', shadows: 'off' }}
         onLightingChange={onLightingChange}
         onQualityStepChange={onQualityStepChange}
       />,
     );
+    // Lighting, Supersampling, GI lighting, Shadows.
     const [lightingSel, aaSel, , shadowSel] = qualitySelects(container);
     act(() => {
       lightingSel.value = 'ao';

--- a/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
@@ -120,6 +120,10 @@ describe('umbreonBackend.beginInProcess', () => {
         // denoise "A-trous" -> pt1Denoise off + full-frame a-trous.
         expect(exporter.giDenoise).toBe(false)
         expect(exporter.denoiser).toBe(1)
+        // GI on -> the GI lighting balance (the backend's table, not a prop).
+        expect(exporter.lightIntensity).toBe(1.55)
+        expect(exporter.flashFraction).toBe(0.6)
+        expect(exporter.ambientFraction).toBe(0.16)
 
         // Start sequence: attach -> setPath -> beginRender (non-blocking start).
         expect(exporter.attach).toHaveBeenCalledWith(scene)
@@ -258,6 +262,10 @@ describe('umbreonBackend.beginInProcess', () => {
         // Cross-renderer contact contours stay off, so an unset prop renders
         // the same picture umbreon and the GL view draw.
         expect(exporter.contactEdges).toBe(false)
+        // No GI -> the plain direct-lighting balance (CueMol's POV defaults).
+        expect(exporter.lightIntensity).toBe(1.3)
+        expect(exporter.flashFraction).toBe(0.6)
+        expect(exporter.ambientFraction).toBe(0)
     })
 
     // AO and GI are alternatives (the Lighting selector enforces it), so an AO

--- a/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/umbreonBackend.test.ts
@@ -81,9 +81,12 @@ describe('umbreonBackend.beginInProcess', () => {
                 p('edgeRise', 1),
                 p('contactEdges', true),
                 p('useGI', true),
-                p('giSamples', 64),
-                p('giIntensity', 1.5),
-                p('giEnvIntensity', 0.5),
+                p('giSamples', '64'),
+                p('lightIntensity', 1.4),
+                p('flashFraction', 0.5),
+                p('ambientFraction', 0.3),
+                p('giSkyGradient', true),
+                p('giGroundColor', '#333333'),
                 p('denoise', 'A-trous'),
             ],
         }
@@ -115,15 +118,19 @@ describe('umbreonBackend.beginInProcess', () => {
         // GI (pt1) props.
         expect(exporter.useGI).toBe(true)
         expect(exporter.giSamples).toBe(64)
-        expect(exporter.giIntensity).toBe(1.5)
-        expect(exporter.giEnvIntensity).toBe(0.5)
+        // giIntensity / giEnvIntensity are not offered: the exporter keeps 1.0.
+        expect(exporter.giIntensity).toBeUndefined()
+        expect(exporter.giEnvIntensity).toBeUndefined()
         // denoise "A-trous" -> pt1Denoise off + full-frame a-trous.
         expect(exporter.giDenoise).toBe(false)
         expect(exporter.denoiser).toBe(1)
-        // GI on -> the GI lighting balance (the backend's table, not a prop).
-        expect(exporter.lightIntensity).toBe(1.55)
-        expect(exporter.flashFraction).toBe(0.6)
-        expect(exporter.ambientFraction).toBe(0.16)
+        // Lighting energy balance and the GI sky model travel from the props
+        // (the ambient fraction only because GI is on).
+        expect(exporter.lightIntensity).toBe(1.4)
+        expect(exporter.flashFraction).toBe(0.5)
+        expect(exporter.ambientFraction).toBe(0.3)
+        expect(exporter.giSkyGradient).toBe(true)
+        expect(exporter.giGroundColor).toBe('#333333')
 
         // Start sequence: attach -> setPath -> beginRender (non-blocking start).
         expect(exporter.attach).toHaveBeenCalledWith(scene)
@@ -262,10 +269,13 @@ describe('umbreonBackend.beginInProcess', () => {
         // Cross-renderer contact contours stay off, so an unset prop renders
         // the same picture umbreon and the GL view draw.
         expect(exporter.contactEdges).toBe(false)
-        // No GI -> the plain direct-lighting balance (CueMol's POV defaults).
-        expect(exporter.lightIntensity).toBe(1.3)
+        // Direct lighting balance (GI lighting step 0); the ambient fraction
+        // is pinned there without GI, where it would only dim the lights.
+        expect(exporter.lightIntensity).toBe(1.55)
         expect(exporter.flashFraction).toBe(0.6)
-        expect(exporter.ambientFraction).toBe(0)
+        expect(exporter.ambientFraction).toBe(0.16)
+        // The gradient sky is the default (it only matters under GI).
+        expect(exporter.giSkyGradient).toBe(true)
     })
 
     // AO and GI are alternatives (the Lighting selector enforces it), so an AO
@@ -475,6 +485,12 @@ describe('umbreonNprBackend.beginInProcess', () => {
         expect(exporter.useGI).toBeUndefined()
         expect(exporter.giSamples).toBeUndefined()
         expect(exporter.denoiser).toBeUndefined()
+        expect(exporter.giSkyGradient).toBeUndefined()
+        // The Lights group still applies; the GI-only ambient fraction is
+        // pinned to its step-0 value so the direct lights match raytracing.
+        expect(exporter.lightIntensity).toBe(1.55)
+        expect(exporter.flashFraction).toBe(0.6)
+        expect(exporter.ambientFraction).toBe(0.16)
     })
 
     it('sends a color only while its Custom switch is on', () => {

--- a/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
@@ -228,13 +228,14 @@ describe('useRenderSettings quality axes', () => {
         expect(h.result.qualitySteps).toEqual({
             aa: 'high',
             ao: 'medium',
-            gi: 'medium',
+            giLighting: '4',
             shadows: 'off',
         });
         // Those defaults are already written into the props.
         expect(valueOf(h.result.backendProps, 'useGI')).toBe(true);
         expect(valueOf(h.result.backendProps, 'supersample')).toBe(3);
-        expect(valueOf(h.result.backendProps, 'giSamples')).toBe(32);
+        // GI samples is a plain dropdown (no ladder), so its own default holds.
+        expect(valueOf(h.result.backendProps, 'giSamples')).toBe('32');
         expect(valueOf(h.result.backendProps, 'shadows')).toBe(false);
         h.unmount();
     });
@@ -298,21 +299,12 @@ describe('useRenderSettings quality axes', () => {
         h.unmount();
     });
 
-    it('the GI ladder follows the umbreon guide steps', () => {
-        const h = umbreonHook();
-        act(() => h.result.setQualityStep('gi', 'low'));
-        expect(valueOf(h.result.backendProps, 'giSamples')).toBe(8);
-        act(() => h.result.setQualityStep('gi', 'reference'));
-        expect(valueOf(h.result.backendProps, 'giSamples')).toBe(256);
-        h.unmount();
-    });
-
     it('editing a prop off the ladder drops only that axis to Custom', () => {
         const h = umbreonHook();
         act(() => h.result.handleChange('supersample', 6));
         expect(h.result.qualitySteps.aa).toBe('custom');
         // The other axes still describe their own props correctly.
-        expect(h.result.qualitySteps.gi).toBe('medium');
+        expect(h.result.qualitySteps.giLighting).toBe('4');
         expect(h.result.qualitySteps.shadows).toBe('off');
         h.unmount();
     });
@@ -350,7 +342,7 @@ describe('useRenderSettings quality axes', () => {
     it('restoring a snapshot reports the steps its values match', () => {
         const h = umbreonHook();
         act(() => h.result.setQualityStep('aa', 'low'));
-        act(() => h.result.setQualityStep('gi', 'high'));
+        act(() => h.result.setQualityStep('giLighting', '3'));
         const snapshot = h.result.getSnapshot();
 
         act(() => h.result.setQualityStep('aa', 'ultra'));
@@ -358,16 +350,51 @@ describe('useRenderSettings quality axes', () => {
         // Re-rendering a past result must not leave every dropdown on Custom
         // over values that plainly match a step.
         expect(h.result.qualitySteps.aa).toBe('low');
-        expect(h.result.qualitySteps.gi).toBe('high');
+        expect(h.result.qualitySteps.giLighting).toBe('3');
         h.unmount();
     });
 
     it('editing a look setting no axis owns keeps every axis', () => {
         const h = umbreonHook();
-        // GI intensity is a look knob, deliberately outside the quality ladders.
-        act(() => h.result.handleChange('giIntensity', 1.5));
-        expect(h.result.qualitySteps.gi).toBe('medium');
+        // The GI ground color is a look knob outside every ladder.
+        act(() => h.result.handleChange('giGroundColor', '#444444'));
+        expect(h.result.qualitySteps.giLighting).toBe('4');
         expect(h.result.qualitySteps.aa).toBe('high');
+        h.unmount();
+    });
+
+    it('the GI lighting axis trades headlight for key light and gathered ambient', () => {
+        const h = umbreonHook();
+        // The default step is the top one; its values are already in the props.
+        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.2);
+        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.05);
+        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.4);
+        act(() => h.result.setQualityStep('giLighting', '2'));
+        expect(h.result.qualitySteps.giLighting).toBe('2');
+        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.38);
+        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.32);
+        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.3);
+        // A hand edit of an owned prop drops the axis to Custom.
+        act(() => h.result.handleChange('lightIntensity', 1.3));
+        expect(h.result.qualitySteps.giLighting).toBe('custom');
+        h.unmount();
+    });
+
+    it('picking a direct method writes the Lights defaults back', () => {
+        const h = umbreonHook();
+        expect(h.result.qualitySteps.giLighting).toBe('4');
+        // The Lights group is shared, so without this a GI step with almost
+        // no headlight would carry over into the raytrace.
+        act(() => h.result.setLighting('none'));
+        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.55);
+        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.6);
+        // The step is derived from those shared values, so leaving GI resets
+        // its lighting to step 0 (the defaults equal it, ambient included);
+        // coming back starts from the raytrace match rather than Custom.
+        expect(h.result.qualitySteps.giLighting).toBe('0');
+        act(() => h.result.setLighting('gi'));
+        expect(h.result.qualitySteps.giLighting).toBe('0');
+        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.16);
         h.unmount();
     });
 

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -108,15 +108,49 @@ const UMBREON_PROPS: PropDef[] = [
   { key: "contactEdges",  label: "Contact edges",      type: "boolean", value: false, group: "Edges" },
   // --- Global Illumination (pt1 path-traced integrator; off by default) ---
   { key: "useGI",         label: "Enable GI",          type: "boolean", value: false, group: "Global Illumination" },
-  { key: "giSamples",     label: "GI samples",         type: "integer", value: 32,   group: "Global Illumination", min: 1, max: 256, step: 1 },
-  { key: "giIntensity",   label: "GI intensity",       type: "real",    value: 1.0,  group: "Global Illumination", min: 0, max: 3, step: 0.1 },
-  { key: "giEnvIntensity", label: "GI environment",    type: "real",    value: 1.0,  group: "Global Illumination", min: 0, max: 3, step: 0.1 },
+  // Gather samples per pixel, as a short list rather than a ladder: with the
+  // OIDN denoiser on, the umbreon guide's low / medium / high / reference
+  // steps (8 / 32 / 64 / 256) converge to the same picture and differ only
+  // in residual detail and animation stability, so a dropdown of those
+  // counts is all the choice that is worth offering.
+  { key: "giSamples",     label: "GI samples",         type: "enum",    value: "32", group: "Global Illumination",
+    options: ["8", "32", "64", "256"] },
+  // giIntensity / giEnvIntensity (umbreon's indirect gain and sky multiplier)
+  // are deliberately NOT offered: the energy balance below covers the same
+  // ground more directly, and they stay at their neutral 1.0 on the exporter.
   // GI denoise method: a single control that composes the two umbreon knobs
   // (pt1Denoise = OIDN on the pre-composite indirect buffer; denoiser =
   // full-frame post-pass). OIDN -> pt1Denoise on; A-trous -> full-frame a-trous;
   // None -> both off. See the DENOISE_MODE map in UmbreonBackend.
   { key: "denoise",       label: "Denoise",            type: "enum",    value: "OIDN", group: "Global Illumination",
     options: ["OIDN", "A-trous", "None"] },
+  // Share of the total light energy the GI gather receives occlusion-aware
+  // (POV _amb_frac). Owned by the "GI lighting" axis below (the value here
+  // is its default step); the direct lights get the rest. Only GI reads it
+  // -- without GI it would merely dim the direct lights, so the backend pins
+  // it there (see UmbreonBackend).
+  { key: "ambientFraction", label: "Ambient fraction", type: "real",    value: 0.4,  group: "Global Illumination", min: 0, max: 1, step: 0.02 },
+  // Sky model of the GI gather: a zenith-white / ground-tinted gradient along
+  // the camera up axis makes the gathered ambient depend on the surface
+  // orientation, a shape cue independent of occlusion (umbreon --sky
+  // gradient / --ao-ground). On by default: at the default GI lighting step
+  // most of the fill comes through the gather, and a uniform sky would make
+  // that fill blind to orientation. libcuemol2 rescales the ambient energy
+  // so the gradient leaves a camera-facing surface as bright as the uniform
+  // sky.
+  { key: "giSkyGradient", label: "Sky gradient",       type: "boolean", value: true,  group: "Global Illumination" },
+  { key: "giGroundColor", label: "Ground color",       type: "color",   value: "#666666", group: "Global Illumination" },
+  // --- Lights (every lighting method; the POV exporter's _light_inten and
+  //     _flash_frac) ---
+  // lightIntensity is the total light energy, the brightness knob.
+  // flashFraction splits the direct light between the shadowless headlight
+  // (flat, view-aligned) and the key light from the upper front right (the
+  // directional shading); less headlight = stronger relief in every method.
+  // Under GI the "GI lighting" axis owns both (it moves the headlight energy
+  // into the key light and the gathered ambient, lowering the total as it
+  // goes); picking a direct method writes DIRECT_LIGHT_DEFAULTS back.
+  { key: "lightIntensity",  label: "Light intensity",  type: "real",    value: 1.55, group: "Lights", min: 0, max: 3, step: 0.05 },
+  { key: "flashFraction",   label: "Flash fraction",   type: "real",    value: 0.6,  group: "Lights", min: 0, max: 1, step: 0.05 },
 ];
 
 /**
@@ -127,19 +161,40 @@ const UMBREON_PROPS: PropDef[] = [
  * Three rules from that guide shape the table:
  * - The axes are independent, so each is its own dropdown: image quality and
  *   shadows have nothing to do with which depth cue is active.
- * - AO and GI are alternatives, so they are one selector, not two switches,
- *   and each brings its own quality axis with the guide's own step names.
+ * - AO and GI are alternatives, so they are one selector, not two switches.
+ *   AO brings its quality axis with the guide's own step names; GI brings a
+ *   look axis instead (its sample count is a dropdown in its own group).
  * - A step moves quality only. Look-changing knobs (GI bounces / intensity,
  *   AO distance / intensity, edge style) are NOT in any patch: if a step
  *   changed those, "High" would mean a different picture, not a better one.
  */
+/**
+ * Lighting values of the direct-lighting methods (raytrace, AO): CueMol's POV
+ * default. The GI lighting axis writes its own per-step values into the same
+ * props, so picking a direct method writes these back -- otherwise a GI step
+ * with almost no headlight would carry over into the raytrace. They equal the
+ * axis' step 0 (the ambient fraction included, although the direct methods
+ * never read it), so the axis reads "0" again afterwards: leaving GI resets
+ * its lighting to the raytrace match, since the step is derived from these
+ * shared values and cannot survive their reset.
+ */
+const DIRECT_LIGHT_DEFAULTS = { lightIntensity: 1.55, flashFraction: 0.6 };
+/** The umbreon backend has the GI-only ambient fraction prop as well. */
+const UMBREON_DIRECT_DEFAULTS = { ...DIRECT_LIGHT_DEFAULTS, ambientFraction: 0.16 };
+
 const UMBREON_QUALITY: RenderQualityConfig = {
   lightings: [
-    { id: "none", label: "Raytrace only", enable: { aoEnabled: false, useGI: false } },
+    {
+      id: "none",
+      label: "Raytrace only",
+      enable: { aoEnabled: false, useGI: false },
+      defaults: UMBREON_DIRECT_DEFAULTS,
+    },
     {
       id: "ao",
       label: "Ambient Occlusion",
       enable: { aoEnabled: true, useGI: false },
+      defaults: UMBREON_DIRECT_DEFAULTS,
       group: "Ambient Occlusion",
     },
     {
@@ -204,19 +259,39 @@ const UMBREON_QUALITY: RenderQualityConfig = {
         },
       ],
     },
-    // Axis B-GI: samples per pixel only. The denoiser stays on at every step
-    // (it is what keeps a low sample count usable); Reference is the guide's
-    // converged step, meant for a final still rather than iteration.
+    // GI has no quality axis: its only quality knob is the sample count, which
+    // the denoiser flattens into near-identical pictures, so it is a plain
+    // dropdown in the Global Illumination group instead of a ladder.
+    //
+    // Axis B-GI look. Unlike every other axis this one changes the picture on
+    // purpose: it takes the flat, view-aligned headlight away in equal
+    // strides (flashFraction 0.60 -> 0.05) and gives its energy to the two
+    // terms that carry shape -- the directional key light and the GI gather
+    // (the only term that carries occlusion). The ambient fraction at each
+    // step follows the curve that keeps the MEAN brightness of a sphere seen
+    // by the camera constant (headlight averages 2/3 of its intensity over
+    // the visible disk, the key light 0.44, the sky a flat 1; the endpoint
+    // trimmed to what looked right). The total energy then comes down with
+    // the steps (1.55 -> 1.2): with the key light grown from 0.52 to 0.88,
+    // the key-lit side of a white surface clips at the raytrace level, and
+    // the lower level is where the relief reads best. Step 0 reproduces the
+    // raytraced picture (the gathered ambient equals the flat material
+    // ambient). The axis owns all three props, so a hand edit of any of them
+    // reads back as Custom. Derivation:
+    // docs/architecture/umbreon-gi-lighting-balance.md
+    // The default is the top step: GI is the default depth cue precisely for
+    // this look, and step 0 is the escape hatch back to the raytraced picture.
     {
-      key: "gi",
-      label: "GI quality",
-      defaultStep: "medium",
+      key: "giLighting",
+      label: "GI lighting",
+      defaultStep: "4",
       lightings: ["gi"],
       steps: [
-        { id: "low", label: "Low", patch: { giSamples: 8, denoise: "OIDN" } },
-        { id: "medium", label: "Medium", patch: { giSamples: 32, denoise: "OIDN" } },
-        { id: "high", label: "High", patch: { giSamples: 64, denoise: "OIDN" } },
-        { id: "reference", label: "Reference", patch: { giSamples: 256, denoise: "OIDN" } },
+        { id: "0", label: "0 (raytrace match)", patch: { lightIntensity: 1.55, flashFraction: 0.6, ambientFraction: 0.16 } },
+        { id: "1", label: "1", patch: { lightIntensity: 1.46, flashFraction: 0.46, ambientFraction: 0.23 } },
+        { id: "2", label: "2", patch: { lightIntensity: 1.38, flashFraction: 0.32, ambientFraction: 0.3 } },
+        { id: "3", label: "3", patch: { lightIntensity: 1.29, flashFraction: 0.18, ambientFraction: 0.35 } },
+        { id: "4", label: "4 (max GI)", patch: { lightIntensity: 1.2, flashFraction: 0.05, ambientFraction: 0.4 } },
       ],
     },
     // Axis C. Shadows fall on meshes only and are independent of the depth
@@ -293,17 +368,23 @@ const UMBREON_NPR_PROPS: PropDef[] = [
  */
 const UMBREON_NPR_QUALITY: RenderQualityConfig = {
   lightings: [
-    { id: "none", label: "Raytrace only", enable: { aoEnabled: false } },
+    {
+      id: "none",
+      label: "Raytrace only",
+      enable: { aoEnabled: false },
+      defaults: DIRECT_LIGHT_DEFAULTS,
+    },
     {
       id: "ao",
       label: "Ambient Occlusion",
       enable: { aoEnabled: true },
+      defaults: DIRECT_LIGHT_DEFAULTS,
       group: "Ambient Occlusion",
     },
   ],
   defaultLighting: "none",
   lightingKeys: ["aoEnabled"],
-  axes: UMBREON_QUALITY.axes.filter((a) => a.key !== "gi"),
+  axes: UMBREON_QUALITY.axes.filter((a) => !a.lightings?.includes("gi")),
 };
 
 /**
@@ -332,6 +413,7 @@ export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> =
     label: "Umbreon",
     groups: [
       { key: "Antialiasing", defaultExpanded: false },
+      { key: "Lights", defaultExpanded: false },
       { key: "Ambient Occlusion", defaultExpanded: false },
       { key: "Shadows", defaultExpanded: false },
       { key: "Edges", defaultExpanded: false },
@@ -349,6 +431,7 @@ export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> =
       // is about; everything below it is shared umbreon tuning.
       { key: "Hatching", defaultExpanded: true },
       { key: "Antialiasing", defaultExpanded: false },
+      { key: "Lights", defaultExpanded: false },
       { key: "Ambient Occlusion", defaultExpanded: false },
       { key: "Shadows", defaultExpanded: false },
       { key: "Edges", defaultExpanded: false },

--- a/tritium/react-gui/src/renderer/data/renderSettings.ts
+++ b/tritium/react-gui/src/renderer/data/renderSettings.ts
@@ -50,6 +50,12 @@ export interface RenderLightingOption {
   label: string;
   /** Props that switch this method on -- and the competing one off. */
   enable: RenderPropPatch;
+  /**
+   * Look defaults written when this method is picked, before its axes are
+   * re-applied (so an axis step still wins). Unlike `enable` these take no
+   * part in identifying the method, so the user may edit them freely.
+   */
+  defaults?: RenderPropPatch;
   /** Accordion group shown only while this method is selected. */
   group?: string;
 }
@@ -157,13 +163,17 @@ export function lightingPatch(
   opts: { includeShared?: boolean } = {},
 ): RenderPropPatch {
   const patch: RenderPropPatch = {};
+  const option = cfg.lightings.find((l) => l.id === lighting);
+  // The method's look defaults go first so that an axis owning the same prop
+  // (re-applied below at its selected step) overrides them.
+  Object.assign(patch, option?.defaults ?? {});
   for (const axis of axesFor(cfg, lighting)) {
     // A method switch only re-applies that method's own axes; the shared ones
     // (image quality, shadows) are unrelated to the method and stay put.
     if (!axis.lightings && !opts.includeShared) continue;
     Object.assign(patch, stepPatch(axis, steps[axis.key] ?? axis.defaultStep));
   }
-  Object.assign(patch, cfg.lightings.find((l) => l.id === lighting)?.enable ?? {});
+  Object.assign(patch, option?.enable ?? {});
   return patch;
 }
 

--- a/tritium/react-gui/src/renderer/features/inspector/RenderSettingsEditor.tsx
+++ b/tritium/react-gui/src/renderer/features/inspector/RenderSettingsEditor.tsx
@@ -42,6 +42,7 @@ const GROUP_ORDER = [
   "Hatching",
   "Antialiasing",
   "Quality",
+  "Lights",
   "Edges",
   "Shadows",
   "Ambient Occlusion",

--- a/tritium/react-gui/src/renderer/worker/server/services/renderjob/backends/UmbreonBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderjob/backends/UmbreonBackend.ts
@@ -70,31 +70,35 @@ const HATCH_COLORING: Record<string, { base: string; ink: string }> = {
 
 // Lighting energy balance, in the POV exporter's terms (_light_inten /
 // _flash_frac / _amb_frac; the exporter's lightIntensity / flashFraction /
-// ambientFraction). This table is the app's single source for these values;
-// the C++ side only carries an "auto" fallback for scripted callers.
+// ambientFraction). lightIntensity and flashFraction come from the Lights
+// group and apply to every lighting method; ambientFraction is the GI-only
+// share of the energy the gather receives occlusion-aware. Under GI all
+// three are owned by the "GI lighting" axis (renderBackends.ts).
 //
-// `direct` is CueMol's POV default (key light 0.52, headlight 0.78, flat
-// material ambient) and is used whenever the flat ambient term is in play:
-// plain raytracing, AO and the NPR backend.
+// DIRECT_LIGHT is that axis' step 0: the direct lights of CueMol's POV
+// default (key 0.52, headlight 0.78) plus a gathered ambient (1.55 * 0.16 =
+// 0.25) that, through umbreon's diffuse weight (0.8), equals the flat
+// material ambient (0.2) of the non-GI render, so GI at step 0 reproduces
+// the raytraced picture. Without GI the ambient fraction only dims the
+// direct lights (POV without radiosity keeps the unit ambient_light), so it
+// is pinned to this value there: the direct lights then stay identical to
+// GI step 0 whatever the GI axis was last set to, instead of a hidden value
+// darkening the raytrace.
 //
-// `gi` replaces that flat ambient with the occlusion-aware GI gather, which
-// umbreon receives through the material diffuse weight (0.8) rather than the
-// ambient one (0.2). Taking the POV radiosity split literally therefore
-// over-fills the picture; these values instead keep the key light at its
-// non-GI value and hold an open camera-facing surface at the non-GI
-// brightness. That constraint fixes lightIntensity at 1.55 and ties the two
-// fractions together (headlight + ambient energy = 1.03), so retuning means
-// moving ambientFraction and flashFraction along that line: more ambient
-// deepens pockets but brightens side-facing surfaces, less does the reverse.
-// The chosen point keeps the direct lights identical to `direct` (key 0.52,
-// headlight 0.78) and puts 0.25 into the gathered ambient, which through the
-// diffuse weight equals the flat ambient of the non-GI render: a white tube
-// keeps its headlight shading (a higher sky fill flattened it to a clipped
-// white blob), and GI adds only occlusion and bounce on top.
+// GI_LIGHT is the axis' default step (4): almost no headlight, the energy
+// moved into the key light and the gather. It is only the fallback for a
+// snapshot that carries no lighting props; the C++ side carries the same
+// values as its "auto" for scripts.
 // Derivation: docs/architecture/umbreon-gi-lighting-balance.md
-const LIGHT_BALANCE = {
-  direct: { lightIntensity: 1.3, flashFraction: 0.6, ambientFraction: 0.0 },
-  gi: { lightIntensity: 1.55, flashFraction: 0.6, ambientFraction: 0.16 },
+const DIRECT_LIGHT = {
+  lightIntensity: 1.55,
+  flashFraction: 0.6,
+  ambientFraction: 0.16,
+} as const;
+const GI_LIGHT = {
+  lightIntensity: 1.2,
+  flashFraction: 0.05,
+  ambientFraction: 0.4,
 } as const;
 
 
@@ -167,13 +171,16 @@ function makeExporter(
   exporter.shadows = boolVal(ub, "shadows", false);
   exporter.shadowSamples = numVal(ub, "shadowSamples", 1);
   exporter.lightRadius = numVal(ub, "lightRadius", 0.0);
-  // Energy balance: the GI table only while GI actually renders (the NPR
-  // backend never enables it, see below).
+  // Energy balance (see DIRECT_LIGHT / GI_LIGHT). The ambient fraction is
+  // read only while GI actually renders (the NPR backend never enables it,
+  // see below).
   const useGI = !npr && boolVal(ub, "useGI", false);
-  const balance = useGI ? LIGHT_BALANCE.gi : LIGHT_BALANCE.direct;
-  exporter.lightIntensity = balance.lightIntensity;
-  exporter.flashFraction = balance.flashFraction;
-  exporter.ambientFraction = balance.ambientFraction;
+  const fallback = useGI ? GI_LIGHT : DIRECT_LIGHT;
+  exporter.lightIntensity = numVal(ub, "lightIntensity", fallback.lightIntensity);
+  exporter.flashFraction = numVal(ub, "flashFraction", fallback.flashFraction);
+  exporter.ambientFraction = useGI
+    ? numVal(ub, "ambientFraction", fallback.ambientFraction)
+    : DIRECT_LIGHT.ambientFraction;
   exporter.creaseLimit = numVal(ub, "creaseLimit", -1.0);
   exporter.edgeRise = numVal(ub, "edgeRise", 0.5);
   // Contact contours between DIFFERENT renderers (umbreon strokeEdges.contact).
@@ -212,12 +219,18 @@ function makeExporter(
   } else {
     // Diffuse global illumination (pt1 path-traced integrator).
     exporter.useGI = useGI;
-    exporter.giSamples = numVal(ub, "giSamples", 32);
-    exporter.giIntensity = numVal(ub, "giIntensity", 1.0);
-    exporter.giEnvIntensity = numVal(ub, "giEnvIntensity", 1.0);
+    // The sample count is an enum prop (a dropdown of counts), so it arrives
+    // as a string.
+    exporter.giSamples = Number(strVal(ub, "giSamples", "32")) || 32;
+    // giIntensity / giEnvIntensity are not offered in the UI and stay at the
+    // exporter's neutral 1.0 (the energy balance above covers that ground).
     const denoise = DENOISE_MODE[strVal(ub, "denoise", "OIDN")] ?? DENOISE_MODE.OIDN;
     exporter.giDenoise = denoise.giDenoise; // pt1Denoise: OIDN on the indirect buffer
     exporter.denoiser = denoise.denoiser; // full-frame post-pass (0 = None, 1 = a-trous)
+    // Gather sky model: uniform white or a camera-up gradient down to the
+    // ground color (libcuemol2 keeps the overall brightness constant).
+    exporter.giSkyGradient = boolVal(ub, "giSkyGradient", true);
+    exporter.giGroundColor = strVal(ub, "giGroundColor", "#666666");
   }
 
   return exporter;

--- a/tritium/react-gui/src/renderer/worker/server/services/renderjob/backends/UmbreonBackend.ts
+++ b/tritium/react-gui/src/renderer/worker/server/services/renderjob/backends/UmbreonBackend.ts
@@ -68,6 +68,35 @@ const HATCH_COLORING: Record<string, { base: string; ink: string }> = {
   "Colored ink on color fill": { base: "albedo", ink: "albedo" },
 };
 
+// Lighting energy balance, in the POV exporter's terms (_light_inten /
+// _flash_frac / _amb_frac; the exporter's lightIntensity / flashFraction /
+// ambientFraction). This table is the app's single source for these values;
+// the C++ side only carries an "auto" fallback for scripted callers.
+//
+// `direct` is CueMol's POV default (key light 0.52, headlight 0.78, flat
+// material ambient) and is used whenever the flat ambient term is in play:
+// plain raytracing, AO and the NPR backend.
+//
+// `gi` replaces that flat ambient with the occlusion-aware GI gather, which
+// umbreon receives through the material diffuse weight (0.8) rather than the
+// ambient one (0.2). Taking the POV radiosity split literally therefore
+// over-fills the picture; these values instead keep the key light at its
+// non-GI value and hold an open camera-facing surface at the non-GI
+// brightness. That constraint fixes lightIntensity at 1.55 and ties the two
+// fractions together (headlight + ambient energy = 1.03), so retuning means
+// moving ambientFraction and flashFraction along that line: more ambient
+// deepens pockets but brightens side-facing surfaces, less does the reverse.
+// The chosen point keeps the direct lights identical to `direct` (key 0.52,
+// headlight 0.78) and puts 0.25 into the gathered ambient, which through the
+// diffuse weight equals the flat ambient of the non-GI render: a white tube
+// keeps its headlight shading (a higher sky fill flattened it to a clipped
+// white blob), and GI adds only occlusion and bounce on top.
+// Derivation: docs/architecture/umbreon-gi-lighting-balance.md
+const LIGHT_BALANCE = {
+  direct: { lightIntensity: 1.3, flashFraction: 0.6, ambientFraction: 0.0 },
+  gi: { lightIntensity: 1.55, flashFraction: 0.6, ambientFraction: 0.16 },
+} as const;
+
 
 /**
  * Create the umbreon exporter and apply every setting from `snapshot`.
@@ -138,6 +167,13 @@ function makeExporter(
   exporter.shadows = boolVal(ub, "shadows", false);
   exporter.shadowSamples = numVal(ub, "shadowSamples", 1);
   exporter.lightRadius = numVal(ub, "lightRadius", 0.0);
+  // Energy balance: the GI table only while GI actually renders (the NPR
+  // backend never enables it, see below).
+  const useGI = !npr && boolVal(ub, "useGI", false);
+  const balance = useGI ? LIGHT_BALANCE.gi : LIGHT_BALANCE.direct;
+  exporter.lightIntensity = balance.lightIntensity;
+  exporter.flashFraction = balance.flashFraction;
+  exporter.ambientFraction = balance.ambientFraction;
   exporter.creaseLimit = numVal(ub, "creaseLimit", -1.0);
   exporter.edgeRise = numVal(ub, "edgeRise", 0.5);
   // Contact contours between DIFFERENT renderers (umbreon strokeEdges.contact).
@@ -175,7 +211,7 @@ function makeExporter(
     }
   } else {
     // Diffuse global illumination (pt1 path-traced integrator).
-    exporter.useGI = boolVal(ub, "useGI", false);
+    exporter.useGI = useGI;
     exporter.giSamples = numVal(ub, "giSamples", 32);
     exporter.giIntensity = numVal(ub, "giIntensity", 1.0);
     exporter.giEnvIntensity = numVal(ub, "giEnvIntensity", 1.0);


### PR DESCRIPTION
## Summary

With GI on, the umbreon renderer took the POV radiosity light split (`_light_inten 1.6 / _amb_frac 0.5 / _flash_frac 0.5`) literally. umbreon drops the flat material ambient under GI and receives the gathered ambient through the material *diffuse* weight (0.8) rather than the ambient one (0.2), so that split gave an open surface 3.2x the fill of the raytraced picture while dimming the direct lights: a brighter, flatter image in which white tubes lost their shading.

This PR:

- **libcuemol2**: exposes `lightIntensity / flashFraction / ambientFraction` on `UmbreonSceneExporter` with the POV exporter's semantics (negative = auto), plus `giSkyGradient / giGroundColor` (umbreon `pt1SkyMode 1` + ground tint along the camera up axis). The gradient sky rescales the ambient energy by `2 / (1 + ground luminance)` so it changes only how the ambient shades by orientation, not the overall brightness. The GI auto fallback mirrors the app's default.
- **tritium render window**:
  - a **GI lighting** look axis with five steps: step 0 reproduces the raytraced picture (same key light / headlight, gathered ambient equal to the flat material ambient); the steps take the headlight down (`flashFraction 0.60 -> 0.05`) and move its energy into the key light and the GI gather, with the ambient fraction following the constant-mean-brightness curve and the total lowered from 1.55 to 1.2 so the key-lit side of a white surface no longer clips. Step 4 is the default, with the gradient sky on.
  - a **Lights** group (light intensity / flash fraction) that applies to every lighting method (raytrace / AO / GI / NPR); picking a direct method writes its defaults back through the new `RenderLightingOption.defaults` (not part of method identity).
  - **GI intensity / GI environment** leave the UI (the energy balance covers them; the qif properties stay for scripts), and the **GI quality** ladder becomes a plain sample-count dropdown (8 / 32 / 64 / 256), since the OIDN denoiser renders its steps near-identical.
- **docs**: `docs/architecture/umbreon-gi-lighting-balance.md` records the derivation, the trial history (uniform sky at higher ambient blew out white tubes; camera-facing parity alone brightened side-facing surfaces) and the UI decisions; ADR-0042 and the pt2-integrator doc link to it.

## Verification

- `task run_gtest TEST=test_umbreon`: 33 passed (new `LightBalancePropertiesChangeTheOutput` pins that each lighting property and the gradient sky reach the renderer)
- `npm test` (react-gui Vitest): 3727 passed (backend wire contract, GI lighting axis, Lights defaults on method switch, registry invariants)
- `tsc -p tsconfig.web.json` / `tsconfig.node.json`: clean
- `task build_tritium`: clean; visual trials of every step, the gradient sky and the direct-method switch done in the app

Merge with a merge commit (`gh pr merge --merge`), per the repository policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fc3Ue3hrkwV1oA3qGV925k
