### PR TITLE
Rendering window: keep the viewer's framing across renders, rebalance the GI lighting ladder

### DIFF
--- a/docs/architecture/umbreon-gi-lighting-balance.md
+++ b/docs/architecture/umbreon-gi-lighting-balance.md
@@ -81,8 +81,9 @@ POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` と�
   GI on では `ambientColor = li*af`、GI off では ambientColor は 1.0 のままで af は直接光を
   減らすだけ (POV 非 radiosity と同じ)。**負値 = auto**。
 - `UmbreonDisplayContext.cpp`: auto は GI off で `1.3 / 0.6 / 0` (従来どおり)、GI on で
-  app の既定 (GI lighting step 4 = `1.2 / 0.05 / 0.4`、勾配 sky on)。スクリプトから `useGI`
-  だけを立てても app と同じ絵になるための写し。
+  app の既定 (GI lighting step 4 = `1.3 / 0 / 0.6`、勾配 sky on)。スクリプトから `useGI`
+  だけを立てても app と同じ絵になるための写し。`UmbreonRenderSettings.qif` の block default
+  も同じ 3 値。
 - `UmbreonSceneExporter::applyRenderSettings` (scene の RenderSettings -> exporter の写像。tritium /
   cuetty / Python が共有) は 3 値を常に明示的に書く。`lightIntensity` / `flashFraction` は block の値
   (Lights グループ)、`ambientFraction` は GI on のときだけ block の値 (GI グループ) で、GI off では
@@ -107,32 +108,48 @@ POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` と�
   sky だとその fill が向きに無関係になるため。勾配は ladder には入れず独立の knob のままにする
   (軸がカメラの上方向なので構図に依存するスタイルであり、配分の段とは性質が違う)。
 - **GI lighting axis** (5 段、GI 選択時のみ): 他の quality axis と違い**絵を変えるための axis**。
-  headlight (ff) を 0.60 → 0.05 まで等間隔に減らし、そのエネルギーを key light と GI の
-  ambient に配りつつ、総光量 (li) を 1.55 → 1.2 まで線形に下げる。axis は 3 値すべてを
-  持つので、どれかを手で編集すると Custom になる。
+  headlight (ff) を 0.60 → 0 まで等間隔に減らし、そのエネルギーを GI の ambient に渡す。
+  axis は 3 値すべてを持つので、どれかを手で編集すると Custom になる。
 
 | step | li | ff | af | key | headlight | ambient | 位置づけ |
 |---|---|---|---|---|---|---|---|
 | 0 | 1.55 | 0.60 | 0.16 | 0.52 | 0.78 | 0.25 | raytrace 一致 |
-| 1 | 1.46 | 0.46 | 0.23 | 0.61 | 0.52 | 0.34 | |
-| 2 | 1.38 | 0.32 | 0.30 | 0.66 | 0.31 | 0.41 | |
-| 3 | 1.29 | 0.18 | 0.35 | 0.69 | 0.15 | 0.45 | |
-| 4 | 1.20 | 0.05 | 0.40 | 0.68 | 0.04 | 0.48 | headlight ほぼ無し (**既定**) |
+| 1 | 1.43 | 0.45 | 0.34 | 0.52 | 0.42 | 0.49 | |
+| 2 | 1.37 | 0.30 | 0.46 | 0.52 | 0.22 | 0.63 | |
+| 3 | 1.32 | 0.15 | 0.54 | 0.52 | 0.09 | 0.71 | |
+| 4 | 1.30 | 0.00 | 0.60 | 0.52 | 0.00 | 0.78 | headlight 無し (**既定**) |
 
   既定は step 4。GI が既定の depth cue である理由がこの見た目なので、step 0 は raytrace の絵に
   戻すための逃げ道と位置づける。
 
-  **li を下げる理由**: li 1.55 のままだと step 4 で key light が 0.88 になり、白い材質の
-  key 側 (右上) が `0.8*0.88 + 0.8*0.62 = 1.2` で clip する。目視で 1.1〜1.2 が最も立体感が
-  出たので、端点を 1.2 にして線形に刻んだ。結果として段を上げるほど絵は少し暗くなるが、
-  key light は 0.6〜0.7 でほぼ一定に保たれ、headlight の flat な fill が GI の遮蔽付き
-  ambient に置き換わっていく。
+  **更新 (2026-09-11)**: 端点を `1.2 / 0.05 / 0.4` から `1.3 / 0 / 0.6` に変更 (目視で決定)。
+  旧 ladder は headlight のエネルギーを key light と ambient に配っていたため key light が
+  0.52 → 0.68 と育ち、段を上げるほど方向性の陰影も強くなっていた。新しい端点は key light が
+  ちょうど step 0 と同じ 0.52 に戻る点で、段が動かすのは「headlight ↔ 遮蔽付き ambient」
+  だけになる。下の 2 制約を全段に課して 1〜3 を引き直した (端点も同じ式が出す値)。
+
+  **段の決め方 (2 つの不変量)**: ff だけを 0.60 → 0 に等間隔で刻み、残る li / af は次の
+  2 式で決まる。
+
+  - **key light 一定**: `li*(1-af)*(1-ff) = 0.52` (raytrace の key light)。
+  - **平均輝度一定**: カメラから見える球の平均輝度が step 0 と同じ。可視円板上の平均は
+    headlight が強度の 2/3、key light (1,1,1 方向) が 0.44、sky が 1 なので
+    `0.44*key + 0.667*flash + amb = 1.0`。
+
+  前者から `D = li*(1-af) = 0.52/(1-ff)`、`flash = D*ff`、後者から
+  `amb = 0.7712 - 0.667*flash`、`li = D + amb`、`af = amb/li`。ff=0.60 を入れると
+  `1.551 / 0.16` (= step 0)、ff=0 で `1.291 / 0.597` (= 採用した端点 `1.3 / 0.6`) となり、
+  両端が独立に決めた値と一致する。li が段を上げるほど少し下がるのは、headlight が正面側に
+  集中していたエネルギーを球全体に広がる ambient に移すため。
 - **照明方式切り替え時の Lights の既定**: Lights グループは全方式で共有なので、GI の段で
   下げた li / ff が raytrace / AO に持ち越されないよう、`RenderLightingOption.defaults`
   (方式の判定には使わない look 既定) に raytrace / AO の `1.55 / 0.6 / 0.16` を持たせ、方式を
   選んだときに書き戻す。この値は GI lighting の step 0 と同じなので、GI を離れると GI lighting
-  は step 0 に戻る (段は共有 prop の値から導出されるため、書き戻しをまたいで残せない)。
-  GI は axis が段を書き戻すので defaults を持たない。
+  は step 0 と読める (段は共有 prop の値から導出されるため、書き戻しをまたいで残せない)。
+  ただしその "0" は raytrace の既定が言っているだけでユーザーの選択ではないので、GI に戻る
+  ときは**既定 step を書き戻す** (axis の `enterAtDefault`)。これが無いと direct な方式を
+  一度経由するだけで GI が raytrace 一致の段に落ちる。GI は axis が段を書き戻すので
+  defaults を持たない。
 
   **af の決め方 (平均輝度一定)**: 最初は「カメラ正面の開放面の輝度一定」(key 0.52 固定、
   `flash + amb = 1.03`) で af を出したが、ff 0.05 で af 0.65 となり全体が明るすぎた。
