### PR TITLE
fix(render): hand stick bonds to umbreon closed, as the POV exporter does

### DIFF
--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -724,7 +724,15 @@ void UmbreonDisplayContext::appendIntData()
     const int cmatIdx = materialIndexFor(cmat);
     c.material = m_pImpl->matTable[cmatIdx];
     c.group = group;
-    c.open = !p->bcap;
+    // Closed (flat-capped), as the POV exporter writes every stick bond
+    // (PovDisplayContext::writeCyls never emits `open`): RendIntData::Cyl::
+    // bcap only decides whether the MESH conversion adds cap discs. An `open`
+    // umbreon cylinder is a round-capped capsule, and a bond capsule's
+    // hemispherical end cap coincides exactly with the atom sphere it starts
+    // from -- two surfaces z-fighting across the whole atom, which the edge
+    // pass classified as a field of one-pixel depth steps at high zoom
+    // (blobs of ink inside the atom). A flat cap lies inside the sphere.
+    c.open = false;
     scene.cylinders.push_back(c);
   }
 #endif  // HAVE_UMBREON


### PR DESCRIPTION
`UmbreonDisplayContext` emitted every `RendIntData` cylinder with `open = !bcap`. `Cyl::bcap` only decides whether the mesh conversion adds cap discs; `PovDisplayContext::writeCyls` never writes `open` for a stick bond, so the POV path has always rendered bonds as closed cylinders.

An `open` umbreon cylinder is a round-capped capsule, and a bond capsule's hemispherical end cap coincides exactly with the atom sphere it starts from (same center, same radius). The two surfaces z-fight across the whole atom: the umbreon G-buffer dump of a ball-and-stick scene shows the first hit alternating between the sphere and the capsule every few pixels with a view-z jitter of about 0.005 A. At an extreme zoom (1.8 A frame) the edge pass read that jitter as a field of one-pixel depth steps and drew blobs of ink inside the atom.

Bonds are now handed to umbreon closed, matching the POV exporter; the flat cap lies inside the atom sphere. Verified with cuetty on the tRNA ball-and-stick scenes (blobs gone, outlines intact) and on the NPR and EAAT2 ribbon scenes (unchanged). The umbreon side of the same investigation is CueMol/umbreon#80, which also floors the classifier's depth tolerance at float precision so coincident surfaces can never produce such steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtJAhjZSes3KPJiJNZ3Gj
