### PR TITLE
feat(render): edge groups decide where umbreon draws contact contours

### DIFF
--- a/src/gfx/DisplayContext.cpp
+++ b/src/gfx/DisplayContext.cpp
@@ -435,6 +435,11 @@ void DisplayContext::setEdgeLineWidth(double w)
   m_dEdgeLineWidth = w;
 }
 
+void DisplayContext::setEdgeGroup(const LString &)
+{
+  // Only the umbreon backend groups renderers for its edge pass.
+}
+
 double DisplayContext::getEdgeLineWidth() const
 {
   return m_dEdgeLineWidth;

--- a/src/gfx/DisplayContext.hpp
+++ b/src/gfx/DisplayContext.hpp
@@ -210,6 +210,12 @@ public:
     virtual ColorPtr getEdgeLineColor() const;
     virtual void setEdgeLineColor(const ColorPtr &c);
 
+    /// Edge group of the renderer about to be displayed (umbreon
+    /// rendering): `name` is the renderer's egroup property; empty means
+    /// "group by the edge settings themselves". The base implementation
+    /// ignores it.
+    virtual void setEdgeGroup(const LString &name);
+
     // Fog
     virtual void enableFog(bool b);
     bool isFogEnabled() const

--- a/src/modules/rendering/RenderSettings.cpp
+++ b/src/modules/rendering/RenderSettings.cpp
@@ -42,7 +42,7 @@ UmbreonRenderSettings::UmbreonRenderSettings()
       m_lightRadius(0.0),
       m_creaseLimit(0.0),
       m_edgeRise(0.0),
-      m_contactEdges(false),
+      m_contactEdges(true),
       m_useGI(false),
       m_giSkyGradient(false),
       m_lightIntensity(0.0),

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -22,6 +22,7 @@
 #  include <cstdint>
 #  include <map>
 #  include <mutex>
+#  include <string>
 #  include <vector>
 #endif
 
@@ -331,10 +332,20 @@ struct UmbreonDisplayContext::Impl
   int curGroup = 0;
   std::vector<umbreon::GroupBlend> groupBlend;
 
-  /// Per-section (per group) native stroke-edge style for umbreon's screen-space
-  /// edge pass (RenderOptions::strokeEdges + Scene::groupEdgeStyle). Indexed by
-  /// group id; a section without edge lines gets an all-disabled EdgeStyle.
+  /// EDGE GROUPS: renderers of one edge group are ONE section for umbreon's
+  /// edge pass (no contact line inside the group, one style). edgeGroupOf maps
+  /// every transparency group (renderer) to its edge group id; edgeGroupIds
+  /// assigns the ids by key ("n:<egroup>" for a named group, else
+  /// "c:<edge settings>" so renderers drawing the same lines are one group).
+  std::vector<std::uint16_t> edgeGroupOf;
+  std::map<LString, int> edgeGroupIds;
+  /// Native stroke-edge style per EDGE GROUP (RenderOptions::strokeEdges +
+  /// Scene::groupEdgeStyle, indexed by edge group id). Set by the first
+  /// renderer of the group that enables edge lines (edgeGroupStyled); a later
+  /// member with different settings is reported and ignored. A group without
+  /// edge lines keeps an all-disabled EdgeStyle.
   std::vector<umbreon::EdgeStyle> groupEdgeStyle;
+  std::vector<char> edgeGroupStyled;
   /// Whether any section enabled edge lines (gates strokeEdges.enable) and
   /// whether any section requested creases (gates the global crease extraction).
   bool anyEdges = false;
@@ -401,7 +412,44 @@ void ensureLogSink()
 }
 #endif
 
