### PR TITLE
fix(render): keep creaseLimit a real; the crease dropdown maps in the GUI

### DIFF
--- a/src/modules/rendering/RenderSettings.cpp
+++ b/src/modules/rendering/RenderSettings.cpp
@@ -40,7 +40,7 @@ UmbreonRenderSettings::UmbreonRenderSettings()
       m_shadows(false),
       m_shadowSamples(1),
       m_lightRadius(0.0),
-      m_creaseLimit("Off"),
+      m_creaseLimit(0.0),
       m_edgeRise(0.0),
       m_contactEdges(true),
       m_outlineFarDepth(0.2),

--- a/src/modules/rendering/RenderSettings.hpp
+++ b/src/modules/rendering/RenderSettings.hpp
@@ -64,7 +64,7 @@ namespace render {
     bool m_shadows;
     int m_shadowSamples;
     double m_lightRadius;
-    LString m_creaseLimit;  // "Off" or the crease fold angle in degrees
+    double m_creaseLimit;
     double m_edgeRise;
     bool m_contactEdges;
     double m_outlineFarDepth;

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -50,12 +50,12 @@ runtime_class UmbreonRenderSettings
   default lightRadius = 0.0;
 
   /// Crease lines (edges edge mode only): a boundary where the surface normal
-  /// folds by more than this angle inks as an edge line, in the renderer's
-  /// edge color and width. "Off" = no crease lines; otherwise the angle in
-  /// degrees ("15", "30", "45", "60", "90", "120" in the GUI; any positive
-  /// number parses). A larger angle inks fewer, sharper folds.
-  property string creaseLimit => m_creaseLimit;
-  default creaseLimit = "Off";
+  /// folds by more than this angle (degrees) inks as an edge line, in the
+  /// renderer's edge color and width. -1 (or 0) = no crease lines. A larger
+  /// angle inks fewer, sharper folds. The GUI offers a fixed set (Off, 15,
+  /// 30, 45, 60, 90, 120); the property itself stays a real.
+  property real creaseLimit => m_creaseLimit;
+  default creaseLimit = -1.0;
   property real edgeRise => m_edgeRise;
   default edgeRise = 0.5;
   /// Draw the depth-continuous contact contour between different edge groups

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -458,20 +458,7 @@ LString UmbreonSceneExporter::applyRenderSettings(
   m_dAmbientFraction =
       useGI ? ub.r("ambientFraction", m_dAmbientFraction) : DIRECT_AMBIENT_FRACTION;
 
-  // Crease angle (the settings' "creaseLimit" string): "Off" -- or any
-  // non-positive number, which is what a scene saved by the older real-typed
-  // setting holds -- disables crease lines; otherwise the fold angle in
-  // degrees. An empty/absent value leaves the exporter's own setting alone.
-  {
-    const LString ca = ub.s("creaseLimit", LString());
-    if (!ca.isEmpty()) {
-      double deg = -1.0;
-      if (ca.equalsIgnoreCase("Off") || !ca.toDouble(&deg) || deg <= 0.0)
-        m_dCreaseLimit = -1.0;
-      else
-        m_dCreaseLimit = deg;
-    }
-  }
+  m_dCreaseLimit = ub.r("creaseLimit", m_dCreaseLimit);
   m_dEdgeRise = ub.r("edgeRise", m_dEdgeRise);
   m_bContactEdges = ub.b("contactEdges", m_bContactEdges);
   m_dOutlineFarDepth = ub.r("outlineFarDepth", m_dOutlineFarDepth);

--- a/src/tests/modules/rendering/test_umbreon_apply_settings.cpp
+++ b/src/tests/modules/rendering/test_umbreon_apply_settings.cpp
@@ -71,7 +71,7 @@ TEST(UmbreonApplySettings, AppliesCommonAndUmbreonBlock)
     EXPECT_TRUE(ub->setPropReal("ambientFraction", 0.3));
     EXPECT_TRUE(ub->setPropBool("giSkyGradient", false));
     EXPECT_TRUE(ub->setPropStr("giGroundColor", "#123456"));
-    EXPECT_TRUE(ub->setPropStr("creaseLimit", "45"));
+    EXPECT_TRUE(ub->setPropReal("creaseLimit", 45.0));
     EXPECT_TRUE(ub->setPropReal("outlineFarDepth", 0.3));
 
     UmbreonSceneExporter ex;
@@ -93,7 +93,7 @@ TEST(UmbreonApplySettings, AppliesCommonAndUmbreonBlock)
     EXPECT_TRUE(propBool(ex, "aoMultiScale"));  // block default, written while AO is on
     EXPECT_TRUE(propBool(ex, "shadows"));
     EXPECT_EQ(propInt(ex, "shadowSamples"), 4);
-    EXPECT_DOUBLE_EQ(propReal(ex, "creaseLimit"), 45.0);  // "45" -> 45 degrees
+    EXPECT_DOUBLE_EQ(propReal(ex, "creaseLimit"), 45.0);
     EXPECT_DOUBLE_EQ(propReal(ex, "outlineFarDepth"), 0.3);
 
     // GI (the block default is GI on)

--- a/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
+++ b/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
@@ -63,7 +63,7 @@ const UMBREON: Record<string, Value> = {
     shadows: false,
     shadowSamples: 1,
     lightRadius: 0,
-    creaseLimit: "Off",
+    creaseLimit: -1,
     contactEdges: false,
     outlineFarDepth: 0.2,
     useGI: true,

--- a/tritium/react-gui/src/renderer/__test__/sceneRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/sceneRenderSettings.test.ts
@@ -93,4 +93,26 @@ describe('sceneRenderSettings', () => {
         expect(valuesFromSnapshot(fresh, { backendExplicit: false }).backend).toBe('');
         warn.mockRestore();
     });
+
+    it('shows a numeric enum (the crease angle) as its label and stores the number', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const key = blockKey('umbreon', 'creaseLimit');
+        // The C++ real -1 (off) and 30 show as their labels...
+        const off = snapshotFromRenderSettings(fixtureValues({ backend: 'umbreon', [key]: -1 }), { defaults, umbreonAvailable: true, mode: 'strict' });
+        expect(valueOf(off.backendProps, 'creaseLimit')).toBe('Off');
+        const deg = snapshotFromRenderSettings(fixtureValues({ backend: 'umbreon', [key]: 30 }), { defaults, umbreonAvailable: true, mode: 'strict' });
+        expect(valueOf(deg.backendProps, 'creaseLimit')).toBe('30');
+        // ...and go back to the scene as numbers, whatever the editor holds.
+        expect(valuesFromSnapshot(deg)[key]).toBe(30);
+        const edited = { ...deg, backendProps: deg.backendProps.map((p) => (p.key === 'creaseLimit' ? { ...p, value: '45' } : p)) };
+        expect(valuesFromSnapshot(edited)[key]).toBe(45);
+        expect(valuesFromSnapshot(off)[key]).toBe(-1);
+        // A number that is not one of the options (an older scene's slider
+        // value) falls back to the default's label with a warning.
+        const odd = snapshotFromRenderSettings(fixtureValues({ backend: 'umbreon', [key]: 33 }), { defaults, umbreonAvailable: true });
+        expect(valueOf(odd.backendProps, 'creaseLimit')).toBe('Off');
+        expect(odd.warnings.map((w) => w.split(':')[0])).toEqual([key]);
+        expect(SCENE_VALUE_TYPES[key]).toBe('real');
+        warn.mockRestore();
+    });
 });

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -99,11 +99,13 @@ const UMBREON_PROPS: RenderPropSpec[] = [
   // --- Edges ---
   // Crease lines (edges edge mode only): folds of the surface normal sharper
   // than this angle ink as edge lines; a larger angle inks fewer, sharper
-  // folds. The C++ side parses the string ("Off" = no crease lines).
+  // folds. A dropdown over the C++ real property (-1 = no crease lines), so
+  // an older libcuemol2 and an older scene keep reading and writing numbers.
   // The POV-Ray-only `edgeRise` (how far its 3D edge geometry is lifted off
   // the surface) is not listed: umbreon's screen-space strokes never use it.
   { key: "creaseLimit",   label: "Crease angle (deg)", type: "enum", group: "Edges",
-    options: ["Off", "15", "30", "45", "60", "90", "120"] },
+    options: ["Off", "15", "30", "45", "60", "90", "120"],
+    enumValues: [-1, 15, 30, 45, 60, 90, 120] },
   // Contact contours BETWEEN renderers: the intersection circle where one
   // renderer's geometry plunges into another's surface (a stick entering a
   // ribbon). It is surface contact, not occlusion, so neither umbreon nor the

