### PR TITLE
fix: group-alpha veil reporting + per-pixel blend setting; keep the hover highlight under the context menu

### DIFF
--- a/docs/architecture/gpu-id-picking.md
+++ b/docs/architecture/gpu-id-picking.md
@@ -203,7 +203,8 @@ GUIView::hitTest(x, y)   [View::hasGpuPick() && stereo == CSM_NONE]
   `setHoverHit` が GPU pick 有効時だけ present 専用フレームを予約すること、hover 要素 -> pick texel ID の変換
   `hoverIdToPickId` (`test_guiview.cpp`)、`hover_hl_color` の既定 (`test_viewinputconfig.cpp`)。tritium:
   `naviHover` の `highlight` 引数が `setHoverHit` / `clearHoverHit` に写ること (`naviHoverService.test.ts`)、
-  hover 終了時に `naviHoverClear` が 1 回だけ送られること (`useHoverInfoHandler.test.tsx`)。
+  hover 終了時に `naviHoverClear` が 1 回だけ送られること、右押下と context menu の hold では clear せず解除で
+  再サンプルすること (`useHoverInfoHandler.test.tsx`)。
 
 ## 8. ビルドの注意
 - tritium の addon は `.build_out` の dylib ではなく `tritium/core/build/lib/libcuemol2.dylib` (core の install 時に
@@ -297,6 +298,15 @@ present 専用フレーム (setHoverHit / clearHoverHit だけが起きた):
   (cartoon 系でも残基 pivot 原子の ID) なので、C++ は `hoverIdToPickId` で pick texel の ID に戻す。
 - hover の終了 (pane 外 / drag 開始 / view 切替 / pref off) で `useHoverInfoHandler` が `naviHoverClear` を
   1 回だけ (`{ quiet: true }`) 送る。worker はメッセージを順に処理するので、in-flight の hover 要求の後に届く。
+- **context menu 中は hold**: 右押下 (`e.button === 2`) は navigation drag ではなく context menu のジェスチャなので
+  hover を終了させない (左 / 中ボタンは従来どおり clear)。`useNaviContextMenu` はメニューの `await` (macOS の
+  `NAVI_CTX_SHOW` / Windows・Linux の `showContextMenu`) だけを `withHoverHold`
+  (`features/molview/hoverHold.ts`) で包み、hold 中の `useHoverInfoHandler` は mousemove / mouseleave で clear も
+  再サンプルもせず、ポインタ位置だけ記録する。メニューが実行 / キャンセルで解決したら記録した位置で hit test を
+  1 回出し直す (canvas 外に出ていれば clear)。凍結した hit を残すのではなく再サンプルするのは、`centerAt` の
+  ようにビューを動かすアクションの後でもポインタ下の要素が光るようにするため。hold は context ではなく module
+  state — holder (`useNaviContextMenu`) と controller (`MolViewHoverLabel` 内) は兄弟で、hold でどちらも
+  再描画させない。メニュー実行後のダイアログ (`createSymmMol`) には hold を伸ばさない。
 - highlight の同値判定は C++ (`setHoverHit`) 側。chip の dedupe (`hoverLabelKey`) とは独立。
 
 ### 10.4 制約

--- a/docs/architecture/umbreon-group-alpha-blend.md
+++ b/docs/architecture/umbreon-group-alpha-blend.md
@@ -5,9 +5,11 @@ a multi-pass blend whose weights must sum to exactly 1, what breaks when they
 do not, and why the background coefficient is allowed to go negative. Written
 up after opaque renderers blew out to white in a scene with two nearly-opaque
 sections (fixed in [CueMol/umbreon#66](https://github.com/CueMol/umbreon/pull/66),
-host-verified from tritium on 2026-07-25).
+host-verified from tritium on 2026-07-25), and extended after black edge lines
+came out **white** under two translucent sections of the same alpha — the same
+formula, read per pixel (see "Sections sharing an alpha are one veil").
 
-Related: [umbreon の Electron メモリ制約と process 分離設計](umbreon-process-isolation.md).
+Related: [umbreon の Electron メモリ制約と process 分離設計](../plans/umbreon-process-isolation-plan.md).
 
 ## Context
 
@@ -28,8 +30,11 @@ maps one CueMol section to one umbreon transparency group and hands umbreon a
 
 ```
 out = (1 - sum_i a_i) * render(scene minus every blend group)
-    + sum_i a_i       * render(scene with group i kept, other groups hidden)
+    + sum_i a_i       * render(scene with veil i kept, other veils hidden)
 ```
+
+where `i` runs over **veils**: entries sharing an alpha are one veil (see
+below), so the host's per-section entries are the input, not the layer list.
 
 ## The defect: clamping the background weight
 
@@ -59,6 +64,49 @@ libcuemol2 keeps a cross-layer regression test
 blend table it hands to umbreon (`Umbreon> group alpha: ...`, including the
 background weight).
 
+## Sections sharing an alpha are one veil
+
+A second scene (`transp/transp_test1.qsc`: `dsurf2 @0.6`, `ballstick @1.0` with
+black edge lines, `cpk @0.6`) drew those **black edge lines white**. The log
+read `sum=1.200, bg weight=-0.200`: two sections at the same alpha reached
+umbreon as two separate blend entries, so that one veil was counted twice.
+
+The formula above is a global weighted sum, but its effect is per pixel. For a
+pixel covered by the veil set `K`, collapsing the passes gives
+
+```
+out = (1 - sum_{i in K} a_i) * B  +  sum_{i in K} a_i * S_i
+```
+
+because a veil pass shows the opaque geometry `B` wherever its own veil does
+not cover. So a pixel under **one** 0.6 veil is fine (`0.4*B + 0.6*S`) even
+with a negative global weight — that is why nothing looked wrong outside the
+overlap. Where **both** 0.6 veils cover, the coefficient of `B` is `-0.2`, and
+a negative coefficient inverts contrast: black ink contributes nothing while
+its lit surroundings subtract, so the ink comes out the brightest thing in the
+frame.
+
+The fix bucket the entries by alpha in umbreon's `renderImpl` (1e-4 tolerance;
+first appearance names the veil's alpha and its pass order), one pass per
+**distinct** alpha showing every group of that veil. Two 0.6 sections are then
+one 0.6 veil, `bg weight = 0.4`, and the scene renders in 2 passes instead of 3.
+
+**Why the merge is umbreon's and not the host's.** `appendIntData` assigns the
+transparency group id, but that id is also the key of the edge-group table
+(`edgeGroupOf` -> `Scene::edgeGroupOfGroup`), of `Scene::groupHatchStyle` and of
+the objectId AOV. `edgeGroupFor(group)` is a *function of group id*, so two
+sections sharing an id could not sit in different edge groups at all — merging
+ids host-side would silently collapse edge groups. The id therefore stays a
+per-section **identity**; the veils (by alpha) and the edge groups (by the
+table) partition the same ids independently, and any combination is
+expressible. The legacy POV path merged in the same place: the layering lives
+in the render driver (`povrender.js`), not in section identity.
+
+The host consequently stopped restating the arithmetic: its log line now reports
+only which sections are translucent and at what alpha, and umbreon logs the
+veil/weight table (`group-alpha: 2 blend group(s) -> 1 veil(s), sum 0.600, bg
+weight 0.400`) plus a warning whenever the background weight is still negative.
+
 ## Consequences and limits
 
 - Scenes with several nearly-opaque renderers render correctly. libcuemol2
@@ -68,12 +116,16 @@ background weight).
   from source at `UMBREON_GIT_REF` (`build_scripts/deplibs.env`, currently
   `main`), so the umbreon change had to land first. A local checkout with a
   stale umbreon fails the regression test — which is the intended signal.
-- Two blend groups that **overlap each other** can still overshoot: asking for
-  0.95 + 0.95 in one pixel yields `-0.9*B + 0.95*G1 + 0.95*G2`, which can
-  exceed 1 and clip. This is inherent to the model and blendpng behaves the
-  same way; not addressed.
-- One extra full render pass per translucent section remains the cost of the
-  model. The new log line makes that visible (`N of M sections`).
+- Veils that **overlap each other** can still overshoot, but only with two or
+  more **distinct** alphas: 0.6 + 0.5 in one pixel yields
+  `-0.1*B + 0.6*G1 + 0.5*G2`, which inverts `B` there exactly as the same-alpha
+  case did. This is inherent to a model that weights whole frames; blendpng
+  behaves the same way. umbreon now warns when the background weight goes
+  negative, so the case is announced instead of silent. A real fix needs
+  per-pixel weights (the coverage set is per pixel, the weights are not).
+- One extra full render pass per **veil** is the cost of the model, so equal
+  alphas are also cheaper: the log lines make both visible (host: which sections
+  are translucent; umbreon: groups -> veils and the weights).
 
 ## Why POV-Ray never showed it
 
@@ -87,6 +139,11 @@ scene. umbreon has no such constraint and correctly keeps `alpha = 0.95` as a
 95% blend; that divergence in the `[0.95, 1.0)` range is intentional and not
 "fixed" by matching POV's cutoff.
 