+#ifdef HAVE_UMBREON
+/// Signature of a per-section edge style: which natures are enabled, their
+/// color/width/opacity, the silhouette mode and the alignment -- everything
+/// that decides which lines the section draws. Two renderers with the same
+/// signature draw the same lines, which is what the DEFAULT edge grouping
+/// keys on (one group, one style).
+LString edgeStyleKey(const umbreon::EdgeStyle &es)
+{
+  std::string s =
+      LString::format("m%d|a%d", int(es.silhouetteMode), int(es.align)).c_str();
+  for (int k = 0; k < int(umbreon::EdgeClass::Count); ++k) {
+    const umbreon::EdgeClassStyle &cs = es.cls[k];
+    if (!cs.enabled) {
+      s += "|-";
+      continue;
+    }
+    s += LString::format("|%.4f,%.4f,%.4f,%.4f,%.4f", double(cs.width),
+                         double(cs.opacity), double(cs.color[0]),
+                         double(cs.color[1]), double(cs.color[2]))
+             .c_str();
+  }
+  return LString(s.c_str());
+}
+
+/// Whether two per-section edge styles draw the same lines: the edge-group
+/// check that a later member of a NAMED group matches its first.
+bool sameEdgeStyle(const umbreon::EdgeStyle &a, const umbreon::EdgeStyle &b)
+{
+  return edgeStyleKey(a).equals(edgeStyleKey(b));
+}
+#endif
+
 }  // anonymous namespace
+
+void UmbreonDisplayContext::setEdgeGroup(const LString &name)
+{
+  m_edgeGroupName = name;
+}
 
 UmbreonDisplayContext::UmbreonDisplayContext()
      : super_t(), m_pImpl(new Impl()),
@@ -454,6 +502,9 @@ void UmbreonDisplayContext::startRender()
   m_pImpl->curGroup = 0;
   m_pImpl->groupBlend.clear();
   m_pImpl->groupEdgeStyle.clear();
+  m_pImpl->edgeGroupOf.clear();
+  m_pImpl->edgeGroupIds.clear();
+  m_pImpl->edgeGroupStyled.clear();
   m_pImpl->anyEdges = false;
   m_pImpl->anyCrease = false;
   m_pImpl->edgeThicknessPx = float(EDGE_THICKNESS_PX);
@@ -643,9 +694,58 @@ void UmbreonDisplayContext::appendIntData()
                                           : "edges(full)",
                   double(widthPx));
     }
-    if (m_pImpl->groupEdgeStyle.size() <= group)
-      m_pImpl->groupEdgeStyle.resize(std::size_t(group) + 1);
-    m_pImpl->groupEdgeStyle[group] = es;
+    // EDGE GROUP of this section (see Impl::edgeGroupOf). Renderers of one
+    // edge group are ONE section for umbreon's edge pass: no contact contour
+    // inside the group, its depth steps are self-occlusion, an Outline-mode
+    // group unions, and the group carries one style. The transparency group
+    // above stays per renderer.
+    //
+    // By DEFAULT the key is the renderer's own edge settings (type/mode,
+    // width, color), so renderers that draw the same lines are one group
+    // wherever they sit in the scene and renderers that draw different lines
+    // are separate -- which is the only grouping consistent with "one group,
+    // one style". A non-empty `egroup` property overrides it and groups by
+    // name (its first member's settings then style the whole group).
+    // (a section that draws no edge line at all has an all-disabled style,
+    // so every such section shares one key)
+    const LString egKey = m_edgeGroupName.isEmpty()
+                              ? "c:" + edgeStyleKey(es)
+                              : "n:" + m_edgeGroupName;
+    int egid;
+    {
+      auto it = m_pImpl->edgeGroupIds.find(egKey);
+      if (it == m_pImpl->edgeGroupIds.end()) {
+        egid = int(m_pImpl->edgeGroupIds.size());
+        m_pImpl->edgeGroupIds.insert(std::make_pair(egKey, egid));
+        m_pImpl->groupEdgeStyle.push_back(umbreon::EdgeStyle());
+        m_pImpl->edgeGroupStyled.push_back(0);
+      } else {
+        egid = it->second;
+      }
+    }
+    if (m_pImpl->edgeGroupOf.size() <= group)
+      m_pImpl->edgeGroupOf.resize(std::size_t(group) + 1, 0);
+    m_pImpl->edgeGroupOf[group] = static_cast<std::uint16_t>(egid);
+    MB_DPRINTLN("UmbreonDC> section %s: edge group %d (%s)",
+                getSecName().c_str(), egid, egKey.c_str());
+
+    // The edge group's style comes from its FIRST renderer with edge lines;
+    // a later member with different settings is reported and ignored (one
+    // group = one section = one style). Under the default keying the members
+    // agree by construction, so this only reports a named group whose
+    // members were given different settings. Members without edge lines
+    // leave the group's style alone.
+    if (bSil || bBorder || bCrease) {
+      umbreon::EdgeStyle &gs = m_pImpl->groupEdgeStyle[std::size_t(egid)];
+      if (!m_pImpl->edgeGroupStyled[std::size_t(egid)]) {
+        gs = es;
+        m_pImpl->edgeGroupStyled[std::size_t(egid)] = 1;
+      } else if (!sameEdgeStyle(gs, es)) {
+        LOG_DPRINTLN("Umbreon> section %s: edge settings differ from edge "
+                     "group '%s' first renderer; the group's settings are used",
+                     getSecName().c_str(), m_edgeGroupName.c_str());
+      }
+    }
   }
 
   // --- triangle mesh (de-indexed: 3 corners per triangle) ---