--- a/tritium/react-gui/src/renderer/data/rendererProperties.ts
+++ b/tritium/react-gui/src/renderer/data/rendererProperties.ts
@@ -43,6 +43,12 @@ export interface PropDef {
   decimals?: number;
   /** For enum types: valid options. For combo types: preset suggestions. */
   options?: string[];
+  /**
+   * For enum types whose C++ property is a NUMBER: the stored value of each
+   * option, by index. The editor shows the option label; the scene holds the
+   * number (a crease angle dropdown over a real property, say).
+   */
+  enumValues?: number[];
   /** Accordion group this property belongs to in the editor. */
   group: string;
   /**

--- a/tritium/react-gui/src/renderer/features/render/sceneRenderSettings.ts
+++ b/tritium/react-gui/src/renderer/features/render/sceneRenderSettings.ts
@@ -69,6 +69,19 @@ const HATCH_SPEC_KEYS = ["hatchLayersSpec", "hatchToneSpec"] as const;
 /** The stored key of a backend row. */
 export const blockKey = (backend: RenderBackendId, key: string): string => `${backend}.${key}`;
 
+/** An enum row stored as a number (PropDef.enumValues): label <-> value by index. */
+const isNumericEnum = (p: RenderPropSpec): boolean => p.type === "enum" && p.enumValues !== undefined;
+
+function enumLabelOf(p: RenderPropSpec, v: number): string | undefined {
+  const i = (p.enumValues ?? []).indexOf(v);
+  return i >= 0 ? p.options?.[i] : undefined;
+}
+
+function enumValueOf(p: RenderPropSpec, label: string): number | undefined {
+  const i = (p.options ?? []).indexOf(label);
+  return i >= 0 ? p.enumValues?.[i] : undefined;
+}
+
 function catalogType(p: RenderPropSpec): SceneValueType {
   switch (p.type) {
     case "boolean":
@@ -77,6 +90,8 @@ function catalogType(p: RenderPropSpec): SceneValueType {
       return "integer";
     case "real":
       return "real";
+    case "enum":
+      return isNumericEnum(p) ? "real" : "string";
     default:
       return "string";
   }
@@ -127,6 +142,7 @@ function accepts(p: RenderPropSpec, v: unknown): boolean {
       return true;
     }
     case "enum":
+      if (isNumericEnum(p)) return typeof v === "number" && (p.enumValues ?? []).includes(v);
       return typeof v === "string" && (p.options ?? []).includes(v);
     case "combo":
       // Presets only suggest: a typed value (450 DPI) is as valid as a preset.
@@ -170,18 +186,22 @@ export function withValues(
       return placeholderValue(row);
     };
 
+    // A numeric enum row shows its option label; the scene holds the number.
+    const shown = (v: string | number | boolean): string | number | boolean =>
+      isNumericEnum(row) && typeof v === "number" ? (enumLabelOf(row, v) ?? v) : v;
+
     const v = values[path];
     if (v === undefined) {
       const fb = fallback();
       warnings.push(`${path}: missing, using ${JSON.stringify(fb)}`);
-      return { ...row, value: fb };
+      return { ...row, value: shown(fb) };
     }
     if (!accepts(row, v)) {
       const fb = fallback();
       warnings.push(`${path}: unacceptable value ${JSON.stringify(v)}, using ${JSON.stringify(fb)}`);
-      return { ...row, value: fb };
+      return { ...row, value: shown(fb) };
     }
-    return { ...row, value: v };
+    return { ...row, value: shown(v) };
   });
 }
 