+Merging equal alphas, on the other hand, is a real rule and umbreon now has it
+(above). Only POV's **quantisation** is the accident: `povrender.js:329` renders
+the quantised weight (`0.<key>`), so 0.64 and 0.55 both come out as 0.6. umbreon
+merges within 1e-4 and renders the alpha it was given.
+
 ## Reproduction
 
 `src/tests/modules/rendering/test_umbreon_export.cpp`
@@ -97,16 +154,27 @@ scene. umbreon has no such constraint and correctly keeps `alpha = 0.95` as a
 |---|---|---|---|
 | 0 | 0.00 | 1.00 | 217 |
 | 1 (0.95) | 0.95 | 1.00 | 217 |
-| 2 (0.95 x 2) | 1.90 | 1.90 | 255 (white) |
+| 2 (0.95 + 0.9) | 1.85 | 1.00 | 217 |
 
-umbreon's own unit-level guard is `T9` in
+(The two-section case uses **distinct** alphas: equal ones are now one veil and
+would not reach `sum > 1` at all.)
+
+The same-alpha inversion is pinned by
+`UmbreonExport.DarkFeatureStaysDarkUnderTwoSameAlphaSections` in the same file:
+a black patch on an opaque section, covered by two 0.6 sections, must stay
+darker than the lit part of that section (both sampled pixels sit under both
+veils, so the veil term cancels and only the background weight is compared).
+
+umbreon's own unit-level guards are `T9` (distinct alphas keep the negative
+background weight) and `T10` (equal alphas are one veil) in
 `tests/test_render_transparency.cpp`.
 
 ## Implementation pointers
 
 - `src/modules/rendering/UmbreonDisplayContext.cpp` — `appendIntData` assigns
   one group per section and pushes the `groupBlend` entry; `render()` hands
-  `scene.groupBlend` over and logs the summary.
+  `scene.groupBlend` over and logs which sections are translucent (the veil /
+  weight table is umbreon's and is logged there).
 - `src/utils/blendpng.cpp` — `solvebeta` (`:281`) and the lerp chain
   (`:466-480`). Expanding it for `beta = [0.9, 0.8]` gives coefficients
   `(-0.7, 0.9, 0.8)`, summing to 1: the reference for the closed form above.

--- a/docs/architecture/umbreon-group-alpha-blend.md
+++ b/docs/architecture/umbreon-group-alpha-blend.md
@@ -117,8 +117,7 @@ force the sum under 1 would change the transparency the user asked for.
 
 umbreon therefore has a second mode (`RenderOptions::groupBlendMode`, exposed as
 the `perPixelBlend` render setting and the Rendering window's *Per-pixel
-transparency* switch, default **off**). It composites at the stage where coverage
-still exists -- the supersampled, linear frame, before the box-downsample that
+transparency* switch). It composites at the stage where coverage still exists -- the supersampled, linear frame, before the box-downsample that
 turns per-sample coverage into partial pixels -- with weights built per sample
 from the veils covering it:
 
@@ -148,6 +147,26 @@ What it does not do: the weights are order-free, so within an overlap the veils
 do not attenuate each other by depth (a true front-to-back `over` would need a
 depth buffer per veil). Shadow / GI interaction between veils stays the
 per-pass approximation it always was.
+
+**This mode is the default** (`perPixelBlend = true`), host-verified on the
+transp test scenes. The layer weights remain selectable, and stay the reference
+for blendpng / POV-Ray parity -- the regression test for the negative background
+weight pins that mode explicitly.
+
+Measured on `data/1ab0_scene2.pov` with two veils (0.6 + 0.5), Apple Silicon:
+
+| | layer weights | per-pixel |
+|---|---|---|
+| 900 px, ss 3 | 0.71 s, 553 MB peak | 0.69 s, 819 MB peak |
+| 1600 px, ss 3, edges | 2.56 s, 2.31 GB peak | 2.40 s, 3.15 GB peak |
+
+Time is a wash and slightly favours per-pixel: the pass count is the same, and
+per-pixel runs the finishing stage (downsample, denoise, gamma) once instead of
+once per pass -- the saving grows with OIDN on. It holds ~36 B per supersampled
+sample more (the three accumulators plus the background pass's frame, kept alive
+as the coverage reference), in allocations of the same size class the frame
+buffers already use, so the per-allocation ceiling that the Electron renderer
+trips on (see the process-isolation plan) is not moved by the mode.
 
 Pinned by `UmbreonExport.PerPixelBlendKeepsDarkFeatureUnderDistinctAlphas`
 (host, 0.6 + 0.5 over a dark feature) and umbreon's `P1` / `P2` / `P3` in

--- a/docs/architecture/umbreon-group-alpha-blend.md
+++ b/docs/architecture/umbreon-group-alpha-blend.md
@@ -107,6 +107,53 @@ only which sections are translucent and at what alpha, and umbreon logs the
 veil/weight table (`group-alpha: 2 blend group(s) -> 1 veil(s), sum 0.600, bg
 weight 0.400`) plus a warning whenever the background weight is still negative.
 
+## Per-pixel compositing (the overlap case)
+
+Merging equal alphas removes the reported defect but not its cause: the weights
+are global while the coverage set is per pixel, so two **distinct** alphas that
+sum above 1 (0.6 + 0.5) still give an overlapped pixel a negative background
+coefficient. No choice of global weights fixes that, and rescaling the alphas to
+force the sum under 1 would change the transparency the user asked for.
+
+umbreon therefore has a second mode (`RenderOptions::groupBlendMode`, exposed as
+the `perPixelBlend` render setting and the Rendering window's *Per-pixel
+transparency* switch, default **off**). It composites at the stage where coverage
+still exists -- the supersampled, linear frame, before the box-downsample that
+turns per-sample coverage into partial pixels -- with weights built per sample
+from the veils covering it:
+
+```
+T   = prod_{i in K} (1 - a_i)              the background's weight
+w_i = a_i * (1 - T) / sum_{j in K} a_j
+```
+
+Properties: non-negative and summing to 1 for any alphas and any `K`, so nothing
+inverts; `T > 0` always (an alpha-1 section is not a veil), so what lies behind a
+veil is never lost; and a sample covered by a SINGLE veil reproduces that veil's
+alpha exactly (`T = 1 - a`, `w = a`) -- the alphas are never approximated. The
+difference from the layer mode is confined to overlaps, where the background
+keeps its physical transmittance (0.6 and 0.5 leave 0.2) instead of going
+negative. Note the mode also mixes in **linear light**, so even a single veil is
+numerically a little different from the layer mode, which mixes the
+display-encoded finished frames as blendpng did.
+
+Cost is unchanged (one pass per veil plus one), and only three extra hi-res
+buffers are needed -- the veils' weighted color, the alpha sum and the
+transmittance product -- so no pass's color has to be kept and nothing is
+rendered twice. Coverage comes from the pass depths: both passes trace the same
+opaque geometry, so a veil covers a sample exactly when that pass's frontmost hit
+is nearer than the background pass's.
+
+What it does not do: the weights are order-free, so within an overlap the veils
+do not attenuate each other by depth (a true front-to-back `over` would need a
+depth buffer per veil). Shadow / GI interaction between veils stays the
+per-pass approximation it always was.
+
+Pinned by `UmbreonExport.PerPixelBlendKeepsDarkFeatureUnderDistinctAlphas`
+(host, 0.6 + 0.5 over a dark feature) and umbreon's `P1` / `P2` / `P3` in
+`tests/test_render_transparency.cpp` (overlap weights, a lone veil's exact
+alpha, and edge groups staying independent of the veils).
+
 ## Consequences and limits
 
 - Scenes with several nearly-opaque renderers render correctly. libcuemol2
@@ -120,9 +167,9 @@ weight 0.400`) plus a warning whenever the background weight is still negative.
   more **distinct** alphas: 0.6 + 0.5 in one pixel yields
   `-0.1*B + 0.6*G1 + 0.5*G2`, which inverts `B` there exactly as the same-alpha
   case did. This is inherent to a model that weights whole frames; blendpng
-  behaves the same way. umbreon now warns when the background weight goes
-  negative, so the case is announced instead of silent. A real fix needs
-  per-pixel weights (the coverage set is per pixel, the weights are not).
+  behaves the same way. umbreon warns when the background weight goes negative,
+  so the case is announced instead of silent, and the per-pixel mode above is
+  the fix for it (opt-in).
 - One extra full render pass per **veil** is the cost of the model, so equal
   alphas are also cheaper: the log lines make both visible (host: which sections
   are translucent; umbreon: groups -> veils and the weights).

--- a/docs/architecture/umbreon-group-alpha-blend.md
+++ b/docs/architecture/umbreon-group-alpha-blend.md
@@ -117,9 +117,9 @@ force the sum under 1 would change the transparency the user asked for.
 
 umbreon therefore has a second mode (`RenderOptions::groupBlendMode`, exposed as
 the `perPixelBlend` render setting and the Rendering window's *Per-pixel
-transparency* switch). It composites at the stage where coverage still exists -- the supersampled, linear frame, before the box-downsample that
-turns per-sample coverage into partial pixels -- with weights built per sample
-from the veils covering it:
+transparency* switch). It composites at the stage where coverage still exists --
+the supersampled frame, before the box-downsample that turns per-sample coverage
+into partial pixels -- with weights built per sample from the veils covering it:
 
 ```
 T   = prod_{i in K} (1 - a_i)              the background's weight