@@ -145,7 +162,7 @@ POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` と�
   少し多め)。端点は観察値 0.40 を採り、中間は同じ曲線の形で刻んでいる。余った
   エネルギーは key light に行くので、段を上げると方向性の陰影も強くなる。
 
-  照明方式を GI に切り替えると axis が選択中の step を書き戻すので、GI の既定配分は
+  照明方式を GI に切り替えると axis が**既定 step (4)** を書き戻すので、GI の既定配分は
   自動的に揃う。手で fraction を編集すると Custom になる (他の axis と同じ)。
 
 ## Consequences
@@ -162,7 +179,9 @@ POV backend では同じ 3 値が `_light_inten / _flash_frac / _amb_frac` と�
   diff_metal (ambient 0.35 / diffuse 0.30) は GI on で GI off よりやや暗くなる。
 - 既定値が C++ の 2 か所にある: `UmbreonDisplayContext` の auto (負値のとき) と `applyRenderSettings`
   の 0.16 固定 (+ qif の block default)。アプリ / cuetty / Python は常に applyRenderSettings 経由で明示値を
-  書くので実害はないが、GI lighting axis の step 0 を変えたら C++ の auto も揃えること。
+  書くので実害はないが、GI lighting axis の端点を変えたら C++ も揃えること
+  (step 0 → `applyRenderSettings` の `DIRECT_AMBIENT_FRACTION`、step 4 → auto の GI 分岐と
+  `UmbreonRenderSettings.qif` の block default)。
 - 勾配 sky は上を向いた面を明るく、下を向いた面を暗くする。輝度補正で正面の明るさは保つが、
   下向きの面は一様 sky より暗くなる。
 

--- a/docs/migration/adr/ADR-0035-render-window.md
+++ b/docs/migration/adr/ADR-0035-render-window.md
@@ -112,6 +112,27 @@ Key constraints and choices:
   wheel to scroll natively. Registered through `@use-gesture`'s `useWheel` with
   `passive: false`, as `MolViewPane` does: React's own `onWheel` is passive at
   the root and could not suppress the browser's page zoom.
+- **Framing survives a render.** The viewer keeps the zoom and the scroll
+  offset when the image is replaced, instead of re-fitting: a render is
+  normally the same scene again with one setting changed, and re-fitting made
+  the user zoom back in on every turn of the loop the history exists for.
+  Stepping the history keeps it too, which is what makes two attempts
+  comparable. An image of a different pixel size is rescaled by the ratio of
+  the two fit scales and re-centred on the same relative point, so the same
+  part of the picture stays on screen; a fit happens only on the first image
+  and when the user asks for it. The movie preview and the finished result are
+  separate components, so the handoff between them still re-fits.
+
+  The toolbar's zoom steps (and 100%) are anchored at the centre of the
+  viewport -- what the user is looking at when reaching for them -- while a
+  pinch stays anchored at the pointer. Both paths share one restore, which had
+  to be fixed first: it built the scroll offset from the stage's
+  `offsetLeft`/`offsetTop`, which are measured from the nearest *positioned*
+  ancestor. `.riv-scroll` is not positioned, so the vertical one carried the
+  toolbar's height and every zoom jumped to the bottom of the image (the
+  horizontal one was right only because that offset happened to be zero). It
+  now measures both client rects after the relayout and shifts the scroll by
+  the difference, which depends on no CSS positioning at all.
 - **Save / Copy** are back in the result toolbar. They were dropped as clutter
   while the window had no history; with one, exporting the render you settled
   on is the point of keeping the earlier attempts. Both act on what is on

--- a/src/modules/rendering/UmbreonDisplayContext.cpp
+++ b/src/modules/rendering/UmbreonDisplayContext.cpp
@@ -1004,24 +1004,26 @@ void UmbreonDisplayContext::buildSceneAndOptions(const UmbreonRenderParams &prm)
   // the direct lights, which is a brighter and flatter picture.
   //
   // The GI auto defaults are the render window's default "GI lighting" step
-  // (the top of its five): the flat, view-aligned headlight is all but gone
-  // (flash 0.04), its energy moved into the directional key light (0.68)
-  // and the gathered ambient (0.48), and the total is lowered to 1.2 so the
-  // key-lit side of a white surface does not clip. The step ladder's other
-  // end, li 1.55 / af 0.16 / ff 0.6, reproduces the non-GI picture exactly
-  // (same key 0.52 / headlight 0.78, and a gathered ambient of 0.25 that
-  // through the diffuse weight equals the 0.2 flat ambient). Derivation of
-  // the ladder and its trade-offs:
+  // (the top of its five): the flat, view-aligned headlight is gone entirely
+  // and all of its energy has moved into the gathered ambient (0.78), while
+  // the directional key light stays at the non-GI 0.52. The step ladder's
+  // other end, li 1.55 / af 0.16 / ff 0.6, reproduces the non-GI picture
+  // exactly (same key 0.52 / headlight 0.78, and a gathered ambient of 0.25
+  // that through the diffuse weight equals the 0.2 flat ambient); every step
+  // holds that key light and the mean brightness of a camera-facing sphere.
+  // Derivation of the ladder and its trade-offs:
   // docs/architecture/umbreon-gi-lighting-balance.md
-  const double li = (prm.lightIntensity >= 0.0)
-                        ? prm.lightIntensity
-                        : (prm.giEnabled ? 1.2 : 1.3);
+  //
+  // The two branches happen to share a total of 1.3: without GI all of it is
+  // direct light (key 0.52 / headlight 0.78), with GI 0.52 stays on the key
+  // light and the other 0.78 is gathered as ambient.
+  const double li = (prm.lightIntensity >= 0.0) ? prm.lightIntensity : 1.3;
   const double af = (prm.ambientFraction >= 0.0)
                         ? prm.ambientFraction
-                        : (prm.giEnabled ? 0.4 : 0.0);
+                        : (prm.giEnabled ? 0.6 : 0.0);
   const double ff = (prm.flashFraction >= 0.0)
                         ? prm.flashFraction
-                        : (prm.giEnabled ? 0.05 : 0.6);
+                        : (prm.giEnabled ? 0.0 : 0.6);
   if (scene.lights.empty()) {
     // SpecLighting: directional key light from the upper-front-right
     // (positioned at normalize(1,1,1), pointing at the origin). CueMol calls it

--- a/src/modules/rendering/UmbreonRenderSettings.qif
+++ b/src/modules/rendering/UmbreonRenderSettings.qif
@@ -101,13 +101,17 @@ runtime_class UmbreonRenderSettings
   property string giGroundColor => m_giGroundColor;
   default giGroundColor = "#666666";
 
-  /// Lighting energy balance (shared with the POV-Ray block, own defaults)
+  /// Lighting energy balance (shared with the POV-Ray block, own defaults).
+  /// These are the GI lighting ladder's top step, since useGI defaults on --
+  /// no headlight, its energy gathered as ambient instead. Keep them in step
+  /// with the ladder in tritium data/renderBackends.ts and with the auto
+  /// fallback in UmbreonDisplayContext.cpp.
   property real lightIntensity => m_lightIntensity;
-  default lightIntensity = 1.2;
+  default lightIntensity = 1.3;
   property real flashFraction => m_flashFraction;
-  default flashFraction = 0.05;
+  default flashFraction = 0.0;
   property real ambientFraction => m_ambientFraction;
-  default ambientFraction = 0.4;
+  default ambientFraction = 0.6;
 };
 
 #endif

--- a/src/tests/modules/rendering/test_render_settings.cpp
+++ b/src/tests/modules/rendering/test_render_settings.cpp
@@ -172,7 +172,7 @@ TEST_F(RenderSettingsTest, FreshObjectMatchesDeclaredDefaults)
     EXPECT_TRUE(getStr(p.get(), "backend").isEmpty());
     EXPECT_DOUBLE_EQ(getReal(p.get(), "width"), 1200.0);
     EXPECT_DOUBLE_EQ(getReal(p.get(), "povray.lightIntensity"), 1.3);
-    EXPECT_DOUBLE_EQ(getReal(p.get(), "umbreon.lightIntensity"), 1.2);
+    EXPECT_DOUBLE_EQ(getReal(p.get(), "umbreon.lightIntensity"), 1.3);
     EXPECT_TRUE(getBool(p.get(), "umbreon.useGI"));
     EXPECT_DOUBLE_EQ(getReal(p.get(), "umbreon_npr.lightIntensity"), 1.55);
     EXPECT_FALSE(getBool(p.get(), "umbreon_npr.useGI"));

--- a/src/tests/modules/rendering/test_umbreon_apply_settings.cpp
+++ b/src/tests/modules/rendering/test_umbreon_apply_settings.cpp
@@ -129,7 +129,7 @@ TEST(UmbreonApplySettings, GatesAoAmbientAndHatchByBlock)
     EXPECT_DOUBLE_EQ(propReal(ex, "aoDistance"), 1.0e20);  // ctor value, untouched
     EXPECT_FALSE(propBool(ex, "useGI"));
     EXPECT_DOUBLE_EQ(propReal(ex, "ambientFraction"), 0.16);
-    EXPECT_DOUBLE_EQ(propReal(ex, "lightIntensity"), 1.2);  // the block's default
+    EXPECT_DOUBLE_EQ(propReal(ex, "lightIntensity"), 1.3);  // the block's default
 
     // NPR block: hatching on, GI never, colors only behind their Custom switch
     render::UmbreonNprRenderSettings *np = p->getUmbreonNpr().get();

--- a/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
+++ b/tritium/react-gui/src/renderer/__test__/fixtures/renderSettingsValues.ts
@@ -72,9 +72,9 @@ const UMBREON: Record<string, Value> = {
     denoise: 'OIDN',
     giSkyGradient: true,
     giGroundColor: '#666666',
-    lightIntensity: 1.2,
-    flashFraction: 0.05,
-    ambientFraction: 0.4,
+    lightIntensity: 1.3,
+    flashFraction: 0,
+    ambientFraction: 0.6,
 };
 
 // The NPR block inherits the umbreon properties (GI keys included) with the

--- a/tritium/react-gui/src/renderer/__test__/renderImageViewer.test.tsx
+++ b/tritium/react-gui/src/renderer/__test__/renderImageViewer.test.tsx
@@ -1,11 +1,16 @@
 /**
  * @file __test__/renderImageViewer.test.tsx
- * @description Degrade-detection test for the Render Result image viewer.
+ * @description Degrade-detection tests for the rendering window's image viewer.
  *
- * Pins the no-flicker contract: the initial fit is applied in a layout effect
- * (before paint), computed from the container size + image dimensions, WITHOUT
- * waiting for the <img> onLoad. The test never fires onLoad, so a regression to
- * onLoad-only fitting would leave the viewer at 100% and fail here.
+ * Three contracts, each one something that broke in practice:
+ *  - the initial fit is applied in a layout effect (before paint), computed
+ *    from the container size + image dimensions, WITHOUT waiting for the <img>
+ *    to load. The tests never fire onLoad, so a regression to onLoad-only
+ *    fitting would leave the viewer at 100% and fail here.
+ *  - a new image keeps the framing instead of re-fitting.
+ *  - an anchored zoom lands the anchor where it was pinned. This one runs
+ *    against a fake layout, because the bug it pins was a coordinate-space
+ *    mistake that jsdom's all-zero geometry cannot express.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -17,6 +22,10 @@ import { RenderImageViewer } from '@renderer/features/render/RenderImageViewer';
 void React;
 ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
+/** Viewport the fake layout reports for .riv-scroll. */
+const VIEW_W = 400;
+const VIEW_H = 300;
+
 let root: Root;
 let container: HTMLDivElement;
 let origW: PropertyDescriptor | undefined;
@@ -27,8 +36,8 @@ beforeEach(() => {
   // viewport is 400x300 so computeFit yields a real ratio.
   origW = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'clientWidth');
   origH = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'clientHeight');
-  Object.defineProperty(window.HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 400 });
-  Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => 300 });
+  Object.defineProperty(window.HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => VIEW_W });
+  Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', { configurable: true, get: () => VIEW_H });
 });
 
 afterEach(() => {
@@ -38,22 +47,22 @@ afterEach(() => {
   if (origH) Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', origH);
 });
 
-function mount(imgWidth: number, imgHeight: number, fitKey?: string): void {
+function mount(imgWidth: number, imgHeight: number): void {
   container = document.createElement('div');
   document.body.appendChild(container);
   act(() => {
     root = createRoot(container);
     root.render(
-      <RenderImageViewer src="data:," imgWidth={imgWidth} imgHeight={imgHeight} name="scene1" fitKey={fitKey} />,
+      <RenderImageViewer src="data:," imgWidth={imgWidth} imgHeight={imgHeight} name="scene1" />,
     );
   });
 }
 
-/** Re-render the SAME viewer instance with a different fitKey / size. */
-function rerender(imgWidth: number, imgHeight: number, fitKey?: string): void {
+/** Re-render the SAME viewer instance with a different image. */
+function rerender(imgWidth: number, imgHeight: number): void {
   act(() => {
     root.render(
-      <RenderImageViewer src="data:," imgWidth={imgWidth} imgHeight={imgHeight} name="scene1" fitKey={fitKey} />,
+      <RenderImageViewer src="data:," imgWidth={imgWidth} imgHeight={imgHeight} name="scene1" />,
     );
   });
 }
@@ -79,12 +88,12 @@ describe('RenderImageViewer -- fit before paint', () => {
   });
 });
 
-// A finished render should arrive fitted, not at whatever zoom the previous
-// image was left at. The viewer stays mounted between results (same component
-// at the same position), so without a fit key it would keep the old scale --
-// which is exactly what users saw: a new render showing at 100%, or at some
-// zoom inherited from the last one.
-describe('RenderImageViewer -- re-fit on a new image', () => {
+// A render is usually the same scene again with one setting changed, so the
+// zoom the user set is theirs to keep -- re-fitting made them zoom back in on
+// every iteration. The viewer stays mounted between results (same component at
+// the same position), so keeping the framing is the default and only an image
+// of a DIFFERENT pixel size needs any work.
+describe('RenderImageViewer -- framing survives a new image', () => {
   /** Pinch-zoom in, so the current scale is clearly not the fitted one. */
   function zoomIn(): void {
     const el = container.querySelector('.riv-scroll') as HTMLElement;
@@ -97,36 +106,125 @@ describe('RenderImageViewer -- re-fit on a new image', () => {
     });
   }
 
-  it('re-fits when the fit key changes, even at an unchanged image size', () => {
-    mount(800, 600, 'result-1');
-    expect(readZoomPct()).toBe(50);
-    zoomIn();
-    expect(readZoomPct()).toBeGreaterThan(50);
-
-    // A new render result at the same size: computeFit's identity is unchanged,
-    // so only the key can tell the viewer this is a different image.
-    rerender(800, 600, 'result-2');
-    expect(readZoomPct()).toBe(50);
-  });
-
-  it('keeps the zoom while the key holds (movie frame scrubbing)', () => {
-    mount(800, 600, 'result-1');
-    zoomIn();
-    const zoomed = readZoomPct();
-    expect(zoomed).toBeGreaterThan(50);
-
-    // Same result, next frame: the user's zoom is theirs to keep.
-    rerender(800, 600, 'result-1');
-    expect(readZoomPct()).toBe(zoomed);
-  });
-
-  it('fits once on mount when no key is given', () => {
+  it('keeps the zoom when a new image of the same size arrives', () => {
     mount(800, 600);
     expect(readZoomPct()).toBe(50);
     zoomIn();
     const zoomed = readZoomPct();
+    expect(zoomed).toBeGreaterThan(50);
+
+    // A new render result at the same size: nothing about the layout changes,
+    // so the zoom -- and the scroll offset the browser holds -- must survive.
     rerender(800, 600);
     expect(readZoomPct()).toBe(zoomed);
+  });
+
+  it('rescales the zoom by the fit ratio when the image size changes', () => {
+    mount(800, 600);
+    expect(readZoomPct()).toBe(50);
+
+    // Twice the pixels for the same picture: half the zoom shows the same
+    // region, so the framing is what is preserved, not the percentage.
+    rerender(1600, 1200);
+    expect(readZoomPct()).toBe(25);
+  });
+});
+
+// Anchored zoom. The scroll offset that keeps the anchor in place is written
+// after the stage has been re-laid out, and it used to be built from
+// stage.offsetLeft/offsetTop -- which are relative to the nearest POSITIONED
+// ancestor, not to the scroll container. .riv-scroll is not positioned, so the
+// vertical offset carried the toolbar's height and every zoom jumped to the
+// bottom of the image (the horizontal one was right only by luck). The fake
+// layout below reproduces that geometry: a viewport inset from the top by the
+// toolbar, and a stage whose offsetTop is measured past it.
+describe('RenderImageViewer -- anchored zoom', () => {
+  const TOOLBAR_H = 40;
+  const saved: Record<string, PropertyDescriptor | undefined> = {};
+  const scrolls = new WeakMap<HTMLElement, { l: number; t: number }>();
+  const pos = (el: HTMLElement) => scrolls.get(el) ?? { l: 0, t: 0 };
+
+  /** Stage size, as the component wrote it (imgWidth * scale). */
+  const stageBox = (stage: HTMLElement) => ({
+    w: parseFloat(stage.style.width) || 0,
+    h: parseFloat(stage.style.height) || 0,
+  });
+  /** The `margin: auto` centring the stage gets while it fits the viewport. */
+  const centring = (stage: HTMLElement) => {
+    const { w, h } = stageBox(stage);
+    return { x: Math.max(0, (VIEW_W - w) / 2), y: Math.max(0, (VIEW_H - h) / 2) };
+  };
+
+  beforeEach(() => {
+    for (const k of ['scrollLeft', 'scrollTop', 'getBoundingClientRect', 'offsetLeft', 'offsetTop']) {
+      saved[k] = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, k);
+    }
+    // jsdom keeps scroll offsets at 0; back them with real storage.
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollLeft', {
+      configurable: true,
+      get(this: HTMLElement) { return pos(this).l; },
+      set(this: HTMLElement, v: number) { scrolls.set(this, { ...pos(this), l: v }); },
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get(this: HTMLElement) { return pos(this).t; },
+      set(this: HTMLElement, v: number) { scrolls.set(this, { ...pos(this), t: v }); },
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value(this: HTMLElement): DOMRect {
+        const box = (x: number, y: number, w: number, h: number) =>
+          ({ x, y, left: x, top: y, width: w, height: h, right: x + w, bottom: y + h }) as DOMRect;
+        if (this.classList.contains('riv-scroll')) return box(0, TOOLBAR_H, VIEW_W, VIEW_H);
+        if (this.classList.contains('riv-stage')) {
+          const el = this.parentElement as HTMLElement;
+          const { w, h } = stageBox(this);
+          const c = centring(this);
+          return box(c.x - el.scrollLeft, TOOLBAR_H + c.y - el.scrollTop, w, h);
+        }
+        return box(0, 0, 0, 0);
+      },
+    });
+    // Present only so a regression to the offsetLeft/offsetTop formula computes
+    // a different answer: these are offsetParent-relative, so the vertical one
+    // includes the toolbar the scroll container sits below.
+    Object.defineProperty(window.HTMLElement.prototype, 'offsetLeft', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.classList.contains('riv-stage') ? centring(this).x : 0;
+      },
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'offsetTop', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return this.classList.contains('riv-stage') ? TOOLBAR_H + centring(this).y : 0;
+      },
+    });
+  });
+
+  afterEach(() => {
+    for (const [k, d] of Object.entries(saved)) {
+      if (d) Object.defineProperty(window.HTMLElement.prototype, k, d);
+      else delete (window.HTMLElement.prototype as unknown as Record<string, unknown>)[k];
+    }
+  });
+
+  it('keeps the viewport centre put when the toolbar zooms in', () => {
+    mount(800, 600); // fit 50% -> the stage is exactly the 400x300 viewport
+    const el = container.querySelector('.riv-scroll') as HTMLElement;
+    expect(el.scrollTop).toBe(0);
+
+    act(() => {
+      (container.querySelector('[aria-label="Zoom in"]') as HTMLElement).click();
+    });
+
+    // 0.5 * 1.25 -> stage 500x375, i.e. 100x75 of overflow. The image centre
+    // was in the middle of the viewport and has to stay there, which is half
+    // the overflow in each direction. The old offsetTop-based formula landed
+    // at 77.5 here -- a toolbar's height too far down.
+    expect(container.querySelector('.riv-stage')).toHaveProperty('style.width', '500px');
+    expect(el.scrollLeft).toBe(50);
+    expect(el.scrollTop).toBe(37.5);
   });
 });
 

--- a/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
+++ b/tritium/react-gui/src/renderer/__test__/useRenderSettings.test.ts
@@ -380,19 +380,19 @@ describe('useRenderSettings quality axes', () => {
         h.unmount();
     });
 
-    it('the GI lighting axis trades headlight for key light and gathered ambient', () => {
+    it('the GI lighting axis trades the headlight for gathered ambient', () => {
         const h = umbreonHook();
         // The default step is the top one; its values are already in the props.
-        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.2);
-        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.05);
-        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.4);
+        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.3);
+        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0);
+        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.6);
         act(() => h.result.setQualityStep('giLighting', '2'));
         expect(h.result.qualitySteps.giLighting).toBe('2');
-        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.38);
-        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.32);
-        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.3);
+        expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.37);
+        expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.3);
+        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.46);
         // A hand edit of an owned prop drops the axis to Custom.
-        act(() => h.result.handleChange('lightIntensity', 1.3));
+        act(() => h.result.handleChange('lightIntensity', 1.1));
         expect(h.result.qualitySteps.giLighting).toBe('custom');
         h.unmount();
     });
@@ -405,13 +405,16 @@ describe('useRenderSettings quality axes', () => {
         act(() => h.result.setLighting('none'));
         expect(valueOf(h.result.backendProps, 'lightIntensity')).toBe(1.55);
         expect(valueOf(h.result.backendProps, 'flashFraction')).toBe(0.6);
-        // The step is derived from those shared values, so leaving GI resets
-        // its lighting to step 0 (the defaults equal it, ambient included);
-        // coming back starts from the raytrace match rather than Custom.
+        // The step is derived from those shared values, so leaving GI reads
+        // back as step 0 (the defaults equal it, ambient included). That "0"
+        // is the raytrace defaults talking, not a pick, so coming back to GI
+        // must enter at the axis' default step -- otherwise every round trip
+        // through a direct method would silently land GI on the raytrace
+        // match.
         expect(h.result.qualitySteps.giLighting).toBe('0');
         act(() => h.result.setLighting('gi'));
-        expect(h.result.qualitySteps.giLighting).toBe('0');
-        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.16);
+        expect(h.result.qualitySteps.giLighting).toBe('4');
+        expect(valueOf(h.result.backendProps, 'ambientFraction')).toBe(0.6);
         h.unmount();
     });
 

--- a/tritium/react-gui/src/renderer/data/renderBackends.ts
+++ b/tritium/react-gui/src/renderer/data/renderBackends.ts
@@ -197,9 +197,10 @@ const UMBREON_PROPS: RenderPropSpec[] = [
  * props, so picking a direct method writes these back -- otherwise a GI step
  * with almost no headlight would carry over into the raytrace. They equal the
  * axis' step 0 (the ambient fraction included, although the direct methods
- * never read it), so the axis reads "0" again afterwards: leaving GI resets
- * its lighting to the raytrace match, since the step is derived from these
- * shared values and cannot survive their reset.
+ * never read it), so the axis reads "0" again afterwards: the step is derived
+ * from these shared values and cannot survive their reset. Coming back to GI
+ * therefore enters at the axis' default step rather than at what it reads
+ * (`enterAtDefault`), since that "0" is these defaults talking, not a pick.
  */
 const DIRECT_LIGHT_DEFAULTS = { lightIntensity: 1.55, flashFraction: 0.6 };
 /** The umbreon backend has the GI-only ambient fraction prop as well. */
@@ -287,34 +288,40 @@ const UMBREON_QUALITY: RenderQualityConfig = {
     // dropdown in the Global Illumination group instead of a ladder.
     //
     // Axis B-GI look. Unlike every other axis this one changes the picture on
-    // purpose: it takes the flat, view-aligned headlight away in equal
-    // strides (flashFraction 0.60 -> 0.05) and gives its energy to the two
-    // terms that carry shape -- the directional key light and the GI gather
-    // (the only term that carries occlusion). The ambient fraction at each
-    // step follows the curve that keeps the MEAN brightness of a sphere seen
-    // by the camera constant (headlight averages 2/3 of its intensity over
-    // the visible disk, the key light 0.44, the sky a flat 1; the endpoint
-    // trimmed to what looked right). The total energy then comes down with
-    // the steps (1.55 -> 1.2): with the key light grown from 0.52 to 0.88,
-    // the key-lit side of a white surface clips at the raytrace level, and
-    // the lower level is where the relief reads best. Step 0 reproduces the
+    // purpose: it takes the flat, view-aligned headlight away in equal strides
+    // (flashFraction 0.60 -> 0) and hands its energy to the GI gather, the
+    // only term that carries occlusion. Two invariants fix the other two props
+    // at every step, so the ladder changes exactly one thing:
+    //   key light  li*(1-af)*(1-ff) = 0.52, the raytrace key light
+    //   mean brightness of a camera-facing sphere = the raytrace one, i.e.
+    //     0.44*key + 0.667*flash + amb = 1.0 (the headlight averages 2/3 of
+    //     its intensity over the visible disk, the key light 0.44, the sky 1)
+    // Solving them for each headlight fraction gives li and af below; the two
+    // ends land on the raytrace values (1.55 / 0.6 / 0.16) and on the
+    // headlight-free 1.3 / 0 / 0.6. The total energy comes down as the steps
+    // rise only because ambient is spread over the whole sphere while the
+    // headlight was concentrated on the facing side. Step 0 reproduces the
     // raytraced picture (the gathered ambient equals the flat material
     // ambient). The axis owns all three props, so a hand edit of any of them
     // reads back as Custom. Derivation:
     // docs/architecture/umbreon-gi-lighting-balance.md
     // The default is the top step: GI is the default depth cue precisely for
     // this look, and step 0 is the escape hatch back to the raytraced picture.
+    // enterAtDefault because the direct methods reset the props this axis owns
+    // to values that read back as step 0 -- without it, picking GI after a
+    // raytrace would enter at the raytrace match instead of the default.
     {
       key: "giLighting",
       label: "GI lighting",
       defaultStep: "4",
       lightings: ["gi"],
+      enterAtDefault: true,
       steps: [
         { id: "0", label: "0 (raytrace match)", patch: { lightIntensity: 1.55, flashFraction: 0.6, ambientFraction: 0.16 } },
-        { id: "1", label: "1", patch: { lightIntensity: 1.46, flashFraction: 0.46, ambientFraction: 0.23 } },
-        { id: "2", label: "2", patch: { lightIntensity: 1.38, flashFraction: 0.32, ambientFraction: 0.3 } },
-        { id: "3", label: "3", patch: { lightIntensity: 1.29, flashFraction: 0.18, ambientFraction: 0.35 } },
-        { id: "4", label: "4 (max GI)", patch: { lightIntensity: 1.2, flashFraction: 0.05, ambientFraction: 0.4 } },
+        { id: "1", label: "1", patch: { lightIntensity: 1.43, flashFraction: 0.45, ambientFraction: 0.34 } },
+        { id: "2", label: "2", patch: { lightIntensity: 1.37, flashFraction: 0.3, ambientFraction: 0.46 } },
+        { id: "3", label: "3", patch: { lightIntensity: 1.32, flashFraction: 0.15, ambientFraction: 0.54 } },
+        { id: "4", label: "4 (max GI)", patch: { lightIntensity: 1.3, flashFraction: 0, ambientFraction: 0.6 } },
       ],
     },
     // Axis C. Shadows fall on meshes only and are independent of the depth

--- a/tritium/react-gui/src/renderer/data/renderSettings.ts
+++ b/tritium/react-gui/src/renderer/data/renderSettings.ts
@@ -90,6 +90,15 @@ export interface RenderQualityAxis {
   defaultStep: string;
   /** Shown only while one of these methods is active (omit = always). */
   lightings?: RenderLightingMode[];
+  /**
+   * Enter the method at `defaultStep` rather than at the step the props
+   * currently derive to. Set it on an axis whose props the OTHER methods
+   * overwrite with their own look defaults: once those have been written, the
+   * derived step is an artifact of them (it lands on whichever step happens to
+   * coincide) rather than a pick the user made, and feeding it back would
+   * enter the method at that step instead of its default.
+   */
+  enterAtDefault?: boolean;
 }
 
 /** A backend's quality axes plus the depth-cue methods they can apply to. */
@@ -181,7 +190,8 @@ export function lightingPatch(
     // A method switch only re-applies that method's own axes; the shared ones
     // (image quality, shadows) are unrelated to the method and stay put.
     if (!axis.lightings && !opts.includeShared) continue;
-    Object.assign(patch, stepPatch(axis, steps[axis.key] ?? axis.defaultStep));
+    const step = axis.enterAtDefault ? axis.defaultStep : steps[axis.key];
+    Object.assign(patch, stepPatch(axis, step ?? axis.defaultStep));
   }
   Object.assign(patch, option?.enable ?? {});
   return patch;

--- a/tritium/react-gui/src/renderer/features/render/RenderImageViewer.tsx
+++ b/tritium/react-gui/src/renderer/features/render/RenderImageViewer.tsx
@@ -1,22 +1,33 @@
 /**
  * @file features/render/RenderImageViewer.tsx
- * @description Zoomable / pannable image viewer for the Render Result tab.
+ * @description Zoomable / pannable image viewer for the rendering window.
  *
  * The image is laid out at `width x height x scale` inside a scrollable
  * container; panning is drag-to-scroll, and a two-finger swipe pans it as
  * ordinary scrolling. Zoom is the toolbar buttons plus a trackpad pinch --
  * which every browser encodes as a wheel event with a synthetic `ctrlKey`, the
- * only way to read a pinch on an element -- anchored at the pointer so the
- * spot under the cursor stays put. Fit-to-view and 100% are explicit
- * actions. The initial fit is applied in a layout effect -- before the browser
- * paints -- so switching to the tab never flashes the image at 100% before it
- * shrinks to fit. The fit needs only the container size and the image
- * dimensions (props), so it does not wait for the <img> to load.
+ * only way to read a pinch on an element. A pinch (and cmd/ctrl + wheel) is
+ * anchored at the pointer, so the spot under the cursor stays put; the toolbar
+ * buttons are anchored at the centre of the viewport, which is what the user
+ * is looking at when reaching for them.
  *
- * The viewer owns the single toolbar for the Render Result tab: the parent's
- * result actions are passed in via `actions` and rendered alongside the zoom
- * controls, and the info text (scene name / size / zoom) sits at the end. This
- * keeps the tab to one toolbar row rather than stacking a separate action bar.
+ * A new image keeps the framing instead of re-fitting. A render is usually the
+ * same scene again with one setting changed, so re-fitting made the user zoom
+ * back in on every iteration of the loop the render history exists for. When
+ * the new image has a different pixel size, the zoom is rescaled by the ratio
+ * of the two fit scales and the viewport is re-centred on the same relative
+ * point, so the same part of the picture stays on screen. Fit-to-view and 100%
+ * are explicit actions.
+ *
+ * The initial fit is applied in a layout effect -- before the browser paints --
+ * so opening the window never flashes the image at 100% before it shrinks to
+ * fit. The fit needs only the container size and the image dimensions (props),
+ * so it does not wait for the <img> to load.
+ *
+ * The viewer owns the single toolbar for the image area: the parent's result
+ * actions are passed in via `actions` and rendered alongside the zoom controls,
+ * and the info text (scene name / size / zoom) sits at the end. This keeps the
+ * pane to one toolbar row rather than stacking a separate action bar.
  */
 
 import React, { useRef, useState, useCallback, useLayoutEffect } from "react";
@@ -35,15 +46,6 @@ interface RenderImageViewerProps {
   name: string;
   /** Result action buttons, rendered at the start of the single toolbar. */
   actions?: React.ReactNode;
-  /**
-   * Identity of the image being shown. When it changes the viewer re-fits: a
-   * newly rendered image is a new thing to look at, and the zoom that suited
-   * the previous one is not a property of it. Frame scrubbing within one movie
-   * result keeps the same key, so a zoomed-in look survives it.
-   *
-   * Omit to fit only once, on mount.
-   */
-  fitKey?: string | number;
 }
 
 const MIN_SCALE = 0.05;
@@ -68,40 +70,114 @@ export const RenderImageViewer: React.FC<RenderImageViewerProps> = ({
   imgHeight,
   name,
   actions,
-  fitKey,
 }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
+  const scaleRef = useRef(scale);
+  scaleRef.current = scale;
+  /** Whether an initial fit has been applied (it needs a measurable container). */
   const fittedRef = useRef(false);
-  const fitKeyRef = useRef(fitKey);
-
-  // Arm the fit for a new image. Done during render rather than in an effect so
-  // the layout effect below already sees it disarmed and re-fits BEFORE the
-  // browser paints -- the whole point of fitting in a layout effect.
-  if (fitKey !== fitKeyRef.current) {
-    fitKeyRef.current = fitKey;
-    fittedRef.current = false;
-  }
+  /** Image size the current framing was computed for. */
+  const sizeRef = useRef({ w: imgWidth, h: imgHeight });
 
   /**
-   * Scale that fits the whole image within the viewport, or null when the
+   * Scale that fits a `w x h` image within the viewport, or null when the
    * container is not measurable yet (zero-sized). Uses only the container size
-   * and the known image dimensions, so it does not need a loaded <img>.
+   * and the given dimensions, so it does not need a loaded <img>.
    */
-  const computeFit = useCallback((): number | null => {
+  const fitFor = useCallback((w: number, h: number): number | null => {
     const el = scrollRef.current;
-    if (!el || el.clientWidth <= 0 || el.clientHeight <= 0 || imgWidth <= 0 || imgHeight <= 0) {
+    if (!el || el.clientWidth <= 0 || el.clientHeight <= 0 || w <= 0 || h <= 0) {
       return null;
     }
-    return clamp(
-      Math.min(el.clientWidth / imgWidth, el.clientHeight / imgHeight),
-      MIN_SCALE,
-      MAX_SCALE,
-    );
+    return clamp(Math.min(el.clientWidth / w, el.clientHeight / h), MIN_SCALE, MAX_SCALE);
+  }, []);
+  const computeFit = useCallback(
+    (): number | null => fitFor(imgWidth, imgHeight),
+    [fitFor, imgWidth, imgHeight],
+  );
+
+  // --- Anchored zoom ---
+  //
+  // The scroll offset that keeps the anchored spot in place can only be set
+  // once the stage has been re-laid out at the new scale, so the caller records
+  // what to line up and a layout effect applies it after the resize.
+  const anchorRef = useRef<{
+    /** Image-space point to pin. */
+    cx: number;
+    cy: number;
+    /** Where that point should sit in the viewport. */
+    px: number;
+    py: number;
+  } | null>(null);
+
+  /**
+   * Viewport centre in normalized image coordinates (0..1), kept current as the
+   * container scrolls. It has to be tracked rather than computed on demand: by
+   * the time a new image size is in the DOM the old scroll offset is already
+   * gone, clamped to the new content size.
+   */
+  const centerRef = useRef({ nx: 0.5, ny: 0.5 });
+  const updateCenter = useCallback(() => {
+    const el = scrollRef.current;
+    const stage = stageRef.current;
+    if (!el || !stage) return;
+    const s = scaleRef.current;
+    if (s <= 0 || imgWidth <= 0 || imgHeight <= 0) return;
+    const elRect = el.getBoundingClientRect();
+    const stageRect = stage.getBoundingClientRect();
+    centerRef.current = {
+      nx: clamp(
+        (elRect.left + el.clientWidth / 2 - stageRect.left) / (imgWidth * s),
+        0,
+        1,
+      ),
+      ny: clamp(
+        (elRect.top + el.clientHeight / 2 - stageRect.top) / (imgHeight * s),
+        0,
+        1,
+      ),
+    };
   }, [imgWidth, imgHeight]);
 
-  // Fit before the browser paints, so switching to this tab never flashes the
-  // image at 100% before it shrinks to fit.
+  /**
+   * Scroll the pending anchor's image point back to the viewport spot it was
+   * pinned to. Must run against the layout the given scale produced.
+   */
+  const applyAnchor = useCallback(
+    (scaleNow: number) => {
+      const anchor = anchorRef.current;
+      const el = scrollRef.current;
+      const stage = stageRef.current;
+      if (!anchor || !el || !stage) return;
+      anchorRef.current = null;
+      // Measured, not derived from offsetLeft/offsetTop: .riv-scroll is not a
+      // positioned element, so those are relative to the nearest positioned
+      // ancestor (the Allotment pane) and carry the toolbar's height in the
+      // vertical direction -- which used to send every zoom to the bottom of
+      // the image. Both rects are read before either write, since scrolling
+      // the container moves the stage.
+      const elRect = el.getBoundingClientRect();
+      const stageRect = stage.getBoundingClientRect();
+      el.scrollLeft += stageRect.left + anchor.cx * scaleNow - elRect.left - anchor.px;
+      el.scrollTop += stageRect.top + anchor.cy * scaleNow - elRect.top - anchor.py;
+      // A zoom can change the visible region without moving the scroll offset
+      // (the stage grows around a pinned edge), so no scroll event would fire.
+      updateCenter();
+    },
+    [updateCenter],
+  );
+
+  // Declared before the effects that set an anchor, so that within a commit the
+  // anchor is always applied against the layout its scale was chosen for.
+  useLayoutEffect(() => {
+    applyAnchor(scale);
+  }, [scale, imgWidth, imgHeight, applyAnchor]);
+
+  // Fit before the browser paints, so opening the window never flashes the
+  // image at 100% before it shrinks to fit. Only the first image is fitted;
+  // later ones keep the framing (below).
   useLayoutEffect(() => {
     if (fittedRef.current) return;
     const f = computeFit();
@@ -109,69 +185,81 @@ export const RenderImageViewer: React.FC<RenderImageViewerProps> = ({
       fittedRef.current = true;
       setScale(f);
     }
-    // fitKey is a dependency, not just a guard: a re-render at the SAME size
-    // leaves computeFit's identity untouched, so without it the effect would
-    // never re-run for the new image.
-  }, [computeFit, fitKey]);
-
-  const fit = useCallback(() => {
-    const f = computeFit();
-    if (f !== null) setScale(f);
   }, [computeFit]);
-  const zoom = useCallback(
-    (factor: number) => setScale((s) => clamp(s * factor, MIN_SCALE, MAX_SCALE)),
-    [],
-  );
 
-  // --- Pointer-anchored zoom (trackpad pinch / ctrl+wheel) ---
-  //
-  // The scroll offset that keeps the pointed-at spot in place can only be set
-  // once the stage has been re-laid out at the new scale, so the wheel handler
-  // records what to line up and a layout effect applies it after the resize.
-  const scaleRef = useRef(scale);
-  scaleRef.current = scale;
-  const stageRef = useRef<HTMLDivElement>(null);
-  const anchorRef = useRef<{
-    /** Image-space point under the pointer. */
-    cx: number;
-    cy: number;
-    /** Where that point sat in the viewport. */
-    px: number;
-    py: number;
-  } | null>(null);
+  // Keep the framing when the image is replaced by one of a different size:
+  // rescale by the ratio of the two fit scales and re-centre on the same
+  // relative point, so the same part of the picture stays on screen. An image
+  // of the SAME size needs nothing -- the stage keeps its layout, so the
+  // browser keeps the scroll offset.
+  useLayoutEffect(() => {
+    const prev = sizeRef.current;
+    if (prev.w === imgWidth && prev.h === imgHeight) return;
+    sizeRef.current = { w: imgWidth, h: imgHeight };
+    // The first image belongs to the fit effect above.
+    if (!fittedRef.current) return;
+    const el = scrollRef.current;
+    const before = fitFor(prev.w, prev.h);
+    const after = fitFor(imgWidth, imgHeight);
+    if (!el || before === null || after === null) return;
+    const { nx, ny } = centerRef.current;
+    anchorRef.current = {
+      cx: nx * imgWidth,
+      cy: ny * imgHeight,
+      px: el.clientWidth / 2,
+      py: el.clientHeight / 2,
+    };
+    // Both fits use the current container size, so a container resize cancels
+    // out of the ratio and only the image's own change scales the zoom.
+    const current = scaleRef.current;
+    const next = clamp((current * after) / before, MIN_SCALE, MAX_SCALE);
+    // An unchanged scale re-renders nothing, so the anchor would never be
+    // applied -- do it here, against the layout that is already final.
+    if (next === current) applyAnchor(next);
+    else setScale(next);
+  }, [imgWidth, imgHeight, fitFor, applyAnchor]);
 
-  const zoomAt = useCallback(
-    (factor: number, clientX: number, clientY: number) => {
+  /** Zoom to an absolute scale, pinning an image point to a viewport spot. */
+  const zoomTo = useCallback(
+    (next: number, clientX: number, clientY: number) => {
       const el = scrollRef.current;
       const stage = stageRef.current;
       if (!el || !stage) return;
       const current = scaleRef.current;
-      const next = clamp(current * factor, MIN_SCALE, MAX_SCALE);
-      if (next === current) return;
-      const rect = el.getBoundingClientRect();
+      const target = clamp(next, MIN_SCALE, MAX_SCALE);
+      if (target === current) return;
+      const elRect = el.getBoundingClientRect();
       const stageRect = stage.getBoundingClientRect();
       anchorRef.current = {
         cx: (clientX - stageRect.left) / current,
         cy: (clientY - stageRect.top) / current,
-        px: clientX - rect.left,
-        py: clientY - rect.top,
+        px: clientX - elRect.left,
+        py: clientY - elRect.top,
       };
-      setScale(next);
+      setScale(target);
     },
     [],
   );
 
-  useLayoutEffect(() => {
-    const anchor = anchorRef.current;
-    const el = scrollRef.current;
-    const stage = stageRef.current;
-    if (!anchor || !el || !stage) return;
-    anchorRef.current = null;
-    // offsetLeft/Top carry the centring margin the stage gets while it is
-    // smaller than the viewport, which the image-space point knows nothing of.
-    el.scrollLeft = anchor.cx * scale + stage.offsetLeft - anchor.px;
-    el.scrollTop = anchor.cy * scale + stage.offsetTop - anchor.py;
-  }, [scale]);
+  /** Zoom to an absolute scale about the centre of the viewport. */
+  const zoomCentered = useCallback(
+    (next: number) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      zoomTo(next, rect.left + el.clientWidth / 2, rect.top + el.clientHeight / 2);
+    },
+    [zoomTo],
+  );
+  /** The toolbar's zoom steps: centred, since that is where the user is looking. */
+  const zoomBy = useCallback(
+    (factor: number) => zoomCentered(scaleRef.current * factor),
+    [zoomCentered],
+  );
+  const fit = useCallback(() => {
+    const f = computeFit();
+    if (f !== null) zoomCentered(f);
+  }, [computeFit, zoomCentered]);
 
   // Registered on the element with passive:false, because React's own onWheel
   // is passive at the root and could not suppress the browser's page zoom.
@@ -183,7 +271,11 @@ export const RenderImageViewer: React.FC<RenderImageViewerProps> = ({
       event.preventDefault();
       const delta =
         event.deltaMode === 1 ? event.deltaY * LINE_HEIGHT_PX : event.deltaY;
-      zoomAt(Math.exp(-delta * ZOOM_RATE), event.clientX, event.clientY);
+      zoomTo(
+        scaleRef.current * Math.exp(-delta * ZOOM_RATE),
+        event.clientX,
+        event.clientY,
+      );
     },
     { target: scrollRef, eventOptions: { passive: false } },
   );
@@ -225,17 +317,17 @@ export const RenderImageViewer: React.FC<RenderImageViewerProps> = ({
         {actions}
         <ButtonGroup>
           <Tooltip content="Zoom out">
-            <Button small icon={<AppIcon name="ui.zoomOut" aria-hidden />} aria-label="Zoom out" onClick={() => zoom(0.8)} />
+            <Button small icon={<AppIcon name="ui.zoomOut" aria-hidden />} aria-label="Zoom out" onClick={() => zoomBy(0.8)} />
           </Tooltip>
           <Tooltip content="Zoom in">
-            <Button small icon={<AppIcon name="ui.zoomIn" aria-hidden />} aria-label="Zoom in" onClick={() => zoom(1.25)} />
+            <Button small icon={<AppIcon name="ui.zoomIn" aria-hidden />} aria-label="Zoom in" onClick={() => zoomBy(1.25)} />
           </Tooltip>
         </ButtonGroup>
         <Tooltip content="Fit to window">
           <Button small icon={<AppIcon name="ui.zoomToFit" aria-hidden />} text="Fit" onClick={fit} />
         </Tooltip>
         <Tooltip content="Actual size (100%)">
-          <Button small text="100%" onClick={() => setScale(1)} />
+          <Button small text="100%" onClick={() => zoomCentered(1)} />
         </Tooltip>
         <span className="riv-info">
           {name} · {imgWidth}×{imgHeight} · {Math.round(scale * 100)}%
@@ -244,6 +336,7 @@ export const RenderImageViewer: React.FC<RenderImageViewerProps> = ({
       <div
         className="riv-scroll"
         ref={scrollRef}
+        onScroll={updateCenter}
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
         onMouseUp={endDrag}

--- a/tritium/react-gui/src/renderer/features/render/RenderResultPane.tsx
+++ b/tritium/react-gui/src/renderer/features/render/RenderResultPane.tsx
@@ -315,9 +315,6 @@ export const RenderResultPane: React.FC<RenderResultPaneProps> = ({
         src={frameUrl ?? imageSrc ?? ""}
         imgWidth={result.width}
         imgHeight={result.height}
-        // Keyed on the result, not the shown image: a finished render arrives
-        // fitted, while stepping the frame slider keeps the zoom the user set.
-        fitKey={result.id}
         name={
           movie
             ? `${result.sourceSceneName} -- frame ${shownFrame + 1} / ${movie.frameCount}`


### PR DESCRIPTION
## Rendering window の画像ビューア

再レンダリングのたびに zoom がリセットされ、拡大して見比べるループのたびに拡大し直す必要があった。あわせて、ツールバーの zoom が viewport 左上基準だった点と、ポインタ基準 zoom (pinch / cmd+wheel) が縦方向にだけ最下部へ飛ぶバグを直す。

- **framing を保つ**: 新しい画像が来ても zoom と scroll offset をそのまま保つ。画像サイズが変わった場合は 2 つの fit scale の比で zoom を補正し、正規化した中心位置に合わせ直すので「見えている構図」が残る。fit するのは最初の画像と Fit ボタンのときだけ。history の Back / Forward でも保たれるので、2 つの試行を同じ倍率で比較できる。
- **ツールバーの zoom を中心基準に**: `+` / `-` / `100%` / `Fit` が viewport の中心を固定する。pinch は従来どおりポインタ基準。
- **anchor 復元のバグ修正**: scroll offset を `stage.offsetLeft/offsetTop` から組み立てていたが、これは最も近い *positioned* な祖先からの距離で、`.riv-scroll` は positioned ではない。そのため縦方向だけツールバーの高さが混入し、zoom のたびに画像の最下部へ飛んでいた (横方向はその offset がたまたま 0 だったので正しかった)。再レイアウト後に両方の client rect を実測し、差分だけスクロールをずらす形に変更 — CSS の positioning に依存しない。
- `fitKey` prop は廃止 (画像サイズの変化が framing ロジックのトリガーになり、movie の frame スクラブはサイズを変えないため)。

## GI lighting ladder

- **step 4 = `1.3 / 0 / 0.6`** (light intensity / flash fraction / ambient fraction) に変更。この点は raytrace の key light (0.52) とカメラ正面から見た球の平均輝度の両方をちょうど保つので、その 2 つを不変量として headlight を 0.60 → 0 に等間隔で刻み、step 1-3 を引き直した。旧 ladder は余ったエネルギーを key light にも回して 0.52 → 0.68 と育てていたため、段を上げると方向性の陰影まで強くなっていた。新しい ladder が動かすのは「flat な headlight → 遮蔽を運ぶ ambient」だけ。

  | step | li | ff | af | key | headlight | ambient |
  |---|---|---|---|---|---|---|
  | 0 | 1.55 | 0.60 | 0.16 | 0.52 | 0.78 | 0.25 |
  | 1 | 1.43 | 0.45 | 0.34 | 0.52 | 0.42 | 0.49 |
  | 2 | 1.37 | 0.30 | 0.46 | 0.52 | 0.22 | 0.63 |
  | 3 | 1.32 | 0.15 | 0.54 | 0.52 | 0.09 | 0.71 |
  | 4 | 1.30 | 0.00 | 0.60 | 0.52 | 0.00 | 0.78 |

- **GI に切り替えたとき既定 step に入る**: direct な方式 (raytrace / AO) の look 既定は GI lighting の step 0 と同じ値に揃えてあり、方式切り替えがそこから導出した step をそのまま書き戻していたため、direct 方式を一度経由するだけで GI が step 0 に落ちていた。quality axis に `enterAtDefault` を追加し (GI ladder が宣言)、方式に入るときは既定 step から始まるようにした。
- umbreon の block default (`UmbreonRenderSettings.qif`) と display context の auto fallback は従来どおり step 4 に追随。

## 互換性

旧値 (`1.2 / 0.05 / 0.4`) を保存済みの `.qsc` を開くと GI lighting が **Custom** と表示される (どの段にも一致しないため)。段を選び直せば新しい値になる。

## Test plan

- C++ `task run_gtest`: 1640 / 1640 pass
- tritium `npm test`: 3757 / 3757 pass (399 files)
- `npx tsc -p tsconfig.web.json --noEmit` クリーン、`task build_tritium` 成功
- ビューアの回帰テストは fake layout (ツールバー分 top にずれた viewport) 上で anchor 後の `scrollTop` を pin する。旧実装に戻すと 37.5 に対して 77.5 = ツールバー高さぶんずれて落ちることを確認済み。
- **Host E2E 確認済み** (ユーザー): pinch / cmd+wheel でポインタ下の点が留まる、再レンダリング・history 移動・画像サイズ変更で構図が保たれる、ツールバー zoom で中心が動かない、ドラッグ pan 維持、GI の見た目と既定 step。

## Docs

- `docs/migration/adr/ADR-0035-render-window.md` — ビューアの framing 保持と anchor バグ
- `docs/architecture/umbreon-gi-lighting-balance.md` — 新しい ladder、2 不変量による導出、`enterAtDefault`

🤖 Generated with [Claude Code](https://claude.com/claude-code)