@@ -1160,10 +1260,16 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
     // chained silhouette is cut into visible runs.
     opt.strokeEdges.roundCap = true;
     opt.strokeEdges.roundJoin = true;
-    // Cover every group id; sections with no edge lines keep an all-disabled
-    // EdgeStyle, so the stroke pass draws nothing for them.
-    if (m_pImpl->groupEdgeStyle.size() < std::size_t(m_pImpl->nextGroup))
-      m_pImpl->groupEdgeStyle.resize(std::size_t(m_pImpl->nextGroup));
+    // One style per EDGE GROUP (groupEdgeStyle is indexed by edge group id;
+    // groups with no edge lines keep an all-disabled EdgeStyle, so the
+    // stroke pass draws nothing for them) and the renderer -> edge group map
+    // the pass keys its sections on. Every section went through
+    // appendIntData, so edgeGroupOf covers every transparency group.
+    if (m_pImpl->edgeGroupOf.size() < std::size_t(m_pImpl->nextGroup))
+      m_pImpl->edgeGroupOf.resize(std::size_t(m_pImpl->nextGroup), 0);
+    if (m_pImpl->groupEdgeStyle.size() < m_pImpl->edgeGroupIds.size())
+      m_pImpl->groupEdgeStyle.resize(m_pImpl->edgeGroupIds.size());
+    scene.edgeGroupOfGroup = m_pImpl->edgeGroupOf;
     scene.groupEdgeStyle = m_pImpl->groupEdgeStyle;
 
     // NPR default contours: give each section whose renderer requested no

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -91,13 +91,15 @@ namespace render {
     /// Ink the depth-CONTINUOUS contact/intersection contour between DIFFERENT
     /// renderer sections (umbreon strokeEdges.contact): the circle where one
     /// section's primitive plunges into another section's surface, e.g. a
-    /// stick entering another renderer's ribbon mesh. Such a boundary is
-    /// surface contact rather than occlusion, so umbreon vetoes it by default
-    /// and so does the GL view (its inverted hull is buried inside the other
-    /// surface there); a silhouette-mode section is therefore left with an
-    /// OPEN outer contour wherever it meets another renderer. Turning this on
-    /// closes it. Same-section contact stays seamless whatever this says.
-    bool contactEdges = false;
+    /// stick entering the ribbon mesh of another EDGE GROUP (renderers are
+    /// grouped by their egroup property, unnamed ones per object). Inside an
+    /// edge group a contact never inks: such a boundary is surface contact
+    /// rather than occlusion, and the GL view draws no line there either
+    /// (its inverted hull is buried inside the other surface). Between edge
+    /// groups the contact contour inks by default, closing a silhouette-mode
+    /// group's outer contour where it meets another group; false suppresses
+    /// every contact line.
+    bool contactEdges = true;
     /// When true, render a transparent background: the output is RGBA (4
     /// components) with alpha = coverage (0 where no geometry is hit), so the
     /// PNG can be composited over another image (POV "_transpbg").
@@ -246,6 +248,14 @@ namespace render {
     void enableEdgeLines(bool b) { m_bEnableEdgeLines = b; }
     void setCreaseLimit(double d) { m_dCreaseLimit = d; }
     void setEdgeRise(double d) { m_dEdgeRise = d; }
+    /// Edge group of the next section (Scene::displayRendImpl calls this
+    /// before startSection): renderers of one edge group are ONE section for
+    /// umbreon's edge pass. A non-empty `name` (the renderer's egroup
+    /// property) groups by name across the scene; an empty name groups the
+    /// renderer with every other renderer that draws the SAME edge lines
+    /// (type/mode, width, color) -- the only grouping consistent with one
+    /// style per group.
+    void setEdgeGroup(const LString &name) override;
 
   private:
     struct Impl;
@@ -257,6 +267,9 @@ namespace render {
     double m_dCreaseLimit;
     /// Edge line rise from the surface (along the vertex normal)
     double m_dEdgeRise;
+    /// Edge group name of the section being displayed (setEdgeGroup); empty
+    /// means "group by the edge settings themselves".
+    LString m_edgeGroupName;
 
     /// Build the umbreon camera from the seeded view state (eye-space:
     /// camera at (0,0,viewDist) looking down -Z).

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -53,8 +53,11 @@ runtime_class UmbreonRenderSettings
   default creaseLimit = -1.0;
   property real edgeRise => m_edgeRise;
   default edgeRise = 0.5;
+  /// Draw the depth-continuous contact contour between different edge groups
+  /// (renderer property egroup; unnamed renderers group per object). Inside
+  /// an edge group a contact never inks. False suppresses every contact line.
   property boolean contactEdges => m_contactEdges;
-  default contactEdges = false;
+  default contactEdges = true;
 
   property boolean useGI => m_useGI;
   default useGI = true;

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -147,7 +147,7 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_dLightIntensity(-1.0), m_dFlashFraction(-1.0),
        m_dAmbientFraction(-1.0),
        m_bEnableEdgeLines(true), m_dCreaseLimit(-1.0), m_dEdgeRise(0.5),
-       m_bContactEdges(false),
+       m_bContactEdges(true),
        m_bTransparentBackground(false),
        m_bGI(false), m_nGiSamples(32), m_dGiIntensity(1.0),
        m_dGiEnvIntensity(1.0), m_bGiDenoise(true), m_nDenoiser(0),

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -116,10 +116,10 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   property real edgeRise => m_dEdgeRise;
 
   /// ink the depth-CONTINUOUS contact/intersection contour between DIFFERENT
-  /// renderer sections (the circle where a stick plunges into another
-  /// renderer's ribbon surface). Off by default: such a boundary is surface
-  /// contact rather than occlusion, and the interactive GL view draws no line
-  /// there either. Same-section contact never inks whatever this says.
+  /// edge groups (the circle where a stick plunges into the ribbon of another
+  /// object). Renderers are grouped by their egroup property (unnamed ones
+  /// per object); inside a group a contact never inks whatever this says.
+  /// On by default; false suppresses every contact line.
   property boolean contactEdges => m_bContactEdges;
 
   //////////

--- a/src/qsys/Renderer.hpp
+++ b/src/qsys/Renderer.hpp
@@ -275,7 +275,20 @@ namespace qsys {
     /// Color of edge lines
     gfx::ColorPtr m_pEgLineCol;
 
+    /// Edge group name (umbreon rendering): renderers sharing a non-empty
+    /// name form one edge/silhouette group (no contact line inside the
+    /// group, one edge style); an empty name groups the renderer with the
+    /// other unnamed renderers of its object.
+    LString m_edgeGroupName;
+
   public:
+    const LString &getEdgeGroupName() const {
+      return m_edgeGroupName;
+    }
+    void setEdgeGroupName(const LString &n) {
+      m_edgeGroupName = n;
+    }
+
     double getEdgeLineWidth() const {
       return m_dEdgeLineWidth;
     }

--- a/src/qsys/Renderer.qif
+++ b/src/qsys/Renderer.qif
@@ -80,6 +80,13 @@ runtime_class Renderer
   property object<AbstractColor$> egcolor => redirect(getEdgeLineColor, setEdgeLineColor);
   default egcolor = gfx::SolidColor::createRGB(.0, .0, .0);
 
+  /// Edge group (umbreon rendering): renderers with the same non-empty
+  /// name form one edge/silhouette group -- no contact line between them and
+  /// one edge style (the first member's) for the whole group. Empty: grouped
+  /// with the other unnamed renderers of the same object.
+  property string egroup => redirect(getEdgeGroupName, setEdgeGroupName);
+  default egroup = "";
+
   //////////
 
   string toString();

--- a/src/qsys/Scene.cpp
+++ b/src/qsys/Scene.cpp
@@ -731,6 +731,7 @@ void Scene::displayRendImpl(DisplayContext *pdc, ObjectPtr pObj, RendererPtr pRe
   pdc->setEdgeLineType(nelt);
   pdc->setEdgeLineWidth(pRend->getEdgeLineWidth());
   pdc->setEdgeLineColor(pRend->getEdgeLineColor());
+  pdc->setEdgeGroup(pRend->getEdgeGroupName());
   
   bool bmat = false;
   Matrix4D xform = pRend->getXformMatrix();

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -1546,14 +1546,19 @@ void renderTwoSectionContact(bool contactEdges, std::size_t &outInk,
 
     ctx.startRender();
 
-    // One sphere per section, so the boundary between them is a CROSS-section
-    // one (same-section contact is seamless whatever contactEdges says).
+    // One sphere per section, in DIFFERENT edge groups (the two renderers
+    // have identical edge settings, which the default keying would put in one
+    // group), so the boundary between them is a cross-group one -- what
+    // contactEdges controls. A contact inside one group is seamless whatever
+    // the flag says.
+    ctx.setEdgeGroup("left");
     ctx.startSection("left");
     ctx.setMaterial("nolighting");
     ctx.color(gfx::SolidColor::createRGB(1.0, 1.0, 1.0));
     ctx.sphere(1.5, Vector4D(-0.9, 0.0, 0.0));
     ctx.endSection();
 
+    ctx.setEdgeGroup("right");
     ctx.startSection("right");
     ctx.setMaterial("nolighting");
     ctx.color(gfx::SolidColor::createRGB(1.0, 1.0, 1.0));
@@ -1634,6 +1639,135 @@ TEST(UmbreonExport, ContactEdgesInkTheCrossSectionIntersection)
     EXPECT_EQ(runsOff, 2);
     EXPECT_EQ(runsOn, 3);
     EXPECT_GT(inkOn, inkOff + 30);
+}
+
+namespace {
+
+/// The two intersecting spheres of renderTwoSectionContact, each section
+/// given an edge group NAME through setEdgeGroup (the renderer's egroup
+/// property, as Scene::displayRendImpl does; empty = group by the edge
+/// settings). `widthMulB` and `colorB` change the right section's edge
+/// SETTINGS (its width / its color), which the default keying separates on;
+/// the color also makes its ink invisible to countEdgeInk, so the width is
+/// what the contact-run counts vary.
+/// Returns the center-row ink count/runs and the frame.
+void renderTwoSectionGroups(const char *egA, const char *egB, double widthMulB,
+                            bool colorB, std::size_t &outInk, int &outRuns,
+                            std::vector<unsigned char> &outPix)
+{
+    const double kViewH = 6.0;
+    const double kLineScale = kViewH / kEdgeModeDim;
+
+    UmbreonDisplayContext ctx;
+    ctx.init();
+
+    ctx.setPerspective(false);
+    ctx.setViewDist(100.0);
+    ctx.setZoom(kViewH);
+    ctx.setLineScale(kLineScale);
+    ctx.setBgColor(gfx::SolidColor::createRGB(0.0, 0.0, 1.0));
+    ctx.loadIdent();
+
+    ctx.enableEdgeLines(true);
+    ctx.setEdgeLineType(gfx::DisplayContext::ELT_SILHOUETTE);
+    ctx.setEdgeLineWidth(2.0 * kLineScale);  // a 2 px band
+
+    ctx.startRender();
+
+    ctx.setEdgeLineColor(gfx::SolidColor::createRGB(0.0, 0.0, 0.0));
+    ctx.setEdgeGroup(egA);
+    ctx.startSection("left");
+    ctx.setMaterial("nolighting");
+    ctx.color(gfx::SolidColor::createRGB(1.0, 1.0, 1.0));
+    ctx.sphere(1.5, Vector4D(-0.9, 0.0, 0.0));
+    ctx.endSection();
+
+    ctx.setEdgeLineColor(colorB ? gfx::SolidColor::createRGB(1.0, 0.0, 0.0)
+                                : gfx::SolidColor::createRGB(0.0, 0.0, 0.0));
+    ctx.setEdgeLineWidth(widthMulB * 2.0 * kLineScale);
+    ctx.setEdgeGroup(egB);
+    ctx.startSection("right");
+    ctx.setMaterial("nolighting");
+    ctx.color(gfx::SolidColor::createRGB(1.0, 1.0, 1.0));
+    ctx.sphere(1.5, Vector4D(0.9, 0.0, 0.0));
+    ctx.endSection();
+
+    UmbreonRenderParams prm;
+    prm.width = kEdgeModeDim;
+    prm.height = kEdgeModeDim;
+    prm.supersample = 2;
+    prm.contactEdges = true;
+
+    int ow = 0, oh = 0, ncomp = 0;
+    ctx.render(prm, ow, oh, ncomp, outPix);
+    ASSERT_EQ(outPix.size(),
+              static_cast<std::size_t>(kEdgeModeDim * kEdgeModeDim * 3));
+
+    countEdgeInk(outPix, outInk, outRuns);
+}
+
+/// Red pixels (the right section's own edge color) in an RGB frame.
+std::size_t countRedInk(const std::vector<unsigned char> &pix)
+{
+    std::size_t n = 0;
+    for (std::size_t i = 0; i + 2 < pix.size(); i += 3)
+        if (pix[i] > 180 && pix[i + 1] < 60 && pix[i + 2] < 60) ++n;
+    return n;
+}
+
+}  // namespace
+
+// Pins the EDGE GROUPS (Renderer egroup -> DisplayContext::setEdgeGroup ->
+// Scene::edgeGroupOfGroup): renderers of one edge group are ONE section for
+// umbreon's edge pass, so the depth-continuous contact contour between them
+// never inks, while renderers of different groups get it (contactEdges is on
+// by default).
+//
+// By DEFAULT the grouping is by the edge SETTINGS themselves -- the only
+// grouping consistent with "one group, one style": renderers drawing the same
+// lines are one section wherever they sit, renderers drawing different lines
+// are separate. A non-empty egroup name overrides that either way.
+TEST(UmbreonExport, EdgeGroupsDecideWhereContactContoursInk)
+{
+    std::size_t ink = 0;
+    int runs = 0;
+    std::vector<unsigned char> pix;
+
+    // Same settings, no names: one edge group -> no contact line (2 runs).
+    renderTwoSectionGroups("", "", 1.0, false, ink, runs, pix);
+    EXPECT_EQ(runs, 2);
+
+    // Different settings (the right sphere's edge is twice as wide): two
+    // groups -> the contact line inks (3 runs).
+    renderTwoSectionGroups("", "", 2.0, false, ink, runs, pix);
+    EXPECT_EQ(runs, 3);
+
+    // Different settings but the same egroup name: one group again.
+    renderTwoSectionGroups("grp", "grp", 2.0, false, ink, runs, pix);
+    EXPECT_EQ(runs, 2);
+
+    // Same settings, different names: two groups.
+    renderTwoSectionGroups("a", "b", 1.0, false, ink, runs, pix);
+    EXPECT_EQ(runs, 3);
+}
+
+// One edge group has ONE edge style: the first member renderer with edge
+// lines defines it and a later member's own settings are ignored. The right
+// sphere asks for a red edge color: by default that is a different setting,
+// so it is its own group and its outer contour is red; forced into the (black)
+// left sphere's group by name, it is black.
+TEST(UmbreonExport, EdgeGroupUsesTheFirstMembersEdgeStyle)
+{
+    std::size_t ink = 0;
+    int runs = 0;
+    std::vector<unsigned char> pixOwn, pixShared;
+
+    renderTwoSectionGroups("", "", 1.0, true, ink, runs, pixOwn);
+    EXPECT_GT(countRedInk(pixOwn), 20u);
+
+    renderTwoSectionGroups("grp", "grp", 1.0, true, ink, runs, pixShared);
+    EXPECT_EQ(countRedInk(pixShared), 0u);
+    EXPECT_EQ(runs, 2);
 }
 
 namespace {


### PR DESCRIPTION
Renderers can now be put into **edge groups**, and the edge group -- not the renderer -- is what umbreon's edge pass treats as one section.

## Why

umbreon's screen-space edge pass keys every section rule on one unit: a depth-continuous **contact** contour never inks inside it and does across it, its depth steps are self-occlusion (vs. an object border across), an Outline-mode section unions, and it carries one style. That unit was one CueMol renderer, so the contact contour between renderers could only be switched scene-wide (`contactEdges`, off by default). There was no way to say "draw it between objects, but not between the renderers of one object".

## What changed

- **`Renderer::egroup`** (new string property, default empty): renderers with the same non-empty name are one edge group.
- **Default grouping (empty `egroup`): by the edge settings themselves** -- type/mode, width, color. Renderers drawing the same lines are one group wherever they sit in the scene; renderers drawing different lines are separate groups. This is the only default consistent with "one group, one style", and it puts the contact contour where it carries information (a ball-and-stick plunging into a ribbon) and not where it is noise (two renderers of one cartoon).
- `DisplayContext::setEdgeGroup(name)` carries it from `Scene::displayRendImpl`; `UmbreonDisplayContext` assigns the group ids and fills `Scene::edgeGroupOfGroup` (umbreon PR CueMol/umbreon#80). The transparency group stays per renderer.
- A named group takes its **first member's** edge settings; a later member with different settings is reported in the log and ignored.
- **`contactEdges` now defaults to true**: it selects whether cross-group contact contours are drawn at all, and the grouping decides where. `false` still suppresses every contact line.

## Verification

`task run_gtest FILTER=Umbreon`: 38/38, including two new tests (contact contours appear between groups and not inside one, by settings and by name in both directions; a named group takes its first member's style).

Rendered through `cuetty` against the previous per-renderer behavior:

| scene | result |
|---|---|
| tRNA_ion_test1 / test3 / test4 / test5 | byte-identical (their renderers' edge settings all differ, so each is its own group) |
| tRNA_ion_test2 | 1233 px: the stick and the dashed-line renderers share settings and merge, so their mutual contact lines go |
| test_color_1 | 2501 px, same cause |
| EAAT2 (8 chains, one style) | 15980 px: the chains merge into one group, so the contact contours between chains go. Per-chain `egroup` names bring them back |
| egrp_test5 (ribbon 0.06 A + ball-and-stick 0.15 A) | two groups, and the intersection contour where the sticks enter the ribbon is drawn -- the scene this feature is for |

The style of a cross-group contact contour is decided on the umbreon side (CueMol/umbreon#80, fix 11): the side whose line is wider, then darker, owns it, so in egrp_test5 the intersection contour continues the ball-and-stick's 0.15 A line rather than depending on which renderer the scene lists first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtJAhjZSes3KPJiJNZ3Gj