@@ -130,11 +130,11 @@ Properties: non-negative and summing to 1 for any alphas and any `K`, so nothing
 inverts; `T > 0` always (an alpha-1 section is not a veil), so what lies behind a
 veil is never lost; and a sample covered by a SINGLE veil reproduces that veil's
 alpha exactly (`T = 1 - a`, `w = a`) -- the alphas are never approximated. The
-difference from the layer mode is confined to overlaps, where the background
-keeps its physical transmittance (0.6 and 0.5 leave 0.2) instead of going
-negative. Note the mode also mixes in **linear light**, so even a single veil is
-numerically a little different from the layer mode, which mixes the
-display-encoded finished frames as blendpng did.
+blend runs in the same display-encoded domain the layer mode uses, so a sample
+under one veil is **identical** to the layer blend: the difference is confined to
+samples under two or more veils, where the background keeps its physical
+transmittance (0.6 and 0.5 leave 0.2) instead of going negative. umbreon's `P2`
+renders a no-overlap scene in both modes and requires every pixel to match.
 
 Cost is unchanged (one pass per veil plus one), and only three extra hi-res
 buffers are needed -- the veils' weighted color, the alpha sum and the

--- a/src/modules/rendering/RenderSettings.cpp
+++ b/src/modules/rendering/RenderSettings.cpp
@@ -44,6 +44,7 @@ UmbreonRenderSettings::UmbreonRenderSettings()
       m_edgeRise(0.0),
       m_contactEdges(true),
       m_outlineFarDepth(0.2),
+      m_perPixelBlend(false),
       m_useGI(false),
       m_giSamples(32),
       m_giSkyGradient(false),

--- a/src/modules/rendering/RenderSettings.cpp
+++ b/src/modules/rendering/RenderSettings.cpp
@@ -44,7 +44,7 @@ UmbreonRenderSettings::UmbreonRenderSettings()
       m_edgeRise(0.0),
       m_contactEdges(true),
       m_outlineFarDepth(0.2),
-      m_perPixelBlend(false),
+      m_perPixelBlend(true),
       m_useGI(false),
       m_giSamples(32),
       m_giSkyGradient(false),