@@ -298,13 +318,16 @@ export function valuesFromSnapshot(
   opts: { backendExplicit: boolean } = { backendExplicit: true },
 ): RenderSettingsValues {
   const out: RenderSettingsValues = { backend: opts.backendExplicit ? s.backend : "" };
-  const put = (path: string, value: string | number | boolean): void => {
+  const put = (path: string, value: string | number | boolean, row?: PropDef): void => {
     const type = SCENE_VALUE_TYPES[path];
     if (!type) return;
-    out[path] = coerce(type, value);
+    // A numeric enum row holds its option label; the scene gets the number.
+    const stored =
+      row && isNumericEnum(row) && typeof value === "string" ? (enumValueOf(row, value) ?? value) : value;
+    out[path] = coerce(type, stored);
   };
-  for (const p of s.commonProps) put(p.key, p.value);
-  for (const p of s.backendProps) put(blockKey(s.backend, p.key), p.value);
+  for (const p of s.commonProps) put(p.key, p.value, p);
+  for (const p of s.backendProps) put(blockKey(s.backend, p.key), p.value, p);
   if (s.backend === "umbreon_npr") {
     put(blockKey("umbreon_npr", "hatchLayersSpec"), s.hatch?.layersSpec ?? "");
     put(blockKey("umbreon_npr", "hatchToneSpec"), s.hatch?.toneSpec ?? "");


### PR DESCRIPTION
Fixes the Rendering window drift reported after #601 (a lighting change flipping the projection to perspective, projection and lighting edits not sticking).

## Cause

#601 changed the umbreon settings block's `creaseLimit` from a real to a string enum ("Off" / "15" / ...). The tritium addon loads its own copy of libcuemol2 (`tritium/core/build/lib`), so a GUI from `develop` running against an addon built a few minutes earlier met a real property where the catalog expected a string: the settings write failed inside its undo transaction and the editor drifted from the scene. Any property TYPE change carries that hazard across the addon / GUI boundary; a change of the value set does not.

## What changed

- `creaseLimit` is a real again (-1 = off; the exporter reads it as before, in degrees).
- The dropdown is a GUI matter: an enum row may declare `enumValues`, the number stored for each option, and the render settings conversion shows the label for the stored number and writes the number for the chosen label ("Off" <-> -1, "30" <-> 30). A stored number outside the options (an older slider value) falls back to the default's label with a warning. Works against an addon built before or after this change.
- `edgeRise` stays unlisted for umbreon.

## Verification

`task run_gtest FILTER=Umbreon` 41/41 (the settings round trip sets 45 and reads 45 back); tritium `tsc` clean, vitest 3739/3739 with a new test for the numeric enum (label <-> number both ways, out-of-set fallback, stored type real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtJAhjZSes3KPJiJNZ3Gj
