### PR TITLE
refactor(render): giSamples is an integer property

### DIFF
--- a/src/modules/rendering/RenderSettings.cpp
+++ b/src/modules/rendering/RenderSettings.cpp
@@ -45,6 +45,7 @@ UmbreonRenderSettings::UmbreonRenderSettings()
       m_contactEdges(true),
       m_outlineFarDepth(0.2),
       m_useGI(false),
+      m_giSamples(32),
       m_giSkyGradient(false),
       m_lightIntensity(0.0),
       m_flashFraction(0.0),

--- a/src/modules/rendering/RenderSettings.hpp
+++ b/src/modules/rendering/RenderSettings.hpp
@@ -69,7 +69,7 @@ namespace render {
     bool m_contactEdges;
     double m_outlineFarDepth;
     bool m_useGI;
-    LString m_giSamples;
+    int m_giSamples;
     LString m_denoise;
     bool m_giSkyGradient;
     LString m_giGroundColor;

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -76,9 +76,10 @@ runtime_class UmbreonRenderSettings
 
   property boolean useGI => m_useGI;
   default useGI = true;
-  /// Gather samples per pixel as the GUI option string ("8" | "32" | ...)
-  property string giSamples => m_giSamples;
-  default giSamples = "32";
+  /// GI gather samples per pixel. Any positive count; the GUI offers a
+  /// fixed set (8, 32, 64, 256).
+  property integer giSamples => m_giSamples;
+  default giSamples = 32;
   /// "OIDN" | "A-trous" | "None"
   property string denoise => m_denoise;
   default denoise = "OIDN";

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -485,12 +485,11 @@ LString UmbreonSceneExporter::applyRenderSettings(
     m_sHatchToneSpec = ub.s("hatchToneSpec", "");
   } else {
     //////////
-    // Diffuse global illumination. The sample count is stored as the GUI's
-    // option string; giIntensity / giEnvIntensity are not stored and stay
-    // at the exporter's neutral 1.0 (the energy balance covers that ground).
-    int nSamples = 32;
-    if (!ub.s("giSamples", "32").toInt(&nSamples) || nSamples <= 0) nSamples = 32;
-    m_nGiSamples = nSamples;
+    // Diffuse global illumination. giIntensity / giEnvIntensity are not
+    // stored and stay at the exporter's neutral 1.0 (the energy balance
+    // covers that ground).
+    m_nGiSamples = ub.i("giSamples", m_nGiSamples);
+    if (m_nGiSamples <= 0) m_nGiSamples = 32;
     denoiseMode(ub.s("denoise", "OIDN"), m_bGiDenoise, m_nDenoiser);
     m_bGiSkyGradient = ub.b("giSkyGradient", m_bGiSkyGradient);
     m_sGiGroundColor = ub.s("giGroundColor", m_sGiGroundColor);

--- a/src/tests/modules/rendering/test_umbreon_apply_settings.cpp
+++ b/src/tests/modules/rendering/test_umbreon_apply_settings.cpp
@@ -65,7 +65,7 @@ TEST(UmbreonApplySettings, AppliesCommonAndUmbreonBlock)
     EXPECT_TRUE(ub->setPropReal("aoDiffuseFactor", 0.5));
     EXPECT_TRUE(ub->setPropBool("shadows", true));
     EXPECT_TRUE(ub->setPropInt("shadowSamples", 4));
-    EXPECT_TRUE(ub->setPropStr("giSamples", "64"));
+    EXPECT_TRUE(ub->setPropInt("giSamples", 64));
     EXPECT_TRUE(ub->setPropStr("denoise", "A-trous"));
     EXPECT_TRUE(ub->setPropReal("lightIntensity", 1.0));
     EXPECT_TRUE(ub->setPropReal("ambientFraction", 0.3));

--- a/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
+++ b/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
@@ -67,7 +67,7 @@ const UMBREON: Record<string, Value> = {
     contactEdges: false,
     outlineFarDepth: 0.2,
     useGI: true,
-    giSamples: '32',
+    giSamples: 32,
     denoise: 'OIDN',
     giSkyGradient: true,
     giGroundColor: '#666666',

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -123,9 +123,10 @@ const UMBREON_PROPS: RenderPropSpec[] = [
   // OIDN denoiser on, the umbreon guide's low / medium / high / reference
   // steps (8 / 32 / 64 / 256) converge to the same picture and differ only
   // in residual detail and animation stability, so a dropdown of those
-  // counts is all the choice that is worth offering.
+  // counts is all the choice that is worth offering. The C++ property is an
+  // integer (any count); the dropdown is this catalog's restriction only.
   { key: "giSamples",     label: "GI samples",         type: "enum", group: "Global Illumination",
-    options: ["8", "32", "64", "256"] },
+    options: ["8", "32", "64", "256"], enumValues: [8, 32, 64, 256] },
   // giIntensity / giEnvIntensity (umbreon's indirect gain and sky multiplier)
   // are deliberately NOT offered: the energy balance below covers the same
   // ground more directly, and they stay at their neutral 1.0 on the exporter.


### PR DESCRIPTION
The umbreon settings block stored the GI sample count as the GUI's option string (`"8" | "32" | "64" | "256"`) and the exporter parsed it back to an integer: a dropdown's restriction pushed down into the backend's schema, the same shape as the `creaseLimit` mistake fixed in #602. A survey of every `.qif` (166 files), the exporters' string-to-number parsing and the GUI's option lists found this to be the only remaining instance.

## What changed

- `UmbreonRenderSettings.qif`: `property integer giSamples` (any positive count, default 32) instead of `property string`; the exporter reads it with `ub.i` (a non-positive value falls back to 32).
- GUI: the "GI samples" row keeps its dropdown (8 / 32 / 64 / 256) through the numeric enum rows of #602 (`enumValues`), so the scene holds the number and the editor shows the label.
- A scene saved with the old string attribute (`giSamples="32"`) loads into the integer property the way every integer attribute does.

**Local builds**: this is a property TYPE change, so the addon's libcuemol2 copy (`tritium/core/build/lib`) and the GUI must be updated together (`task build_tritium`); a GUI from this branch against an older addon would drift as in the creaseLimit case.

## Verification

`task run_gtest FILTER=Umbreon` 41/41 (the settings round trip sets 64 with `setPropInt` and reads 64 back on the exporter); tritium `tsc` clean, vitest 3739/3739 (the fixture holds the number; the editor still shows "32").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPtJAhjZSes3KPJiJNZ3Gj