--- a/src/modules/rendering/RenderSettings.hpp
+++ b/src/modules/rendering/RenderSettings.hpp
@@ -68,6 +68,8 @@ namespace render {
     double m_edgeRise;
     bool m_contactEdges;
     double m_outlineFarDepth;
+    /// Group-alpha compositing: per-pixel instead of global layer weights.
+    bool m_perPixelBlend;
     bool m_useGI;
     int m_giSamples;
     LString m_denoise;

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -1102,6 +1102,14 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   opt.shadowSamples = (prm.shadowSamples > 0) ? prm.shadowSamples : 1;
   opt.lightRadius = float(prm.lightRadius);
   opt.transparentBackground = prm.transparentBackground;
+  // Group-alpha compositing: sections sharing an alpha are one veil either
+  // way (umbreon buckets them); this only chooses whether the veils are
+  // combined with global weights over the finished frames or per sample at
+  // the supersampled stage. Per-pixel is the one that cannot go negative
+  // where veils overlap (docs/architecture/umbreon-group-alpha-blend.md).
+  opt.groupBlendMode =
+      static_cast<int>(prm.perPixelBlend ? umbreon::GroupBlendMode::PerPixel
+                                         : umbreon::GroupBlendMode::LayerWeights);
 
   // Diffuse global illumination (pt2 path-traced integrator). Enabling GI sets
   // gi + giIntegrator=2. pt2 is a superset of pt1 built on the same gather core,

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -329,7 +329,10 @@ struct UmbreonDisplayContext::Impl
   /// blendpng-equivalent multi-pass group alpha), instead of blending each
   /// overlapping sphere/triangle over the next (which double-darkens overlaps).
   /// The alpha is the renderer's getAlpha(), matching CueMol's per-section
-  /// transparency (PovDisplayContext::startSection / blendTab beta).
+  /// transparency (PovDisplayContext::startSection / blendTab beta). The group
+  /// id is a per-section IDENTITY, not a grouping: umbreon buckets the entries
+  /// by alpha into veils (one pass per distinct alpha), and the same ids are
+  /// partitioned independently by edgeGroupOf below.
   int nextGroup = 0;
   int curGroup = 0;
   std::vector<umbreon::GroupBlend> groupBlend;
@@ -574,9 +577,18 @@ void UmbreonDisplayContext::appendIntData()
 
   // Assign this section (= one CueMol renderer) a transparency group. A
   // semi-transparent section is registered as a groupBlend {group, alpha} entry
-  // so umbreon post-blends the whole section (one extra render pass per group)
+  // so umbreon post-blends the whole section (one extra render pass per veil)
   // instead of blending each overlapping sphere/triangle over the next (which
   // double-darkens the overlaps). This matches CueMol's per-section transparency.
+  //
+  // Sections that share an alpha must end up in ONE veil (otherwise that veil's
+  // weight is counted twice and the background weight goes negative), but that
+  // merge belongs to umbreon, not here: this group id is ALSO the key of the
+  // edge group table (edgeGroupOf below -> Scene::edgeGroupOfGroup), of
+  // Scene::groupHatchStyle and of the objectId AOV. Two sections sharing one id
+  // could not sit in different edge groups at all, so the id stays a per-section
+  // identity and umbreon buckets the alphas (docs/architecture/
+  // umbreon-group-alpha-blend.md).
   m_pImpl->curGroup = m_pImpl->nextGroup++;
   const std::uint16_t group = static_cast<std::uint16_t>(m_pImpl->curGroup);
   if (defAlpha < 1.0f - 1.0e-4f)
@@ -886,19 +898,30 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
 
   // Semi-transparent sections (one per renderer) are post-blended per group so
   // overlapping primitives within a renderer do not double-blend (umbreon's
-  // blendpng-equivalent multi-pass group alpha).
+  // blendpng-equivalent multi-pass group alpha). Sections sharing an alpha are
+  // ONE veil sharing one pass, and umbreon decides that -- see the group
+  // assignment in appendIntData for why it cannot be decided here.
   scene.groupBlend = m_pImpl->groupBlend;
 
-  // Report the blend table umbreon receives. Each entry costs a full extra
-  // render pass, and the background pass weight (1 - sum) goes negative once
-  // several sections are nearly opaque -- both are worth seeing in a render
-  // log when an image comes out unexpectedly bright or slow.
+  // Report what this side knows: which sections are translucent and at what
+  // alpha. The veil / weight table (how many passes, and the background
+  // weight) is umbreon's decision and umbreon logs it -- restating it here
+  // would duplicate the rule and disagree with it, since equal alphas count
+  // once there.
   if (!scene.groupBlend.empty()) {
-    double sumA = 0.0;
-    for (const umbreon::GroupBlend &gb : scene.groupBlend) sumA += gb.alpha;
-    LOG_DPRINTLN("Umbreon> group alpha: %d of %d sections, sum=%f, bg weight=%f",
-                 int(scene.groupBlend.size()), m_pImpl->nextGroup, sumA,
-                 1.0 - sumA);
+    LString alphas;
+    const std::size_t kMaxListed = 8;
+    for (std::size_t i = 0; i < scene.groupBlend.size(); ++i) {
+      if (i >= kMaxListed) {
+        alphas += ", ...";
+        break;
+      }
+      if (i > 0) alphas += ", ";
+      alphas += LString::format("%.3f", double(scene.groupBlend[i].alpha));
+    }
+    LOG_DPRINTLN("Umbreon> group alpha: %d of %d sections translucent (alpha %s)",
+                 int(scene.groupBlend.size()), m_pImpl->nextGroup,
+                 alphas.c_str());
   }
 
   // background color (passed through as the linear working color); default black

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -109,6 +109,13 @@ namespace render {
     /// fogged zone between the fog end and the far clip plane (dist + slab)
     /// lies beyond.
     double outlineFarDepth = 0.2;
+    /// Group-alpha (section transparency) compositing. False = umbreon's
+    /// legacy LayerWeights blend (global weights over the finished frames, the
+    /// blendpng closed form); true = its PerPixel mode, which composites at
+    /// the supersampled stage from the veils covering each sample, so an
+    /// overlap of veils whose alphas sum above 1 no longer inverts what they
+    /// cover. See docs/architecture/umbreon-group-alpha-blend.md.
+    bool perPixelBlend = false;
     /// When true, render a transparent background: the output is RGBA (4
     /// components) with alpha = coverage (0 where no geometry is hit), so the
     /// PNG can be composited over another image (POV "_transpbg").

--- a/src/modules/rendering/UmbreonDisplayContext.hpp
+++ b/src/modules/rendering/UmbreonDisplayContext.hpp
@@ -109,13 +109,13 @@ namespace render {
     /// fogged zone between the fog end and the far clip plane (dist + slab)
     /// lies beyond.
     double outlineFarDepth = 0.2;
-    /// Group-alpha (section transparency) compositing. False = umbreon's
-    /// legacy LayerWeights blend (global weights over the finished frames, the
-    /// blendpng closed form); true = its PerPixel mode, which composites at
-    /// the supersampled stage from the veils covering each sample, so an
-    /// overlap of veils whose alphas sum above 1 no longer inverts what they
-    /// cover. See docs/architecture/umbreon-group-alpha-blend.md.
-    bool perPixelBlend = false;
+    /// Group-alpha (section transparency) compositing. True (the default) =
+    /// umbreon's PerPixel mode, which composites at the supersampled stage from
+    /// the veils covering each sample, so an overlap of veils whose alphas sum
+    /// above 1 no longer inverts what they cover; false = its legacy
+    /// LayerWeights blend (global weights over the finished frames, the
+    /// blendpng closed form). See docs/architecture/umbreon-group-alpha-blend.md.
+    bool perPixelBlend = true;
     /// When true, render a transparent background: the output is RGBA (4
     /// components) with alpha = coverage (0 where no geometry is hit), so the
     /// PNG can be composited over another image (POV "_transpbg").

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -74,6 +74,17 @@ runtime_class UmbreonRenderSettings
   property real outlineFarDepth => m_outlineFarDepth;
   default outlineFarDepth = 0.2;
 
+  /// Group-alpha (section transparency) compositing. False = the legacy
+  /// blendpng-equivalent blend: the finished frames are summed with global
+  /// weights, and where veils whose alphas sum above 1 overlap, the background
+  /// coefficient is negative and inverts what they cover (dark edge lines read
+  /// bright). True = composite per pixel at the supersampled stage, weighting
+  /// each sample by the veils that actually cover it, so nothing inverts and a
+  /// single veil keeps its exact alpha. The two differ only where veils
+  /// overlap (and per-pixel mixes in linear light).
+  property boolean perPixelBlend => m_perPixelBlend;
+  default perPixelBlend = false;
+
   property boolean useGI => m_useGI;
   default useGI = true;
   /// GI gather samples per pixel. Any positive count; the GUI offers a

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -74,16 +74,17 @@ runtime_class UmbreonRenderSettings
   property real outlineFarDepth => m_outlineFarDepth;
   default outlineFarDepth = 0.2;
 
-  /// Group-alpha (section transparency) compositing. False = the legacy
-  /// blendpng-equivalent blend: the finished frames are summed with global
-  /// weights, and where veils whose alphas sum above 1 overlap, the background
-  /// coefficient is negative and inverts what they cover (dark edge lines read
-  /// bright). True = composite per pixel at the supersampled stage, weighting
-  /// each sample by the veils that actually cover it, so nothing inverts and a
-  /// single veil keeps its exact alpha. The two differ only where veils
-  /// overlap (and per-pixel mixes in linear light).
+  /// Group-alpha (section transparency) compositing. True (the default)
+  /// composites per pixel at the supersampled stage, weighting each sample by
+  /// the veils that actually cover it: the background weight prod(1 - alpha_i)
+  /// is never negative and a single veil keeps its exact alpha. False is the
+  /// legacy blendpng-equivalent blend, which sums the finished frames with
+  /// global weights: where veils whose alphas sum above 1 overlap, the
+  /// background coefficient goes negative and inverts what they cover (dark
+  /// edge lines read bright). Per-pixel also mixes in linear light rather than
+  /// in the display-encoded domain, so a lone veil differs slightly too.
   property boolean perPixelBlend => m_perPixelBlend;
-  default perPixelBlend = false;
+  default perPixelBlend = true;
 
   property boolean useGI => m_useGI;
   default useGI = true;

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -81,8 +81,8 @@ runtime_class UmbreonRenderSettings
   /// legacy blendpng-equivalent blend, which sums the finished frames with
   /// global weights: where veils whose alphas sum above 1 overlap, the
   /// background coefficient goes negative and inverts what they cover (dark
-  /// edge lines read bright). Per-pixel also mixes in linear light rather than
-  /// in the display-encoded domain, so a lone veil differs slightly too.
+  /// edge lines read bright). Both blend in the same domain, so a pixel under a
+  /// single veil renders identically either way; only overlaps differ.
   property boolean perPixelBlend => m_perPixelBlend;
   default perPixelBlend = true;
 

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -147,7 +147,7 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_dLightIntensity(-1.0), m_dFlashFraction(-1.0),
        m_dAmbientFraction(-1.0),
        m_bEnableEdgeLines(true), m_dCreaseLimit(-1.0), m_dEdgeRise(0.5),
-       m_bContactEdges(true), m_dOutlineFarDepth(0.2), m_bPerPixelBlend(false),
+       m_bContactEdges(true), m_dOutlineFarDepth(0.2), m_bPerPixelBlend(true),
        m_bTransparentBackground(false),
        m_bGI(false), m_nGiSamples(32), m_dGiIntensity(1.0),
        m_dGiEnvIntensity(1.0), m_bGiDenoise(true), m_nDenoiser(0),

--- a/src/modules/rendering/UmbreonSceneExporter.cpp
+++ b/src/modules/rendering/UmbreonSceneExporter.cpp
@@ -147,7 +147,7 @@ UmbreonSceneExporter::UmbreonSceneExporter()
        m_dLightIntensity(-1.0), m_dFlashFraction(-1.0),
        m_dAmbientFraction(-1.0),
        m_bEnableEdgeLines(true), m_dCreaseLimit(-1.0), m_dEdgeRise(0.5),
-       m_bContactEdges(true), m_dOutlineFarDepth(0.2),
+       m_bContactEdges(true), m_dOutlineFarDepth(0.2), m_bPerPixelBlend(false),
        m_bTransparentBackground(false),
        m_bGI(false), m_nGiSamples(32), m_dGiIntensity(1.0),
        m_dGiEnvIntensity(1.0), m_bGiDenoise(true), m_nDenoiser(0),
@@ -244,6 +244,7 @@ void UmbreonSceneExporter::setupContext(UmbreonDisplayContext &ctx,
   prm.ambientFraction = m_dAmbientFraction;
   prm.contactEdges = m_bContactEdges;
   prm.outlineFarDepth = m_dOutlineFarDepth;
+  prm.perPixelBlend = m_bPerPixelBlend;
   prm.transparentBackground = m_bTransparentBackground;
   prm.giEnabled = m_bGI;
   prm.giSamples = m_nGiSamples;
@@ -462,6 +463,7 @@ LString UmbreonSceneExporter::applyRenderSettings(
   m_dEdgeRise = ub.r("edgeRise", m_dEdgeRise);
   m_bContactEdges = ub.b("contactEdges", m_bContactEdges);
   m_dOutlineFarDepth = ub.r("outlineFarDepth", m_dOutlineFarDepth);
+  m_bPerPixelBlend = ub.b("perPixelBlend", m_bPerPixelBlend);
 
   m_bGI = useGI;
   m_bHatchEnable = npr;

--- a/src/modules/rendering/UmbreonSceneExporter.hpp
+++ b/src/modules/rendering/UmbreonSceneExporter.hpp
@@ -107,6 +107,10 @@ namespace render {
     /// renderer sections (umbreon strokeEdges.contact); default off
     bool m_bContactEdges;
 
+    /// group-alpha compositing: per-pixel (umbreon groupBlendMode = PerPixel)
+    /// instead of the legacy global layer weights; default off
+    bool m_bPerPixelBlend;
+
     /// silhouette (outline) edge mode: depth, as a fraction of the fog range
     /// (0 = view center, 1 = fog end), beyond which a same-group surface no
     /// longer hides a nearer object's contour (umbreon outlineFarVz)

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -130,6 +130,14 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   /// over a surface beyond this depth draws as in the edges mode.
   property real outlineFarDepth => m_dOutlineFarDepth;
 
+  /// group-alpha (section transparency) compositing: false = the legacy
+  /// blendpng-equivalent blend of the finished frames with global weights
+  /// (where veils whose alphas sum above 1 overlap, the background weight is
+  /// negative and inverts what they cover); true = composite per pixel at the
+  /// supersampled stage from the veils that cover each sample, which never
+  /// inverts and keeps a lone veil's alpha exact. Differs only over overlaps.
+  property boolean perPixelBlend => m_bPerPixelBlend;
+
   //////////
   // transparent background: emit an RGBA PNG with alpha = coverage (POV
   // "_transpbg") so it can be composited over another image

--- a/src/modules/rendering/UmbreonSceneExporter.qif
+++ b/src/modules/rendering/UmbreonSceneExporter.qif
@@ -135,7 +135,8 @@ runtime_class UmbreonSceneExporter extends SceneExporter
   /// (where veils whose alphas sum above 1 overlap, the background weight is
   /// negative and inverts what they cover); true = composite per pixel at the
   /// supersampled stage from the veils that cover each sample, which never
-  /// inverts and keeps a lone veil's alpha exact. Differs only over overlaps.
+  /// inverts and keeps a lone veil's alpha exact. A pixel under a single veil
+  /// renders identically either way; only overlaps differ.
   property boolean perPixelBlend => m_bPerPixelBlend;
 
   //////////

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -1202,16 +1202,17 @@ TEST(UmbreonExport, OpaqueSectionSurvivesTwoTranslucentSections)
         << "opaque geometry was scaled by the group-alpha weight sum";
 }
 
-// The reported transp_test1 defect, at the host level: a DARK feature on an
-// opaque section, covered by two translucent sections of the SAME alpha, must
-// stay darker than the lit part of that same section. Two sections at 0.6 used
-// to reach the blend table as two veils summing to 1.2, leaving the background
-// pass at -0.2, and a negative background weight INVERTS whatever the veils
-// cover -- the dark feature came out brighter than its surroundings (which is
-// how black edge lines read as white). Plain geometry, no stroke edges: the ink
-// is only the most visible instance of the inversion, and both sampled pixels
-// sit under both veils, so the veil contribution cancels out of the comparison.
-TEST(UmbreonExport, DarkFeatureStaysDarkUnderTwoSameAlphaSections)
+namespace {
+
+/// Render a dark feature on an OPAQUE section under two translucent sections,
+/// both covering it: a lit grey plane with a black patch over its left half,
+/// then two veils (alpha `a1` / `a2`) spanning the frame at different depths.
+/// `perPixelBlend` selects umbreon's group-blend mode. Fills `dark` / `lit`
+/// with the offsets of a pixel over the black patch and one over the grey.
+std::vector<unsigned char> renderVeiledDarkFeature(double a1, double a2,
+                                                   bool perPixelBlend,
+                                                   std::size_t &dark,
+                                                   std::size_t &lit)
 {
     UmbreonDisplayContext ctx;
     ctx.init();
@@ -1222,7 +1223,7 @@ TEST(UmbreonExport, DarkFeatureStaysDarkUnderTwoSameAlphaSections)
 
     ctx.startRender();
 
-    // A flat quad facing the camera, spanning x0..x1 vertically full height.
+    // A flat quad facing the camera, spanning x0..x1 over the full height.
     auto quad = [&ctx](double x0, double x1, double z) {
         ctx.startTriangles();
         const Vector4D n(0.0, 0.0, 1.0);
@@ -1246,14 +1247,14 @@ TEST(UmbreonExport, DarkFeatureStaysDarkUnderTwoSameAlphaSections)
     quad(-2.5, 0.0, 0.5);
     ctx.endSection();
 
-    // Two translucent sections at the SAME alpha, both covering everything.
-    ctx.setAlpha(0.6);
+    // Two translucent sections, both covering everything.
+    ctx.setAlpha(a1);
     ctx.startSection("veil1");
     ctx.color(gfx::SolidColor::createRGB(0.2, 0.3, 0.4));
     quad(-2.5, 2.5, 1.0);
     ctx.endSection();
 
-    ctx.setAlpha(0.6);
+    ctx.setAlpha(a2);
     ctx.startSection("veil2");
     ctx.color(gfx::SolidColor::createRGB(0.3, 0.2, 0.4));
     quad(-2.5, 2.5, 1.5);
@@ -1263,26 +1264,66 @@ TEST(UmbreonExport, DarkFeatureStaysDarkUnderTwoSameAlphaSections)
     prm.width = 64;
     prm.height = 64;
     prm.supersample = 1;
+    prm.perPixelBlend = perPixelBlend;
 
     int ow = 0, oh = 0, ncomp = 0;
     std::vector<unsigned char> pix;
     ctx.render(prm, ow, oh, ncomp, pix);
-    ASSERT_EQ(pix.size(), static_cast<std::size_t>(64 * 64 * 3));
 
     // Row 32 crosses both halves: column 16 is over the black patch, column 48
-    // over the lit grey. Same veils above both.
-    const std::size_t dark = (static_cast<std::size_t>(32) * 64 + 16) * 3;
-    const std::size_t lit = (static_cast<std::size_t>(32) * 64 + 48) * 3;
+    // over the lit grey. The same veils cover both.
+    dark = (static_cast<std::size_t>(32) * 64 + 16) * 3;
+    lit = (static_cast<std::size_t>(32) * 64 + 48) * 3;
+    return pix;
+}
+
+/// The dark feature must read darker than the lit surface beside it, in every
+/// channel. Both samples sit under the same veils, so the veil contribution
+/// cancels and only the background weight is compared -- a negative one
+/// inverts the pair.
+void expectDarkStaysDark(const std::vector<unsigned char> &pix,
+                         std::size_t dark, std::size_t lit)
+{
+    ASSERT_EQ(pix.size(), static_cast<std::size_t>(64 * 64 * 3));
     // Neither sample may be a clipped extreme, or the comparison is vacuous.
     ASSERT_GT(pix[lit], 8);
     ASSERT_LT(pix[lit], 250);
-
     for (int c = 0; c < 3; ++c) {
         EXPECT_LT(pix[dark + c] + 8, pix[lit + c])
             << "channel " << c
             << ": the dark feature is not darker than the lit surface under the"
                " veils (negative background weight inverted it)";
     }
+}
+
+}  // namespace
+
+// The reported transp_test1 defect, at the host level: two translucent sections
+// of the SAME alpha used to reach the blend table as two veils summing to 1.2,
+// leaving the background pass at -0.2, and a negative background weight INVERTS
+// whatever the veils cover -- the dark feature came out brighter than its
+// surroundings (which is how black edge lines read as white). umbreon now counts
+// equal alphas as one veil, so the sum is 0.6 and the background keeps 0.4.
+// Plain geometry, no stroke edges: the ink is only the most visible instance.
+TEST(UmbreonExport, DarkFeatureStaysDarkUnderTwoSameAlphaSections)
+{
+    std::size_t dark = 0, lit = 0;
+    const std::vector<unsigned char> pix =
+        renderVeiledDarkFeature(0.6, 0.6, false, dark, lit);
+    expectDarkStaysDark(pix, dark, lit);
+}
+
+// DISTINCT alphas can still sum above 1 (0.6 + 0.5 = 1.1), which no choice of
+// global weights survives: the background coefficient of an overlapped pixel is
+// 1 minus the alphas covering it. The per-pixel group blend computes exactly
+// that coefficient per sample -- prod(1 - a_i) = 0.2 here -- so the dark feature
+// stays dark. This is what the perPixelBlend render parameter is for.
+TEST(UmbreonExport, PerPixelBlendKeepsDarkFeatureUnderDistinctAlphas)
+{
+    std::size_t dark = 0, lit = 0;
+    const std::vector<unsigned char> pix =
+        renderVeiledDarkFeature(0.6, 0.5, true, dark, lit);
+    expectDarkStaysDark(pix, dark, lit);
 }
 
 // Pins the asynchronous render path (startAsyncRender -> finishAsyncRender)

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -1172,6 +1172,10 @@ TEST(UmbreonExport, OpaqueSectionSurvivesTwoTranslucentSections)
         prm.width = 64;
         prm.height = 64;
         prm.supersample = 1;
+        // The property under test is the LayerWeights partition of unity, so
+        // pin that mode: per-pixel (the default) reproduces the uncovered
+        // triangle exactly and would not exercise the negative weight at all.
+        prm.perPixelBlend = false;
 
         int ow = 0, oh = 0, ncomp = 0;
         std::vector<unsigned char> pix;

--- a/src/tests/modules/rendering/test_umbreon_export.cpp
+++ b/src/tests/modules/rendering/test_umbreon_export.cpp
@@ -1132,9 +1132,12 @@ TEST(UmbreonExport, PostBlendsTranslucentSectionWithoutDoubleBlend)
 // sum(a) = 1.9; anything above ~0.24 linear then clips to pure white.
 TEST(UmbreonExport, OpaqueSectionSurvivesTwoTranslucentSections)
 {
-    // A bright opaque triangle, plus `nTrans` translucent sections placed well
-    // away from it (off to the sides), so they never cover the triangle.
-    auto renderWith = [](int nTrans, double transAlpha) {
+    // A bright opaque triangle, plus one translucent section per entry of
+    // `transAlphas`, placed well away from it (off to the sides), so they never
+    // cover the triangle. The alphas must DIFFER to sum above 1: umbreon counts
+    // sections sharing an alpha as one veil (see
+    // DarkFeatureStaysDarkUnderTwoSameAlphaSections).
+    auto renderWith = [](const std::vector<double> &transAlphas) {
         UmbreonDisplayContext ctx;
         ctx.init();
         ctx.setPerspective(false);
@@ -1157,9 +1160,9 @@ TEST(UmbreonExport, OpaqueSectionSurvivesTwoTranslucentSections)
         ctx.end();
         ctx.endSection();
 
-        for (int i = 0; i < nTrans; ++i) {
-            ctx.setAlpha(transAlpha);
-            ctx.startSection(LString::format("trans%d", i));
+        for (std::size_t i = 0; i < transAlphas.size(); ++i) {
+            ctx.setAlpha(transAlphas[i]);
+            ctx.startSection(LString::format("trans%d", int(i)));
             ctx.color(gfx::SolidColor::createRGB(0.2, 0.4, 1.0));
             ctx.sphere(0.4, Vector4D((i == 0) ? -2.5 : 2.5, 2.0, 0.0));
             ctx.endSection();
@@ -1180,7 +1183,7 @@ TEST(UmbreonExport, OpaqueSectionSurvivesTwoTranslucentSections)
     // the triangle spans y = -1 .. 1 with its wide edge at the bottom).
     const std::size_t c = (static_cast<std::size_t>(38) * 64 + 32) * 3;
 
-    const std::vector<unsigned char> none = renderWith(0, 1.0);
+    const std::vector<unsigned char> none = renderWith({});
     ASSERT_EQ(none.size(), static_cast<std::size_t>(64 * 64 * 3));
     // Baseline: lit grey, not saturated.
     ASSERT_GT(none[c], 8);
@@ -1188,14 +1191,98 @@ TEST(UmbreonExport, OpaqueSectionSurvivesTwoTranslucentSections)
 
     // One translucent section: sum(a) = 0.95 <= 1, so the opaque triangle is
     // unaffected.
-    const std::vector<unsigned char> one = renderWith(1, 0.95);
+    const std::vector<unsigned char> one = renderWith({0.95});
     EXPECT_NEAR(one[c], none[c], 2);
 
-    // Two translucent sections: sum(a) = 1.9. The opaque triangle must still
-    // match the baseline -- it is in no blend group and nothing occludes it.
-    const std::vector<unsigned char> two = renderWith(2, 0.95);
+    // Two translucent sections at DIFFERENT alphas: sum(a) = 1.85. The opaque
+    // triangle must still match the baseline -- it is in no blend group and
+    // nothing occludes it.
+    const std::vector<unsigned char> two = renderWith({0.95, 0.9});
     EXPECT_NEAR(two[c], none[c], 2)
         << "opaque geometry was scaled by the group-alpha weight sum";
+}
+
+// The reported transp_test1 defect, at the host level: a DARK feature on an
+// opaque section, covered by two translucent sections of the SAME alpha, must
+// stay darker than the lit part of that same section. Two sections at 0.6 used
+// to reach the blend table as two veils summing to 1.2, leaving the background
+// pass at -0.2, and a negative background weight INVERTS whatever the veils
+// cover -- the dark feature came out brighter than its surroundings (which is
+// how black edge lines read as white). Plain geometry, no stroke edges: the ink
+// is only the most visible instance of the inversion, and both sampled pixels
+// sit under both veils, so the veil contribution cancels out of the comparison.
+TEST(UmbreonExport, DarkFeatureStaysDarkUnderTwoSameAlphaSections)
+{
+    UmbreonDisplayContext ctx;
+    ctx.init();
+    ctx.setPerspective(false);
+    ctx.setViewDist(100.0);
+    ctx.setZoom(6.0);
+    ctx.loadIdent();
+
+    ctx.startRender();
+
+    // A flat quad facing the camera, spanning x0..x1 vertically full height.
+    auto quad = [&ctx](double x0, double x1, double z) {
+        ctx.startTriangles();
+        const Vector4D n(0.0, 0.0, 1.0);
+        const Vector4D v[6] = {
+            Vector4D(x0, -2.5, z), Vector4D(x1, -2.5, z), Vector4D(x1, 2.5, z),
+            Vector4D(x0, -2.5, z), Vector4D(x1, 2.5, z),  Vector4D(x0, 2.5, z),
+        };
+        for (int i = 0; i < 6; ++i) {
+            ctx.normal(n);
+            ctx.vertex(v[i]);
+        }
+        ctx.end();
+    };
+
+    // Opaque section: a lit grey plane with a black patch over its left half.
+    ctx.setAlpha(1.0);
+    ctx.startSection("opaque");
+    ctx.color(gfx::SolidColor::createRGB(0.8, 0.8, 0.8));
+    quad(-2.5, 2.5, 0.0);
+    ctx.color(gfx::SolidColor::createRGB(0.0, 0.0, 0.0));
+    quad(-2.5, 0.0, 0.5);
+    ctx.endSection();
+
+    // Two translucent sections at the SAME alpha, both covering everything.
+    ctx.setAlpha(0.6);
+    ctx.startSection("veil1");
+    ctx.color(gfx::SolidColor::createRGB(0.2, 0.3, 0.4));
+    quad(-2.5, 2.5, 1.0);
+    ctx.endSection();
+
+    ctx.setAlpha(0.6);
+    ctx.startSection("veil2");
+    ctx.color(gfx::SolidColor::createRGB(0.3, 0.2, 0.4));
+    quad(-2.5, 2.5, 1.5);
+    ctx.endSection();
+
+    UmbreonRenderParams prm;
+    prm.width = 64;
+    prm.height = 64;
+    prm.supersample = 1;
+
+    int ow = 0, oh = 0, ncomp = 0;
+    std::vector<unsigned char> pix;
+    ctx.render(prm, ow, oh, ncomp, pix);
+    ASSERT_EQ(pix.size(), static_cast<std::size_t>(64 * 64 * 3));
+
+    // Row 32 crosses both halves: column 16 is over the black patch, column 48
+    // over the lit grey. Same veils above both.
+    const std::size_t dark = (static_cast<std::size_t>(32) * 64 + 16) * 3;
+    const std::size_t lit = (static_cast<std::size_t>(32) * 64 + 48) * 3;
+    // Neither sample may be a clipped extreme, or the comparison is vacuous.
+    ASSERT_GT(pix[lit], 8);
+    ASSERT_LT(pix[lit], 250);
+
+    for (int c = 0; c < 3; ++c) {
+        EXPECT_LT(pix[dark + c] + 8, pix[lit + c])
+            << "channel " << c
+            << ": the dark feature is not darker than the lit surface under the"
+               " veils (negative background weight inverted it)";
+    }
 }
 
 // Pins the asynchronous render path (startAsyncRender -> finishAsyncRender)

--- a/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
+++ b/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
@@ -66,6 +66,7 @@ const UMBREON: Record<string, Value> = {
     creaseLimit: -1,
     contactEdges: false,
     outlineFarDepth: 0.2,
+    perPixelBlend: false,
     useGI: true,
     giSamples: 32,
     denoise: 'OIDN',

--- a/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
+++ b/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
@@ -66,7 +66,7 @@ const UMBREON: Record<string, Value> = {
     creaseLimit: -1,
     contactEdges: false,
     outlineFarDepth: 0.2,
-    perPixelBlend: false,
+    perPixelBlend: true,
     useGI: true,
     giSamples: 32,
     denoise: 'OIDN',

--- a/tritium/react-gui/src/renderer/__test__/useHoverInfoHandler.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/useHoverInfoHandler.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@renderer/contexts/PickingPrefsContext', () => ({
 
 import { useHoverInfoHandler } from '@renderer/features/molview/useHoverInfoHandler'
 import type { HoverLabel } from '@renderer/features/molview/useHoverInfoHandler'
+import { withHoverHold } from '@renderer/features/molview/hoverHold'
 
 const LABEL_M: HoverLabel = { objName: '1CRN', rendName: 'cartoon1', rendType: 'cartoon', residueLevel: true, chain: 'A', resName: 'ALA', resIndex: '10' }
 
@@ -110,6 +111,65 @@ describe('useHoverInfoHandler', () => {
         expect(invokeService).toHaveBeenCalledTimes(3)
 
         expect(setter.mock.calls).toEqual([[LABEL_M], [null]])
+        unmount()
+    })
+
+    it('a right press and the context menu hold keep the hit; the release resyncs', async () => {
+        invokeService.mockImplementation((method: string) =>
+            Promise.resolve(method === 'naviHover' ? { hit: true, label: LABEL_M } : { ok: true }),
+        )
+        const setter = vi.fn()
+
+        const { container, unmount } = mountTree(<Probe setter={setter} />)
+        const canvas = container.querySelector('canvas') as HTMLCanvasElement
+        canvas.getBoundingClientRect = () =>
+            ({ left: 0, top: 0, width: 400, height: 300, right: 400, bottom: 300, x: 0, y: 0, toJSON() {} }) as DOMRect
+
+        let timerCb: (() => void) | null = null
+        vi.spyOn(globalThis, 'setTimeout').mockImplementation(((cb: () => void) => { timerCb = cb; return 0 }) as any)
+        vi.spyOn(Date, 'now').mockReturnValue(1000)
+
+        const move = (x: number, y: number) =>
+            act(async () => {
+                canvas.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, buttons: 0, bubbles: true }))
+                await flushPromises()
+            })
+        const press = (button: number) =>
+            act(async () => {
+                canvas.dispatchEvent(new MouseEvent('mousedown', { button, buttons: button === 2 ? 2 : 1, bubbles: true }))
+                await flushPromises()
+            })
+
+        await move(10, 10)
+        expect(setter).toHaveBeenLastCalledWith(LABEL_M)
+        invokeService.mockClear()
+
+        // The right press is the context-menu gesture, not a drag: no clear.
+        await press(2)
+        expect(invokeService).not.toHaveBeenCalled()
+
+        // While the menu is up the pointer is recorded but neither sampled nor
+        // cleared, so the label and the view highlight stay as the menu found them.
+        let closeMenu: () => void = () => undefined
+        const held = withHoverHold(() => new Promise<void>((resolve) => { closeMenu = resolve }))
+        await move(12, 12)
+        expect(invokeService).not.toHaveBeenCalled()
+        expect(setter).toHaveBeenCalledTimes(1)
+
+        // Menu resolved (item picked or dismissed): resample where the pointer is.
+        await act(async () => { closeMenu(); await held; await flushPromises() })
+        expect(timerCb).not.toBeNull()
+        await act(async () => { timerCb!(); await flushPromises() })
+        expect(invokeService).toHaveBeenCalledTimes(1)
+        expect(invokeService).toHaveBeenLastCalledWith('naviHover', { viewId: 7, x: 12, y: 12, highlight: true }, { quiet: true })
+
+        // A left press still ends the hover (a navigation drag follows).
+        invokeService.mockClear()
+        await press(0)
+        expect(invokeService).toHaveBeenCalledTimes(1)
+        expect(invokeService).toHaveBeenLastCalledWith('naviHoverClear', { viewId: 7 }, { quiet: true })
+        expect(setter).toHaveBeenLastCalledWith(null)
+
         unmount()
     })
 

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -120,12 +120,13 @@ const UMBREON_PROPS: RenderPropSpec[] = [
   // --- Transparency ---
   // Group-alpha (section transparency) is a multi-pass blend: each translucent
   // renderer is rendered opaque in its own pass and the passes are combined.
-  // Off (the default) combines the finished frames with GLOBAL weights, the
-  // legacy blendpng behaviour: where veils whose alphas sum above 1 overlap,
-  // the background weight is negative and inverts what they cover (black edge
-  // lines read white). On composites per pixel from the veils that actually
-  // cover each sample, which cannot go negative and keeps a lone veil's alpha
-  // exact; the two differ only over overlaps. Same render cost either way.
+  // On (the default) composites per pixel from the veils that actually cover
+  // each sample: the background weight cannot go negative and a lone veil keeps
+  // its alpha exact. Off is the legacy blendpng behaviour, which combines the
+  // finished frames with GLOBAL weights -- where veils whose alphas sum above 1
+  // overlap, the background weight is negative and inverts what they cover
+  // (black edge lines read white). Same render cost either way; per-pixel also
+  // mixes in linear light, so a lone veil differs slightly from the legacy.
   { key: "perPixelBlend", label: "Per-pixel transparency", type: "boolean", group: "Transparency" },
   // --- Global Illumination (pt1 path-traced integrator; off by default) ---
   { key: "useGI",         label: "Enable GI",          type: "boolean", group: "Global Illumination" },

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -117,6 +117,16 @@ const UMBREON_PROPS: RenderPropSpec[] = [
   // nearer object's contour (drawn as in the edges mode there). The far clip
   // plane sits half a slab behind the fog end, as in the GL view.
   { key: "outlineFarDepth", label: "Outline far depth", type: "real", group: "Edges", min: 0, max: 1, step: 0.01 },
+  // --- Transparency ---
+  // Group-alpha (section transparency) is a multi-pass blend: each translucent
+  // renderer is rendered opaque in its own pass and the passes are combined.
+  // Off (the default) combines the finished frames with GLOBAL weights, the
+  // legacy blendpng behaviour: where veils whose alphas sum above 1 overlap,
+  // the background weight is negative and inverts what they cover (black edge
+  // lines read white). On composites per pixel from the veils that actually
+  // cover each sample, which cannot go negative and keeps a lone veil's alpha
+  // exact; the two differ only over overlaps. Same render cost either way.
+  { key: "perPixelBlend", label: "Per-pixel transparency", type: "boolean", group: "Transparency" },
   // --- Global Illumination (pt1 path-traced integrator; off by default) ---
   { key: "useGI",         label: "Enable GI",          type: "boolean", group: "Global Illumination" },
   // Gather samples per pixel, as a short list rather than a ladder: with the
@@ -429,6 +439,7 @@ export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> =
       { key: "Ambient Occlusion", defaultExpanded: false },
       { key: "Shadows", defaultExpanded: false },
       { key: "Edges", defaultExpanded: false },
+      { key: "Transparency", defaultExpanded: false },
       { key: "Global Illumination", defaultExpanded: false },
     ],
     props: UMBREON_PROPS,
@@ -447,6 +458,7 @@ export const RENDER_BACKENDS: Record<RenderBackendId, RenderBackendDescriptor> =
       { key: "Ambient Occlusion", defaultExpanded: false },
       { key: "Shadows", defaultExpanded: false },
       { key: "Edges", defaultExpanded: false },
+      { key: "Transparency", defaultExpanded: false },
     ],
     props: UMBREON_NPR_PROPS,
     quality: UMBREON_NPR_QUALITY,

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -125,8 +125,8 @@ const UMBREON_PROPS: RenderPropSpec[] = [
   // its alpha exact. Off is the legacy blendpng behaviour, which combines the
   // finished frames with GLOBAL weights -- where veils whose alphas sum above 1
   // overlap, the background weight is negative and inverts what they cover
-  // (black edge lines read white). Same render cost either way; per-pixel also
-  // mixes in linear light, so a lone veil differs slightly from the legacy.
+  // (black edge lines read white). Same render cost either way, and a pixel
+  // under a single veil renders identically in both -- only overlaps differ.
   { key: "perPixelBlend", label: "Per-pixel transparency", type: "boolean", group: "Transparency" },
   // --- Global Illumination (pt1 path-traced integrator; off by default) ---
   { key: "useGI",         label: "Enable GI",          type: "boolean", group: "Global Illumination" },

--- a/tritium/react-gui/src/renderer/features/molview/hoverHold.ts
+++ b/tritium/react-gui/src/renderer/features/molview/hoverHold.ts
@@ -1,0 +1,45 @@
+/**
+ * @file features/molview/hoverHold.ts
+ * @description Freeze the 3D view hover state -- the label chip and the C++
+ * hover highlight -- while a context menu owns the pointer.
+ *
+ * A right-click opens the navi context menu, and the menu (a React overlay on
+ * Windows / Linux, a native popup on macOS) takes the pointer away from the
+ * canvas. Under the plain hover rules that clears the very hit the menu is
+ * about. `withHoverHold` marks the window from the menu appearing until the
+ * user picks an item or dismisses it; while it is held `useHoverInfoHandler`
+ * keeps the last hit and sends no clear, then resamples on release.
+ *
+ * Module state rather than a context: the holder (useNaviContextMenu) and the
+ * hover controller (inside MolViewHoverLabel) are siblings, and a hold must
+ * re-render neither of them.
+ */
+
+let holds = 0;
+const releaseListeners = new Set<() => void>();
+
+/** True while a context menu (or another pointer owner) holds the hover. */
+export function isHoverHeld(): boolean {
+    return holds > 0;
+}
+
+/** Subscribe to "the last hold ended"; returns the unsubscribe. */
+export function onHoverHoldRelease(fn: () => void): () => void {
+    releaseListeners.add(fn);
+    return () => {
+        releaseListeners.delete(fn);
+    };
+}
+
+/** Hold the hover for as long as `fn` runs; nested holds are counted. */
+export async function withHoverHold<T>(fn: () => Promise<T>): Promise<T> {
+    holds += 1;
+    try {
+        return await fn();
+    } finally {
+        holds -= 1;
+        if (holds === 0) {
+            for (const listener of [...releaseListeners]) listener();
+        }
+    }
+}

--- a/tritium/react-gui/src/renderer/features/molview/useHoverInfoHandler.ts
+++ b/tritium/react-gui/src/renderer/features/molview/useHoverInfoHandler.ts
@@ -10,6 +10,11 @@
  * is dropped. Listeners are delegated on the content pane rather than the
  * canvas because the rubber-band overlay covers the canvas while a select
  * tool is active; both the canvas and the overlay bubble to the pane.
+ *
+ * The hover ends on a left / middle press (a navigation drag follows), but not
+ * on a right press: that opens the navi context menu, which holds the hover
+ * (see hoverHold.ts) so the hit the menu is about stays visible and
+ * highlighted until the menu resolves.
  */
 
 import { useEffect, useRef } from 'react';
@@ -20,6 +25,7 @@ import { useStaleGuard } from '@renderer/hooks/react/useStaleGuard';
 import { usePickingPrefs } from '@renderer/contexts/PickingPrefsContext';
 import type { HoverLabel } from '@renderer/worker/server/services/navi/naviTool';
 import { MOLVIEW_CANVAS_SELECTOR } from './molViewCanvas';
+import { isHoverHeld, onHoverHoldRelease } from './hoverHold';
 
 export type { HoverLabel };
 
@@ -75,6 +81,10 @@ export function useHoverInfoHandler({ containerRef, setHoverLabel }: UseHoverInf
         let lastSent: Pos | null = null;
         let lastIssuedAt = -Infinity;
         let lastKey: string | null = null;
+        // Where the pointer last was, hoverable or not (null off the canvas /
+        // during a drag). Tracked even while held, so the resync on release
+        // knows where to resample.
+        let lastPos: Pos | null = null;
         // The view currently shows a highlight set by our last reply.
         let highlighted = false;
         let disposed = false;
@@ -159,16 +169,19 @@ export function useHoverInfoHandler({ containerRef, setHoverLabel }: UseHoverInf
                 });
         };
 
+        /** The hoverable position of an event: null while dragging / off the view. */
+        const readPos = (e: MouseEvent): Pos | null => {
+            if (e.buttons !== 0) return null;  // any button held: no hover during a drag
+            if (!overCanvas(e)) return null;
+            return toLocal(e);
+        };
+
         const onMouseMove = (e: MouseEvent): void => {
-            if (e.buttons !== 0) {
-                clear();  // any button held: no hover during a drag
-                return;
-            }
-            if (!overCanvas(e)) {
-                clear();
-                return;
-            }
-            const p = toLocal(e);
+            lastPos = readPos(e);
+            // A context menu owns the pointer: keep the frozen hit and send
+            // nothing, but the position above is still recorded.
+            if (isHoverHeld()) return;
+            const p = lastPos;
             if (p === null) {
                 clear();
                 return;
@@ -177,17 +190,40 @@ export function useHoverInfoHandler({ containerRef, setHoverLabel }: UseHoverInf
             pending = p;
             schedule();
         };
-        const onMouseDown = (): void => clear();
-        const onMouseLeave = (): void => clear();
+        // Right press: the navi context menu it opens is about the element
+        // under the pointer, so the hit survives until the menu resolves.
+        const onMouseDown = (e: MouseEvent): void => {
+            if (e.button === 2) return;
+            clear();
+        };
+        const onMouseLeave = (): void => {
+            lastPos = null;
+            if (isHoverHeld()) return;
+            clear();
+        };
+        // Menu resolved: pick up where the pointer actually is. Resampling
+        // rather than keeping the frozen hit is what makes the highlight right
+        // after an action that moved the view (e.g. Center at).
+        const onHoldRelease = (): void => {
+            if (disposed) return;
+            if (lastPos === null) {
+                clear();
+                return;
+            }
+            pending = lastPos;
+            schedule();
+        };
 
         container.addEventListener('mousemove', onMouseMove);
         container.addEventListener('mousedown', onMouseDown);
         container.addEventListener('mouseleave', onMouseLeave);
+        const unsubscribeHold = onHoverHoldRelease(onHoldRelease);
         return () => {
             disposed = true;
             container.removeEventListener('mousemove', onMouseMove);
             container.removeEventListener('mousedown', onMouseDown);
             container.removeEventListener('mouseleave', onMouseLeave);
+            unsubscribeHold();
             clear();
         };
     }, [cm, enabled, viewId, containerRef, guard, hoverHighlight]);

--- a/tritium/react-gui/src/renderer/features/molview/useNaviContextMenu.ts
+++ b/tritium/react-gui/src/renderer/features/molview/useNaviContextMenu.ts
@@ -8,6 +8,7 @@ import { useShowContextMenu } from '@renderer/shell/menu/ContextMenuProvider';
 import { useShowNewRendererDialog } from '@renderer/dialogs/NewRendererDialogProvider';
 import { useShowErrorAlert } from '@renderer/dialogs/ErrorAlertDialogProvider';
 import { recordAppliedSel, type AppliedSelResult } from '@renderer/h3-kit/MolSelList';
+import { withHoverHold } from './hoverHold';
 
 export function useNaviContextMenu(): {
     openContextMenu: (hit: HitTestResult, viewId: number, x: number, y: number) => Promise<void>;
@@ -31,11 +32,17 @@ export function useNaviContextMenu(): {
         // macOS shows the native menu (main process); Windows / Linux render
         // the same shared template with the React MenuPanel for a look that
         // matches the menu bar dropdowns.
+        //
+        // The hover hold spans the menu only: the hit stays labelled and
+        // highlighted while the user reads it, and is released as soon as an
+        // item is picked or the menu is dismissed -- not for the whole action,
+        // which may open a dialog of its own (createSymmMol).
         const api = window.electronAPI;
-        const action: NaviCtxAction | null =
+        const action: NaviCtxAction | null = await withHoverHold(async () =>
             api?.platform === 'darwin'
                 ? await api.invoke(IPC.NAVI_CTX_SHOW, { x, y, ...payload })
-                : await showContextMenu(buildNaviCtxMenuNodes(payload), { x, y });
+                : await showContextMenu(buildNaviCtxMenuNodes(payload), { x, y }),
+        );
 
         if (!action || !cm) return;
 


### PR DESCRIPTION
Two unrelated fixes, one PR by request. Reviewable per commit.

## 1-2. umbreon group-alpha transparency

`transp/transp_test1.qsc` (`dsurf2 @0.6`, `ballstick @1.0` with black edge lines, `cpk @0.6`) rendered the **black edge lines white**, with `sum=1.200, bg weight=-0.200` in the log.

The cause is on the umbreon side (CueMol/umbreon#82, which must merge first): two sections at the same alpha reached the blend table as two veils, so that veil was counted twice. The negative background weight only breaks the pixels where the veils **overlap** — there the per-pixel coefficient of the background is `1 - sum(alphas covering it)`, and a negative one inverts contrast, so dark ink reads brighter than the lit surface around it. umbreon now buckets entries by alpha into veils.

**`fix(render)`: report the sections, not the veil arithmetic.** With the merge on the other side of the seam, the host's log line restated a sum umbreon no longer computes (it printed `sum=1.200, bg weight=-0.200` while umbreon composites `0.600 / 0.400`). It now reports only what the host knows — which sections are translucent and at what alpha — and umbreon logs the veil / weight table, so the rule lives in one place. The comments record why the merge cannot happen here: the transparency group id is also the key of the edge group table (`edgeGroupOf` -> `Scene::edgeGroupOfGroup`), of `Scene::groupHatchStyle` and of the objectId AOV, so merging ids would collapse edge groups that must stay independent of the veils.

**`feat(render)`: per-pixel group-alpha blend as a render setting.** Two **distinct** alphas can still sum above 1 (0.6 + 0.5), and no choice of global weights avoids the negative coefficient, because the coverage set is per pixel and the weights are not. `perPixelBlend` (scene-persisted, exporter property -> `RenderOptions::groupBlendMode`) selects umbreon's per-pixel mode, which weights each sample by the veils that actually cover it: background weight `prod(1 - a_i)`, the rest shared out in `a_i` proportion. Never negative, and a lone veil keeps its **exact** alpha, so no transparency value is approximated. Surfaced in the Rendering window as *Transparency > Per-pixel transparency*, and **on by default** (last commit), host-verified on the transp test scenes: it is the only mode in which a veil overlap cannot invert what it covers, whatever the alphas.

Measured on `data/1ab0_scene2.pov` with two veils (0.6 + 0.5): 0.69 s vs 0.71 s at 900 px ss3, and 2.40 s vs 2.56 s at 1600 px ss3 with edges — a wash, slightly in per-pixel's favour, because the pass count is identical and the finishing stage (downsample, denoise, gamma) runs once instead of once per pass. It holds ~36 B per supersampled sample more (819 MB vs 553 MB peak; 3.15 GB vs 2.31 GB at the larger size), in allocations of the size class the frame buffers already use, so the per-allocation ceiling the Electron renderer trips on is unchanged.

The layer weights stay selectable and stay the reference for blendpng / POV-Ray parity. Both modes blend in the same display-encoded domain, so a pixel covered by a **single** veil renders identically either way — only pixels under two or more veils differ, which is exactly where the layer blend's background coefficient can go negative.

Tests: `DarkFeatureStaysDarkUnderTwoSameAlphaSections` (the reported same-alpha case) and `PerPixelBlendKeepsDarkFeatureUnderDistinctAlphas` (0.6 + 0.5) both render a dark feature under two veils and require it to stay darker than the lit surface beside it; both samples sit under the same veils, so only the background weight is compared. Verified that each fails without its fix (layer mode gives dark 89/92/142 vs lit 57/59/100 — inverted). `OpaqueSectionSurvivesTwoTranslucentSections` is rebased to distinct alphas (now the only way to reach a weight sum above 1) and pins the layer mode explicitly, since its subject is the negative background weight. `docs/architecture/umbreon-group-alpha-blend.md` records the per-pixel formula, the per-pixel reading of the old one, and why the merge is umbreon's.

## 3. Hover highlight under the navi context menu

The GPU-pick hover highlight vanished the instant the right-click context menu was raised: the hover controller cleared on **any** mousedown, so the label and `naviHoverClear` went out before the menu appeared, and the menu then takes the pointer anyway (a React overlay, or the native popup on macOS).

A right press no longer ends the hover (left and middle still do — a navigation drag follows), and `useNaviContextMenu` holds the hover across the menu `await` only: while held the controller neither clears nor samples, it records where the pointer went, and on release it resamples there, or clears when the pointer left the view. Resampling rather than keeping the frozen hit is what makes the highlight right after an action that moved the view (*Center at*). The hold ends when an item is picked or the menu is dismissed, so an action that opens a dialog of its own (`createSymmMol`) does not extend it. Module state, not a context: holder and controller are siblings and a hold must re-render neither.

Test pins the observable sequence: the right press sends no clear, a mousemove / mouseleave under the hold sends none either, the release re-issues `naviHover` for the last pointer position, and a left press still clears.

## Verification

- `task run_gtest TEST=test_umbreon` 40/40, `TEST=test_render` 9/9
- `task typecheck_tritium` clean; react-gui `vitest run` 399 files / 3748 tests
- `task build_tritium` + `run_tritium`, both fixes confirmed visually on `transp_test1.qsc` and in the 3D view

Requires CueMol/umbreon#82 (`UMBREON_GIT_REF=main`), so merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

